### PR TITLE
feat(deploy): Define nats config to define endpoint for nats

### DIFF
--- a/aihub_agent/aihub_agent/runners/AgentRunner.py
+++ b/aihub_agent/aihub_agent/runners/AgentRunner.py
@@ -57,7 +57,7 @@ class AgentRunner:
 
     ### Example
     ```python
-    runner = AgentRunner(servers=["nats://localhost:4222"], agent_type=MyAgent, agent_config=my_config)
+    runner = AgentRunner(servers=[NatsConfig().NATS_ENDPOINT], agent_type=MyAgent, agent_config=my_config)
     await runner.run_forever()
     ```
     This code connects to NATS, listens for events, and processes them indefinitely until stopped.

--- a/aihub_agent/aihub_agent/runners/AgentTestRunner.py
+++ b/aihub_agent/aihub_agent/runners/AgentTestRunner.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from typing import AsyncGenerator, List, Optional, Type
 
 from aihub_lib.generative_ai.agent.AgentConfig import AgentConfig
+from aihub_lib.nats.NatsConfig import NatsConfig
 from aihub_lib.nats.events import AgentDiscoveryResponseEvent, BaseEvent, DiscoveryRequestEvent
 from aihub_lib.nats.events.control import ExceptionEvent, StartEvent, StopEvent
 from aihub_lib.nats.subscribers.NCSubscriber import NCSubscriber
