### PR TITLE
fix(aihub): Default locale as fallback in dispatcher

### DIFF
--- a/aihub_agent/aihub_agent/dispatchers/Dispatcher.py
+++ b/aihub_agent/aihub_agent/dispatchers/Dispatcher.py
@@ -4,6 +4,16 @@ import logging
 import traceback
 from typing import Annotated, Any, Callable, Dict, List, Optional, Set, Type, get_origin
 
+from bson import ObjectId
+from nats.aio.client import Client as NATS
+from nats.js import JetStreamContext
+
+from aihub_agent.agents.abstract.Agent import Agent
+from aihub_agent.dispatchers.stores.event.DistributedEventStore import DistributedEventStore
+from aihub_agent.dispatchers.stores.step.StepStore import DistributedStepStore
+from aihub_agent.i18n.AgentLocaleHandler import AgentLocaleHandler
+from aihub_agent.tracing.coordinators.RunTraceCoordinator import RunTraceCoordinator
+from aihub_agent.workflow.annotations.custom_types.ListOfSize import ListOfSize
 from aihub_lib.agents.AgentConfig import AgentConfig
 from aihub_lib.displayers.EventDisplayer import EventDisplayer
 from aihub_lib.i18n.LocaleHandler import LocaleHandler
@@ -18,16 +28,6 @@ from aihub_lib.nats.topic_managers.agents.AgentInstanceTopicManager import Agent
 from aihub_lib.nats.topic_managers.agents.AgentThreadTopicManager import AgentThreadTopicManager
 from aihub_lib.nats.topics import Topic
 from aihub_lib.nats.topics.agents.AgentTopic import AgentTopic
-from bson import ObjectId
-from nats.aio.client import Client as NATS
-from nats.js import JetStreamContext
-
-from aihub_agent.agents.abstract.Agent import Agent
-from aihub_agent.dispatchers.stores.event.DistributedEventStore import DistributedEventStore
-from aihub_agent.dispatchers.stores.step.StepStore import DistributedStepStore
-from aihub_agent.i18n.AgentLocaleHandler import AgentLocaleHandler
-from aihub_agent.tracing.coordinators.RunTraceCoordinator import RunTraceCoordinator
-from aihub_agent.workflow.annotations.custom_types.ListOfSize import ListOfSize
 
 logger = logging.getLogger(__name__)
 
@@ -346,7 +346,7 @@ class Dispatcher:
 
             # Handle LocaleHandler
             if param.annotation in [LocaleHandler, AgentLocaleHandler]:
-                locale = await run_context.get("locale")
+                locale = await run_context.get("locale", LocaleHandler.DEFAULT_LOCALE)
                 kwargs[param.name] = self.locale_handler.in_locale(locale)
                 continue
 


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Use default locale as fallback in dispatcher

- Reorganize import statements for clarity


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dispatcher.py</strong><dd><code>Implement default locale fallback and reorganize imports</code>&nbsp; </dd></summary>
<hr>

aihub_agent/aihub_agent/dispatchers/Dispatcher.py

<li>Added default locale fallback in <code>execute_step</code> method<br> <li> Reorganized import statements for better readability


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/164/files#diff-3c17d20098e781cd60e6dae24ad438b708e7f080f99fdd6a88395fbfc97f1af3">+11/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>