### PR TITLE
fix(aihub): Always use current branch to get github workflows

### DIFF
--- a/.github/workflows/analyze-test-pr.yml
+++ b/.github/workflows/analyze-test-pr.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Run Tests
-        uses: bbvch-ai/aihub-core/aihub_action/test_backend@${{ github.head_ref }}
+        uses: bbvch-ai/aihub-core/aihub_action/test_backend@${{ github.head_ref || 'main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           working_directory: ${{ matrix.module }}

--- a/.github/workflows/analyze-test-pr.yml
+++ b/.github/workflows/analyze-test-pr.yml
@@ -46,6 +46,9 @@ jobs:
             docker_compose_files: "docker-compose.yml"
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Run Tests
         uses: ./aihub_action/test_backend
         with:

--- a/.github/workflows/analyze-test-pr.yml
+++ b/.github/workflows/analyze-test-pr.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Run Tests
-        uses: bbvch-ai/aihub-core/aihub_action/test_backend@${{ github.head_ref || 'main' }}
+        uses: ./aihub_action/test_backend
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           working_directory: ${{ matrix.module }}

--- a/.github/workflows/analyze-test-pr.yml
+++ b/.github/workflows/analyze-test-pr.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Run Tests
-        uses: bbvch-ai/aihub-core/aihub_action/test_backend@bots/aihub-bots
+        uses: bbvch-ai/aihub-core/aihub_action/test_backend@${{ github.head_ref }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           working_directory: ${{ matrix.module }}


### PR DESCRIPTION
### **PR Type**
bug fix


___

### **Description**
- Always use the current branch to get GitHub workflows.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>analyze-test-pr.yml</strong><dd><code>Use current branch for GitHub action in workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/analyze-test-pr.yml

- Updated the `uses` directive to dynamically use the current branch.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/87/files#diff-f4d8ebc4cbbb6965cc6da8a33cdb1b1764c2b0c877a8adc6351bb002bed02f88">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>