### PR TITLE
fix(aihub): Switch how files are read from fs

### DIFF
--- a/aihub_lib/aihub_lib/generative_ai/document/loaders/DoclingLoader.py
+++ b/aihub_lib/aihub_lib/generative_ai/document/loaders/DoclingLoader.py
@@ -69,8 +69,8 @@ class DoclingLoader(BaseReader):
         )
 
     def _read_file_sync(self, fs: AbstractFileSystem, file: str) -> str:
-        with fs.open(file, "rb") as pdf_file:
-            return base64.b64encode(pdf_file.read()).decode("utf-8")
+        file_content = fs.cat_file(file)
+        return base64.b64encode(file_content).decode("utf-8")
 
     def _process_docling_response(
         self,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Use fs.cat_file instead of fs.open

- Simplify synchronous file reading logic


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DoclingLoader.py</strong><dd><code>Use fs.cat_file for synchronous file reading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_lib/aihub_lib/generative_ai/document/loaders/DoclingLoader.py

<ul><li>Replaced <code>fs.open(file, "rb")</code> with <code>fs.cat_file(file)</code><br> <li> Removed file context manager usage<br> <li> Continued Base64 encoding of file content</ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/662/files#diff-5566a6bfaad636431851429ad3e228268570fcea9410c28269945f247e57b564">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

