### PR TITLE
fix(iac): Keep IP for nats fixed

### DIFF
--- a/aihub_iac/aihub_iac/azure/modules/nats/Nats.py
+++ b/aihub_iac/aihub_iac/azure/modules/nats/Nats.py
@@ -16,6 +16,8 @@ class Nats(pulumi.ComponentResource):
     Nats(stack, name, config=config)
     """
 
+    NATS_IP_ADDRESS = "10.0.1.4"
+
     def __init__(self, stack: str, name: str, config: NatsConfig, opts: Optional[pulumi.ResourceOptions] = None):
         super().__init__(f"{stack}:{name}", name, None, opts)
 
@@ -124,6 +126,7 @@ class Nats(pulumi.ComponentResource):
                     containerinstance.PortArgs(port=8222, protocol=containerinstance.ContainerGroupNetworkProtocol.TCP),
                     containerinstance.PortArgs(port=6379, protocol=containerinstance.ContainerGroupNetworkProtocol.TCP),
                 ],
+                ip=self.NATS_IP_ADDRESS,
             ),
             containers=[self.nats_container, self.redis_container],
             image_registry_credentials=[


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fix NATS IP to prevent changes on restart

- Add static IP address for NATS service


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Nats.py</strong><dd><code>Add static IP address to NATS configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_iac/aihub_iac/azure/modules/nats/Nats.py

<li>Added a static IP address for NATS<br> <li> Updated container group configuration with fixed IP


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/344/files#diff-6b0f06fd6354c21af1f0ba044c6be40a3a09c07165e6da59288f80187c9808f7">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>