### PR TITLE
fix(aihub): Default Dockerfile

### DIFF
--- a/aihub_action/build_image/action.yml
+++ b/aihub_action/build_image/action.yml
@@ -19,7 +19,6 @@ inputs:
   file:
     description: 'Dockerfile path'
     required: false
-    default: './Dockerfile'
   github_token:
     description: 'GitHub token for authentication'
     required: true


### PR DESCRIPTION
### **PR Type**
bug fix


___

### **Description**
- Removed default Dockerfile path in action.yml


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>Remove default Dockerfile path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_action/build_image/action.yml

- Removed the default value for the `file` input.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/149/files#diff-fe0340903273aedf091dd20117cb849db7a22dae61837b5dfd33b418ceeae429">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>