### PR TITLE
fix(aihub): AgentThreadTopicManager Agent agnostic

### DIFF
--- a/aihub_api/aihub_api/routes/agent/AgentService.py
+++ b/aihub_api/aihub_api/routes/agent/AgentService.py
@@ -185,6 +185,8 @@ class AgentService:
         )
         resources: JsonResources = await ChatService.start_json_event_interaction(
             user=user,
+            agent_class=agent_class,
+            agent_id=agent_id,
             ws_event=ws_event,
             topic_manager=topic_manager,
             nc=nc,

--- a/aihub_api/aihub_api/routes/openai/OpenaiService.py
+++ b/aihub_api/aihub_api/routes/openai/OpenaiService.py
@@ -15,7 +15,6 @@ from aihub_lib.generative_ai.resources.models.llm.embedding.EmbeddingLLMConfig i
 from aihub_lib.generative_ai.resources.models.stt.azure.AzureSTTConfig import AzureOpenaiSTTConfig
 from aihub_lib.generative_ai.resources.models.tts.azure.AzureTTSConfig import AzureOpenaiTTSConfig
 from aihub_lib.nats.distributor.ExternalEventDistributor import ExternalEventDistributor
-from aihub_lib.nats.events import HumanInTheLoopRequestEvent
 from aihub_lib.persistence.messaging.entities.ThreadEntity import ThreadEntity
 from aihub_lib.routes.chat.ChatService import ChatService, JsonResources, StreamingResources
 from fastapi import HTTPException, UploadFile

--- a/aihub_lib/aihub_lib/nats/distributor/ExternalEventDistributor.py
+++ b/aihub_lib/aihub_lib/nats/distributor/ExternalEventDistributor.py
@@ -6,8 +6,6 @@ from nats.js import JetStreamContext
 
 from aihub_lib.auth.AuthenticatedUser import AuthenticatedUser
 from aihub_lib.nats.distributor.events.ExternalEvent import ExternalEvent
-from aihub_lib.nats.events import DisplayEvent, StartEvent
-from aihub_lib.nats.events.human_in_the_loop import HumanInTheLoopResponseEvent
 from aihub_lib.nats.publishers.JSPublisher import JSPublisher
 from aihub_lib.nats.publishers.NCPublisher import NCPublisher
 from aihub_lib.nats.topic_managers.agents.AgentThreadTopicManager import AgentThreadTopicManager

--- a/aihub_lib/aihub_lib/routes/chat/ChatService.py
+++ b/aihub_lib/aihub_lib/routes/chat/ChatService.py
@@ -210,9 +210,9 @@ class ChatService:
     @staticmethod
     async def start_json_event_interaction(
         user: AuthenticatedUser,
-        agent_class: str,
-        agent_id: str,
-        external_event: ExternalEvent,
+            agent_class: str,
+            agent_id: str,
+            external_event: ExternalEvent,
         topic_manager: AgentThreadTopicManager,
         nc: NATS,
         external_event_distributor: ExternalEventDistributor,

--- a/aihub_lib/aihub_lib/routes/chat/ChatService.py
+++ b/aihub_lib/aihub_lib/routes/chat/ChatService.py
@@ -91,13 +91,12 @@ class ChatService:
         hitl_responses = PersistedEventEntity.human_in_the_loop_response_events_for_thread(str(thread.id))
 
         thread_id = str(thread.id)
-        display_id = str(ObjectId())
 
         if len(hitl_requests) != len(hitl_responses):
             open_hitl_request = hitl_requests[-1]
             event = HumanInTheLoopResponseEvent(
                 response=messages[-1]["content"],
-                request_event=HumanInTheLoopRequestEvent(**open_hitl_request.event_data),
+                request_event=HumanInTheLoopRequestEvent.deserialize_event(open_hitl_request.event_data),
             )
             display_id = event.request_event.topic.display_id
         else:
@@ -105,6 +104,7 @@ class ChatService:
                 messages=messages,
                 user=user,
             )
+            display_id = str(ObjectId())
 
         event = WSUserEvent(
             thread_id=thread_id,

--- a/aihub_lib/aihub_lib/routes/chat/ChatService.py
+++ b/aihub_lib/aihub_lib/routes/chat/ChatService.py
@@ -111,8 +111,8 @@ class ChatService:
         logger.debug(f"Created event: {event}")
 
         topic_manager = AgentThreadTopicManager(
-            agent_class=agent_class,
-            agent_id=agent_id,
+            agent_class="*",
+            agent_id="*",
             thread_id=event.thread_id,
             display_id=event.display_id,
             run_id="*",

--- a/aihub_lib/aihub_lib/routes/chat/ChatService.py
+++ b/aihub_lib/aihub_lib/routes/chat/ChatService.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from dataclasses import dataclass
-from typing import List, Optional, Tuple, Annotated
+from typing import Annotated, List, Optional, Tuple
 
 import mongoengine.errors
 from bson import ObjectId
@@ -61,7 +61,9 @@ class ChatService:
         agent_id: str,
         messages: List[ChatMessage],
         thread_id: Optional[str] = None,
-        subscribe_to_thread: Annotated[bool, "Receive all events in thread, not just the ones from the specified agents"] = False
+        subscribe_to_thread: Annotated[
+            bool, "Receive all events in thread, not just the ones from the specified agents"
+        ] = False,
     ) -> Tuple[WSUserEvent, AgentThreadTopicManager]:
         """
         Common initialization steps for both streaming and JSON interactions.
@@ -200,9 +202,11 @@ class ChatService:
             agent_id=agent_id,
             messages=messages,
             thread_id=thread_id,
-            subscribe_to_thread=True
+            subscribe_to_thread=True,
         )
-        return await ChatService.start_json_event_interaction(user, agent_class, agent_id, ws_event, topic_manager, nc, ws_receiver)
+        return await ChatService.start_json_event_interaction(
+            user, agent_class, agent_id, ws_event, topic_manager, nc, ws_receiver
+        )
 
     @staticmethod
     async def start_json_event_interaction(

--- a/aihub_lib/aihub_lib/routes/chat/ChatService.py
+++ b/aihub_lib/aihub_lib/routes/chat/ChatService.py
@@ -202,11 +202,13 @@ class ChatService:
             thread_id=thread_id,
             subscribe_to_thread=True
         )
-        return await ChatService.start_json_event_interaction(user, ws_event, topic_manager, nc, ws_receiver)
+        return await ChatService.start_json_event_interaction(user, agent_class, agent_id, ws_event, topic_manager, nc, ws_receiver)
 
     @staticmethod
     async def start_json_event_interaction(
         user: AuthenticatedUser,
+        agent_class: str,
+        agent_id: str,
         ws_event: WSUserEvent,
         topic_manager: AgentThreadTopicManager,
         nc: NATS,
@@ -228,7 +230,7 @@ class ChatService:
 
         async def response_aggregator(display_event: DisplayEvent, topic: AgentTopic):
             logger.debug(f"Received display event: {display_event}")
-            is_primary_agent = topic.agent_class == topic_manager.agent_class and topic.agent_id == topic_manager.agent_id
+            is_primary_agent = topic.agent_class == agent_class and topic.agent_id == agent_id
             if isinstance(display_event, ChunkEvent):
                 resources.chunk_events.append(display_event)
             elif isinstance(display_event, HumanInTheLoopRequestEvent):

--- a/aihub_lib/aihub_lib/routes/chat/ChatService.py
+++ b/aihub_lib/aihub_lib/routes/chat/ChatService.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Annotated
 
 import mongoengine.errors
 from bson import ObjectId
@@ -61,6 +61,7 @@ class ChatService:
         agent_id: str,
         messages: List[ChatMessage],
         thread_id: Optional[str] = None,
+        subscribe_to_thread: Annotated[bool, "Receive all events in thread, not just the ones from the specified agents"] = False
     ) -> Tuple[WSUserEvent, AgentThreadTopicManager]:
         """
         Common initialization steps for both streaming and JSON interactions.
@@ -111,8 +112,8 @@ class ChatService:
         logger.debug(f"Created event: {event}")
 
         topic_manager = AgentThreadTopicManager(
-            agent_class="*",
-            agent_id="*",
+            agent_class="*" if subscribe_to_thread else agent_class,
+            agent_id="*" if subscribe_to_thread else agent_id,
             thread_id=event.thread_id,
             display_id=event.display_id,
             run_id="*",
@@ -138,6 +139,7 @@ class ChatService:
             agent_id=agent_id,
             messages=messages,
             thread_id=thread_id,
+            subscribe_to_thread=True,
         )
 
         stop_signal = asyncio.Event()
@@ -150,6 +152,7 @@ class ChatService:
         )
 
         async def response_aggregator(display_event: DisplayEvent, topic: AgentTopic):
+            is_primary_agent = topic.agent_class == agent_class and topic.agent_id == agent_id
             logger.debug(f"Received display event: {display_event}")
             if isinstance(display_event, ChunkEvent):
                 logger.debug(f"Received chunk event: {display_event}")
@@ -158,7 +161,7 @@ class ChatService:
                 resources.stop_event = display_event
                 await subscriber.stop()
                 stop_signal.set()
-            elif isinstance(display_event, StopEvent):
+            elif isinstance(display_event, StopEvent) and is_primary_agent:
                 logger.debug("Received stop event. Stop streaming")
                 resources.stop_event = display_event
                 await subscriber.stop()
@@ -197,6 +200,7 @@ class ChatService:
             agent_id=agent_id,
             messages=messages,
             thread_id=thread_id,
+            subscribe_to_thread=True
         )
         return await ChatService.start_json_event_interaction(user, ws_event, topic_manager, nc, ws_receiver)
 
