### PR TITLE
feat(aihub): Add mirror-image target to Makefile

### DIFF
--- a/aihub_iac/Makefile
+++ b/aihub_iac/Makefile
@@ -24,7 +24,7 @@ pr-ready: sort-imports format lint
 mirror-image:
 	@if [ -z "$(SOURCE)" ] || [ -z "$(TARGET)" ]; then \
 		echo "Error: SOURCE and TARGET parameters are required"; \
-		echo "Usage: make mirror SOURCE=source/image:tag TARGET=target/image:tag"; \
+		echo "Usage: make mirror-image SOURCE=source/image:tag TARGET=target/image:tag"; \
 		exit 1; \
 	fi
 	@echo "Mirroring $(SOURCE) to $(TARGET)..."

--- a/aihub_iac/Makefile
+++ b/aihub_iac/Makefile
@@ -16,3 +16,20 @@ sort-imports:
 
 pr-ready: sort-imports format lint
 	@echo "Running full check (format, sort)..."
+
+.PHONY: mirror help
+
+# Mirror an image from source to target
+# Usage: make mirror SOURCE=source/image:tag TARGET=target/image:tag
+mirror-image:
+	@if [ -z "$(SOURCE)" ] || [ -z "$(TARGET)" ]; then \
+		echo "Error: SOURCE and TARGET parameters are required"; \
+		echo "Usage: make mirror SOURCE=source/image:tag TARGET=target/image:tag"; \
+		exit 1; \
+	fi
+	@echo "Mirroring $(SOURCE) to $(TARGET)..."
+	@docker login ghcr.io
+	@docker pull $(SOURCE)
+	@docker tag $(SOURCE) $(TARGET)
+	@docker push $(TARGET)
+	@echo "Successfully mirrored $(SOURCE) to $(TARGET)"

--- a/aihub_iac/Makefile
+++ b/aihub_iac/Makefile
@@ -20,7 +20,7 @@ pr-ready: sort-imports format lint
 .PHONY: mirror
 
 # Mirror an image from source to target
-# Usage: make mirror SOURCE=source/image:tag TARGET=target/image:tag
+# Usage: make mirror-image SOURCE=source/image:tag TARGET=target/image:tag
 mirror-image:
 	@if [ -z "$(SOURCE)" ] || [ -z "$(TARGET)" ]; then \
 		echo "Error: SOURCE and TARGET parameters are required"; \

--- a/aihub_iac/Makefile
+++ b/aihub_iac/Makefile
@@ -17,7 +17,7 @@ sort-imports:
 pr-ready: sort-imports format lint
 	@echo "Running full check (format, sort)..."
 
-.PHONY: mirror help
+.PHONY: mirror
 
 # Mirror an image from source to target
 # Usage: make mirror SOURCE=source/image:tag TARGET=target/image:tag

--- a/aihub_iac/Makefile
+++ b/aihub_iac/Makefile
@@ -17,7 +17,7 @@ sort-imports:
 pr-ready: sort-imports format lint
 	@echo "Running full check (format, sort)..."
 
-.PHONY: mirror
+.PHONY: mirror-image
 
 # Mirror an image from source to target
 # Usage: make mirror-image SOURCE=source/image:tag TARGET=target/image:tag

--- a/aihub_iac/Makefile
+++ b/aihub_iac/Makefile
@@ -21,6 +21,7 @@ pr-ready: sort-imports format lint
 
 # Mirror an image from source to target
 # Usage: make mirror-image SOURCE=source/image:tag TARGET=target/image:tag
+# Example: make mirror-image SOURCE=ghcr.io/open-webui/open-webui:v0.6.10 TARGET=ghcr.io/bbvch-ai/aihub-core/open-webui:v0.6.10
 mirror-image:
 	@if [ -z "$(SOURCE)" ] || [ -z "$(TARGET)" ]; then \
 		echo "Error: SOURCE and TARGET parameters are required"; \


### PR DESCRIPTION
### **User description**
This new target enables mirroring Docker images from a source to a target registry. It includes parameter validation, Docker login, and image pull/tag/push steps, streamlining the process.


___

### **PR Type**
enhancement, other


___

### **Description**
- Add 'mirror-image' target to Makefile for Docker image mirroring.

- Implement parameter validation for 'mirror-image' target.

- Remove unused 'help' target from .PHONY declaration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Add 'mirror-image' target and remove unused 'help' target</code></dd></summary>
<hr>

aihub_iac/Makefile

<li>Added 'mirror-image' target for Docker image mirroring.<br> <li> Implemented parameter validation for 'mirror-image'.<br> <li> Removed unused 'help' target from .PHONY.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/350/files#diff-da6d180a7c785b108ee5ef7577d6c062d24179f2b3c5ceff8785bdfbda059f30">+18/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>