### PR TITLE
fix(aihub): Add index for `event_data.created_at` in PersistedEventEntity

### DIFF
--- a/aihub_api/aihub_api/routes/openai/OpenaiService.py
+++ b/aihub_api/aihub_api/routes/openai/OpenaiService.py
@@ -152,7 +152,6 @@ class OpenaiService:
         model_parameters = None
         if isinstance(embedding_model_config, AzureOpenAIEmbeddingConfig):
             model_parameters = AzureOpenAIEmbeddingParameter(
-                dimensions=dimensions or embedding_model_config.default_parameter.dimensions,
                 encoding_format=encoding_format or embedding_model_config.default_parameter.encoding_format,
             )
         embedding_model, _ = embedding_model_config.to_llama_index(model_parameter=model_parameters)

--- a/aihub_api/aihub_api/routes/openai/OpenaiService.py
+++ b/aihub_api/aihub_api/routes/openai/OpenaiService.py
@@ -152,6 +152,7 @@ class OpenaiService:
         model_parameters = None
         if isinstance(embedding_model_config, AzureOpenAIEmbeddingConfig):
             model_parameters = AzureOpenAIEmbeddingParameter(
+                dimensions=dimensions or embedding_model_config.default_parameter.dimensions,
                 encoding_format=encoding_format or embedding_model_config.default_parameter.encoding_format,
             )
         embedding_model, _ = embedding_model_config.to_llama_index(model_parameter=model_parameters)

--- a/aihub_lib/aihub_lib/generative_ai/resources/models/llm/embedding/EmbeddingLLMConfig.py
+++ b/aihub_lib/aihub_lib/generative_ai/resources/models/llm/embedding/EmbeddingLLMConfig.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Annotated
 
 from llama_index.core.base.embeddings.base import BaseEmbedding
 from pydantic import Field
@@ -17,7 +17,13 @@ class EmbeddingLLMParameter(LLMModelParameter):
     we maintain consistency and facilitate extension if embedding models require parameters in the future.
     """
 
-    # Currently no additional fields, but can be extended in the future.
+    dimensions: Annotated[
+        Optional[int],
+        Field(
+            None,
+            description="The number of dimensions in the embedding vector. Supported in text-embedding-3 and later models.",
+        ),
+    ]
     pass
 
 

--- a/aihub_lib/aihub_lib/persistence/messaging/entities/PersistedEventEntity.py
+++ b/aihub_lib/aihub_lib/persistence/messaging/entities/PersistedEventEntity.py
@@ -78,6 +78,7 @@ class PersistedEventEntity(Document):
             {"fields": ["agent_id", "event_type"]},
             {"fields": ["thread_id", "event_parents"]},
             {"fields": ["run_id"]},
+            {"fields": ["event_data.created_at"]},
         ],
     }
     agent_class = StringField(required=True)


### PR DESCRIPTION
This change introduces a database index for the `event_data.created_at` field to facilitate `order_by("event_data__created_at")`