@@ -211,7 +215,7 @@ class ChatService:
         stop_signal = asyncio.Event()
         chunk_events: List[ChunkEvent] = []
         costs = LLMCosts.from_zero()
-        model_name = "bbv-ai-hub"
+        model_name = f"{topic_manager.agent_class}/{topic_manager.agent_id}"
 
         resources = JsonResources(
             stop_signal=stop_signal,
@@ -224,13 +228,14 @@ class ChatService:
 
         async def response_aggregator(display_event: DisplayEvent, topic: AgentTopic):
             logger.debug(f"Received display event: {display_event}")
+            is_primary_agent = topic.agent_class == topic_manager.agent_class and topic.agent_id == topic_manager.agent_id
             if isinstance(display_event, ChunkEvent):
                 resources.chunk_events.append(display_event)
             elif isinstance(display_event, HumanInTheLoopRequestEvent):
                 resources.stop_event = display_event
                 await subscriber.stop()
                 stop_signal.set()
-            elif isinstance(display_event, StopEvent):
+            elif isinstance(display_event, StopEvent) and is_primary_agent:
                 logger.debug("Received stop event. Stop streaming")
                 resources.stop_event = display_event
                 await resources.subscriber.stop()

--- a/aihub_lib/aihub_lib/routes/chat/ChatService.py
+++ b/aihub_lib/aihub_lib/routes/chat/ChatService.py
@@ -210,9 +210,9 @@ class ChatService:
     @staticmethod
     async def start_json_event_interaction(
         user: AuthenticatedUser,
-            agent_class: str,
-            agent_id: str,
-            external_event: ExternalEvent,
+        agent_class: str,
+        agent_id: str,
+        external_event: ExternalEvent,
         topic_manager: AgentThreadTopicManager,
         nc: NATS,
         external_event_distributor: ExternalEventDistributor,


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Replaced specific agent identifiers with wildcards.

- Updated `AgentThreadTopicManager` initialization.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChatService.py</strong><dd><code>Use wildcards in AgentThreadTopicManager initialization</code>&nbsp; &nbsp; </dd></summary>
<hr>

aihub_lib/aihub_lib/routes/chat/ChatService.py

<li>Changed <code>agent_class</code> and <code>agent_id</code> to wildcards.<br> <li> Modified <code>AgentThreadTopicManager</code> initialization.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/221/files#diff-549c8f8430946032b1a2d84afdd2556c69f69820a295ee85f312b8a8b9bcf088">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>