### PR TITLE
fix(aihub): Allow overwrite of llama index default vector store dimen…

### DIFF
--- a/aihub_lib/aihub_lib/persistence/rag/vectors/stores/AzureAISearchVectorStoreFactory.py
+++ b/aihub_lib/aihub_lib/persistence/rag/vectors/stores/AzureAISearchVectorStoreFactory.py
@@ -20,7 +20,7 @@ def create_azure_ai_search_vector_store(
     metadata_fields: List[str] | None = None,
     language: str = "de",
     semantic_configuration_name: str = "mySemanticConfig",
-    dimensions: int = 1536,
+    dimensions: int = 3072,
 ) -> AzureAISearchVectorStore:
     search_client_singleton = AISearchAccess()
     index_client = search_client_singleton.get_client()

--- a/aihub_lib/aihub_lib/persistence/rag/vectors/stores/AzureAISearchVectorStoreFactory.py
+++ b/aihub_lib/aihub_lib/persistence/rag/vectors/stores/AzureAISearchVectorStoreFactory.py
@@ -20,6 +20,7 @@ def create_azure_ai_search_vector_store(
     metadata_fields: List[str] | None = None,
     language: str = "de",
     semantic_configuration_name: str = "mySemanticConfig",
+    dimensions: int = 1536,
 ) -> AzureAISearchVectorStore:
     search_client_singleton = AISearchAccess()
     index_client = search_client_singleton.get_client()
@@ -42,4 +43,5 @@ def create_azure_ai_search_vector_store(
         doc_id_field_key=DOCUMENT_ID,
         language_analyzer=f"{language}.microsoft",
         semantic_configuration_name=semantic_configuration_name,
+        embedding_dimensionality=dimensions,
     )

--- a/aihub_pipeline/aihub_pipeline/resources/factory.py
+++ b/aihub_pipeline/aihub_pipeline/resources/factory.py
@@ -45,8 +45,9 @@ def mongo_aisearch_storage_context_resources(
     vector_store_name: str,
     document_store_name: str,
     namespace_name: str,
+    dimension: int = 1536,
 ) -> Dict[str, ConfigurableResourceFactory]:
-    vector_store = AzureAISearchVectorStoreResource(vector_store_name=vector_store_name)
+    vector_store = AzureAISearchVectorStoreResource(vector_store_name=vector_store_name, dimensions=dimension)
     doc_store = MongoDocumentStoreResource(document_store_name=document_store_name, namespace_name=namespace_name)
     vector_store_io_manager = VectorStoreIOManager(vector_store=vector_store)
     doc_store_io_manager = DocStoreIOManager(doc_store=doc_store)

--- a/aihub_pipeline/aihub_pipeline/resources/factory.py
+++ b/aihub_pipeline/aihub_pipeline/resources/factory.py
@@ -45,9 +45,9 @@ def mongo_aisearch_storage_context_resources(
     vector_store_name: str,
     document_store_name: str,
     namespace_name: str,
-    dimension: int = 1536,
+    dimensions: int = 1536,
 ) -> Dict[str, ConfigurableResourceFactory]:
-    vector_store = AzureAISearchVectorStoreResource(vector_store_name=vector_store_name, dimensions=dimension)
+    vector_store = AzureAISearchVectorStoreResource(vector_store_name=vector_store_name, dimensions=dimensions)
     doc_store = MongoDocumentStoreResource(document_store_name=document_store_name, namespace_name=namespace_name)
     vector_store_io_manager = VectorStoreIOManager(vector_store=vector_store)
     doc_store_io_manager = DocStoreIOManager(doc_store=doc_store)

--- a/aihub_pipeline/aihub_pipeline/resources/factory.py
+++ b/aihub_pipeline/aihub_pipeline/resources/factory.py
@@ -45,7 +45,7 @@ def mongo_aisearch_storage_context_resources(
     vector_store_name: str,
     document_store_name: str,
     namespace_name: str,
-    dimensions: int = 1536,
+    dimensions: int = 3072,
 ) -> Dict[str, ConfigurableResourceFactory]:
     vector_store = AzureAISearchVectorStoreResource(vector_store_name=vector_store_name, dimensions=dimensions)
     doc_store = MongoDocumentStoreResource(document_store_name=document_store_name, namespace_name=namespace_name)

