### PR TITLE
fix(aihub): Ensure step is executed with same set of events used to evaluate its readyness

### DIFF
--- a/aihub_agent/aihub_agent/dispatchers/Dispatcher.py
+++ b/aihub_agent/aihub_agent/dispatchers/Dispatcher.py
@@ -166,7 +166,9 @@ class Dispatcher:
             events = await self.event_store.get_all_events(topic.run_id, before=event.created_at)
             if await self.is_step_ready(step_method, topic.run_id, events):
                 logger.debug(f"Triggering step '{step_method.__name__}' due to event '{event.__class__.__name__}'")
-                task = asyncio.create_task(self.execute_step(event, step_method, events, run_context, thread_context, topic))
+                task = asyncio.create_task(
+                    self.execute_step(event, step_method, events, run_context, thread_context, topic)
+                )
                 tasks.append(task)
 
         if tasks:

--- a/aihub_agent/aihub_agent/dispatchers/Dispatcher.py
+++ b/aihub_agent/aihub_agent/dispatchers/Dispatcher.py
@@ -163,9 +163,10 @@ class Dispatcher:
         tasks = []
         for step_method in steps:
             logger.debug(f"Checking step '{step_method.__name__}' for readiness")
-            if await self.is_step_ready(step_method, topic.run_id, event):
+            events = await self.event_store.get_all_events(topic.run_id, before=event.created_at)
+            if await self.is_step_ready(step_method, topic.run_id, events):
                 logger.debug(f"Triggering step '{step_method.__name__}' due to event '{event.__class__.__name__}'")
-                task = asyncio.create_task(self.execute_step(event, step_method, run_context, thread_context, topic))
+                task = asyncio.create_task(self.execute_step(event, step_method, events, run_context, thread_context, topic))
                 tasks.append(task)
 
         if tasks:
@@ -175,7 +176,7 @@ class Dispatcher:
         self,
         step_method: Annotated[Callable, "The step method to check."],
         run_id: Annotated[str, "The current run ID."],
-        event: Annotated[ControlEvent, "The triggering event."],
+        events: Annotated[Dict[str, List[ControlEvent]], "All events for this run, keyed by event_type_name."],
     ) -> bool:
         """
         Checks if a step can be run given the current state (events available, max executions, etc.).
@@ -204,7 +205,6 @@ class Dispatcher:
         parameter_optional_map: Dict[str, bool] = getattr(step_method, "_parameter_optional_map", {})
         size_requirements: Dict[str, Optional[int]] = getattr(step_method, "_size_requirements", {})
 
-        events = await self.event_store.get_all_events(run_id, before=event.created_at)
         # For each parameter, check if we have enough events
         for argument_name, event_types in input_event_mapping.items():
             logger.debug(f"[{step_method.__name__}] Checking argument '{argument_name}' for event types {event_types}")
@@ -291,6 +291,7 @@ class Dispatcher:
         self,
         trigger_event: Annotated[ControlEvent, "The event that caused this step to trigger."],
         step_method: Annotated[Callable, "The step method to execute."],
+        events: Annotated[Dict[str, List[ControlEvent]], "All events for this run, keyed by event_type_name."],
         run_context: Annotated[RunContext, "Per-run context for state and configuration."],
         thread_context: Annotated[ThreadContext, "Per-thread context for longer-lived state."],
         topic: Annotated[AgentTopic, "Topic info for the current run and thread."],
@@ -310,7 +311,6 @@ class Dispatcher:
 
         kwargs: Dict[str, Any] = {}
         step_signature = inspect.signature(step_method)
-        events = await self.event_store.get_all_events(topic.run_id)
         parameter_optional_map = getattr(step_method, "_parameter_optional_map", {})
 
         # Prepare arguments

--- a/aihub_agent/aihub_agent/dispatchers/stores/StoreBase.py
+++ b/aihub_agent/aihub_agent/dispatchers/stores/StoreBase.py
@@ -51,7 +51,7 @@ class StoreBase:
     ):
         self.js = js
         self.prefix = prefix
-        self._kv_stores: Dict[str, Any] = {}
+        self._kv_stores: Dict[str, KeyValue] = {}
         self.max_retries = 10  # Up to 1 second backoff
         self.base_backoff = 0.001  # 1ms initial backoff
 
@@ -69,9 +69,16 @@ class StoreBase:
                         storage=StorageType.FILE,
                     )
                 )
-            except Exception:
-                # If the bucket already exists, we just retrieve it
-                self._kv_stores[run_id] = await self.js.key_value(f"{self.prefix}_{run_id}")
+                logger.debug(f"Created new KV store '{self.prefix}_{run_id}'")
+            except Exception as e:
+                if "already in use" in str(e).lower():
+                    # If the bucket already exists, we just retrieve it
+                    self._kv_stores[run_id] = await self.js.key_value(f"{self.prefix}_{run_id}")
+                    logger.debug(f"Using existing KV store '{self.prefix}_{run_id}'")
+                else:
+                    logger.error(f"Error creating KV store '{self.prefix}_{run_id}': {e}")
+                    raise
+
         return self._kv_stores[run_id]
 
     async def delete_run_store(
@@ -81,13 +88,14 @@ class StoreBase:
         """
         Deletes the KV store for a specific run, removing all associated data.
         Also clears any cached references in _kv_stores.
