### PR TITLE
fix(aihub): Semantic Config default name

### DIFF
--- a/aihub_lib/aihub_lib/persistence/rag/vectors/stores/AzureAISearchVectorStoreFactory.py
+++ b/aihub_lib/aihub_lib/persistence/rag/vectors/stores/AzureAISearchVectorStoreFactory.py
@@ -19,7 +19,7 @@ def create_azure_ai_search_vector_store(
     vector_store_name: str,
     metadata_fields: List[str] | None = None,
     language: str = "de",
-    semantic_configuration_name: str | None = None,
+    semantic_configuration_name: str = "mySemanticConfig",
 ) -> AzureAISearchVectorStore:
     search_client_singleton = AISearchAccess()
     index_client = search_client_singleton.get_client()
@@ -30,30 +30,16 @@ def create_azure_ai_search_vector_store(
     except Exception:
         filterable_metadata_field_keys = metadata_fields or DEFAULT_METADATA_FIELDS
 
-    if semantic_configuration_name is not None:
-        return AzureAISearchVectorStore(
-            search_or_index_client=index_client,
-            index_name=vector_store_name,
-            filterable_metadata_field_keys=filterable_metadata_field_keys,
-            index_management=IndexManagement.CREATE_IF_NOT_EXISTS,
-            id_field_key=NODE_ID,
-            chunk_field_key=NODE_CONTENT,
-            embedding_field_key=NODE_EMBEDDING,
-            metadata_string_field_key=NODE_METADATA,
-            doc_id_field_key=DOCUMENT_ID,
-            language_analyzer=f"{language}.microsoft",
-            semantic_configuration_name=semantic_configuration_name,
-        )
-    else:
-        return AzureAISearchVectorStore(
-            search_or_index_client=index_client,
-            index_name=vector_store_name,
-            filterable_metadata_field_keys=filterable_metadata_field_keys,
-            index_management=IndexManagement.CREATE_IF_NOT_EXISTS,
-            id_field_key=NODE_ID,
-            chunk_field_key=NODE_CONTENT,
-            embedding_field_key=NODE_EMBEDDING,
-            metadata_string_field_key=NODE_METADATA,
-            doc_id_field_key=DOCUMENT_ID,
-            language_analyzer=f"{language}.microsoft",
-        )
+    return AzureAISearchVectorStore(
+        search_or_index_client=index_client,
+        index_name=vector_store_name,
+        filterable_metadata_field_keys=filterable_metadata_field_keys,
+        index_management=IndexManagement.CREATE_IF_NOT_EXISTS,
+        id_field_key=NODE_ID,
+        chunk_field_key=NODE_CONTENT,
+        embedding_field_key=NODE_EMBEDDING,
+        metadata_string_field_key=NODE_METADATA,
+        doc_id_field_key=DOCUMENT_ID,
+        language_analyzer=f"{language}.microsoft",
+        semantic_configuration_name=semantic_configuration_name,
+    )


### PR DESCRIPTION
### **User description**
Otherwise get this error when creating a vector store: Details: semantic.configurations[0].name : The name field is required.


___

### **PR Type**
bug_fix, enhancement


___

### **Description**
- Set default semantic configuration name to avoid errors

- Simplified return logic in vector store creation

- Removed conditional check for semantic configuration name


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AzureAISearchVectorStoreFactory.py</strong><dd><code>Default semantic configuration name and logic simplification</code></dd></summary>
<hr>

aihub_lib/aihub_lib/persistence/rag/vectors/stores/AzureAISearchVectorStoreFactory.py

<li>Set default value for <code>semantic_configuration_name</code><br> <li> Removed conditional logic for semantic configuration<br> <li> Simplified return statement in function


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/177/files#diff-fb9c059b009d274508878f5481f81af3ae3df1dc874241f7886aeca83bc957d5">+14/-28</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>