### PR TITLE
fix(aihub): Rename last_updated to updated_at in NamespaceEntity

### DIFF
--- a/aihub_lib/aihub_lib/persistence/rag/datalake/entities/NamespaceEntity.py
+++ b/aihub_lib/aihub_lib/persistence/rag/datalake/entities/NamespaceEntity.py
@@ -65,7 +65,7 @@ class NamespaceEntity(Document):
             display_name=display_name,
             description=description,
             created_at=current_time,
-            last_updated=current_time,
+            updated_at=current_time,
             inserted_at=current_time,
         )
         namespace.save()


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Rename `last_updated` to `updated_at` in NamespaceEntity


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NamespaceEntity.py</strong><dd><code>Rename timestamp field in NamespaceEntity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_lib/aihub_lib/persistence/rag/datalake/entities/NamespaceEntity.py

<ul><li>Updated constructor field from last_updated to updated_at<br> <li> Ensures consistency of timestamp naming</ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/536/files#diff-6c83c3ba434cea31cadae2a15cb9054993688fa8714b509de44d8ba6707ffd3b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