--- a/aihub_pipeline/aihub_pipeline/resources/vector_store/AzureAISearchVectorStoreResource.py
+++ b/aihub_pipeline/aihub_pipeline/resources/vector_store/AzureAISearchVectorStoreResource.py
@@ -67,6 +67,7 @@ class AzureAISearchVectorStoreResource(ConfigurableResource):
     """
 
     vector_store_name: str
+    dimensions: int = 1536
 
     def create_resource(self, context: InitResourceContext) -> AzureAISearchVectorStore:
-        return create_azure_ai_search_vector_store(vector_store_name=self.vector_store_name)
+        return create_azure_ai_search_vector_store(vector_store_name=self.vector_store_name, dimensions=self.dimensions)

--- a/aihub_pipeline/aihub_pipeline/resources/vector_store/AzureAISearchVectorStoreResource.py
+++ b/aihub_pipeline/aihub_pipeline/resources/vector_store/AzureAISearchVectorStoreResource.py
@@ -67,7 +67,7 @@ class AzureAISearchVectorStoreResource(ConfigurableResource):
     """
 
     vector_store_name: str
-    dimensions: int = 1536
+    dimensions: int = 3072
 
     def create_resource(self, context: InitResourceContext) -> AzureAISearchVectorStore:
         return create_azure_ai_search_vector_store(vector_store_name=self.vector_store_name, dimensions=self.dimensions)

--- a/aihub_pipeline/aihub_pipeline/util/definitions_util.py
+++ b/aihub_pipeline/aihub_pipeline/util/definitions_util.py
@@ -49,6 +49,7 @@ def default_definitions(
     datalake_directory_name: str,
     vector_store_name: str,
     document_store_name: str,
+    dimensions: int = 1536,
 ) -> Definitions:
     document_partitions = DynamicPartitionsDefinition(name="document_partitions")
 
@@ -83,6 +84,7 @@ def default_definitions(
                 vector_store_name=vector_store_name,
                 document_store_name=document_store_name,
                 namespace_name=namespace_name,
+                dimension=dimensions,
             ),
             **azure_data_lake_resources(container_name=datalake_container_name, directory_name=datalake_directory_name),
         },

--- a/aihub_pipeline/aihub_pipeline/util/definitions_util.py
+++ b/aihub_pipeline/aihub_pipeline/util/definitions_util.py
@@ -84,7 +84,7 @@ def default_definitions(
                 vector_store_name=vector_store_name,
                 document_store_name=document_store_name,
                 namespace_name=namespace_name,
-                dimension=dimensions,
+                dimensions=dimensions,
             ),
             **azure_data_lake_resources(container_name=datalake_container_name, directory_name=datalake_directory_name),
         },

--- a/aihub_pipeline/aihub_pipeline/util/definitions_util.py
+++ b/aihub_pipeline/aihub_pipeline/util/definitions_util.py
@@ -49,7 +49,7 @@ def default_definitions(
     datalake_directory_name: str,
     vector_store_name: str,
     document_store_name: str,
-    dimensions: int = 1536,
+    dimensions: int = 3072,
 ) -> Definitions:
     document_partitions = DynamicPartitionsDefinition(name="document_partitions")
 


### PR DESCRIPTION
### **User description**
…sions


___

### **PR Type**
enhancement


___

### **Description**
- Add ability to specify vector store dimensions

- Update function signatures to include dimensions

- Modify resource creation to accept dimensions

- Set default dimension value to 3072


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AzureAISearchVectorStoreFactory.py</strong><dd><code>Add dimensions parameter to vector store factory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_lib/aihub_lib/persistence/rag/vectors/stores/AzureAISearchVectorStoreFactory.py

<li>Added <code>dimensions</code> parameter to function signature<br> <li> Set default dimension value to 1536<br> <li> Passed <code>dimensions</code> to vector store creation


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/278/files#diff-fb9c059b009d274508878f5481f81af3ae3df1dc874241f7886aeca83bc957d5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>factory.py</strong><dd><code>Include dimension parameter in resource factory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_pipeline/aihub_pipeline/resources/factory.py

<li>Added <code>dimension</code> parameter with default 1536<br> <li> Passed <code>dimension</code> to vector store resource creation


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/278/files#diff-af5503cb519afaf785087eab3e9eac6eb73be0bdb18a579bf42c6bacdfd06183">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AzureAISearchVectorStoreResource.py</strong><dd><code>Add dimensions attribute to vector store resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_pipeline/aihub_pipeline/resources/vector_store/AzureAISearchVectorStoreResource.py

<li>Added <code>dimensions</code> attribute with default 1536<br> <li> Updated resource creation to use <code>dimensions</code>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/278/files#diff-64d93962e335e815763d089c80556894ad225625733aea8212390edd9a176f6a">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>definitions_util.py</strong><dd><code>Add dimensions parameter to definitions utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_pipeline/aihub_pipeline/util/definitions_util.py

<li>Added <code>dimensions</code> parameter with default 1536<br> <li> Passed <code>dimensions</code> to storage context resources


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/278/files#diff-8e9ed7c0751824d8e55b3de0787517e743544a7dcd6fef467841d370703b985f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>