### PR TITLE
fix(bots): Handle missing locale in locale handler

### DIFF
--- a/aihub_bot/aihub_bot/bots/chat/BaseChatBot.py
+++ b/aihub_bot/aihub_bot/bots/chat/BaseChatBot.py
@@ -64,7 +64,10 @@ class BaseChatBot(ActivityHandler):
         await self._process_message(turn_context, is_streaming=False)
 
     def _get_locale_handler(self, turn_context: TurnContext) -> LocaleHandler:
-        locale = self.locale_handler.get_locale(turn_context.activity.locale.split("-")[0])
+        if turn_context.activity.locale:
+            locale = self.locale_handler.get_locale(turn_context.activity.locale.split("-")[0])
+        else:
+            locale = self.locale_handler.DEFAULT_LOCALE
         return self.locale_handler.in_locale(locale)
 
     async def _process_message(self, turn_context: TurnContext, is_streaming: bool = False):


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Handle missing locale in `_get_locale_handler` method.

- Default to `DEFAULT_LOCALE` if locale is missing.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BaseChatBot.py</strong><dd><code>Handle missing locale in `_get_locale_handler` method</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_bot/aihub_bot/bots/chat/BaseChatBot.py

<li>Added check for missing locale in <code>_get_locale_handler</code>.<br> <li> Default locale set to <code>DEFAULT_LOCALE</code> if missing.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/366/files#diff-7a749d2ea5f0a89ff72d2dfda205c4ea0110fc44ddd634890ab01dd443b6aa64">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>