### PR TITLE
fix(aihub): Remove dependency on messages

### DIFF
--- a/aihub_lib/aihub_lib/sockets/receiver/WebSocketReceiver.py
+++ b/aihub_lib/aihub_lib/sockets/receiver/WebSocketReceiver.py
@@ -90,7 +90,7 @@ class WebSocketReceiver:
         """
         logger.debug(f"Handling start event for thread {ws_event.thread_id}")
 
-        if len(ws_event.event.messages) == 0:
+        if hasattr(ws_event.event, "messages") and len(ws_event.event.messages) == 0:
             ws_event.event.messages = PersistedEventEntity.to_message_history(str(thread.id))
             logger.debug(f"Assembled message history {ws_event.event.messages}")
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix handling of start events without messages.

- Add check for 'messages' attribute existence.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WebSocketReceiver.py</strong><dd><code>Fix start event handling by checking 'messages' attribute</code></dd></summary>
<hr>

aihub_lib/aihub_lib/sockets/receiver/WebSocketReceiver.py

<li>Added check for 'messages' attribute existence.<br> <li> Fixed handling of start events without messages.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/176/files#diff-da7fa99c7d79a0d0354c3279ad6e73a027f671d97a01b05be3923ec3f2e9d2e4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>