### PR TITLE
fix(aihub): Namespace validation and other minor fixes

### DIFF
--- a/aihub_api/aihub_api/runners/lifetime/initialize_db.py
+++ b/aihub_api/aihub_api/runners/lifetime/initialize_db.py
@@ -34,7 +34,7 @@ async def initialize_roles() -> None:
     if AIHubSettings().CREATE_DEFAULT_ROLES:
         await initialize_role(
             name="AIHubUser",
-            description="Grants global administrative access to AI-Hub",
+            description="Grants global user access to AI-Hub",
             access_rules=["aihub.user.>"],
         )
         await initialize_role(

--- a/aihub_api/aihub_api/services/TranslationService.py
+++ b/aihub_api/aihub_api/services/TranslationService.py
@@ -1,10 +1,10 @@
 import logging
 
-from aihub_lib.generative_ai.resources.models.llm.LiteLLMBase import OpenAILike
 from aihub_lib.generative_ai.resources.models.llm.LLMConfig import LLMConfig
 from aihub_lib.i18n.LocaleHandler import LocaleHandler
 from aihub_lib.i18n.LocaleString import LocaleString
 from llama_index.core import PromptTemplate
+from llama_index.llms.openai_like import OpenAILike
 
 logger = logging.getLogger(__name__)
 

--- a/aihub_bot/aihub_bot/setup_azure_bot.py
+++ b/aihub_bot/aihub_bot/setup_azure_bot.py
@@ -186,8 +186,6 @@ def save_credentials_in_mongo(
     print("Credentials successfully saved in MongoDB.")
 
 
-
-
 def main():
     parser = argparse.ArgumentParser(
         description="Set up an Azure Bot using the Azure CLI by creating an Azure AD app "

--- a/aihub_lib/aihub_lib/persistence/rag/datalake/entities/NamespaceEntity.py
+++ b/aihub_lib/aihub_lib/persistence/rag/datalake/entities/NamespaceEntity.py
@@ -1,3 +1,4 @@
+import re
 import time
 
 from bson import ObjectId
@@ -31,9 +32,21 @@ class NamespaceEntity(Document):
     inserted_at = IntField(required=True)
 
     @staticmethod
-    def _validate_name(name: str, field_name: str) -> None:
+    def _validate_namespace_name(name: str) -> None:
         if not name:
-            raise ValidationError(f"{field_name} cannot be empty")
+            raise ValidationError("namespace_name cannot be empty")
+        if not re.match(r"^[a-zA-Z0-9_-]+$", name):
+            raise ValidationError("namespace_name can only contain alphanumeric characters, hyphens, and underscores")
+
+    @staticmethod
+    def _validate_folder_name(name: str) -> None:
+        if not name:
+            raise ValidationError("folder_name cannot be empty")
+
+    @staticmethod
+    def _sanitize_namespace_name(name: str) -> str:
+        """Sanitize namespace name to only contain alphanumeric, hyphens, and underscores."""
+        return re.sub(r"[^a-zA-Z0-9_-]", "_", name)
 
     @classmethod
     def create_namespace(
@@ -45,16 +58,17 @@ class NamespaceEntity(Document):
         description: LocaleStringEntity | None = None,
         namespace_id: ObjectId | None = None,
     ) -> "NamespaceEntity":
-        cls._validate_name(namespace_name, "namespace_name")
+        sanitized_namespace_name = cls._sanitize_namespace_name(namespace_name)
+        cls._validate_namespace_name(sanitized_namespace_name)
 
         resolved_folder_name = folder_name or namespace_name
-        cls._validate_name(resolved_folder_name, "folder_name")
+        cls._validate_folder_name(resolved_folder_name)
 
         current_time = int(time.time())
         namespace = cls(
             id=namespace_id or ObjectId(),
             bucket_id=bucket_id,
-            namespace_name=namespace_name,
+            namespace_name=sanitized_namespace_name,
             folder_name=resolved_folder_name,
             display_name=display_name,
             description=description,
@@ -100,15 +114,13 @@ class NamespaceEntity(Document):
         display_name: LocaleStringEntity | None = None,
         description: LocaleStringEntity | None = None,
     ) -> "NamespaceEntity":
-        if namespace_name:
-            cls._validate_name(namespace_name, "namespace_name")
-        if folder_name:
-            cls._validate_name(folder_name, "folder_name")
-
         namespace = cls.get_namespace_by_id(namespace_id)
         if namespace_name:
-            namespace.namespace_name = namespace_name
+            sanitized_namespace_name = cls._sanitize_namespace_name(namespace_name)
+            cls._validate_namespace_name(sanitized_namespace_name)
+            namespace.namespace_name = sanitized_namespace_name
         if folder_name:
+            cls._validate_folder_name(folder_name)
             namespace.folder_name = folder_name
         if display_name:
             namespace.display_name = display_name

--- a/aihub_pipeline/aihub_pipeline/util/definitions_util.py
+++ b/aihub_pipeline/aihub_pipeline/util/definitions_util.py
@@ -96,10 +96,10 @@ def default_definitions(
     """
     document_partitions = DynamicPartitionsDefinition(name="document_partitions")
 
-    data_lake_key = AssetKey([datalake_container_name, "data_lake"])
-    document_key = AssetKey([datalake_container_name, "documents"])
-    nodes_key = AssetKey([datalake_container_name, "nodes"])
-    removed_documents_key = AssetKey([datalake_container_name, "removed_documents"])
+    data_lake_key = AssetKey([datalake_container_name, "datalake_to_vectorstore", "data_lake"])
+    document_key = AssetKey([datalake_container_name, "datalake_to_vectorstore", "documents"])
+    nodes_key = AssetKey([datalake_container_name, "datalake_to_vectorstore", "nodes"])
+    removed_documents_key = AssetKey([datalake_container_name, "datalake_to_vectorstore", "removed_documents"])
 
     observable_asset = observable_data_lake_factory(data_lake_key, document_partitions)
     assets = [
@@ -196,9 +196,11 @@ def default_sharepoint_to_datalake_definitions(
     """
     sharepoint_partitions = DynamicPartitionsDefinition(name="sharepoint_partitions")
 
-    sharepoint_key = AssetKey([datalake_container_name, "sharepoint"])
-    data_lake_files_key = AssetKey([datalake_container_name, "data_lake_files"])
-    removed_data_lake_files_key = AssetKey([datalake_container_name, "removed_data_lake_files"])
+    sharepoint_key = AssetKey([datalake_container_name, "sharepoint_to_datalake", "sharepoint"])
+    data_lake_files_key = AssetKey([datalake_container_name, "sharepoint_to_datalake", "data_lake_files"])
+    removed_data_lake_files_key = AssetKey(
+        [datalake_container_name, "sharepoint_to_datalake", "removed_data_lake_files"]
+    )
 
     observable_sharepoint_asset = observable_share_point_factory(sharepoint_key, sharepoint_partitions)
 
@@ -291,9 +293,9 @@ def default_local_filesystem_to_datalake_definitions(
     """
     filesystem_partitions = DynamicPartitionsDefinition(name="local_fs_partitions")
 
-    filesystem_key = AssetKey([datalake_container_name, "local_fs"])
-    data_lake_files_key = AssetKey([datalake_container_name, "data_lake_files"])
-    removed_data_lake_files_key = AssetKey([datalake_container_name, "removed_data_lake_files"])
+    filesystem_key = AssetKey([datalake_container_name, "local_fs_to_datalake", "local_fs"])
+    data_lake_files_key = AssetKey([datalake_container_name, "local_fs_to_datalake", "data_lake_files"])
+    removed_data_lake_files_key = AssetKey([datalake_container_name, "local_fs_to_datalake", "removed_data_lake_files"])
 
     observable_filesystem_asset = observable_local_file_system_factory(filesystem_key, filesystem_partitions)
 

--- a/aihub_pipeline/aihub_pipeline/util/definitions_util.py
+++ b/aihub_pipeline/aihub_pipeline/util/definitions_util.py
@@ -295,7 +295,9 @@ def default_local_filesystem_to_datalake_definitions(
 
     filesystem_key = AssetKey([datalake_container_name, "local_fs_to_datalake", "local_fs"])
     data_lake_files_key = AssetKey([datalake_container_name, "local_fs_to_datalake", "data_lake_files"])
-    removed_data_lake_files_key = AssetKey([datalake_container_name, "local_fs_to_datalake", "removed_data_lake_files"])
+    removed_data_lake_files_key = AssetKey(
+        [datalake_container_name, "local_fs_to_datalake", "removed_data_lake_files"]
+    )
 
     observable_filesystem_asset = observable_local_file_system_factory(filesystem_key, filesystem_partitions)
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add namespace sanitization and validation logic

- Prefix asset keys with pipeline stage prefixes

- Fix OpenAILike import path

- Update default role description and formatting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Raw namespace name"] --> B["Sanitize name"]
  B --> C["Validate sanitized name"]
  C --> D["Persist to DB"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>initialize_db.py</strong><dd><code>Update AIHubUser role description</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_api/aihub_api/runners/lifetime/initialize_db.py

- Updated `AIHubUser` role description text


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/721/files#diff-80f922e0e440dca69db7cbc0a2fd8e90e4d85c6bdc8bf880f4bd78891b9644e8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TranslationService.py</strong><dd><code>Correct OpenAILike import source</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_api/aihub_api/services/TranslationService.py

- Changed import path for `OpenAILike`


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/721/files#diff-7573dfacb94d087488dfff6de444ddc2d4bdaf4d8d452b41c8637ae3f721a56a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setup_azure_bot.py</strong><dd><code>Remove redundant blank lines</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_bot/aihub_bot/setup_azure_bot.py

- Removed extra blank lines before `main` function


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/721/files#diff-792e972d91dcb94af4291c7753383e0fa3907cadd39d5ad0bc0eb8c7511a3d04">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NamespaceEntity.py</strong><dd><code>Sanitize and validate namespace names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_lib/aihub_lib/persistence/rag/datalake/entities/NamespaceEntity.py

<ul><li>Added regex import and sanitize method<br> <li> Introduced namespace and folder name validators<br> <li> Updated create/update to sanitize and validate names</ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/721/files#diff-6c83c3ba434cea31cadae2a15cb9054993688fa8714b509de44d8ba6707ffd3b">+23/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>definitions_util.py</strong><dd><code>Prefix asset keys with pipeline names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_pipeline/aihub_pipeline/util/definitions_util.py

- Prefixed `AssetKey` paths with pipeline stage identifiers


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/721/files#diff-8e9ed7c0751824d8e55b3de0787517e743544a7dcd6fef467841d370703b985f">+12/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

