### PR TITLE
fix(dagster): Document names with period handled

### DIFF
--- a/aihub_agent/poetry.lock
+++ b/aihub_agent/poetry.lock
@@ -103,7 +103,7 @@ transformers = "^4.48.1"
 type = "git"
 url = "https://github.com/bbvch-ai/aihub-core.git"
 reference = "v0.189.0"
-resolved_reference = "6443130686ab9376dc9b36da7febfdd00f567c37"
+resolved_reference = "e5e62b05d837e462c1e3ea24c042bdc62d2d1b27"
 subdirectory = "aihub_lib"
 
 [[package]]

--- a/aihub_api/poetry.lock
+++ b/aihub_api/poetry.lock
@@ -103,7 +103,7 @@ transformers = "^4.48.1"
 type = "git"
 url = "https://github.com/bbvch-ai/aihub-core.git"
 reference = "v0.189.0"
-resolved_reference = "6443130686ab9376dc9b36da7febfdd00f567c37"
+resolved_reference = "e5e62b05d837e462c1e3ea24c042bdc62d2d1b27"
 subdirectory = "aihub_lib"
 
 [[package]]

--- a/aihub_bot/poetry.lock
+++ b/aihub_bot/poetry.lock
@@ -103,7 +103,7 @@ transformers = "^4.48.1"
 type = "git"
 url = "https://github.com/bbvch-ai/aihub-core.git"
 reference = "v0.189.0"
-resolved_reference = "6443130686ab9376dc9b36da7febfdd00f567c37"
+resolved_reference = "e5e62b05d837e462c1e3ea24c042bdc62d2d1b27"
 subdirectory = "aihub_lib"
 
 [[package]]

--- a/aihub_pipeline/aihub_pipeline/util/path_utils.py
+++ b/aihub_pipeline/aihub_pipeline/util/path_utils.py
@@ -3,6 +3,7 @@ import os
 
 def create_data_lake_figures_folder_name(uri: str, figures_directory_name: str) -> str:
     base_path = os.path.dirname(uri)
-    doc_name, doc_type = os.path.basename(uri).split(".")
-    doc_name = f"{doc_name}_{doc_type}"
+    file_name = os.path.basename(uri)
+    doc_name, doc_type = os.path.splitext(file_name)
+    doc_name = f"{doc_name}_{doc_type[1:]}"
     return f"{base_path}/{figures_directory_name}/{doc_name}"

--- a/aihub_pipeline/poetry.lock
+++ b/aihub_pipeline/poetry.lock
@@ -103,7 +103,7 @@ transformers = "^4.48.1"
 type = "git"
 url = "https://github.com/bbvch-ai/aihub-core.git"
 reference = "v0.189.0"
-resolved_reference = "6443130686ab9376dc9b36da7febfdd00f567c37"
+resolved_reference = "e5e62b05d837e462c1e3ea24c042bdc62d2d1b27"
 subdirectory = "aihub_lib"
 
 [[package]]


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fix handling of filenames with periods in `create_data_lake_figures_folder_name`.

- Use `os.path.splitext` for safer file extension extraction.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>path_utils.py</strong><dd><code>Correct filename handling with periods in utility function</code></dd></summary>
<hr>

aihub_pipeline/aihub_pipeline/util/path_utils.py

<li>Fix handling of filenames with periods.<br> <li> Use <code>os.path.splitext</code> for extension extraction.


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/377/files#diff-52002f16da3932973916c659b5476144d7c9b2864908284300443fe4ed698d18">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>