### PR TITLE
fix(aihub): Fix tag updater to update lib in lockfiles

### DIFF
--- a/.github/workflows/add-tag.yml
+++ b/.github/workflows/add-tag.yml
@@ -126,6 +126,20 @@ jobs:
             cd -
           done
 
+      - name: Update lib version tag in poetry.lock
+        run: |
+          VERSION="${{ steps.create-tag.outputs.version }}"
+            update_version_tag() {
+                echo "Update version tag in $1"
+                sed -i '/name = "aihub-lib"/,/^version =/ s/version = "[^"]*"/version = "'"$VERSION"'"/' $1
+            }
+          
+          directories="${{ steps.define-directories.outputs.directories }}"
+            IFS=' ' read -r -a dir_array <<< "$directories"
+            for dir in "${dir_array[@]}"; do
+                update_version_tag "$dir/poetry.lock"
+            done
+
       - name: Delete existing tag (in case we re-tag)
         run: |
           # Remove local tag if exists
@@ -146,6 +160,7 @@ jobs:
             git add "$dir/poetry.lock"
           done
           git add aihub_lib/pyproject.toml
+          git add Makefile
           git commit -m "ops(bot): Update tag number to ${VERSION} [skip ci]" || true
           git push origin --force
         env:


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix tag updater to update library version in `poetry.lock` files.

- Ensure `TAG` in `Makefile` is updated.

- Add new step to update version tag in `poetry.lock`.

- Include `Makefile` in the git commit for version update.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>add-tag.yml</strong><dd><code>Update version tag handling in workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/add-tag.yml

<li>Add step to update library version tag in <code>poetry.lock</code>.<br> <li> Include <code>Makefile</code> in the git commit for version update.<br> <li> Ensure <code>TAG</code> in <code>Makefile</code> is updated.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/146/files#diff-a36f7d26e0c65f69e81cd8885d8ce7e3eebc5dbaf3f32388ded64b2f4812c705">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>