### PR TITLE
fix(ci-cd): Remove GitHub release creation step from action.yml

### DIFF
--- a/aihub_action/build_image/action.yml
+++ b/aihub_action/build_image/action.yml
@@ -51,17 +51,3 @@ runs:
         tags: |
           ghcr.io/${{ inputs.github_repository_owner }}/${{ inputs.github_event_repository_name }}/${{ inputs.image_name }}:${{ inputs.release_version }}
           ghcr.io/${{ inputs.github_repository_owner }}/${{ inputs.github_event_repository_name }}/${{ inputs.image_name }}:latest
-
-
-    - name: Create GitHub Release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ inputs.github_token }}
-      with:
-        tag_name: ${{ inputs.image_name }}-${{ inputs.release_version }}
-        release_name: Release ${{ inputs.image_name }} ${{ inputs.release_version }}
-        body: |
-          Docker image '${{ inputs.image_name }}' for version ${{ inputs.release_version }} is available at:
-          `ghcr.io/${{ inputs.github_repository_owner }}/${{ inputs.github_event_repository_name }}/${{ inputs.image_name }}:${{ inputs.release_version }}`.
-        draft: false
-        prerelease: false


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove GitHub release creation step from `action.yml`

- Adjust Docker image tagging process


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Remove GitHub release creation"] -- "Adjust Docker image tagging" --> B["Docker image tagging process"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>Remove GitHub release creation step</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_action/build_image/action.yml

<ul><li>Removed GitHub release creation step<br> <li> Adjusted Docker image tagging process</ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/497/files#diff-fe0340903273aedf091dd20117cb849db7a22dae61837b5dfd33b418ceeae429">+1/-15</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

