### PR TITLE
fix(aihub): Fix Auto Tag Action

### DIFF
--- a/.github/workflows/add-tag.yml
+++ b/.github/workflows/add-tag.yml
@@ -126,11 +126,6 @@ jobs:
             cd -
           done
 
-      - name: Clean up SSH keys
-        run: |
-          rm -rf ~/.ssh
-          git config --global --unset url."git@github.com:".insteadOf
-
       - name: Delete existing tag (in case we re-tag)
         run: |
           # Remove local tag if exists
@@ -169,3 +164,8 @@ jobs:
           GIT_COMMITTER_EMAIL: ${{ github.actor }}@users.noreply.github.com
           GIT_AUTHOR_NAME: ${{ github.actor }}
           GIT_AUTHOR_EMAIL: ${{ github.actor }}@users.noreply.github.com
+
+      - name: Clean up SSH keys
+        run: |
+          rm -rf ~/.ssh
+          git config --global --unset url."git@github.com:".insteadOf


### PR DESCRIPTION
### **User description**
Reset ssh only at end to bypass ruleset using deployment key


___

### **PR Type**
bug fix, enhancement


___

### **Description**
- Move SSH key cleanup to the end of the workflow

- Ensure SSH keys are reset after all operations

- Maintain deployment key usage throughout the workflow


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>add-tag.yml</strong><dd><code>Move SSH key cleanup to the end of the workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/add-tag.yml

<li>Moved SSH key cleanup step to the end of the workflow<br> <li> Ensured SSH keys are reset after all tagging operations


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/78/files#diff-a36f7d26e0c65f69e81cd8885d8ce7e3eebc5dbaf3f32388ded64b2f4812c705">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>