### PR TITLE
feat(knowledge): Add document delete functionality

### DIFF
--- a/aihub_api/aihub_api/routes/knowledge/KnowledgeController.py
+++ b/aihub_api/aihub_api/routes/knowledge/KnowledgeController.py
@@ -289,3 +289,40 @@ class KnowledgeController(Controller):
             return KnowledgeService.get_supported_file_types()
 
         return self
+
+    def delete_document(
+        self, route: str = "/databases/{database}/namespaces/{namespace}/documents/{document_id}"
+    ) -> "KnowledgeController":
+        @self.router.delete(route, tags=self.tags, summary="Delete a document")
+        async def delete_document(
+            database: Annotated[str, Path(title="Database name", pattern=r"^[a-zA-Z0-9][a-zA-Z0-9 _\-]*$")],
+            namespace: Annotated[str, Path(title="Namespace", pattern=r"^[a-zA-Z0-9][a-zA-Z0-9 _\-]*$")],
+            document_id: Annotated[str, Path(title="Document ID")],
+            nc: Annotated[NATS, Depends(use_nats)],
+            _: Annotated[
+                UserIdentity, Security(self.user_with_permission("aihub.admin.knowledge.{database}.{namespace}"))
+            ],
+        ) -> dict[str, bool]:
+            """
+            Deletes a document from the knowledge base.
+
+            This endpoint permanently removes:
+            - The document from the vector store (Milvus)
+            - The document from the document store (MongoDB)
+            - The source file from the datalake (S3/MinIO)
+            - Associated figure images from the datalake
+
+            Requires admin permission for the namespace.
+            """
+            if database in ["admin", "local", "config"]:
+                raise HTTPException(status_code=403, detail="Not authorized to modify this database")
+            await KnowledgeService.delete_document(
+                nc=nc,
+                database=database,
+                namespace=namespace,
+                document_id=document_id,
+                vector_store_factory=self.vector_store_factory,
+            )
+            return {"success": True}
+
+        return self

--- a/aihub_api/aihub_api/routes/knowledge/KnowledgeService.py
+++ b/aihub_api/aihub_api/routes/knowledge/KnowledgeService.py
@@ -9,11 +9,12 @@ from aihub_lib.generative_ai.document.accessor.S3AnonymousFileAccessService impo
 from aihub_lib.generative_ai.document.types.FileTypeConfig import FileTypeConfig
 from aihub_lib.generative_ai.document.types.IngestedNode import IngestedNode
 from aihub_lib.generative_ai.resources.models.llm.LLMConfig import LLMConfig
-from aihub_lib.generative_ai.utils.path_utils import FIGURES_DIRECTORY_NAME
+from aihub_lib.generative_ai.utils.path_utils import FIGURES_DIRECTORY_NAME, create_figures_folder_name
 from aihub_lib.i18n.LocaleHandler import LocaleHandler
 from aihub_lib.i18n.LocaleString import LocaleString
 from aihub_lib.infrastructure.mongo.MongoSettings import MongoSettings
 from aihub_lib.infrastructure.opentelemetry.tracing.decorators.trace_fn import trace_fn
+from aihub_lib.nats.events.pipeline.SourceDeletedEvent import SourceDeletedEvent
 from aihub_lib.nats.events.pipeline.SourceUpdatedEvent import SourceUpdatedEvent
 from aihub_lib.nats.publishers.NCPublisher import NCPublisher
 from aihub_lib.nats.topic_managers.pipeline.PipelineInstanceTopicManager import PipelineInstanceTopicManager
@@ -517,3 +518,142 @@ class KnowledgeService:
     @staticmethod
     def get_supported_file_types() -> list[str]:
         return FileTypeConfig().get_unique_extensions()