-
-        Use this at run completion to reclaim resources and maintain a clean state.
         """
         if run_id in self._kv_stores:
-            logger.debug(f"Deleting Distributed Event or Step store for run {run_id}")
-            await self.js.delete_key_value(f"{self.prefix}_{run_id}")
-            del self._kv_stores[run_id]
+            try:
+                await self.js.delete_key_value(f"{self.prefix}_{run_id}")
+                del self._kv_stores[run_id]
+                logger.debug(f"Deleted KV store '{self.prefix}_{run_id}'")
+            except Exception as e:
+                logger.error(f"Error deleting KV store '{self.prefix}_{run_id}': {e}")
 
     async def get_value(
         self, run_id: str, key: str, default_value: T = None, transform_func: Callable[[bytes], T] = None
@@ -105,15 +113,23 @@ class StoreBase:
             logger.error(f"Error retrieving key '{key}': {e}")
             return default_value
 
-    async def put_json_value(self, run_id: str, key: str, value: Any) -> bool:
-        """Stores a JSON-serializable value in the KV store."""
+    async def put_value(self, run_id: str, key: str, value: bytes) -> bool:
+        """Stores a raw byte value in the KV store."""
         kv = await self._get_kv_store(run_id)
         try:
-            serialized = json.dumps(value).encode()
-            await kv.put(key, serialized)
+            await kv.put(key, value)
             return True
         except Exception as e:
-            logger.error(f"Error storing JSON value for key '{key}': {e}")
+            logger.error(f"Error storing value for key '{key}': {e}")
+            return False
+
+    async def put_json_value(self, run_id: str, key: str, value: Any) -> bool:
+        """Stores a JSON-serializable value in the KV store."""
+        try:
+            serialized = json.dumps(value).encode()
+            return await self.put_value(run_id, key, serialized)
+        except Exception as e:
+            logger.error(f"Error serializing JSON value for key '{key}': {e}")
             return False
 
     async def get_json_value(self, run_id: str, key: str, default_value: Any = None) -> Any:
@@ -124,9 +140,8 @@ class StoreBase:
 
         return await self.get_value(run_id, key, default_value, json_transform)
 
-    async def atomic_operation(
+    async def retry_operation(
         self,
-        run_id: str,
         operation_func: Callable[[], Any],
         max_attempts: int = None,
     ) -> Any:
@@ -154,62 +169,3 @@ class StoreBase:
                 await asyncio.sleep(backoff)
 
         return None
-
-    async def synchronized_update(
-        self, run_id: str, key: str, update_func: Callable[[Any], Any], default_value: Any = None
-    ) -> bool:
-        """
-        Performs a synchronized update on a JSON value using a mutex pattern.
-
-        Since the NATS JetStream KeyValue API doesn't appear to support native optimistic
-        concurrency control, we create a mutex key specifically for this operation.
-        """
-        # Create a mutex key to synchronize access
-        mutex_key = f"mutex_{key}"
-        kv = await self._get_kv_store(run_id)
-
-        # Try to acquire the mutex
-        max_attempts = 10
-        attempts = 0
-        mutex_acquired = False
-
-        while attempts < max_attempts and not mutex_acquired:
-            try:
-                # Try to create the mutex
-                try:
-                    await kv.create(mutex_key, b"locked")
-                    mutex_acquired = True
-                except Exception:
-                    # Mutex already exists, wait and retry
-                    attempts += 1
-                    if attempts >= max_attempts:
-                        logger.error(f"Failed to acquire mutex for key '{key}' after {attempts} attempts")
-                        return False
-
-                    backoff = self.base_backoff * (2**attempts)
-                    logger.debug(f"Waiting for mutex ({attempts}/{max_attempts}): {key}")
-                    await asyncio.sleep(backoff)
-            except Exception as e:
-                logger.error(f"Error acquiring mutex for key '{key}': {e}")
-                return False
-
-        if not mutex_acquired:
-            return False
-
-        try:
-            # Read current value
-            current_value = await self.get_json_value(run_id, key, default_value)
-
-            # Apply update function
-            new_value = update_func(current_value)
-
-            # Store updated value
-            success = await self.put_json_value(run_id, key, new_value)
-            return success
-
-        finally:
-            # Always release the mutex, even if the update fails
-            try:
-                await kv.delete(mutex_key)
-            except Exception as e:
-                logger.error(f"Error releasing mutex for key '{key}': {e}")

--- a/aihub_agent/aihub_agent/dispatchers/stores/StoreBase.py
+++ b/aihub_agent/aihub_agent/dispatchers/stores/StoreBase.py
@@ -52,8 +52,8 @@ class StoreBase:
         self.js = js
         self.prefix = prefix
         self._kv_stores: Dict[str, Any] = {}
-        self.max_retries = 5
-        self.base_backoff = 0.01  # 10ms initial backoff
+        self.max_retries = 10  # Up to 1 second backoff
+        self.base_backoff = 0.001  # 1ms initial backoff
 
     async def _get_kv_store(
         self, run_id: Annotated[str, "The run identifier for which we need a KV store."]
@@ -85,6 +85,7 @@ class StoreBase:
         Use this at run completion to reclaim resources and maintain a clean state.
         """
         if run_id in self._kv_stores:
