### PR TITLE
fix(aihub): Pytest coverage comment only on PR

### DIFF
--- a/.github/workflows/analyze-test-pr.yml
+++ b/.github/workflows/analyze-test-pr.yml
@@ -122,7 +122,7 @@ jobs:
   pytest-coverage-comment:
     name: Pytest Coverage Comment
     needs: test-modules
-    runs-on: ubuntu-
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && !github.event.pull_request.draft
 
     permissions:

--- a/.github/workflows/analyze-test-pr.yml
+++ b/.github/workflows/analyze-test-pr.yml
@@ -122,8 +122,8 @@ jobs:
   pytest-coverage-comment:
     name: Pytest Coverage Comment
     needs: test-modules
-    runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-
+    if: github.event_name == 'pull_request' && !github.event.pull_request.draft
 
     permissions:
       contents: read


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Adjusted the condition for running the 'Pytest Coverage Comment' job in GitHub Actions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analyze-test-pr.yml</strong><dd><code>Adjusted Pytest Coverage Comment Trigger</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/analyze-test-pr.yml

<li>Modified the condition for running the 'Pytest Coverage Comment' job.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/50/files#diff-f4d8ebc4cbbb6965cc6da8a33cdb1b1764c2b0c877a8adc6351bb002bed02f88">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information