### PR TITLE
fix(aihub): Use all metadata fields for document header

### DIFF
--- a/aihub_lib/aihub_lib/generative_ai/utils/combine_nodes_in_order.py
+++ b/aihub_lib/aihub_lib/generative_ai/utils/combine_nodes_in_order.py
@@ -17,13 +17,9 @@ from aihub_lib.persistence.rag.vectors.node_metadata import (
     H5,
     H6,
     INSERTED_AT,
-    LANGUAGE,
-    NAMESPACE,
     SECTION_START_LINE,
     SOURCE,
-    TYPE,
-    UPDATED_AT,
-    VERSION,
+    UPDATED_AT, DEFAULT_METADATA,
 )
 
 _headers_in_order = [H6, H5, H4, H3, H2, H1]
@@ -65,20 +61,22 @@ def combine_nodes_in_order(
     for key, nodes in nodes_per_document.items():
         metadata = nodes[0].metadata
 
-        metadata_fields = {
-            "source": key,
-            "namespace": metadata.get(NAMESPACE),
-            "type": metadata.get(TYPE),
-            "language": metadata.get(LANGUAGE),
-            "version": metadata.get(VERSION),
-            "created_at": format_unix_timestamp(metadata.get(CREATED_AT)),
-            "updated_at": format_unix_timestamp(metadata.get(UPDATED_AT)),
-            "inserted_at": format_unix_timestamp(metadata.get(INSERTED_AT)),
-        }
+        metadata_fields = {}
+        for field in DEFAULT_METADATA:
+            value = metadata.get(field)
+            if value is None:
+                continue
+            if field in {CREATED_AT, UPDATED_AT, INSERTED_AT}:
+                value = format_unix_timestamp(value)
+                if value is None:
+                    continue
+            metadata_fields[field] = value
 
-        metadata_fields = {k: v for k, v in metadata_fields.items() if v is not None}
+        metadata_fields[SOURCE] = key
 
-        metadata_string = " ".join(f"{k}='{sanitize_metadata_value(v)}'" for k, v in metadata_fields.items())
+        metadata_string = " ".join(
+            f"{k}='{sanitize_metadata_value(v)}'" for k, v in metadata_fields.items()
+        )
 
         doc_header = f"<DOCUMENT {metadata_string}>\n\n"
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Refactor to use all metadata fields for document header

- Remove hardcoded metadata fields, use `DEFAULT_METADATA`

- Format timestamps for specific metadata fields

- Ensure metadata fields are sanitized and formatted


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>combine_nodes_in_order.py</strong><dd><code>Refactor metadata handling in combine_nodes_in_order</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_lib/aihub_lib/generative_ai/utils/combine_nodes_in_order.py

<li>Refactored metadata handling to use <code>DEFAULT_METADATA</code><br> <li> Removed hardcoded metadata fields<br> <li> Added timestamp formatting for specific fields<br> <li> Updated metadata string construction


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/256/files#diff-ed7813c8ea059af83c64f3bcc102955d2ffb433a5258ea15fb2099bf0d7853ff">+17/-19</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>