+            logger.debug(f"Deleting Distributed Event or Step store for run {run_id}")
             await self.js.delete_key_value(f"{self.prefix}_{run_id}")
             del self._kv_stores[run_id]
 
@@ -182,7 +183,7 @@ class StoreBase:
                     # Mutex already exists, wait and retry
                     attempts += 1
                     if attempts >= max_attempts:
-                        logger.warning(f"Failed to acquire mutex for key '{key}' after {attempts} attempts")
+                        logger.error(f"Failed to acquire mutex for key '{key}' after {attempts} attempts")
                         return False
 
                     backoff = self.base_backoff * (2**attempts)

--- a/aihub_agent/aihub_agent/dispatchers/stores/event/DistributedEventStore.py
+++ b/aihub_agent/aihub_agent/dispatchers/stores/event/DistributedEventStore.py
@@ -79,7 +79,7 @@ class DistributedEventStore(StoreBase):
         success = await self.synchronized_update(run_id, event_type, update_event_list, default_value=[])
 
         if not success:
-            logger.warning(f"Failed to store event of type {event_type}")
+            logger.error(f"Failed to store event of type {event_type}")
 
     async def get_events_of_type(
         self,

--- a/aihub_agent/aihub_agent/dispatchers/stores/event/DistributedEventStore.py
+++ b/aihub_agent/aihub_agent/dispatchers/stores/event/DistributedEventStore.py
@@ -50,75 +50,99 @@ class DistributedEventStore(StoreBase):
         event: Annotated[ControlEvent, "The event instance to store."],
     ):
         """
-        Appends a new event to the run's event list for its type.
-        Uses synchronized_update to safely handle concurrent updates.
+        Stores an event using a direct key (ClassName.EventId).
+        This approach completely eliminates race conditions.
         """
         event_type = event.__class__.__name__
         event_data = event.model_dump()
         event_id = event_data["event_id"]
 
-        # Define update function for synchronized operation
-        def update_event_list(current_list):
-            # Start with empty list if none exists
-            if current_list is None:
-                current_list = []
+        # Create a unique key for this event
+        key = f"{event_type}.{event_id}"
 
-            # Check if this event ID already exists
-            existing_ids = {e["event_id"] for e in current_list}
+        # Store the event directly
+        success = await self.put_json_value(run_id, key, event_data)
 
