### PR TITLE
fix(bots): Adjust typing indicator logic to ensure it only starts afte…

### DIFF
--- a/aihub_bot/aihub_bot/bots/chat/BaseChatBot.py
+++ b/aihub_bot/aihub_bot/bots/chat/BaseChatBot.py
@@ -101,7 +101,7 @@ class BaseChatBot(ActivityHandler):
             if turn_context is None:
                 return
 
-        # Typing indicator cannot start before the Slack message is processed such that no typing indicator is sent
+        # Typing must be sent after the Slack message is processed such that no typing indicator is sent
         # when the bot should not respond to the message.
         typing_stop_signal = Event()
         typing_task: Task = asyncio.create_task(

--- a/aihub_bot/aihub_bot/bots/chat/BaseChatBot.py
+++ b/aihub_bot/aihub_bot/bots/chat/BaseChatBot.py
@@ -74,7 +74,7 @@ class BaseChatBot(ActivityHandler):
         locale_handler = self._get_locale_handler(turn_context)
         conversation_id = turn_context.activity.conversation.id
 
-        # Check if we should show expiration message
+        # Check if we should show an expiration message
         if (
             ConversationTracker.should_show_expiration_message(conversation_id)
             and turn_context.activity.type == "message"

--- a/aihub_bot/aihub_bot/bots/chat/BaseChatBot.py
+++ b/aihub_bot/aihub_bot/bots/chat/BaseChatBot.py
@@ -74,17 +74,6 @@ class BaseChatBot(ActivityHandler):
         locale_handler = self._get_locale_handler(turn_context)
         conversation_id = turn_context.activity.conversation.id
 
-        # Start typing indicator
-        typing_stop_signal = Event()
-        typing_task: Task = asyncio.create_task(
-            self.completion_handler.send_typing_activity(
-                turn_context=turn_context,
-                signal=typing_stop_signal,
-                t=locale_handler,
-                timeout_seconds=self.typing_timeout_seconds,
-            )
-        )
-
         # Check if we should show expiration message
         if (
             ConversationTracker.should_show_expiration_message(conversation_id)
@@ -111,6 +100,18 @@ class BaseChatBot(ActivityHandler):
             turn_context = self.completion_handler.handle_slack_message(turn_context)
             if turn_context is None:
                 return
+
+        # Typing indicator cannot start before the Slack message is processed such that no typing indicator is sent
+        # when the bot should not respond to the message.
+        typing_stop_signal = Event()
+        typing_task: Task = asyncio.create_task(
+            self.completion_handler.send_typing_activity(
+                turn_context=turn_context,
+                signal=typing_stop_signal,
+                t=locale_handler,
+                timeout_seconds=self.typing_timeout_seconds,
+            )
+        )
 
         # Get response from completion handler
         try:


### PR DESCRIPTION
### **User description**
…r processing Slack messages


___

### **PR Type**
Bug fix


___

### **Description**
- Adjust typing indicator logic for Slack messages.

- Ensure typing starts after message processing.

- Prevent typing indicator when bot doesn't respond.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BaseChatBot.py</strong><dd><code>Adjust typing indicator logic in BaseChatBot</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_bot/aihub_bot/bots/chat/BaseChatBot.py

<li>Moved typing indicator logic after Slack message processing.<br> <li> Prevented typing indicator if bot doesn't respond.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/369/files#diff-7a749d2ea5f0a89ff72d2dfda205c4ea0110fc44ddd634890ab01dd443b6aa64">+12/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>