### PR TITLE
fix(ci-cd): Add action to tag commit and push to repository

### DIFF
--- a/.github/workflows/add-tag.yml
+++ b/.github/workflows/add-tag.yml
@@ -93,10 +93,35 @@ jobs:
 
       - name: Tag the commit and push the tag
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git tag ${{ steps.create-tag.outputs.version }}
-          git push origin ${{ steps.create-tag.outputs.version }}
+          set -euo pipefail
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          
+          TAG_NAME="${{ steps.create-tag.outputs.version }}"
+          TAG_MESSAGE="Initial Tag for: $TAG_NAME"
+          
+          # Check if tag already exists (locally or remotely)
+          if git rev-parse "$TAG_NAME" >/dev/null 2>&1 || git ls-remote --tags origin | grep -q "refs/tags/$TAG_NAME$"; then
+            echo "Error: Tag $TAG_NAME already exists. Aborting."
+            exit 1
+          fi
+          # Create annotated tag
+          git tag -a "$TAG_NAME" -m "$TAG_MESSAGE"
+      
+          # Verify tag exists locally
+          if ! git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+            echo "Error: Failed to create tag $TAG_NAME."
+            exit 1
+          fi
+          
+          # Push the tag
+          git push origin "$TAG_NAME"
+
+          # Verify tag exists remotely
+          if ! git ls-remote --tags origin | grep -q "refs/tags/$TAG_NAME$"; then
+            echo "Error: Failed to push tag $TAG_NAME to remote."
+            exit 1
+          fi
 
   changelog:
     name: Generate Changelog
@@ -327,13 +352,26 @@ jobs:
               echo "License report updated."
             fi
           fi
+          
+          git add -A
   
           git commit -m "ops(bot): Update tag number to ${VERSION} [skip ci]" || echo "No file changes to commit."
-
+          git push origin HEAD:${{ github.event.pull_request.base.ref }}
+          
+          
           echo "Creating final tag ${VERSION} and pushing..."
-          git tag -f "${VERSION}"
-          git push origin --force
-          git push origin --tags --force
+          git tag -a -f "${VERSION}" -m "Release ${VERSION}"
+          git push origin "refs/tags/${VERSION}" --force
+          
+          # Verify remote tag matches local
+          LOCAL_SHA="$(git rev-parse "${VERSION}^{commit}")"
+          REMOTE_SHA="$(git ls-remote --tags origin "refs/tags/${VERSION}" | awk '{print $1}')"
+          if [ -z "${REMOTE_SHA}" ] || [ "${LOCAL_SHA}" != "${REMOTE_SHA}" ]; then
+            echo "Error: remote tag ${VERSION} not updated (local ${LOCAL_SHA}, remote ${REMOTE_SHA:-<none>})."
+            exit 1
+          fi
+
+          echo "Tag ${VERSION} updated to ${LOCAL_SHA} and verified on origin."
 
       - name: Clean up SSH keys
         run: |

--- a/.github/workflows/add-tag.yml
+++ b/.github/workflows/add-tag.yml
@@ -91,6 +91,13 @@ jobs:
           # Expose it to subsequent steps via outputs (not just GITHUB_ENV).
           echo "version=$new_tag" >> $GITHUB_OUTPUT
 
+      - name: Tag the commit and push the tag
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git tag ${{ steps.create-tag.outputs.version }}
+          git push origin ${{ steps.create-tag.outputs.version }}
+
   changelog:
     name: Generate Changelog
     needs: [compute-and-initial-tag]


### PR DESCRIPTION
Need to create tag already early so that later when using "use-remote-core" with the new tag works. at the end after updating the version numbers of the packages and adding the changelog and licence report reset the tag to that new commit