### PR TITLE
fix(aihub): Accept also uri without s3:// prefix in handle output

### DIFF
--- a/aihub_pipeline/aihub_pipeline/io/S3DataLakeIOManager.py
+++ b/aihub_pipeline/aihub_pipeline/io/S3DataLakeIOManager.py
@@ -99,17 +99,17 @@ class S3DataLakeIOManager(ConfigurableIOManager):
                 context.log.error(f"No content found for file {data_lake_file.uri}. Cannot write to S3.")
                 raise ValueError(f"No content to write for file {data_lake_file.uri}.")
 
-            # Parse S3 URI to get bucket and key
-            if not data_lake_file.uri.startswith("s3://"):
-                context.log.error(f"Invalid S3 URI: {data_lake_file.uri}")
-                raise ValueError(f"URI must start with 's3://': {data_lake_file.uri}")
+            uri = data_lake_file.uri
+            if uri.startswith("s3://"):
+                path = uri[5:]
+            else:
+                path = uri.lstrip("/")
 
-            # Remove s3:// prefix and split into bucket and key
-            s3_path = data_lake_file.uri[5:]  # Remove 's3://'
-            parts = s3_path.split("/", 1)
+            # Split into bucket and key
+            parts = path.split("/", 1)
             if len(parts) != 2:
-                context.log.error(f"Invalid S3 URI format: {data_lake_file.uri}")
-                raise ValueError(f"Invalid S3 URI format: {data_lake_file.uri}")
+                context.log.error(f"Invalid S3 URI format: {uri}")
+                raise ValueError(f"Invalid S3 URI format: {uri}")
 
             bucket_name = parts[0]
             object_key = parts[1]
@@ -131,7 +131,7 @@ class S3DataLakeIOManager(ConfigurableIOManager):
             # Write the content to S3 with metadata using put_object
             self.data_lake_client.raw_client.put_object(**put_params)
 
-            context.log.info(f"Successfully wrote file {data_lake_file.uri} to S3.")
+            context.log.info(f"Successfully wrote file s3://{bucket_name}/{object_key} to S3.")
 
     def load_input(self, context: InputContext) -> DataLakeFile | list[DataLakeFile]:
         if context.has_partition_key:

--- a/aihub_pipeline/aihub_pipeline/io/S3DataLakeIOManager.py
+++ b/aihub_pipeline/aihub_pipeline/io/S3DataLakeIOManager.py
@@ -99,17 +99,13 @@ class S3DataLakeIOManager(ConfigurableIOManager):
                 context.log.error(f"No content found for file {data_lake_file.uri}. Cannot write to S3.")
                 raise ValueError(f"No content to write for file {data_lake_file.uri}.")
 
-            uri = data_lake_file.uri
-            if uri.startswith("s3://"):
-                path = uri[5:]
-            else:
-                path = uri.lstrip("/")
+            path = data_lake_file.uri.removeprefix("s3://").lstrip("/")
 
             # Split into bucket and key
             parts = path.split("/", 1)
             if len(parts) != 2:
-                context.log.error(f"Invalid S3 URI format: {uri}")
-                raise ValueError(f"Invalid S3 URI format: {uri}")
+                context.log.error(f"Invalid S3 URI format: {data_lake_file.uri}")
+                raise ValueError(f"Invalid S3 URI format: {data_lake_file.uri}")
 
             bucket_name = parts[0]
             object_key = parts[1]

--- a/aihub_pipeline/aihub_pipeline/resources/data_lake/s3/S3DataLakeClient.py
+++ b/aihub_pipeline/aihub_pipeline/resources/data_lake/s3/S3DataLakeClient.py
@@ -92,7 +92,7 @@ class S3DataLakeClient(AbstractDataLakeClient):
                 )
 
         # Extract key from s3://bucket/key format
-        uri_parts = document_uri[5:].split("/", 1)  # Remove 's3://' and split
+        uri_parts = document_uri.removeprefix("s3://").split("/", 1)
         if len(uri_parts) != 2:
             raise ValueError(f"Invalid S3 URI format: {document_uri}")
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Accept URIs with or without s3 prefix

- Normalize path by stripping prefix or slash

- Update error logs to use normalized `uri`

- Log success with full s3:// bucket/key path


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DataLakeFile.uri"] -- "starts with s3://" --> B["Strip 's3://' prefix"]
  A -- "otherwise" --> C["Strip leading slash"]
  B --> D["Split into bucket and key"]
  C --> D
  D --> E["Put object to S3"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>S3DataLakeIOManager.py</strong><dd><code>Support non-prefixed URIs parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_pipeline/aihub_pipeline/io/S3DataLakeIOManager.py

<ul><li>Allow URIs with or without 's3://' prefix.<br> <li> Strip prefix or leading slash before splitting.<br> <li> Use local <code>uri</code> for error logging.<br> <li> Log success with reconstructed s3 path.</ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/635/files#diff-a6d961bb54c899c01dd1548b28005a30d90eef53276916c4c94a86f2007aefef">+11/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

