### PR TITLE
fix(dagster): Fallback for os login

### DIFF
--- a/aihub_pipeline/aihub_pipeline/types/DataLakeFile.py
+++ b/aihub_pipeline/aihub_pipeline/types/DataLakeFile.py
@@ -11,16 +11,6 @@ from pydantic import BaseModel, Field, computed_field
 from aihub_pipeline.util.id_utils import uri_to_id
 
 
-def _get_current_user():
-    user = os.getenv('USER') or os.getenv('USERNAME')
-    if user:
-        return user
-    try:
-        return os.getlogin()
-    except OSError:
-        return 'pipeline-user'
-
-
 class DataLakeFile(BaseModel):
     """
     A Pydantic model representing a file in Azure Data Lake, including its metadata and optional content.
@@ -121,7 +111,7 @@ class DataLakeFile(BaseModel):
             uri=uri,
             size=size,
             content_type=mimetypes.guess_type(filename)[0] or "application/octet-stream",
-            owner=_get_current_user(),
+            owner=os.getenv('USER') or os.getenv('USERNAME') or 'pipeline-user',
             hash=md5_hash_str,
             created=current_timestamp,
             updated=current_timestamp,

--- a/aihub_pipeline/aihub_pipeline/types/DataLakeFile.py
+++ b/aihub_pipeline/aihub_pipeline/types/DataLakeFile.py
@@ -111,7 +111,7 @@ class DataLakeFile(BaseModel):
             uri=uri,
             size=size,
             content_type=mimetypes.guess_type(filename)[0] or "application/octet-stream",
-            owner=os.getenv("USER") or os.getenv("USERNAME") or "pipeline-user",
+            owner=os.getenv("USER") or os.getenv("USERNAME") or "pipeline-user", #  Fallback chain: Unix USER -> Windows USERNAME -> default
             hash=md5_hash_str,
             created=current_timestamp,
             updated=current_timestamp,

--- a/aihub_pipeline/aihub_pipeline/types/DataLakeFile.py
+++ b/aihub_pipeline/aihub_pipeline/types/DataLakeFile.py
@@ -11,6 +11,16 @@ from pydantic import BaseModel, Field, computed_field
 from aihub_pipeline.util.id_utils import uri_to_id
 
 
+def _get_current_user():
+    user = os.getenv('USER') or os.getenv('USERNAME')
+    if user:
+        return user
+    try:
+        return os.getlogin()
+    except OSError:
+        return 'pipeline-user'
+
+
 class DataLakeFile(BaseModel):
     """
     A Pydantic model representing a file in Azure Data Lake, including its metadata and optional content.
@@ -111,7 +121,7 @@ class DataLakeFile(BaseModel):
             uri=uri,
             size=size,
             content_type=mimetypes.guess_type(filename)[0] or "application/octet-stream",
-            owner=os.getlogin(),
+            owner=_get_current_user(),
             hash=md5_hash_str,
             created=current_timestamp,
             updated=current_timestamp,

--- a/aihub_pipeline/aihub_pipeline/types/DataLakeFile.py
+++ b/aihub_pipeline/aihub_pipeline/types/DataLakeFile.py
@@ -111,7 +111,7 @@ class DataLakeFile(BaseModel):
             uri=uri,
             size=size,
             content_type=mimetypes.guess_type(filename)[0] or "application/octet-stream",
-            owner=os.getenv('USER') or os.getenv('USERNAME') or 'pipeline-user',
+            owner=os.getenv("USER") or os.getenv("USERNAME") or "pipeline-user",
             hash=md5_hash_str,
             created=current_timestamp,
             updated=current_timestamp,


### PR DESCRIPTION
### **PR Type**
bug_fix, enhancement


___

### **Description**
- Implement fallback for determining file owner.

- Replace `os.getlogin()` with environment variable checks.

- Default to "pipeline-user" if no environment variable is set.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DataLakeFile.py</strong><dd><code>Implement fallback for file owner determination</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_pipeline/aihub_pipeline/types/DataLakeFile.py

<li>Replaced <code>os.getlogin()</code> with environment variable checks.<br> <li> Added fallback to "pipeline-user" if no user is found.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/347/files#diff-5039ea44b2ea848bd3eece071c4593be41ca7827a2c021a6f7b605e7669793b0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>