### PR TITLE
fix(aihub): Use datalake file metadata if present

### DIFF
--- a/aihub_pipeline/aihub_pipeline/types/RefDocDocument.py
+++ b/aihub_pipeline/aihub_pipeline/types/RefDocDocument.py
@@ -21,28 +21,28 @@ if TYPE_CHECKING:
 
 
 class RefDocDocument(Document):
-    """A Pydantic model representing specialized Document (llama-index)
+    """A Pydantic model representing a specialized Document (llama-index)
     that represents a reference document with additional metadata."""
 
     @computed_field
     @property
     def namespace(self) -> str:
-        return self.metadata[NAMESPACE]
+        return self.metadata.get(NAMESPACE, "")
 
     @computed_field
     @property
     def hash(self) -> str:
-        return self.metadata[HASH]
+        return self.metadata.get(HASH, "")
 
     @computed_field
     @property
     def uri(self) -> str:
-        return self.metadata[DATA_LAKE_URI]
+        return self.metadata.get(DATA_LAKE_URI, "")
 
     @computed_field
     @property
     def updated(self) -> int:
-        return self.metadata[UPDATED_AT]
+        return self.metadata.get(UPDATED_AT, int(datetime.now().timestamp()))
 
     def add_metadata_from_data_lake_file(self, data_lake_file: "DataLakeFile") -> "RefDocDocument":
         """Enrich the document's metadata with information from a `DataLakeFile`."""
@@ -52,14 +52,14 @@ class RefDocDocument(Document):
         self.metadata = {
             **self.metadata,
             **data_lake_file.metadata,
-            NAMESPACE: data_lake_file.namespace,
-            HASH: data_lake_file.hash,
-            UPDATED_AT: data_lake_file.updated,
+            NAMESPACE: data_lake_file.metadata.get(NAMESPACE, data_lake_file.namespace),
+            HASH: data_lake_file.metadata.get(HASH, data_lake_file.hash),
+            UPDATED_AT: int(data_lake_file.metadata.get(UPDATED_AT, data_lake_file.updated)),
             CREATED_AT: int(data_lake_file.metadata.get(CREATED_AT, datetime.now().timestamp())),
             INSERTED_AT: int(datetime.now().timestamp()),  # Convert to current timestamp
             TYPE: NODE_TYPE_CONTENT,
             DATA_LAKE_URI: data_lake_file.uri,
-            SOURCE: data_lake_file.uri,
-            DOCUMENT_TITLE: document_title,
+            SOURCE: data_lake_file.metadata.get(SOURCE, data_lake_file.uri),
+            DOCUMENT_TITLE: data_lake_file.metadata.get(DOCUMENT_TITLE, document_title),
         }
         return self


### PR DESCRIPTION
### **PR Type**
bug_fix, enhancement


___

### **Description**
- Use metadata with default values if not present.

- Enhance metadata enrichment from `DataLakeFile`.

- Improve robustness of metadata access.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RefDocDocument.py</strong><dd><code>Enhance metadata access with defaults and improve documentation</code></dd></summary>
<hr>

aihub_pipeline/aihub_pipeline/types/RefDocDocument.py

<li>Use <code>get</code> method for metadata access with defaults.<br> <li> Update <code>add_metadata_from_data_lake_file</code> to handle missing metadata.<br> <li> Improve documentation string for <code>RefDocDocument</code>.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/207/files#diff-c2027433d8ed14f9574c1aea09e5ed1c2a23bceecf681295a94f3e10d0a40f7d">+10/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>