### PR TITLE
fix(bots): Use NatsConfig for bot

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -27,6 +27,7 @@ jobs:
             agent-custom
             agent-xp
             avatar
+            bots
             chat-xp
             chat-backend
             debt

--- a/aihub_bot/aihub_bot/runners/lifetime/lifetime_manager.py
+++ b/aihub_bot/aihub_bot/runners/lifetime/lifetime_manager.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from typing import Any, AsyncGenerator
 
 from aihub_lib.infrastructure.azure.cosmos.CosmosAccess import CosmosAccess
+from aihub_lib.nats.NatsConfig import NatsConfig
 from aihub_lib.sockets.receiver.WebSocketReceiver import WebSocketReceiver
 from fastapi import FastAPI
 from mongoengine import connect
@@ -23,7 +24,7 @@ async def lifetime_manager(app: FastAPI) -> AsyncGenerator[None, Any]:
 
     try:
         # Connect to NATS and setup JetStream
-        await nc.connect(servers=["nats://localhost:4222"])
+        await nc.connect(servers=[NatsConfig().NATS_ENDPOINT])
         js = nc.jetstream()
         ws_receiver = WebSocketReceiver(js=js)
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Use `NatsConfig` for NATS connection endpoint

- Replace hardcoded NATS endpoint with dynamic configuration


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lifetime_manager.py</strong><dd><code>Use `NatsConfig` for NATS connection endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_bot/aihub_bot/runners/lifetime/lifetime_manager.py

<li>Import <code>NatsConfig</code> for NATS configuration<br> <li> Replace hardcoded NATS endpoint with <code>NatsConfig().NATS_ENDPOINT</code>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/95/files#diff-5800c95de50ab7aba25fb1255e78ca4733ff1b2653650d20097fa9716089c390">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>