### PR TITLE
fix(aihub): Expected timestamp is unix int not str

### DIFF
--- a/aihub_lib/aihub_lib/generative_ai/utils/combine_nodes_in_order.py
+++ b/aihub_lib/aihub_lib/generative_ai/utils/combine_nodes_in_order.py
@@ -37,15 +37,11 @@ def sanitize_metadata_value(value: str) -> str:
     return sanitized_value
 
 
-def format_unix_timestamp(timestamp: Optional[str]) -> Optional[str]:
-    if not timestamp or not timestamp.isdigit():
+def format_unix_timestamp(timestamp: Optional[int]) -> Optional[str]:
+    if timestamp is None or timestamp <= 0:
         return None
-
     try:
-        timestamp_int = int(timestamp)
-        if timestamp_int <= 0:
-            return None
-        dt = datetime.fromtimestamp(timestamp_int, tz=timezone.utc)
+        dt = datetime.fromtimestamp(timestamp, tz=timezone.utc)
         return dt.strftime("%d.%m.%Y")
     except (ValueError, OverflowError):
         return None

--- a/aihub_lib/aihub_lib/generative_ai/utils/tests/test_combine_nodes_in_order.py
+++ b/aihub_lib/aihub_lib/generative_ai/utils/tests/test_combine_nodes_in_order.py
@@ -74,7 +74,7 @@ def _(datatable):
 
     for row in datatable[1:]:
         metadata = {
-            column: (int(row[index]) if column == "section_start_line" else row[index])
+            column: (int(row[index]) if column in {SECTION_START_LINE, INSERTED_AT, UPDATED_AT, CREATED_AT} else row[index])
             for index, column in enumerate(headers)
             if row[index] and column in metadata_fields
         }

--- a/aihub_lib/aihub_lib/generative_ai/utils/tests/test_combine_nodes_in_order.py
+++ b/aihub_lib/aihub_lib/generative_ai/utils/tests/test_combine_nodes_in_order.py
@@ -74,7 +74,9 @@ def _(datatable):
 
     for row in datatable[1:]:
         metadata = {
-            column: (int(row[index]) if column in {SECTION_START_LINE, INSERTED_AT, UPDATED_AT, CREATED_AT} else row[index])
+            column: (
+                int(row[index]) if column in {SECTION_START_LINE, INSERTED_AT, UPDATED_AT, CREATED_AT} else row[index]
+            )
             for index, column in enumerate(headers)
             if row[index] and column in metadata_fields
         }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix expected timestamp type to be integer

- Update `format_unix_timestamp` function to handle integer timestamps

- Adjust test cases to reflect timestamp type change


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>combine_nodes_in_order.py</strong><dd><code>Update `format_unix_timestamp` to handle integer timestamps</code></dd></summary>
<hr>

aihub_lib/aihub_lib/generative_ai/utils/combine_nodes_in_order.py

<li>Change <code>format_unix_timestamp</code> to accept integer timestamps<br> <li> Simplify timestamp validation logic


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/104/files#diff-ed7813c8ea059af83c64f3bcc102955d2ffb433a5258ea15fb2099bf0d7853ff">+3/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_combine_nodes_in_order.py</strong><dd><code>Adjust test cases for integer timestamp handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_lib/aihub_lib/generative_ai/utils/tests/test_combine_nodes_in_order.py

<li>Modify test cases to use integer timestamps<br> <li> Include additional timestamp fields in test metadata


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/104/files#diff-6f53acec6daf389fb93a04ccef5f290eb38e0b0d868e3b817ca7e72117acbd81">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>