### PR TITLE
fix(aihub): Increased HTTP client connect timeout to 30s

### DIFF
--- a/aihub_lib/aihub_lib/auth/dependencies/OAuth2AuthHandler/OAuth2AuthHandler.py
+++ b/aihub_lib/aihub_lib/auth/dependencies/OAuth2AuthHandler/OAuth2AuthHandler.py
@@ -63,7 +63,8 @@ class OAuth2AuthHandler(AuthHandler):
 
         try:
             logger.debug("JWKS cache miss, fetching from %s", OAuth2Settings().JWKS_URL)
-            async with httpx.AsyncClient(timeout=httpx.Timeout(10.0, connect=5.0, read=10.0)) as client:
+            # Increased connect timeout to 30s to allow IPv6 failures to fall back to IPv4
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=30.0, read=10.0)) as client:
                 jwks_response = await client.get(OAuth2Settings().JWKS_URL)
                 jwks_response.raise_for_status()
                 jwks = jwks_response.json()

--- a/aihub_lib/aihub_lib/auth/identity/AzureIdentityProvider/AzureGraphService.py
+++ b/aihub_lib/aihub_lib/auth/identity/AzureIdentityProvider/AzureGraphService.py
@@ -75,7 +75,9 @@ class AzureGraphService:
             **kwargs.pop("headers", {}),
         }
 
-        async with httpx.AsyncClient() as client:
+        # Increased connect timeout to 30s to allow IPv6 failures to fall back to IPv4
+        timeout = httpx.Timeout(30.0, connect=30.0, read=10.0)
+        async with httpx.AsyncClient(timeout=timeout) as client:
             response = await client.request(method, url, headers=headers, **kwargs)
 
         # Handle binary content (e.g., images) separately


### PR DESCRIPTION
### **User description**
to handle IPv6 fallback to IPv4.


___

### **PR Type**
Bug fix


___

### **Description**
- Increase HTTP client connect timeout to 30s

- Apply change in OAuth2AuthHandler and AzureGraphService


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OAuth2AuthHandler.py</strong><dd><code>Increase OAuth2 JWKS client timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_lib/aihub_lib/auth/dependencies/OAuth2AuthHandler/OAuth2AuthHandler.py

<ul><li>Updated httpx.AsyncClient timeout for JWKS fetch<br> <li> Increased connect timeout from 5s to 30s</ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/694/files#diff-707cddc8a098e5ab85d937670877357af1520aac4e7a5399efce83ddb0179e29">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AzureGraphService.py</strong><dd><code>Increase Azure Graph client timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_lib/aihub_lib/auth/identity/AzureIdentityProvider/AzureGraphService.py

<ul><li>Added timeout parameters to httpx.AsyncClient<br> <li> Increased connect timeout to 30s for graph requests</ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/694/files#diff-eb97d039b68e8b4d4d84c3ef5df41004385871d5d3a036041250e69016eff328">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

