### PR TITLE
fix(aihub): AgentService cache can be cleared for use during API tests

### DIFF
--- a/aihub_agent/poetry.lock
+++ b/aihub_agent/poetry.lock
@@ -98,7 +98,7 @@ transformers = "^4.48.1"
 type = "git"
 url = "https://github.com/bbvch-ai/aihub-core.git"
 reference = "v0.106.0"
-resolved_reference = "4add271b87bd63edc6ee679acb5e69649dbca9b6"
+resolved_reference = "9da8f957a3060a67ae61b611d7d2505caf1f0242"
 subdirectory = "aihub_lib"
 
 [[package]]

--- a/aihub_api/aihub_api/routes/agent/AgentService.py
+++ b/aihub_api/aihub_api/routes/agent/AgentService.py
@@ -204,3 +204,4 @@ class AgentService:
         """
         DISCOVER_AGENTS_CACHE.clear()
         GET_AGENT_CACHE.clear()
+        

--- a/aihub_api/aihub_api/routes/agent/AgentService.py
+++ b/aihub_api/aihub_api/routes/agent/AgentService.py
@@ -195,3 +195,12 @@ class AgentService:
         await resources.subscriber.stop()
 
         return resources.stop_event
+
+    @staticmethod
+    def clear_cache() -> None:
+        """
+        Clears the in-memory caches used for agent discovery. Useful for testing purposes to ensure fresh discovery
+        requests.
+        """
+        DISCOVER_AGENTS_CACHE.clear()
+        GET_AGENT_CACHE.clear()

--- a/aihub_api/poetry.lock
+++ b/aihub_api/poetry.lock
@@ -98,7 +98,7 @@ transformers = "^4.48.1"
 type = "git"
 url = "https://github.com/bbvch-ai/aihub-core.git"
 reference = "v0.106.0"
-resolved_reference = "4add271b87bd63edc6ee679acb5e69649dbca9b6"
+resolved_reference = "9da8f957a3060a67ae61b611d7d2505caf1f0242"
 subdirectory = "aihub_lib"
 
 [[package]]

--- a/aihub_bot/poetry.lock
+++ b/aihub_bot/poetry.lock
@@ -98,7 +98,7 @@ transformers = "^4.48.1"
 type = "git"
 url = "https://github.com/bbvch-ai/aihub-core.git"
 reference = "v0.106.0"
-resolved_reference = "4add271b87bd63edc6ee679acb5e69649dbca9b6"
+resolved_reference = "9da8f957a3060a67ae61b611d7d2505caf1f0242"
 subdirectory = "aihub_lib"
 
 [[package]]

--- a/aihub_pipeline/poetry.lock
+++ b/aihub_pipeline/poetry.lock
@@ -98,7 +98,7 @@ transformers = "^4.48.1"
 type = "git"
 url = "https://github.com/bbvch-ai/aihub-core.git"
 reference = "v0.106.0"
-resolved_reference = "4add271b87bd63edc6ee679acb5e69649dbca9b6"
+resolved_reference = "9da8f957a3060a67ae61b611d7d2505caf1f0242"
 subdirectory = "aihub_lib"
 
 [[package]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -372,7 +372,7 @@ version = "0.13.2"
 description = "Style preserving TOML library"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "tomlkit-0.13.2-py3-none-any.whl", hash = "sha256:7a974427f6e119197f670fbbbeae7bef749a6c14e793db934baefc1b5f03efde"},
     {file = "tomlkit-0.13.2.tar.gz", hash = "sha256:fff5fe59a87295b278abd31bec92c15d9bc4a06885ab12bcea52c71119392e79"},
@@ -421,4 +421,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11, <3.12"
-content-hash = "95322fb4c4aa6702f6d6f4874329879d900dacfd455ddd3f089d3400cd14a930"
+content-hash = "a6af03d48ce38482fc95e9572fc7bdf37ee45b29e1c8d138a061df625fe333d7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = ">=3.11, <3.12"
+tomlkit = "^0.13.2"
 
 [tool.poetry.group.dev.dependencies]
 tomlkit = "^0.13.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = ">=3.11, <3.12"
-tomlkit = "^0.13.2"
 
 [tool.poetry.group.dev.dependencies]
 tomlkit = "^0.13.2"


### PR DESCRIPTION
### **PR Type**
enhancement, dependencies


___

### **Description**
- Add `clear_cache` method to `AgentService` for testing.

- Update `pyproject.toml` with `tomlkit` dependency.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AgentService.py</strong><dd><code>Add cache clearing method for testing in AgentService</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_api/aihub_api/routes/agent/AgentService.py

<li>Added <code>clear_cache</code> static method.<br> <li> Clears in-memory caches for agent discovery.<br> <li> Aimed at ensuring fresh discovery during tests.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/213/files#diff-3eec622b217929df897ca0f5cd89d703400b02a5fa145c293b2e2f0d7543b93c">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Update dependencies in pyproject.toml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<li>Added <code>tomlkit</code> dependency to project.<br> <li> Updated dependencies for development and production.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/213/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>