### PR TITLE
fix(aihub): Credential closing issue for data lake access

### DIFF
--- a/aihub_lib/aihub_lib/infrastructure/azure/data_lake/DataLakeAccess.py
+++ b/aihub_lib/aihub_lib/infrastructure/azure/data_lake/DataLakeAccess.py
@@ -1,4 +1,7 @@
+from typing import cast
+
 from adlfs import AzureBlobFileSystem
+from azure.core.credentials import TokenCredential
 from azure.identity import DefaultAzureCredential
 from azure.storage.filedatalake import DataLakeServiceClient
 
@@ -12,6 +15,7 @@ class DataLakeAccess:
     _app = None
     _storage_service_name = None
     _service_endpoint = None
+    _credential = None
 
     def __new__(cls):
         if cls._instance is None:
@@ -27,18 +31,20 @@ class DataLakeAccess:
             DataLakeConfig().DATA_LAKE_ENDPOINT or f"https://{self._storage_service_name}.dfs.core.windows.net"
         )
 
-        credential = DefaultAzureCredential()
+        self._credential = cast(TokenCredential, DefaultAzureCredential())
         self.datalake_client = DataLakeServiceClient(
             account_url=self._service_endpoint,
-            credential=credential,
+            credential=self._credential,
         )
-        self.file_system = AzureBlobFileSystem(account_name=self._storage_service_name, credential=credential)
 
     def get_client(self) -> DataLakeServiceClient:
         return self.datalake_client
 
     def get_fs_client(self) -> AzureBlobFileSystem:
-        return self.file_system
+        return AzureBlobFileSystem(
+            account_name=self._storage_service_name,
+            token_credential=self._credential
+        )
 
     def get_storage_account_name(self) -> str:
         return self._storage_service_name

--- a/aihub_lib/aihub_lib/infrastructure/azure/data_lake/DataLakeAccess.py
+++ b/aihub_lib/aihub_lib/infrastructure/azure/data_lake/DataLakeAccess.py
@@ -1,7 +1,6 @@
-from typing import cast
+from typing import Optional
 
 from adlfs import AzureBlobFileSystem
-from azure.core.credentials import TokenCredential
 from azure.identity import DefaultAzureCredential
 from azure.storage.filedatalake import DataLakeServiceClient
 
@@ -16,6 +15,7 @@ class DataLakeAccess:
     _storage_service_name = None
     _service_endpoint = None
     _credential = None
+    _cached_fs_client: Optional[AzureBlobFileSystem] = None
 
     def __new__(cls):
         if cls._instance is None:
@@ -31,20 +31,20 @@ class DataLakeAccess:
             DataLakeConfig().DATA_LAKE_ENDPOINT or f"https://{self._storage_service_name}.dfs.core.windows.net"
         )
 
-        self._credential = cast(TokenCredential, DefaultAzureCredential())
+        self._credential = DefaultAzureCredential()
         self.datalake_client = DataLakeServiceClient(
             account_url=self._service_endpoint,
             credential=self._credential,
         )
+        self._cached_fs_client = None
 
     def get_client(self) -> DataLakeServiceClient:
         return self.datalake_client
 
     def get_fs_client(self) -> AzureBlobFileSystem:
-        return AzureBlobFileSystem(
-            account_name=self._storage_service_name,
-            token_credential=self._credential
-        )
+        if self._cached_fs_client is None:
+            self._cached_fs_client = AzureBlobFileSystem(account_name=self._storage_service_name)
+        return self._cached_fs_client
 
     def get_storage_account_name(self) -> str:
         return self._storage_service_name


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fix credential handling for Azure Data Lake access.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DataLakeAccess.py</strong><dd><code>Fix credential handling and storage for Data Lake access</code>&nbsp; </dd></summary>
<hr>

aihub_lib/aihub_lib/infrastructure/azure/data_lake/DataLakeAccess.py

<li>Added <code>TokenCredential</code> casting for credentials.<br> <li> Introduced <code>_credential</code> attribute for storing credentials.<br> <li> Updated <code>get_fs_client</code> to use <code>token_credential</code>.<br> <li> Removed direct credential usage in <code>AzureBlobFileSystem</code>.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/331/files#diff-c36a001e7ca9ea0d4fbad3afb098d863b79613943b69e776f637a2531c065e23">+11/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>