### PR TITLE
fix(aihub): Filter data versions by existing partitions

### DIFF
--- a/aihub_pipeline/aihub_pipeline/ops/data_lake/data_version_by_partition_for_data_lake_files.py
+++ b/aihub_pipeline/aihub_pipeline/ops/data_lake/data_version_by_partition_for_data_lake_files.py
@@ -52,6 +52,12 @@ def data_version_by_partition_for_data_lake_files_no_op(
     # Hence, when the issue is resolved, we can wipe the materialized asset when we delete it and hence
     # get rid of the need to incorporate the updated timestamp into the version key, as dagster will "forget"
     # that the asset ever existed and re-process it when it is encountered again.
+    existing_partitions = set(context.instance.get_dynamic_partitions(partition.name))
+    files_with_partitions = [f for f in data_lake_files if f.uri in existing_partitions]
+
     return DataVersionsByPartition(
-        {data_lake_file.uri: f"{data_lake_file.updated}-{data_lake_file.hash}" for data_lake_file in data_lake_files}
+        {
+            data_lake_file.uri: f"{data_lake_file.updated}-{data_lake_file.hash}"
+            for data_lake_file in files_with_partitions
+        }
     )

--- a/aihub_pipeline/aihub_pipeline/ops/data_lake/data_version_by_partition_for_data_lake_files.py
+++ b/aihub_pipeline/aihub_pipeline/ops/data_lake/data_version_by_partition_for_data_lake_files.py
@@ -53,7 +53,7 @@ def data_version_by_partition_for_data_lake_files_no_op(
     # get rid of the need to incorporate the updated timestamp into the version key, as dagster will "forget"
     # that the asset ever existed and re-process it when it is encountered again.
     existing_partitions = set(context.instance.get_dynamic_partitions(partition.name))
-    files_with_partitions = [f for f in data_lake_files if f.uri in existing_partitions]
+    files_with_partitions = [data_lake_file for data_lake_file in data_lake_files if data_lake_file.uri in existing_partitions]
 
     return DataVersionsByPartition(
         {

--- a/aihub_pipeline/aihub_pipeline/ops/local_file_system/data_version_by_partition_for_local_files.py
+++ b/aihub_pipeline/aihub_pipeline/ops/local_file_system/data_version_by_partition_for_local_files.py
@@ -54,8 +54,8 @@ def data_version_by_partition_for_local_files(
     # it will be detected as a new version and trigger reprocessing
     # Using Unix timestamp (int) for consistent string representation, matching DataLake pipeline pattern
     existing_partitions = set(context.instance.get_dynamic_partitions(partition.name))
-    files_with_partitions = [file for file in local_files if file.path in existing_partitions]
+    files_with_partitions = [local_file for local_file in local_files if local_file.path in existing_partitions]
 
     return DataVersionsByPartition(
-        {file.path: f"{file.modified}-{file.size}" for file in files_with_partitions}  # Only files with partitions
+        {local_file.path: f"{local_file.modified}-{local_file.size}" for local_file in files_with_partitions}  # Only files with partitions
     )

--- a/aihub_pipeline/aihub_pipeline/ops/local_file_system/data_version_by_partition_for_local_files.py
+++ b/aihub_pipeline/aihub_pipeline/ops/local_file_system/data_version_by_partition_for_local_files.py
@@ -53,4 +53,9 @@ def data_version_by_partition_for_local_files(
     # This ensures that if a file is deleted and re-uploaded with the same content,
     # it will be detected as a new version and trigger reprocessing
     # Using Unix timestamp (int) for consistent string representation, matching DataLake pipeline pattern
-    return DataVersionsByPartition({file.path: f"{file.modified}-{file.size}" for file in local_files})
+    existing_partitions = set(context.instance.get_dynamic_partitions(partition.name))
+    files_with_partitions = [file for file in local_files if file.path in existing_partitions]
+
+    return DataVersionsByPartition(
+        {file.path: f"{file.modified}-{file.size}" for file in files_with_partitions}  # Only files with partitions
+    )

--- a/aihub_pipeline/aihub_pipeline/ops/share_point/data_version_by_partition_for_share_point_files_no_op.py
+++ b/aihub_pipeline/aihub_pipeline/ops/share_point/data_version_by_partition_for_share_point_files_no_op.py
@@ -46,9 +46,15 @@ def data_version_by_partition_for_share_point_files_no_op(
     # Using both etag and modified timestamp provides robust change detection:
     # - etag changes on any file modification (content or metadata)
     # - modified timestamp provides additional temporal context
+
+    existing_partitions = set(context.instance.get_dynamic_partitions(partition.name))
+    files_with_partitions = [
+        share_point_file for share_point_file in share_point_files if share_point_file.id in existing_partitions
+    ]
+
     return DataVersionsByPartition(
         {
             share_point_file.id: f"{share_point_file.modified}-{share_point_file.etag}"
-            for share_point_file in share_point_files
+            for share_point_file in files_with_partitions
         }
     )


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Filter versions by existing dynamic partitions

- Add partition retrieval via get_dynamic_partitions

- Restrict version mapping to filtered files

- Apply across DataLake, LocalFS, and SharePoint ops


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Retrieve existing dynamic partitions"] --> B["Filter input files"]
  B -- "Only include existing partitions" --> C["Generate DataVersionsByPartition"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data_version_by_partition_for_data_lake_files.py</strong><dd><code>Filter DataLake files by partitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_pipeline/aihub_pipeline/ops/data_lake/data_version_by_partition_for_data_lake_files.py

<ul><li>Retrieve existing dynamic partitions via context.instance<br> <li> Filter data_lake_files by uri in partitions<br> <li> Limit version mapping to filtered files</ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/815/files#diff-e5958cf0fceddc7971ba51b8611ebf02d45a576dd6391d71120fa2d0cd802a44">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>data_version_by_partition_for_local_files.py</strong><dd><code>Filter local files by partitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_pipeline/aihub_pipeline/ops/local_file_system/data_version_by_partition_for_local_files.py

<ul><li>Retrieve existing dynamic partitions via context.instance<br> <li> Filter local_files by path in partitions<br> <li> Return versions only for filtered files</ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/815/files#diff-795665ebffbbba6232956e57024df118890cad3bd54892d98c4f42f4e4938e03">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>data_version_by_partition_for_share_point_files_no_op.py</strong><dd><code>Filter SharePoint files by partitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_pipeline/aihub_pipeline/ops/share_point/data_version_by_partition_for_share_point_files_no_op.py

<ul><li>Retrieve existing dynamic partitions via context.instance<br> <li> Filter share_point_files by id in partitions<br> <li> Return versions only for filtered files</ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/815/files#diff-2c0a220d2539db61be98e1bd34962167cf3d34074a52993fefd5d9bd7bc34adb">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

