### PR TITLE
fix(rag): Put context messages after chat history

### DIFF
--- a/aihub_lib/aihub_lib/generative_ai/utils/limit_chat_history_with_context.py
+++ b/aihub_lib/aihub_lib/generative_ai/utils/limit_chat_history_with_context.py
@@ -33,8 +33,8 @@ def limit_chat_history_with_context(
 
     final_messages = [
         *system_messages,
-        *context_messages,
         *limited_history,
+        *context_messages,
         last_user_message,
     ]
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Reorder context messages after limited history

- Ensure context follows truncated chat history


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>limit_chat_history_with_context.py</strong><dd><code>Reorder context after limited history</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_lib/aihub_lib/generative_ai/utils/limit_chat_history_with_context.py

<ul><li>Swapped <code>context_messages</code> and <code>limited_history</code> order<br> <li> Moved context messages to after truncated history</ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/822/files#diff-ce8b392f004e50b6405d4747d66218e9db32e8bc0c49f73ea3f3dbca83ff76b7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

