### PR TITLE
fix(rag): Correct reasoning reference in rejection prompt

### DIFF
--- a/aihub_agent/aihub_agent/agents/RagAgent/RAGAgent.py
+++ b/aihub_agent/aihub_agent/agents/RagAgent/RAGAgent.py
@@ -289,7 +289,7 @@ class RAGAgent(Agent):
             messages = limited_history_without_context.limited_history + [
                 ChatMessage(
                     role=MessageRole.SYSTEM,
-                    content=PromptTemplate(t("agent.prompt.guard.reject")).format(reason=event.reasoning),
+                    content=PromptTemplate(t("agent.prompt.guard.reject")).format(reason=event.reason),
                 ),
             ]
         else:


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replace incorrect `event.reasoning` attribute


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RAGAgent.py</strong><dd><code>Correct event.reason attribute usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_agent/aihub_agent/agents/RagAgent/RAGAgent.py

- Replaced `event.reasoning` with `event.reason`


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/607/files#diff-12fcbd359ba03e632e821a09da139b97f6f3595737a5fb1329f0a904ddf534f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

