### PR TITLE
fix(aihub): MarkdownParser unescapes html to extract references

### DIFF
--- a/aihub_lib/aihub_lib/generative_ai/document/parsers/MarkdownStructuralNodeParser.py
+++ b/aihub_lib/aihub_lib/generative_ai/document/parsers/MarkdownStructuralNodeParser.py
@@ -1,3 +1,4 @@
+import html
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Sequence
 
@@ -326,6 +327,8 @@ class MarkdownStructuralNodeParser(NodeParser):
         @return: List of TextNodes.
         """
         text = node.get_content(metadata_mode=MetadataMode.NONE)
+        text = html.unescape(text)
+
         splits = self.markdown_splitter.split_content(text, self.metadata)
         if self.metadata_extractor:
             splits = self.metadata_extractor.extract(splits)


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Unescape HTML entities in markdown content.

- Import `html` module for HTML unescaping.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MarkdownStructuralNodeParser.py</strong><dd><code>Unescape HTML entities in markdown content</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_lib/aihub_lib/generative_ai/document/parsers/MarkdownStructuralNodeParser.py

<li>Added import for <code>html</code> module.<br> <li> Unescaped HTML entities in markdown content.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/258/files#diff-e6796c1d345f014a397a7fabea096490fc47f854a1f0f3f65cf9444072de82ae">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>