-            # Only add if not a duplicate
-            if event_id not in existing_ids:
-                current_list.append(event_data)
-                logger.debug(f"Adding event {event_type} with ID {event_id}. " f"Total count: {len(current_list)}")
-            else:
-                logger.debug(f"Event {event_type} with ID {event_id} already exists, skipping")
-
-            return current_list
-
-        # Perform the synchronized update
-        success = await self.synchronized_update(run_id, event_type, update_event_list, default_value=[])
-
-        if not success:
-            logger.error(f"Failed to store event of type {event_type}")
+        if success:
+            logger.debug(f"Stored event {event_type} with ID {event_id} using key {key}")
+        else:
+            logger.error(f"Failed to store event {event_type} with ID {event_id}")
 
     async def get_events_of_type(
         self,
         run_id: Annotated[str, "The run identifier."],
         class_name: Annotated[str, "The event subclass name to fetch."],
     ) -> List[ControlEvent]:
-        """Returns all events of the specified type for the given run."""
-        # Get the raw JSON data
-        event_list_data = await self.get_json_value(run_id, class_name, default_value=[])
+        """
+        Returns all events of the specified type by scanning for keys with the class name prefix.
+        """
+        kv = await self._get_kv_store(run_id)
+        events = []
 
-        # Convert to event objects
-        events = [ControlEvent.deserialize_event(data) for data in event_list_data]
-        logger.debug(f"Retrieved {len(events)} events of type {class_name}")
-        return events
+        try:
+            # Get all keys in the store
+            all_keys = await kv.keys()
+
+            # Filter keys that match the class_name prefix
+            prefix = f"{class_name}."
+            matching_keys = [key for key in all_keys if key.startswith(prefix)]
+
+            # Retrieve and deserialize each matching event
+            for key in matching_keys:
+                event_data = await self.get_json_value(run_id, key)
+                if event_data:
+                    events.append(ControlEvent.deserialize_event(event_data))
+
+            logger.debug(f"Retrieved {len(events)} events of type {class_name}")
+            return events
+
+        except Exception as e:
+            logger.error(f"Error fetching events of type {class_name}: {e}")
+            return []
 
     async def get_all_events(
         self,
         run_id: Annotated[str, "The run identifier."],
         before: Annotated[Optional[int], "Filter timestamp; only include events created_at ≤ before."] = None,
     ) -> Dict[str, List[ControlEvent]]:
-        """Retrieves all events for a run, organized by event type name."""
+        """
+        Retrieves all events for a run, organized by event type name.
+        Scans all keys and groups them by class name.
+        """
         kv = await self._get_kv_store(run_id)
         events: Dict[str, List[ControlEvent]] = {}
 
         try:
-            class_names = await kv.keys()
-            # Filter out mutex keys
-            class_names = [name for name in class_names if not name.startswith("mutex_")]
+            # Get all keys
+            all_keys = await kv.keys()
 
-            for class_name in class_names:
-                # Get events for this type
-                event_list = await self.get_events_of_type(run_id, class_name)
+            # Process each key that contains a dot (indicating it's an event key)
+            for key in all_keys:
+                if "." not in key:
+                    continue
+
+                class_name, _ = key.split(".", 1)
+
+                # Skip keys that aren't events (like utility keys)
+                if class_name.startswith("_"):
+                    continue
+
+                # Fetch the event data
+                event_data = await self.get_json_value(run_id, key)
+                if not event_data:
+                    continue
+
+                # Deserialize the event
+                event = ControlEvent.deserialize_event(event_data)
 
                 # Apply timestamp filter if provided
-                if before is not None:
-                    event_list = [evt for evt in event_list if evt.created_at <= before]
-                    logger.debug(f"After timestamp filtering, {len(event_list)} events of type {class_name} remain")
+                if before is not None and event.created_at > before:
+                    continue
 
-                events[class_name] = event_list
+                # Add to the appropriate list in the result dictionary
+                if class_name not in events:
+                    events[class_name] = []
+                events[class_name].append(event)
 
             # Log counts for debugging
             for class_name, event_list in events.items():

--- a/aihub_agent/aihub_agent/dispatchers/stores/step/StepStore.py
+++ b/aihub_agent/aihub_agent/dispatchers/stores/step/StepStore.py
@@ -91,7 +91,7 @@ class DistributedStepStore(StoreBase):
 
         if not success:
             # Emergency fallback
-            logger.warning(f"Failed to increment execution count for step '{step_name}'. Using emergency fallback.")
+            logger.error(f"Failed to increment execution count for step '{step_name}'. Using emergency fallback.")
             try:
                 current = await self.get_execution_count(run_id, step_name)
                 await self.put_json_value(run_id, step_name, current + 1)

