### PR TITLE
fix(aihub): Strip quantization from modelname for tokenizer

### DIFF
--- a/aihub_lib/aihub_lib/generative_ai/resources/models/llm/chat/self_hosted/SelfHostedLLMConfig.py
+++ b/aihub_lib/aihub_lib/generative_ai/resources/models/llm/chat/self_hosted/SelfHostedLLMConfig.py
@@ -53,7 +53,8 @@ class SelfHostedLLMConfig(ChatLLMConfig):
 
     @property
     def tokenizer(self) -> Callable[[str], List[int]]:
-        return AutoTokenizer.from_pretrained(self.name)
+        base_llm_name: str = self.name.replace("-GGUF", "").replace("-AWQ", "")
+        return AutoTokenizer.from_pretrained(base_llm_name).encode
 
     def to_llama_index(
         self, model_parameter: Optional[SelfHostedLLMParameter] = None


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Strip quantization suffix from model name for tokenizer.

- Modify tokenizer property to use cleaned model name.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SelfHostedLLMConfig.py</strong><dd><code>Strip quantization suffix from model name in tokenizer</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_lib/aihub_lib/generative_ai/resources/models/llm/chat/self_hosted/SelfHostedLLMConfig.py

<li>Strip "-GGUF" and "-AWQ" from model name.<br> <li> Update tokenizer property to use cleaned name.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/169/files#diff-e97df564a1ac880d90e1c847621ed851d500c4968ed92a6e7d8714e546b2d2a3">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>