+
+    @staticmethod
+    @trace_fn
+    async def _publish_source_deleted_event(
+        nc: Annotated[NATS, Field(description="NATS client connection")],
+        database: Annotated[str, Field(description="Target knowledge database name")],
+        container: Annotated[str, Field(description="Container/bucket name")],
+        file_path: Annotated[str, Field(description="Path to the deleted file")],
+        document_id: Annotated[str | None, Field(description="Document ID if known")] = None,
+    ) -> None:
+        """
+        Publishes a SourceDeletedEvent to NATS when a file is deleted.
+
+        This event can be used for observability and downstream cleanup operations.
+        """
+        topic_manager = PipelineInstanceTopicManager(
+            source_type="datalake",
+            source_id=container,
+            target_type="knowledge",
+            target_id=database,
+        )
+
+        event = SourceDeletedEvent(path=file_path, document_id=document_id)
+        subject = topic_manager.get_subject_for_specific_event_in_pipeline_instance(
+            run_key=event.event_id,
+            event_name=event.event_name,
+            event_id=event.event_id,
+        )
+
+        publisher = NCPublisher(name="KnowledgeService", nc=nc)
+        await publisher.publish_event(event, subject)
+
+        logger.info(f"Published SourceDeletedEvent for file {file_path} to subject {subject}")
+
+    @staticmethod
+    @trace_fn
+    async def delete_document(
+        nc: NATS,
+        database: str,
+        namespace: str,
+        document_id: str,
+        vector_store_factory: VectorStoreFactory,
+    ) -> bool:
+        """
+        Deletes a document from the knowledge base.
+
+        This method performs a complete deletion including:
+        1. Deleting nodes from the vector store (Milvus)
+        2. Deleting the RefDoc from the document store (MongoDB)
+        3. Deleting the source file from the datalake (S3)
+        4. Deleting associated figures from the datalake
+        5. Publishing a SourceDeletedEvent to NATS
+        6. Invalidating the cache
+
+        Returns True if the document was successfully deleted, False if not found.
+        """
+        KnowledgeService._ensure_db_exists(database)
+
+        # Get the document to extract its source path
+        try:
+            ref_doc = RefDoc.by_id(db_alias=database, doc_id=document_id)
+        except DoesNotExist:
+            raise HTTPException(status_code=404, detail=f"Document '{document_id}' not found")
+
+        source = ref_doc.data.metadata.source
+        doc_namespace = ref_doc.data.metadata.namespace
+
+        # Verify the document belongs to the requested namespace
+        if doc_namespace != namespace:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Document '{document_id}' does not belong to namespace '{namespace}'",
+            )
+
+        # Get bucket info for S3 operations
+        try:
+            bucket_entity = BucketEntity.get_bucket_by_db_name(database)
+        except Exception as e:
+            raise HTTPException(status_code=404, detail=f"Database '{database}' not found") from e
+
+        container = bucket_entity.bucket_name
+        s3_service = S3AnonymousFileAccessService()
+
+        # Extract file path from source (remove s3:// prefix and bucket name)
+        # Source format: s3://bucket/namespace/filename or bucket/namespace/filename
+        file_path = source.removeprefix(S3_PROTOCOL_PREFIX)
+        if file_path.startswith(f"{container}/"):
+            file_path = file_path[len(container) + 1 :]
+
+        # 1. Delete nodes from vector store
+        try:
+            vector_store = vector_store_factory(database)
+            vector_store.delete(document_id, partition_name=namespace)
+            logger.info(f"Deleted nodes for document {document_id} from vector store")
+        except Exception as e:
+            logger.warning(f"Failed to delete nodes from vector store for document {document_id}: {e}")
+            # Continue with deletion even if vector store deletion fails
+
+        # 2. Delete the RefDoc from MongoDB
+        deleted = RefDoc.delete_by_id(db_alias=database, doc_id=document_id)
+        if not deleted:
+            logger.warning(f"Document {document_id} was not found in docstore during deletion")
+
+        # 3. Delete the source file from S3
+        try:
+            s3_service.delete_file(container=container, file_path=file_path)
+            logger.info(f"Deleted file {file_path} from datalake")
+        except Exception as e:
+            logger.warning(f"Failed to delete file from datalake for document {document_id}: {e}")
+
+        # 4. Delete figures folder from S3
+        try:
+            figures_folder = create_figures_folder_name(source)
+            # Remove s3://bucket/ prefix from figures folder path
+            figures_path = figures_folder.removeprefix(S3_PROTOCOL_PREFIX)
+            if figures_path.startswith(f"{container}/"):
+                figures_path = figures_path[len(container) + 1 :]
+
+            s3_service.delete_directory(container=container, directory_path=figures_path)
+            logger.info(f"Deleted figures folder {figures_path} from datalake")
+        except Exception as e:
+            logger.debug(f"No figures folder to delete or deletion failed for document {document_id}: {e}")
+
+        # 5. Publish SourceDeletedEvent to NATS
+        try:
+            await KnowledgeService._publish_source_deleted_event(
+                nc=nc,
+                database=database,
+                container=container,
+                file_path=file_path,
+                document_id=document_id,
+            )
+        except Exception as e:
+            logger.warning(f"Failed to publish SourceDeletedEvent for document {document_id}: {e}")
+
+        # 6. Invalidate cache
+        KnowledgeService.invalidate_cache()
+
+        return True

