### PR TITLE
fix(aihub): Data lake uri as optional on ref doc

### DIFF
--- a/aihub_pipeline/aihub_pipeline/types/RefDocDocument.py
+++ b/aihub_pipeline/aihub_pipeline/types/RefDocDocument.py
@@ -1,5 +1,8 @@
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
+
+from llama_index.core import Document
+from pydantic import computed_field
 
 from aihub_lib.persistence.rag.vectors.node_metadata import (
     CREATED_AT,
@@ -13,8 +16,6 @@ from aihub_lib.persistence.rag.vectors.node_metadata import (
     TYPE,
     UPDATED_AT,
 )
-from llama_index.core import Document
-from pydantic import computed_field
 
 if TYPE_CHECKING:
     from aihub_pipeline.types.DataLakeFile import DataLakeFile
@@ -36,8 +37,8 @@ class RefDocDocument(Document):
 
     @computed_field
     @property
-    def uri(self) -> str:
-        return self.metadata.get(DATA_LAKE_URI, "")
+    def uri(self) -> Optional[str]:
+        return self.metadata.get(DATA_LAKE_URI, None)
 
     @computed_field
     @property

--- a/aihub_pipeline/aihub_pipeline/types/RefDocDocument.py
+++ b/aihub_pipeline/aihub_pipeline/types/RefDocDocument.py
@@ -1,9 +1,6 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
-from llama_index.core import Document
-from pydantic import computed_field
-
 from aihub_lib.persistence.rag.vectors.node_metadata import (
     CREATED_AT,
     DATA_LAKE_URI,
@@ -16,6 +13,8 @@ from aihub_lib.persistence.rag.vectors.node_metadata import (
     TYPE,
     UPDATED_AT,
 )
+from llama_index.core import Document
+from pydantic import computed_field
 
 if TYPE_CHECKING:
     from aihub_pipeline.types.DataLakeFile import DataLakeFile


### PR DESCRIPTION
### **PR Type**
bug_fix, enhancement


___

### **Description**
- Made `DATA_LAKE_URI` optional in `RefDocDocument`.

- Updated `uri` property to return `Optional[str]`.

- Adjusted imports to include `Optional`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RefDocDocument.py</strong><dd><code>Make `DATA_LAKE_URI` optional and update `uri` property</code>&nbsp; &nbsp; </dd></summary>
<hr>

aihub_pipeline/aihub_pipeline/types/RefDocDocument.py

<li>Made <code>DATA_LAKE_URI</code> optional in metadata.<br> <li> Changed <code>uri</code> property return type to <code>Optional[str]</code>.<br> <li> Updated import statements to include <code>Optional</code>.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/271/files#diff-c2027433d8ed14f9574c1aea09e5ed1c2a23bceecf681295a94f3e10d0a40f7d">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>