### PR TITLE
fix(aihub): Auto-correct missing 's3://' prefix in S3 URI

### DIFF
--- a/aihub_pipeline/aihub_pipeline/resources/data_lake/s3/S3DataLakeClient.py
+++ b/aihub_pipeline/aihub_pipeline/resources/data_lake/s3/S3DataLakeClient.py
@@ -80,10 +80,18 @@ class S3DataLakeClient(AbstractDataLakeClient):
 
     def create_data_lake_file_from_uri(self, document_uri: str) -> DataLakeFile:
         """Create a DataLakeFile from S3 URI by fetching object metadata."""
-        # Auto-correct URI if missing s3:// prefix
         if not document_uri.startswith("s3://"):
-            logger.warning(f"URI missing 's3://' prefix: {document_uri}. Auto-correcting.")
-            document_uri = "s3://" + document_uri
+            uri_without_leading_slash = document_uri.lstrip("/")
+
+            if uri_without_leading_slash.startswith(f"{self.container_name}/"):
+                logger.warning(f"URI missing 's3://' prefix: {document_uri}. Auto-correcting.")
+                document_uri = f"s3://{uri_without_leading_slash}"
+            else:
+                raise ValueError(
+                    f"Invalid S3 URI format or bucket mismatch: {document_uri}. "
+                    f"Expected format: 's3://{self.container_name}/path/to/file', "
+                    f"'{self.container_name}/path/to/file', or '/{self.container_name}/path/to/file'"
+                )
 
         # Extract key from s3://bucket/key format
         uri_parts = document_uri[5:].split("/", 1)  # Remove 's3://' and split

--- a/aihub_pipeline/aihub_pipeline/resources/data_lake/s3/S3DataLakeClient.py
+++ b/aihub_pipeline/aihub_pipeline/resources/data_lake/s3/S3DataLakeClient.py
@@ -80,9 +80,10 @@ class S3DataLakeClient(AbstractDataLakeClient):
 
     def create_data_lake_file_from_uri(self, document_uri: str) -> DataLakeFile:
         """Create a DataLakeFile from S3 URI by fetching object metadata."""
-        # Parse S3 URI to get key
+        # Auto-correct URI if missing s3:// prefix
         if not document_uri.startswith("s3://"):
-            raise ValueError(f"Invalid S3 URI format: {document_uri}")
+            logger.warning(f"URI missing 's3://' prefix: {document_uri}. Auto-correcting.")
+            document_uri = "s3://" + document_uri
 
         # Extract key from s3://bucket/key format
         uri_parts = document_uri[5:].split("/", 1)  # Remove 's3://' and split

--- a/aihub_pipeline/aihub_pipeline/resources/data_lake/s3/S3DataLakeClient.py
+++ b/aihub_pipeline/aihub_pipeline/resources/data_lake/s3/S3DataLakeClient.py
@@ -81,16 +81,14 @@ class S3DataLakeClient(AbstractDataLakeClient):
     def create_data_lake_file_from_uri(self, document_uri: str) -> DataLakeFile:
         """Create a DataLakeFile from S3 URI by fetching object metadata."""
         if not document_uri.startswith("s3://"):
-            uri_without_leading_slash = document_uri.lstrip("/")
-
-            if uri_without_leading_slash.startswith(f"{self.container_name}/"):
+            if document_uri.startswith(f"{self.container_name}/"):
                 logger.warning(f"URI missing 's3://' prefix: {document_uri}. Auto-correcting.")
-                document_uri = f"s3://{uri_without_leading_slash}"
+                document_uri = f"s3://{document_uri}"
             else:
                 raise ValueError(
                     f"Invalid S3 URI format or bucket mismatch: {document_uri}. "
-                    f"Expected format: 's3://{self.container_name}/path/to/file', "
-                    f"'{self.container_name}/path/to/file', or '/{self.container_name}/path/to/file'"
+                    f"Expected format: 's3://{self.container_name}/path/to/file' or "
+                    f"'{self.container_name}/path/to/file'"
                 )
 
         # Extract key from s3://bucket/key format


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Auto-correct missing `s3://` URI prefix  

- Log a warning instead of raising error  

- Preserve existing S3 key extraction logic


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>S3DataLakeClient.py</strong><dd><code>Add auto-correction for missing s3 prefix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_pipeline/aihub_pipeline/resources/data_lake/s3/S3DataLakeClient.py

<ul><li>Replaced strict <code>ValueError</code> with auto-correction logic  <br> <li> Added warning log when prefix is missing  <br> <li> Prepended <code>s3://</code> to URIs lacking it  <br> <li> Kept downstream S3 key parsing unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/622/files#diff-1e2fa4e0f8ee67a8e770969602bf7d92d63d49865af644eb4c53b13513fed53b">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