--- a/aihub_api/app/main.py
+++ b/aihub_api/app/main.py
@@ -94,7 +94,8 @@ runner.mount(
     .get_summary_nodes_for_document()
     .initiate_document_upload()
     .validate_document_upload()
-    .get_supported_file_types(),
+    .get_supported_file_types()
+    .delete_document(),
     FileController(auth=auth).get_file_url().get_file_redirect().get_anonymous_file_url().get_anonymous_file_redirect(),
     NotificationController(auth=auth).get_notifications().update_notifications().update_notification(),
     DoclingController(auth=auth).parse_document(),

--- a/aihub_api/playground/development/main.py
+++ b/aihub_api/playground/development/main.py
@@ -103,7 +103,8 @@ async def main():
         .get_summary_nodes_for_document()
         .initiate_document_upload()
         .validate_document_upload()
-        .get_supported_file_types(),
+        .get_supported_file_types()
+        .delete_document(),
         FileController(auth=auth)
         .get_file_url()
         .get_file_redirect()

--- a/aihub_lib/aihub_lib/generative_ai/document/accessor/S3AnonymousFileAccessService.py
+++ b/aihub_lib/aihub_lib/generative_ai/document/accessor/S3AnonymousFileAccessService.py
@@ -219,3 +219,61 @@ class S3AnonymousFileAccessService:
         except Exception as e:
             logger.error(f"Failed to list files in {container} with prefix '{prefix}': {e}")
             raise Exception(f"Failed to list files: {e}")
+
+    @trace_fn
+    def delete_file(self, container: str, file_path: str) -> None:
+        """
+        Delete a file from S3/MinIO storage.
+
+        Permanently removes the specified file from the storage bucket.
+        This operation cannot be undone.
+        """
+        if not container or not container.strip():
+            raise ValueError("Container name cannot be empty")
+        if not file_path or not file_path.strip():
+            raise ValueError("File path cannot be empty")
+
+        try:
+            self._s3_client.delete_object(Bucket=container, Key=file_path)
+            logger.debug(f"Deleted file: {container}/{file_path}")
+        except ClientError as e:
+            logger.error(f"Failed to delete file {container}/{file_path}: {e}")
+            raise Exception(f"Failed to delete file: {e}")
+
+    @trace_fn
+    def delete_directory(self, container: str, directory_path: str) -> None:
+        """
+        Delete a directory and all its contents from S3/MinIO storage.
+
+        Recursively deletes all files within the specified directory prefix.
+        This operation cannot be undone.
+        """
+        if not container or not container.strip():
+            raise ValueError("Container name cannot be empty")
+        if not directory_path or not directory_path.strip():
+            raise ValueError("Directory path cannot be empty")
+
+        try:
+            # Ensure path ends with / for proper prefix matching
+            prefix = directory_path.rstrip("/") + "/"
+
+            # List all objects with the prefix
+            paginator = self._s3_client.get_paginator("list_objects_v2")
+            pages = paginator.paginate(Bucket=container, Prefix=prefix)
+
+            objects_to_delete = []
+            for page in pages:
+                if "Contents" in page:
+                    for obj in page["Contents"]:
+                        objects_to_delete.append({"Key": obj["Key"]})
+
+            if objects_to_delete:
+                # Delete objects in batches (S3 allows max 1000 per request)
+                for i in range(0, len(objects_to_delete), 1000):
+                    batch = objects_to_delete[i : i + 1000]
+                    self._s3_client.delete_objects(Bucket=container, Delete={"Objects": batch})
+
+            logger.debug(f"Deleted directory: {container}/{directory_path} ({len(objects_to_delete)} objects)")
+        except ClientError as e:
+            logger.error(f"Failed to delete directory {container}/{directory_path}: {e}")
+            raise Exception(f"Failed to delete directory: {e}")

--- a/aihub_lib/aihub_lib/nats/events/pipeline/SourceDeletedEvent.py
+++ b/aihub_lib/aihub_lib/nats/events/pipeline/SourceDeletedEvent.py
@@ -1,0 +1,16 @@
+from typing import Annotated
+
+from pydantic import Field
+
+from aihub_lib.nats.events import BaseEvent
+
+
+class SourceDeletedEvent(BaseEvent):
+    """
+    Signals that a data source has been deleted from the data lake.
+    This event can be used to trigger cleanup operations in downstream systems
+    such as removing corresponding documents from MongoDB docstore and vector stores.
+    """
+
+    path: Annotated[str, Field(description="The object path for the deleted file")]
+    document_id: Annotated[str | None, Field(description="The document ID in the docstore, if known")] = None

--- a/aihub_lib/aihub_lib/persistence/rag/documents/entities/RefDoc.py
+++ b/aihub_lib/aihub_lib/persistence/rag/documents/entities/RefDoc.py
@@ -160,3 +160,15 @@ class RefDoc(Document):
 
         with switch_db(cls, db_alias) as SwitchedRefDoc:
             return list(SwitchedRefDoc.objects.aggregate(pipeline))
+
+    @classmethod
+    @trace_fn
+    def delete_by_id(cls, db_alias: str, doc_id: str) -> bool:
+        """
+        Deletes a document by its ID from the specified database.
+
+        Returns True if the document was deleted, False if it was not found.
+        """
+        with switch_db(cls, db_alias) as SwitchedRefDoc:
+            result = SwitchedRefDoc.objects.filter(id=doc_id).delete()
+            return result > 0

--- a/aihub_web/aihub_web/composables/document/useDeleteDocument.ts
+++ b/aihub_web/aihub_web/composables/document/useDeleteDocument.ts
@@ -1,0 +1,22 @@
+export const useDeleteDocument = defineMutation(() => {
+  const queryCache = useQueryCache()
+
+  const { mutateAsync: deleteDocumentMutation, isPending } = useMutation({
+    mutation: async (params: { database: string, namespace: string, documentId: string }) => {
+      return await $fetch<{ success: boolean }>(
+        `/api/knowledge/databases/${encodeURIComponent(params.database)}/namespaces/${encodeURIComponent(params.namespace)}/documents/${encodeURIComponent(params.documentId)}`,
+        {
+          method: 'DELETE',
+        },
+      )
+    },
+    onSuccess: () => {
+      queryCache.invalidateQueries({ key: ['knowledge'] })
+    },
+  })
+
+  return {
+    deleteDocument: deleteDocumentMutation,
+    isPending,
+  }
+})

--- a/aihub_web/aihub_web/i18n/locales/de.yaml
+++ b/aihub_web/aihub_web/i18n/locales/de.yaml
@@ -296,6 +296,14 @@ knowledge:
       actions:
         upload: "Hochladen"
         cancel: "Abbrechen"
+    delete:
+      button: "Dokument löschen"
+      confirm_title: "Dokument löschen"
+      confirm_message: "Sind Sie sicher, dass Sie dieses Dokument löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden."
+      confirm_accept: "Löschen"
+      confirm_reject: "Abbrechen"
+      success: "Dokument erfolgreich gelöscht"
+      error: "Dokument konnte nicht gelöscht werden"
   nodes:
     title: "Dokument-Chunks"
   summary:

--- a/aihub_web/aihub_web/i18n/locales/en.yaml
+++ b/aihub_web/aihub_web/i18n/locales/en.yaml
@@ -297,6 +297,14 @@ knowledge:
       actions:
         upload: "Upload"
         cancel: "Cancel"
+    delete:
+      button: "Delete document"
+      confirm_title: "Delete Document"
+      confirm_message: "Are you sure you want to delete this document? This action cannot be undone."
+      confirm_accept: "Delete"
+      confirm_reject: "Cancel"
+      success: "Document deleted successfully"
+      error: "Failed to delete document"
   nodes:
     title: "Document Chunks"
   summary:

--- a/aihub_web/aihub_web/i18n/locales/fr.yaml
+++ b/aihub_web/aihub_web/i18n/locales/fr.yaml
@@ -295,6 +295,14 @@ knowledge:
       actions:
         upload: "Télécharger"
         cancel: "Annuler"
+    delete:
+      button: "Supprimer le document"
+      confirm_title: "Supprimer le document"
+      confirm_message: "Êtes-vous sûr de vouloir supprimer ce document ? Cette action est irréversible."
+      confirm_accept: "Supprimer"
+      confirm_reject: "Annuler"
+      success: "Document supprimé avec succès"
+      error: "Échec de la suppression du document"
   nodes:
     title: "Morceaux de document"
   summary:

--- a/aihub_web/aihub_web/i18n/locales/it.yaml
+++ b/aihub_web/aihub_web/i18n/locales/it.yaml
@@ -295,6 +295,14 @@ knowledge:
       actions:
         upload: "Carica"
         cancel: "Annulla"
+    delete:
+      button: "Elimina documento"
+      confirm_title: "Elimina documento"
+      confirm_message: "Sei sicuro di voler eliminare questo documento? Questa azione non può essere annullata."
+      confirm_accept: "Elimina"
+      confirm_reject: "Annulla"
+      success: "Documento eliminato con successo"
+      error: "Impossibile eliminare il documento"
   nodes:
     title: "Chunk di documento"
   summary:

--- a/aihub_web/aihub_web/pages/service/knowledge/[db]/[namespace]/[document_id]/overview.vue
+++ b/aihub_web/aihub_web/pages/service/knowledge/[db]/[namespace]/[document_id]/overview.vue
@@ -4,6 +4,7 @@
     :close-route="`/service/knowledge/${route.params.db}/${route.params.namespace}`"
     :loading="documentIsLoading"
   >
+    <ConfirmDialog />
     <div class="mt-16 rounded-3xl border border-surface-100 p-9 shadow-lg dark:border-surface-800">
       <KnowledgeDocumentOverview :document="document">
         <MarkdownRenderer
@@ -11,12 +12,32 @@
         />
       </KnowledgeDocumentOverview>
     </div>
+    <div class="mt-6 flex justify-end">
+      <Button
+        v-if="document?.is_ingested"
+        severity="danger"
+        :label="t('knowledge.documents.delete.button')"
+        icon="pi pi-trash"
+        :loading="isDeleting"
+        @click="confirmDelete"
+      />
+    </div>
   </StructuralColumn>
 </template>
 
 <script setup lang="ts">
+import { useConfirm } from 'primevue/useconfirm'
+import { useToast } from 'primevue/usetoast'
+
 const { document, documentIsLoading } = useDocument()
 const route = useRoute()
+const router = useRouter()
+const localePath = useLocalePath()
+const { t } = useI18n()
+const confirm = useConfirm()
+const toast = useToast()
+
+const { deleteDocument, isPending: isDeleting } = useDeleteDocument()
 
 const md = computed<string>(() => {
   if (documentIsLoading.value) {
@@ -37,4 +58,43 @@ const md = computed<string>(() => {
     .replace(/(?:<|&lt;)table(?:>|&gt;)/g, '::MarkdownTable\n')
     .replace(/(?:<|&lt;)\/table(?:>|&gt;)/g, '\n::')
 })
+
+const confirmDelete = () => {
+  confirm.require({
+    message: t('knowledge.documents.delete.confirm_message'),
+    header: t('knowledge.documents.delete.confirm_title'),
+    icon: 'pi pi-exclamation-triangle',
+    rejectProps: {
+      label: t('knowledge.documents.delete.confirm_reject'),
+      severity: 'secondary',
+      outlined: true,
+    },
+    acceptProps: {
+      label: t('knowledge.documents.delete.confirm_accept'),
+      severity: 'danger',
+    },
+    accept: async () => {
+      try {
+        await deleteDocument({
+          database: route.params.db as string,
+          namespace: route.params.namespace as string,
+          documentId: route.params.document_id as string,
+        })
+        toast.add({
+          severity: 'success',
+          summary: t('knowledge.documents.delete.success'),
+          life: 3000,
+        })
+        router.push(localePath(`/service/knowledge/${route.params.db}/${route.params.namespace}`))
+      }
+      catch {
+        toast.add({
+          severity: 'error',
+          summary: t('knowledge.documents.delete.error'),
+          life: 5000,
+        })
+      }
+    },
+  })
+}
 </script>


### PR DESCRIPTION
Add the ability to delete documents from the knowledge base including:

- DELETE API endpoint at /knowledge/databases/{database}/namespaces/{namespace}/documents/{document_id}
- Delete documents from vector store (Milvus), document store (MongoDB), and datalake (S3)
- Delete associated figure images from datalake
- Publish SourceDeletedEvent to NATS for observability
- UI delete button with confirmation dialog on document overview page
- Translations for delete UI in en, de, fr, it locales

The deletion requires admin permission for the namespace and performs a complete cleanup across all storage layers.