--- a/aihub_agent/aihub_agent/dispatchers/stores/step/StepStore.py
+++ b/aihub_agent/aihub_agent/dispatchers/stores/step/StepStore.py
@@ -1,4 +1,6 @@
 import logging
+import random
+import time
 from typing import Annotated
 
 from nats.js import JetStreamContext
@@ -36,13 +38,12 @@ class DistributedStepStore(StoreBase):
     - Each run gets its own KV store (e.g. "steps_RUNID").
     - Keys include:
       - "crashed": Indicates if the run is crashed.
-      - A step's name as key, with an integer representing execution count.
+      - For execution counts, one key per execution with pattern: step_name.counter.{timestamp}.{random}
     - Default TTL and storage settings inherited from `StoreBase`.
 
     ### Example
     If a step `my_step` can only run 2 times, after executing once we call `increment_execution_count`.
     If we try again, we first `get_execution_count` to ensure we're not over the limit.
-
     """
 
     def __init__(self, js: JetStreamContext):
@@ -51,51 +52,61 @@ class DistributedStepStore(StoreBase):
     async def mark_run_as_crashed(self, run_id: str):
         """
         Flags the run as crashed by setting a 'crashed' key.
-        This is a simple put operation that doesn't need concurrency control.
+        Once crashed, steps won't be executed further.
         """
-        kv = await self._get_kv_store(run_id)
-        await kv.put("crashed", b"true")
+        await self.put_value(run_id, "crashed", b"true")
+        logger.debug(f"Marked run {run_id} as crashed")
 
     async def is_run_crashed(self, run_id: str) -> bool:
-        """Checks if the run has been marked as crashed."""
+        """
+        Checks if the run has been marked as crashed.
+        Returns True if so, False otherwise.
+        """
 
-        # Using the generic get_value method with a transform function
         def transform_to_bool(value):
             return value is not None and value.decode() == "true"
 
         return await self.get_value(run_id, "crashed", default_value=False, transform_func=transform_to_bool)
 
     async def get_execution_count(self, run_id: str, step_name: str) -> int:
-        """Retrieves how many times a given step has executed for the specified run."""
-        # Using JSON interface for simplicity, storing as a number
-        count = await self.get_json_value(run_id, step_name, default_value=0)
-        return count
+        """
+        Retrieves how many times a given step has executed for the specified run
+        by counting individual counter keys.
+
+        This method is always accurate because it directly counts the keys rather than
+        relying on a cached value.
+        """
+        kv = await self._get_kv_store(run_id)
+
+        try:
+            # Get all keys
+            all_keys = await kv.keys()
+
+            # Filter keys for this step's counters
+            counter_prefix = f"{step_name}.counter."
+            counter_keys = [key for key in all_keys if key.startswith(counter_prefix)]
+            count = len(counter_keys)
+
+            logger.debug(f"Counted {count} executions for step '{step_name}'")
+            return count
+
+        except Exception as e:
+            logger.error(f"Error counting executions for step '{step_name}': {e}")
+            return 0
 
     async def increment_execution_count(self, run_id: Annotated[str, "Run ID"], step_name: Annotated[str, "Step name"]):
         """
