### PR TITLE
fix(ci-cd): Amend tag commit process and remove verification step in auto tag action

### DIFF
--- a/.github/workflows/add-tag.yml
+++ b/.github/workflows/add-tag.yml
@@ -376,23 +376,14 @@ jobs:
           
           git add -A
   
-          git commit -m "ops(bot): Update tag number to ${VERSION} [skip ci]" || echo "No file changes to commit."
-          git push origin HEAD:${{ github.event.pull_request.base.ref }}
+          git commit --amend --no-edit || echo "No file changes to commit."
+          git push origin HEAD:${{ github.event.pull_request.base.ref }} --force-with-lease
           
           
           echo "Creating final tag ${VERSION} and pushing..."
           git tag -a -f "${VERSION}" -m "Release ${VERSION}"
           git push origin "refs/tags/${VERSION}" --force
           
-          # Verify remote tag matches local
-          LOCAL_SHA="$(git rev-parse "${VERSION}^{commit}")"
-          REMOTE_SHA="$(git ls-remote --tags origin "refs/tags/${VERSION}" | awk '{print $1}')"
-          if [ -z "${REMOTE_SHA}" ] || [ "${LOCAL_SHA}" != "${REMOTE_SHA}" ]; then
-            echo "Error: remote tag ${VERSION} not updated (local ${LOCAL_SHA}, remote ${REMOTE_SHA:-<none>})."
-            exit 1
-          fi
-
-          echo "Tag ${VERSION} updated to ${LOCAL_SHA} and verified on origin."
 
       - name: Clean up SSH keys
         run: |


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Use `git commit --amend --no-edit` for tag commit

- Add `--force-with-lease` to push branch

- Remove remote tag SHA verification block


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>add-tag.yml</strong><dd><code>Revise commit and tag push steps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/add-tag.yml

<ul><li>Replace commit step with <code>git commit --amend --no-edit</code><br> <li> Add <code>--force-with-lease</code> flag to <code>git push</code><br> <li> Remove local vs remote tag SHA verification steps</ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/534/files#diff-a36f7d26e0c65f69e81cd8885d8ce7e3eebc5dbaf3f32388ded64b2f4812c705">+2/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

