### PR TITLE
fix(aihub): Update workflow to use `docs:build:ci`

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Build documentation
         working-directory: ./aihub_doc
-        run: pnpm run docs:build
+        run: pnpm run docs:build:ci
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/aihub_doc/package.json
+++ b/aihub_doc/package.json
@@ -9,6 +9,7 @@
     "docs:sync": "bash sync-docs.sh",
     "docs:translate": "bash translate-docs.sh",
     "docs:build": "bash sync-docs.sh && node generate-llm-files.mjs && bash translate-docs.sh && vitepress build",
+    "docs:build:ci": "bash sync-docs.sh && node generate-llm-files.mjs && vitepress build",
     "docs:preview": "vitepress preview"
   },
   "keywords": [],


### PR DESCRIPTION
### **User description**
…ilds


___

### **PR Type**
Enhancement


___

### **Description**
- Add `docs:build:ci` script for CI documentation builds

- Update GitHub Actions workflow to use new CI script


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy-docs.yml</strong><dd><code>Switch CI docs build command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy-docs.yml

<ul><li>Updated "Build documentation" step's run command<br> <li> Switched from <code>pnpm run docs:build</code> to <code>pnpm run docs:build:ci</code></ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/684/files#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add CI-only documentation build script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_doc/package.json

<ul><li>Added <code>docs:build:ci</code> script without translation step<br> <li> Kept existing <code>docs:build</code> script unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/684/files#diff-09b04ede8e745a32f499b2dd1f447af15eab7b7f9e2317a773dc240ebae32f85">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

