### PR TITLE
fix(aihub): Add optional user and locale fields to events

### DIFF
--- a/aihub_lib/aihub_lib/nats/events/BaseEvent.py
+++ b/aihub_lib/aihub_lib/nats/events/BaseEvent.py
@@ -10,6 +10,7 @@ from bson import ObjectId
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, computed_field
 from typing_extensions import override
 
+from aihub_lib.auth.AuthenticatedUser import AuthenticatedUser
 from aihub_lib.nats.events.utils import get_inheritance_depth, get_parent_classes_until_base
 
 logger = logging.getLogger(__name__)
@@ -43,6 +44,8 @@ class BaseEvent(BaseModel):
         default_factory=time.time_ns,
         description="The time (in ns since epoch) the event was stored in the event store",
     )
+    locale: Optional[str] = Field(default=None, description="The locale of the event.")
+    user: Optional[AuthenticatedUser] = Field(default=None, description="The user who triggered the event.")
 
     # Private attributes to handle unknown event types
     _unknown_type: Optional[str] = PrivateAttr(None)


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Add optional `locale` field to `BaseEvent`.

- Add optional `user` field to `BaseEvent`.

- Import `AuthenticatedUser` for user field.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BaseEvent.py</strong><dd><code>Add optional user and locale fields to BaseEvent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_lib/aihub_lib/nats/events/BaseEvent.py

<li>Added <code>locale</code> field to <code>BaseEvent</code>.<br> <li> Added <code>user</code> field to <code>BaseEvent</code>.<br> <li> Imported <code>AuthenticatedUser</code> for new user field.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/239/files#diff-1b9dc29751526373985e324cb94d89abade05aa7cdb62db2c94e30a7f05c6b43">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>