@@ -66,7 +67,7 @@ class AgentTestRunner(AgentRunner):
         locale_paths: Optional[List[str]] = None,
     ):
         super().__init__(
-            servers=["nats://localhost:4222"],
+            servers=[NatsConfig().NATS_ENDPOINT],
             agent_type=agent_type,
             agent_config=agent_config,
             locale_paths=locale_paths,

--- a/aihub_api/aihub_api/runners/SimulatedAgentApiTestRunner.py
+++ b/aihub_api/aihub_api/runners/SimulatedAgentApiTestRunner.py
@@ -7,6 +7,7 @@ from nats.js import JetStreamContext
 from aihub_api.runners.ApiTestRunner import ApiTestRunner
 from aihub_lib.generative_ai.agent.AgentConfig import AgentConfig
 from aihub_lib.i18n.LocaleString import LocaleString
+from aihub_lib.nats.NatsConfig import NatsConfig
 from aihub_lib.nats.events import BaseEvent, ControlEvent, StartEvent, StopEvent, ChunkEvent, DisplayEvent
 from aihub_lib.nats.events.cost.LLMCostEvent import LLMCostEvent
 from aihub_lib.nats.events.discovery.DiscoveryRequestEvent import DiscoveryRequestEvent
@@ -101,9 +102,7 @@ class SimulatedAgentApiTestRunner(ApiTestRunner):
         This simulates the agent being discoverable by clients, providing metadata and start events.
         """
         subject = self.topic_manager.get_agent_discovery_subject_response(topic.call_id)
-        start_events = [
-            StartEventSpecs(event_type=StartEvent.__name__, event_schema=StartEvent.model_json_schema())
-        ]
+        start_events = [StartEventSpecs(event_type=StartEvent.__name__, event_schema=StartEvent.model_json_schema())]
         agent_discovery_response_event = AgentDiscoveryResponseEvent(
             agent_class=self.agent_class,
             agent_id=self.agent_id,
@@ -127,10 +126,7 @@ class SimulatedAgentApiTestRunner(ApiTestRunner):
         and display events to display_event subjects.
         """
         thread_topic_manager = AgentThreadTopicManager.from_agent_instance_topic_manager(
-            self.topic_manager,
-            thread_id=topic.thread_id,
-            display_id=topic.display_id,
-            run_id=topic.run_id
+            self.topic_manager, thread_id=topic.thread_id, display_id=topic.display_id, run_id=topic.run_id
         )
         if isinstance(event, ControlEvent):
             subject = thread_topic_manager.get_subject_for_control_event_in_thread(
@@ -158,7 +154,7 @@ class SimulatedAgentApiTestRunner(ApiTestRunner):
         assert len(self.simulated_events) > 0, "No simulated events provided"
 
         self.nc = NATS()
-        await self.nc.connect(servers=["nats://localhost:4222"])
+        await self.nc.connect(servers=[NatsConfig().NATS_ENDPOINT])
 
         self.nc_publisher = NCPublisher(self.nc)
         self.discovery_subscriber = NCSubscriber.for_agent_discovery_request_events(
@@ -179,7 +175,7 @@ class SimulatedAgentApiTestRunner(ApiTestRunner):
 
         await super().run()
 
-    def with_simple_chunk_events(self) -> 'SimulatedAgentApiTestRunner':
+    def with_simple_chunk_events(self) -> "SimulatedAgentApiTestRunner":
         """
         A convenience method to populate a standard sequence of chunk and cost events, simulating
         a typical LLM-based agent responding with textual chunks and cost metrics.

--- a/aihub_api/aihub_api/runners/lifetime/lifetime_manager.py
+++ b/aihub_api/aihub_api/runners/lifetime/lifetime_manager.py
@@ -10,6 +10,7 @@ from aihub_api.sockets.manager.WebSocketManager import WebSocketManager
 from aihub_api.sockets.receiver.WebSocketReceiver import WebSocketReceiver
 from aihub_api.sockets.sender.WebSocketSender import WebSocketSender
 from aihub_lib.infrastructure.azure.cosmos.CosmosAccess import CosmosAccess
+from aihub_lib.nats.NatsConfig import NatsConfig
 from aihub_lib.nats.subscribers.JSSubscriber import JSSubscriber
 from aihub_lib.nats.subscribers.NCSubscriber import NCSubscriber
 from aihub_lib.nats.topic_managers.TopicManager import TopicManager
@@ -67,7 +68,7 @@ async def lifetime_manager(app: FastAPI) -> None:
 
     try:
         # Connect to NATS and setup JetStream
-        await nc.connect(servers=["nats://localhost:4222"])
+        await nc.connect(servers=[NatsConfig().NATS_ENDPOINT])
         js = nc.jetstream()
 
         topic_manager = TopicManager()

--- a/aihub_lib/aihub_lib/nats/NatsConfig.py
+++ b/aihub_lib/aihub_lib/nats/NatsConfig.py
@@ -1,0 +1,12 @@
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class NatsConfig(BaseSettings):
+    NATS_ENDPOINT: str = Field("nats://localhost:4222")
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Introduced `NatsConfig` class for centralized NATS endpoint configuration.

- Updated various runners to use `NatsConfig` for NATS endpoint.

- Added environment variable support for NATS endpoint configuration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AgentRunner.py</strong><dd><code>Use `NatsConfig` for NATS endpoint in AgentRunner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_agent/aihub_agent/runners/AgentRunner.py

- Updated NATS endpoint configuration to use `NatsConfig`.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/75/files#diff-bc89e97071dfe5ec5055de934e7a4c7b79dce6afcd719d51a4856e235bae1967">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AgentTestRunner.py</strong><dd><code>Use `NatsConfig` for NATS endpoint in AgentTestRunner</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_agent/aihub_agent/runners/AgentTestRunner.py

- Imported `NatsConfig` and updated NATS endpoint configuration.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/75/files#diff-915b6776da4516cc21191d146ea00ce9f20b044a3bf0bf5a75ae9a6b896159c5">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SimulatedAgentApiTestRunner.py</strong><dd><code>Use `NatsConfig` for NATS endpoint in SimulatedAgentApiTestRunner</code></dd></summary>
<hr>

aihub_api/aihub_api/runners/SimulatedAgentApiTestRunner.py

<li>Imported <code>NatsConfig</code> and updated NATS endpoint configuration.<br> <li> Minor formatting changes.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/75/files#diff-31654c72d1af9e21804ab16b4742f6bf24e6f002fa22e9b9e33572a2e9f10db9">+5/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lifetime_manager.py</strong><dd><code>Use `NatsConfig` for NATS endpoint in lifetime_manager</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_api/aihub_api/runners/lifetime/lifetime_manager.py

- Imported `NatsConfig` and updated NATS endpoint configuration.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/75/files#diff-360f64367d6a1fc175c14da2a61503e613bacdb179941bc1de137e3b0ac7447e">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NatsConfig.py</strong><dd><code>Introduce `NatsConfig` class for NATS configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_lib/aihub_lib/nats/NatsConfig.py

<li>Created <code>NatsConfig</code> class for NATS endpoint configuration.<br> <li> Added environment variable support.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/75/files#diff-07b99facacacc6c35c63b7c77b6470e5a0cc853d3ea938067e2c12e550763862">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>