### PR TITLE
fix(aihub): Handle display event through NATs instead of JetStream

### DIFF
--- a/aihub_api/aihub_api/runners/lifetime/lifetime_manager.py
+++ b/aihub_api/aihub_api/runners/lifetime/lifetime_manager.py
@@ -91,7 +91,7 @@ async def lifetime_manager(app: FastAPI) -> AsyncGenerator:
         )
         await ws_subscriber.start()
 
-        ws_receiver = WebSocketReceiver(js=js)
+        ws_receiver = WebSocketReceiver(nc=nc, js=js)
 
         # Store resources in app state
         app.state.nc = nc

--- a/aihub_bot/aihub_bot/runners/lifetime/lifetime_manager.py
+++ b/aihub_bot/aihub_bot/runners/lifetime/lifetime_manager.py
@@ -26,7 +26,7 @@ async def lifetime_manager(app: FastAPI) -> AsyncGenerator[None, Any]:
         # Connect to NATS and setup JetStream
         await nc.connect(servers=[NatsConfig().NATS_ENDPOINT])
         js = nc.jetstream()
-        ws_receiver = WebSocketReceiver(js=js)
+        ws_receiver = WebSocketReceiver(nc=nc, js=js)
 
         # Store resources in app state
         app.state.nc = nc

--- a/aihub_lib/aihub_lib/sockets/receiver/WebSocketReceiver.py
+++ b/aihub_lib/aihub_lib/sockets/receiver/WebSocketReceiver.py
@@ -2,11 +2,13 @@ import logging
 
 from bson import ObjectId
 from nats.js import JetStreamContext
+from nats.aio.client import Client as NATS
 
 from aihub_lib.auth.AuthenticatedUser import AuthenticatedUser
 from aihub_lib.nats.events import DisplayEvent, StartEvent
 from aihub_lib.nats.events.human_in_the_loop import HumanInTheLoopResponseEvent
 from aihub_lib.nats.publishers.JSPublisher import JSPublisher
+from aihub_lib.nats.publishers.NCPublisher import NCPublisher
 from aihub_lib.nats.topic_managers.agents.AgentThreadTopicManager import AgentThreadTopicManager
 from aihub_lib.nats.topic_managers.TopicManager import TopicManager
 from aihub_lib.persistence.messaging.entities.PersistedEventEntity import PersistedEventEntity
@@ -50,8 +52,9 @@ class WebSocketReceiver:
     - If it's a start event, publishes a start event to trigger agent processing.
     """
 
-    def __init__(self, js: JetStreamContext):
-        self.publisher = JSPublisher(js)
+    def __init__(self, nc: NATS, js: JetStreamContext):
+        self.nc_publisher = NCPublisher(nc)
+        self.js_publisher = JSPublisher(js)
 
     async def receive_event(self, ws_event: WSUserEvent, user: AuthenticatedUser):
         """
@@ -110,7 +113,7 @@ class WebSocketReceiver:
                 event_name=ws_event.event.__class__.__name__,
                 event_id=ws_event.event.event_id,
             )
-            await self.publisher.publish_event(ws_event.event, subject)
+            await self.js_publisher.publish_event(ws_event.event, subject)
 
     async def _handle_display_message(self, ws_event: WSUserEvent, run_id: str, user_id: str):
         """
@@ -131,7 +134,7 @@ class WebSocketReceiver:
             event_name=ws_event.event.__class__.__name__,
             event_id=ws_event.event.event_id,
         )
-        await self.publisher.publish_event(ws_event.event, subject)
+        await self.nc_publisher.publish_event(ws_event.event, subject)
 
     async def _handle_human_in_the_loop_response(self, thread: ThreadEntity, ws_event: WSUserEvent):
         """
@@ -163,4 +166,4 @@ class WebSocketReceiver:
             event_name=ws_event.event.__class__.__name__,
             event_id=ws_event.event.event_id,
         )
-        await self.publisher.publish_event(ws_event.event, subject)
+        await self.js_publisher.publish_event(ws_event.event, subject)


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Switch WebSocketReceiver to use NATS for display events.

- Update WebSocketReceiver constructor to accept NATS client.

- Modify event handling to use NCPublisher for display events.

- Ensure JetStream is still used for other event types.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lifetime_manager.py</strong><dd><code>Update WebSocketReceiver instantiation with NATS client</code>&nbsp; &nbsp; </dd></summary>
<hr>

aihub_api/aihub_api/runners/lifetime/lifetime_manager.py

<li>Update WebSocketReceiver to accept NATS client.<br> <li> Modify instantiation to include NATS client.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/217/files#diff-360f64367d6a1fc175c14da2a61503e613bacdb179941bc1de137e3b0ac7447e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lifetime_manager.py</strong><dd><code>Update WebSocketReceiver instantiation with NATS client</code>&nbsp; &nbsp; </dd></summary>
<hr>

aihub_bot/aihub_bot/runners/lifetime/lifetime_manager.py

<li>Update WebSocketReceiver to accept NATS client.<br> <li> Modify instantiation to include NATS client.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/217/files#diff-5800c95de50ab7aba25fb1255e78ca4733ff1b2653650d20097fa9716089c390">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WebSocketReceiver.py</strong><dd><code>Enhance WebSocketReceiver to use NATS and JetStream</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_lib/aihub_lib/sockets/receiver/WebSocketReceiver.py

<li>Add NATS client to WebSocketReceiver constructor.<br> <li> Use NCPublisher for display events.<br> <li> Retain JSPublisher for other events.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/217/files#diff-da7fa99c7d79a0d0354c3279ad6e73a027f671d97a01b05be3923ec3f2e9d2e4">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>