### PR TITLE
fix(bots): Fix chat bot openai with azure LLM

### DIFF
--- a/aihub_bot/aihub_bot/bots/chat/openai/JsonOpenaiChatBot.py
+++ b/aihub_bot/aihub_bot/bots/chat/openai/JsonOpenaiChatBot.py
@@ -1,6 +1,7 @@
+from typing_extensions import override
+
 from botbuilder.core import TurnContext
 from openai import AsyncAzureOpenAI, AsyncOpenAI
-from typing_extensions import override
 
 from aihub_bot.bots.chat.ChatBot import ChatBot
 from aihub_bot.persistence.chat.entities.ConversationEntity import Message
@@ -21,7 +22,7 @@ class JsonOpenaiChatBot(ChatBot):
         user_message = Message(
             user_id=turn_context.activity.from_property.id,
             content=turn_context.activity.text,
-            role=turn_context.activity.from_property.role,
+            role=turn_context.activity.from_property.role or "user",
         )
         response = await OpenaiChatService.json_on_message_activity(
             message=user_message,

--- a/aihub_bot/aihub_bot/routes/chat/openai/OpenaiChatService.py
+++ b/aihub_bot/aihub_bot/routes/chat/openai/OpenaiChatService.py
@@ -79,7 +79,12 @@ class OpenaiChatService(ChatService):
                 stream=True,
             )
             async for chunk in response:
-                yield chunk.choices[0].delta.content
+                if len(chunk.choices) == 0:
+                    continue
+                content = chunk.choices[0].delta.content
+                if content is None:
+                    continue
+                yield content
                 await asyncio.sleep(0)
 
         return stream_chat_completion()


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix default role assignment in `JsonOpenaiChatBot.py`.

- Add error handling for empty or None content in `OpenaiChatService.py`.

- Import `override` from `typing_extensions` in `JsonOpenaiChatBot.py`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JsonOpenaiChatBot.py</strong><dd><code>Fix role assignment and import in `JsonOpenaiChatBot.py`</code>&nbsp; </dd></summary>
<hr>

aihub_bot/aihub_bot/bots/chat/openai/JsonOpenaiChatBot.py

<li>Import <code>override</code> from <code>typing_extensions</code>.<br> <li> Fix default role assignment to "user" if None.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/103/files#diff-79aaa4e6519f40497e0081370e390fd32465d92b73acd63f9ddb483d695e4ea7">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OpenaiChatService.py</strong><dd><code>Add error handling for response content in `OpenaiChatService.py`</code></dd></summary>
<hr>

aihub_bot/aihub_bot/routes/chat/openai/OpenaiChatService.py

<li>Add checks for empty or None content in response chunks.<br> <li> Ensure only valid content is yielded.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/103/files#diff-d965bf7974fb38960faeea295a4bff02ec073c48522982abf3d4dfa270967224">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>