### PR TITLE
fix(aihub): Wrong key reference for Document Intelligence

### DIFF
--- a/aihub_lib/aihub_lib/infrastructure/azure/cognitive_services/document_intelligence/DocumentIntelligenceAccess.py
+++ b/aihub_lib/aihub_lib/infrastructure/azure/cognitive_services/document_intelligence/DocumentIntelligenceAccess.py
@@ -46,7 +46,7 @@ class DocumentIntelligenceAccess(CognitiveServiceAccess):
         self._di_endpoint = account.properties.endpoint
 
         keys = self._client.accounts.list_keys(self._resource_group_name, self._di_service_name)
-        self._primary_admin_key = keys.primary_key
+        self._primary_admin_key = keys.key1
 
         self.di_client = DocumentIntelligenceClient(
             endpoint=account.properties.endpoint,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Corrected key reference in Document Intelligence access.

- Replaced `primary_key` with `key1` for admin key.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DocumentIntelligenceAccess.py"] -- "fix key reference" --> B["Replace primary_key with key1"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DocumentIntelligenceAccess.py</strong><dd><code>Correct key reference in Document Intelligence access</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_lib/aihub_lib/infrastructure/azure/cognitive_services/document_intelligence/DocumentIntelligenceAccess.py

<ul><li>Changed key reference from <code>primary_key</code> to <code>key1</code>.<br> <li> Updated <code>_primary_admin_key</code> assignment.</ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/480/files#diff-dd1c8015fc590cc8e394be39df03666d0f199f8d216729085e04632bc02ba0aa">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

