### PR TITLE
fix(bots): Remove redundant service parameter from completion handler…

### DIFF
--- a/aihub_bot/aihub_bot/bots/chat/BaseChatBot.py
+++ b/aihub_bot/aihub_bot/bots/chat/BaseChatBot.py
@@ -148,7 +148,6 @@ class BaseChatBot(ActivityHandler):
         if is_streaming:
             # Get streaming response
             response_generator = await self.completion_handler.get_stream_completion(
-                service=self.completion_handler,
                 turn_context=turn_context,
                 path=self.path,
                 thread_id=str_to_object_id(turn_context.activity.conversation.id),
@@ -168,7 +167,6 @@ class BaseChatBot(ActivityHandler):
         else:
             # Get json response
             response = await self.completion_handler.get_completion(
-                service=self.completion_handler,
                 turn_context=turn_context,
                 path=self.path,
                 thread_id=str_to_object_id(turn_context.activity.conversation.id),

--- a/aihub_bot/aihub_bot/bots/chat/ContentExtractor.py
+++ b/aihub_bot/aihub_bot/bots/chat/ContentExtractor.py
@@ -182,7 +182,7 @@ class ContentExtractor:
         file_info = ContentExtractor._fetch_file(file_info)
 
         # Process by content type
-        if file_info.content_type.startswith("image/"):
+        if file_info.content_type and file_info.content_type.startswith("image/"):
             data_url = ContentExtractor._to_base64_data_url(file_info)
             return Content(text=data_url, type="image_url")
 
@@ -190,7 +190,7 @@ class ContentExtractor:
             # PDF files are not supported, return a placeholder
             return Content(text=f"<file name='{file_info.name}'>PDF files are not supported yet</file>", type="text")
 
-        elif file_info.content_type.startswith("text/") or file_info.content_type.startswith("application/"):
+        elif file_info.content_type and (file_info.content_type.startswith("text/") or file_info.content_type.startswith("application/")):
             try:
                 text = file_info.content_bytes.decode("utf-8", errors="replace")
                 return Content(text=f"<file name='{file_info.name}'>{text}</file>", type="text")

--- a/aihub_bot/aihub_bot/bots/chat/ContentExtractor.py
+++ b/aihub_bot/aihub_bot/bots/chat/ContentExtractor.py
@@ -190,7 +190,9 @@ class ContentExtractor:
             # PDF files are not supported, return a placeholder
             return Content(text=f"<file name='{file_info.name}'>PDF files are not supported yet</file>", type="text")
 
-        elif file_info.content_type and (file_info.content_type.startswith("text/") or file_info.content_type.startswith("application/")):
+        elif file_info.content_type and (
+            file_info.content_type.startswith("text/") or file_info.content_type.startswith("application/")
+        ):
             try:
                 text = file_info.content_bytes.decode("utf-8", errors="replace")
                 return Content(text=f"<file name='{file_info.name}'>{text}</file>", type="text")

--- a/aihub_bot/aihub_bot/bots/chat/agent/AgentCompletionHandler.py
+++ b/aihub_bot/aihub_bot/bots/chat/agent/AgentCompletionHandler.py
@@ -10,7 +10,7 @@ from bson import ObjectId
 from llama_index.core.base.llms.types import ChatMessage, ContentBlock, ImageBlock, MessageRole, TextBlock
 from nats.aio.client import Client as NATS
 
-from aihub_bot.bots.chat.BaseChatBot import CompletionHandler
+from aihub_bot.bots.chat.CompletionHandler import CompletionHandler
 from aihub_bot.persistence.entities.ConversationEntity import Content, Message
 
 
@@ -77,7 +77,7 @@ class AgentCompletionHandler(CompletionHandler):
             nc=nc,
             external_event_distributor=external_event_distributor,
             thread_id=thread_id,
-            display_id=thread_id,
+            display_id=display_id,
             stream=True,
             locale=locale,
         )

--- a/aihub_bot/aihub_bot/bots/chat/agent/StreamAgentChatBot.py
+++ b/aihub_bot/aihub_bot/bots/chat/agent/StreamAgentChatBot.py
@@ -1,4 +1,5 @@
 from botbuilder.core import TurnContext
+from botframework.connector import Channels
 from typing_extensions import override
 
 from aihub_bot.bots.chat.agent.AgentChatBot import AgentChatBot
@@ -7,7 +8,7 @@ from aihub_bot.bots.chat.agent.AgentChatBot import AgentChatBot
 class StreamAgentChatBot(AgentChatBot):
     @override
     async def on_message_activity(self, turn_context: TurnContext):
-        if turn_context.activity.channel_id == "webchat":
+        if turn_context.activity.channel_id == Channels.webchat:
             return await super().on_message_activity(turn_context)
 
         await self._process_message(turn_context, is_streaming=True)

--- a/aihub_bot/aihub_bot/bots/chat/openai/OpenaiCompletionHandler.py
+++ b/aihub_bot/aihub_bot/bots/chat/openai/OpenaiCompletionHandler.py
@@ -22,7 +22,7 @@ from openai.types.chat import (
 from openai.types.chat.chat_completion_content_part_image_param import ChatCompletionContentPartImageParam, ImageURL
 from typing_extensions import override
 
-from aihub_bot.bots.chat.BaseChatBot import CompletionHandler
+from aihub_bot.bots.chat.CompletionHandler import CompletionHandler
 from aihub_bot.persistence.entities.ConversationEntity import Content, Message
 
 logger = logging.getLogger(__name__)

--- a/aihub_bot/aihub_bot/bots/chat/openai/OpenaiCompletionHandler.py
+++ b/aihub_bot/aihub_bot/bots/chat/openai/OpenaiCompletionHandler.py
@@ -33,7 +33,11 @@ class OpenaiCompletionHandler(CompletionHandler):
 
     @staticmethod
     async def get_completion(
-        turn_context: TurnContext, path: str, model_name: str, client: AsyncOpenAI | AsyncAzureOpenAI, **kwargs
+        turn_context: TurnContext,
+        path: str,
+        model_name: str,
+        client: AsyncOpenAI | AsyncAzureOpenAI,
+        **kwargs,
     ) -> str:
         chat_completion: ChatCompletion = await OpenaiCompletionHandler.chat_completion(
             turn_context=turn_context,
@@ -50,6 +54,7 @@ class OpenaiCompletionHandler(CompletionHandler):
         path: str,
         model_name: str,
         client: AsyncOpenAI | AsyncAzureOpenAI,
+        **kwargs,
     ) -> AsyncGenerator[str, None]:
         """Get a streaming OpenAI completion."""
         chat_completion: AsyncStream[ChatCompletionChunk] = await OpenaiCompletionHandler.chat_completion(

--- a/aihub_bot/aihub_bot/bots/chat/openai/OpenaiCompletionHandler.py
+++ b/aihub_bot/aihub_bot/bots/chat/openai/OpenaiCompletionHandler.py
@@ -6,7 +6,6 @@ from asyncio import Event, Task
 from typing import AsyncGenerator, List
 
 from aihub_lib.i18n.LocaleHandler import LocaleHandler
-
 from botbuilder.core import TurnContext
 from openai import APIStatusError, AsyncAzureOpenAI, AsyncOpenAI, AsyncStream
 from openai.types.chat import (

--- a/aihub_bot/aihub_bot/bots/chat/openai/OpenaiCompletionHandler.py
+++ b/aihub_bot/aihub_bot/bots/chat/openai/OpenaiCompletionHandler.py
@@ -5,6 +5,8 @@ import unicodedata
 from asyncio import Event, Task
 from typing import AsyncGenerator, List
 
+from aihub_lib.i18n.LocaleHandler import LocaleHandler
+
 from botbuilder.core import TurnContext
 from openai import APIStatusError, AsyncAzureOpenAI, AsyncOpenAI, AsyncStream
 from openai.types.chat import (
@@ -173,7 +175,11 @@ class OpenaiCompletionHandler(CompletionHandler):
     @staticmethod
     @override
     async def handle_exception(
-        turn_context: TurnContext, exception: Exception, typing_task: Task, typing_stop_signal: Event
+        turn_context: TurnContext,
+        exception: Exception,
+        typing_task: Task,
+        typing_stop_signal: Event,
+        t: LocaleHandler,
     ) -> str:
         if isinstance(exception, APIStatusError):
             logger.warning(f"APIStatusError: {exception}\nTurnContext: {turn_context}")
@@ -190,4 +196,5 @@ class OpenaiCompletionHandler(CompletionHandler):
                 exception=exception,
                 typing_task=typing_task,
                 typing_stop_signal=typing_stop_signal,
+                t=t,
             )


### PR DESCRIPTION
### **User description**
… methods


___

### **PR Type**
Bug fix


___

### **Description**
- Removed redundant `service` parameter from completion handler methods.

- Updated `_respond` method in `BaseChatBot.py`.

- Refactored `get_completion` and `get_stream_completion` methods.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BaseChatBot.py</strong><dd><code>Remove redundant parameter in BaseChatBot methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_bot/aihub_bot/bots/chat/BaseChatBot.py

<li>Removed <code>service</code> parameter from <code>get_stream_completion</code>.<br> <li> Removed <code>service</code> parameter from <code>get_completion</code>.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/368/files#diff-7a749d2ea5f0a89ff72d2dfda205c4ea0110fc44ddd634890ab01dd443b6aa64">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OpenaiCompletionHandler.py</strong><dd><code>Refactor OpenaiCompletionHandler method parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_bot/aihub_bot/bots/chat/openai/OpenaiCompletionHandler.py

<li>Reformatted parameters in <code>get_completion</code>.<br> <li> Added <code>**kwargs</code> to <code>get_stream_completion</code>.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/368/files#diff-c4fcba03a41728a7a12238d6f0a11be157b02468d84d0d845474160f0125cf2e">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>