-        Increments the execution count for the given step.
-        Uses synchronized_update to handle concurrent increments safely.
+        Increments the execution count by creating a unique counter key for this execution.
+        This approach completely avoids race conditions as each execution creates its own key.
         """
+        # Create a unique counter key for this execution with timestamp and random component
+        unique_id = f"{int(time.time() * 1000)}.{random.randint(1000, 9999)}"
+        counter_key = f"{step_name}.counter.{unique_id}"
 
-        # Define update function for synchronized increment
-        def increment_count(current_count):
-            if current_count is None:
-                current_count = 0
+        # Store the counter (value doesn't matter, just the existence of the key)
+        success = await self.put_value(run_id, counter_key, b"1")
 
-            new_count = current_count + 1
-            logger.debug(f"Incrementing execution count for step '{step_name}' to {new_count}")
-            return new_count
-
-        # Perform synchronized update
-        success = await self.synchronized_update(run_id, step_name, increment_count, default_value=0)
-
-        if not success:
-            # Emergency fallback
-            logger.error(f"Failed to increment execution count for step '{step_name}'. Using emergency fallback.")
-            try:
-                current = await self.get_execution_count(run_id, step_name)
-                await self.put_json_value(run_id, step_name, current + 1)
-            except Exception as e:
-                logger.error(f"Emergency fallback for step '{step_name}' also failed: {e}")
-                # Last resort - just set to 1
-                await self.put_json_value(run_id, step_name, 1)
+        if success:
+            logger.debug(f"Created execution counter {counter_key} for step '{step_name}'")
+        else:
+            logger.error(f"Failed to create execution counter for step '{step_name}'")

--- a/aihub_agent/playground/minimal_workflow/optional_workflow/OptionalAgent.py
+++ b/aihub_agent/playground/minimal_workflow/optional_workflow/OptionalAgent.py
@@ -18,9 +18,9 @@ class OptionalAgent(Agent):
             print("[OptionalAgent.start_step] Only EventA")
             return [EventOptionalA()]
         print("[OptionalAgent.start_step] EventA & EventB")
-        return [EventOptionalA(), EventOptionalB()]
+        return [EventOptionalB(), EventOptionalA()]
 
-    @step()
+    @step(max_executions_per_run=1)
     async def optional_step(
         self, event: EventOptionalA, optional_event: Optional[EventOptionalB]
     ) -> EventOptionalC | EventOptionalD:

--- a/aihub_lib/aihub_lib/nats/subscribers/JSSubscriber.py
+++ b/aihub_lib/aihub_lib/nats/subscribers/JSSubscriber.py
@@ -88,23 +88,19 @@ class JSSubscriber(Generic[TEvent]):
             event_data = msg.data
             event = self.event_cls.deserialize_event(event_data)
             logger.debug(f"Deserialized event: {event}")
-            asyncio.create_task(self._process_and_ack(event, topic, msg))
+            await msg.ack()
+            asyncio.create_task(self._process(event, topic, msg))
         except Exception as e:
             logger.error(f"Error in message handler: {e}")
             traceback.print_exc()
-            if self.ack_on_fail:
-                await msg.ack()
 
-    async def _process_and_ack(self, event, topic, msg):
+    async def _process(self, event, topic, msg):
         """Process the event and acknowledge the message based on result"""
         try:
-            await msg.ack()
             await self.handler(event, topic)
         except Exception as e:
             logger.error(f"Error in async handler: {e}")
             traceback.print_exc()
-            if self.ack_on_fail:
-                await msg.ack()
 
     @classmethod
     def for_all_agent_events(


### PR DESCRIPTION
### **PR Type**
bug_fix, enhancement


___

### **Description**
- Ensure step readiness uses consistent event list

- Adjust retry logic with increased max retries

- Improve logging for error scenarios

- Update step execution order in OptionalAgent


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dispatcher.py</strong><dd><code>Ensure consistent event list for step execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_agent/aihub_agent/dispatchers/Dispatcher.py

<li>Use consistent event list for step readiness<br> <li> Pass events to step execution


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/183/files#diff-3c17d20098e781cd60e6dae24ad438b708e7f080f99fdd6a88395fbfc97f1af3">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>StoreBase.py</strong><dd><code>Enhance retry logic and logging in StoreBase</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_agent/aihub_agent/dispatchers/stores/StoreBase.py

<li>Increase max retries for operations<br> <li> Improve logging for mutex acquisition failures


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/183/files#diff-96e0d5e5f0a4911e7689d04ec509cca8d878ffcb6426a5d428547d329a6ee47f">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DistributedEventStore.py</strong><dd><code>Improve logging for event storage failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_agent/aihub_agent/dispatchers/stores/event/DistributedEventStore.py

- Change logging level from warning to error


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/183/files#diff-4bfad4e1939cad66e834814275ac64c875d854fc630fbad3559312f4b769b6db">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>StepStore.py</strong><dd><code>Improve logging for step execution count failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_agent/aihub_agent/dispatchers/stores/step/StepStore.py

- Change logging level from warning to error


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/183/files#diff-2bd8186f7ad233b849b2d32303e3e86efac7f5de23fabe70834dfd78742015e0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OptionalAgent.py</strong><dd><code>Update event order and execution limit in OptionalAgent</code>&nbsp; &nbsp; </dd></summary>
<hr>

aihub_agent/playground/minimal_workflow/optional_workflow/OptionalAgent.py

<li>Update execution order of events in start_step<br> <li> Limit optional_step to one execution per run


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/183/files#diff-69444f7670e3e06777e7f93a7309a7af1079dad4820e34174eee3d97c0002d6c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>