### PR TITLE
fix(ui): Reverse severity logic for exceptionevents in Trend tags

### DIFF
--- a/aihub_web/aihub_web/components/Dashboard/Trend.vue
+++ b/aihub_web/aihub_web/components/Dashboard/Trend.vue
@@ -17,14 +17,14 @@
 </template>
 
 <script setup lang="ts">
-import type {EventTimeseries} from '@core/sdk/client'
+import type { EventTimeseries } from '@core/sdk/client'
 
 const props = defineProps<{
   timeseries: EventTimeseries
 }>()
 
-const {t} = useI18n()
-const {isTrendingUp} = useEventTimeseriesStats(props.timeseries)
+const { t } = useI18n()
+const { isTrendingUp } = useEventTimeseriesStats(props.timeseries)
 
 const reverseLogic = computed(() => {
   return props.timeseries.event_name === 'ExceptionEvent'

--- a/aihub_web/aihub_web/components/Dashboard/Trend.vue
+++ b/aihub_web/aihub_web/components/Dashboard/Trend.vue
@@ -26,9 +26,9 @@ const props = defineProps<{
 const { t } = useI18n()
 const { isTrendingUp } = useEventTimeseriesStats(props.timeseries)
 
-const EXCEPTION_EVENT = 'ExceptionEvent';
+const EXCEPTION_EVENT = 'ExceptionEvent'
 
 const reverseLogic = computed(() => {
-  return props.timeseries.event_name === EXCEPTION_EVENT;
+  return props.timeseries.event_name === EXCEPTION_EVENT
 })
 </script>

--- a/aihub_web/aihub_web/components/Dashboard/Trend.vue
+++ b/aihub_web/aihub_web/components/Dashboard/Trend.vue
@@ -26,7 +26,9 @@ const props = defineProps<{
 const { t } = useI18n()
 const { isTrendingUp } = useEventTimeseriesStats(props.timeseries)
 
+const EXCEPTION_EVENT = 'ExceptionEvent';
+
 const reverseLogic = computed(() => {
-  return props.timeseries.event_name === 'ExceptionEvent'
+  return props.timeseries.event_name === EXCEPTION_EVENT;
 })
 </script>

--- a/aihub_web/aihub_web/components/Dashboard/Trend.vue
+++ b/aihub_web/aihub_web/components/Dashboard/Trend.vue
@@ -1,7 +1,7 @@
 <template>
   <Tag
     v-if="isTrendingUp"
-    severity="success"
+    :severity="reverseLogic ? 'danger' : 'success'"
     :value="t('chart.trending_up')"
     size="small"
     icon="pi pi-arrow-up-right"
@@ -9,7 +9,7 @@
   />
   <Tag
     v-else
-    severity="danger"
+    :severity="reverseLogic ? 'success' : 'danger'"
     :value="t('chart.trending_down')"
     icon="pi pi-arrow-down-right"
     rounded
@@ -17,12 +17,16 @@
 </template>
 
 <script setup lang="ts">
-import type { EventTimeseries } from '@core/sdk/client'
+import type {EventTimeseries} from '@core/sdk/client'
 
 const props = defineProps<{
   timeseries: EventTimeseries
 }>()
 
-const { t } = useI18n()
-const { isTrendingUp } = useEventTimeseriesStats(props.timeseries)
+const {t} = useI18n()
+const {isTrendingUp} = useEventTimeseriesStats(props.timeseries)
+
+const reverseLogic = computed(() => {
+  return props.timeseries.event_name === 'ExceptionEvent'
+})
 </script>


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Reverse severity logic for trending tags

- Add computed property for reverse logic

- Adjust tag severity based on event name


___

### Diagram Walkthrough


```mermaid
flowchart LR
  isTrendingUp["isTrendingUp condition"] -- "reverse logic applied" --> severity["Tag severity adjusted"]
  timeseries["EventTimeseries"] -- "computed property" --> reverseLogic["reverseLogic"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Trend.vue</strong><dd><code>Reverse severity logic and add computed property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_web/aihub_web/components/Dashboard/Trend.vue

<ul><li>Reverse severity logic for tags<br> <li> Add computed property for reverse logic<br> <li> Adjust tag severity based on event name</ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/487/files#diff-7d0f9022ffc0ba907c62f607bbcb3303bd892dbf45d3d2648f524e365b71f3f1">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

