### PR TITLE
fix(aihub): Allow self hosted llm in llm wrapping agent

### DIFF
--- a/aihub_agent/aihub_agent/agents/basic/LLMWrappingAgent/LLMWrappingAgentConfig.py
+++ b/aihub_agent/aihub_agent/agents/basic/LLMWrappingAgent/LLMWrappingAgentConfig.py
@@ -1,6 +1,6 @@
 from aihub_lib.agents.AgentConfig import AgentConfig
-from aihub_lib.generative_ai.resources.models.llm.chat.azure.AzureOpenAILLMConfig import AzureOpenAILLMConfig
+from aihub_lib.generative_ai.resources.models.llm.chat.ChatLLMConfig import ChatLLMConfig
 
 
 class LLMWrappingAgentConfig(AgentConfig):
-    llm: AzureOpenAILLMConfig
+    llm: ChatLLMConfig


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Update LLM configuration to support self-hosted models

- Replace Azure-specific LLM config with generic Chat LLM config


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LLMWrappingAgentConfig.py</strong><dd><code>Update LLM configuration to support self-hosted models</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_agent/aihub_agent/agents/basic/LLMWrappingAgent/LLMWrappingAgentConfig.py

<li>Changed LLM configuration import to a generic Chat LLM<br> <li> Updated LLM type from Azure-specific to generic Chat LLM


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/166/files#diff-b71bbdc117a41f3233cb69fcf2a53750d064d4fce7156d9ba203c8dcd426eadc">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>