### PR TITLE
fix(aihub): Permissive filename validation in document upload

### DIFF
--- a/aihub_api/aihub_api/routes/knowledge/dto/DocumentUploadRequest.py
+++ b/aihub_api/aihub_api/routes/knowledge/dto/DocumentUploadRequest.py
@@ -25,7 +25,11 @@ class DocumentUploadRequest(BaseModel):
         filename_pattern = r"^[^\x00-\x1f/\\][^\x00-\x1f/\\]*\.[a-zA-Z0-9]+$"
         if not re.match(filename_pattern, v):
             raise ValueError("Invalid filename format.")
-        extension = v.rsplit(".", 1)[-1]
+        parts = v.rsplit(".", 1)
+        if len(parts) < 2 or not parts[1]:
+            raise ValueError("Filename must have a valid extension.")
+
+        extension = parts[1]
         if len(extension) > 10:
             raise ValueError("File extension is too long.")
         return v

--- a/aihub_api/aihub_api/routes/knowledge/dto/DocumentUploadRequest.py
+++ b/aihub_api/aihub_api/routes/knowledge/dto/DocumentUploadRequest.py
@@ -21,14 +21,10 @@ class DocumentUploadRequest(BaseModel):
     @field_validator("filename")
     def validate_filename_format(cls, v: str) -> str:
         v = v.strip()
-        if not v:
-            raise ValueError("Filename cannot be empty.")
-        # allow most characters except control chars and path separators
+        # Regex enforces: Starts with safe char, no path chars, must end in .extension
         filename_pattern = r"^[^\x00-\x1f/\\][^\x00-\x1f/\\]*\.[a-zA-Z0-9]+$"
         if not re.match(filename_pattern, v):
             raise ValueError("Invalid filename format.")
-        if any(pattern in v for pattern in ["..", "/", "\\", "\x00"]):
-            raise ValueError("Filename contains forbidden characters or sequences.")
         extension = v.rsplit(".", 1)[-1]
         if len(extension) > 10:
             raise ValueError("File extension is too long.")
@@ -41,7 +37,7 @@ class DocumentUploadRequest(BaseModel):
         """
         try:
             mime_type = self.content_type.lower().split(";")[0].strip()
-            file_ext = "." + self.filename.split(".")[-1].lower()
+            file_ext = "." + self.filename.rsplit(".", 1)[-1].lower()
         except (AttributeError, IndexError):
             raise ValueError("Invalid filename or content_type format.")
         file_type = FileTypeConfig()

--- a/aihub_api/aihub_api/routes/knowledge/dto/DocumentUploadRequest.py
+++ b/aihub_api/aihub_api/routes/knowledge/dto/DocumentUploadRequest.py
@@ -21,15 +21,16 @@ class DocumentUploadRequest(BaseModel):
     @field_validator("filename")
     def validate_filename_format(cls, v: str) -> str:
         v = v.strip()
-        filename_pattern = r"^[a-zA-Z0-9][a-zA-Z0-9 _\-]*(\.[a-zA-Z0-_ \-]+)*\.[a-zA-Z0-9]+$"
+        if not v:
+            raise ValueError("Filename cannot be empty.")
+        # allow most characters except control chars and path separators
+        filename_pattern = r"^[^\x00-\x1f/\\][^\x00-\x1f/\\]*\.[a-zA-Z0-9]+$"
         if not re.match(filename_pattern, v):
             raise ValueError("Invalid filename format.")
         if any(pattern in v for pattern in ["..", "/", "\\", "\x00"]):
             raise ValueError("Filename contains forbidden characters or sequences.")
-        parts = v.split(".")
-        if len(parts) > 3:
-            raise ValueError("Filename has too many extensions.")
-        if len(parts[-1]) > 10:
+        extension = v.rsplit(".", 1)[-1]
+        if len(extension) > 10:
             raise ValueError("File extension is too long.")
         return v
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Prevent empty filename and trim whitespace

- Restrict illegal characters and separators

- Simplify regex to one-extension files

- Enforce maximum extension length


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DocumentUploadRequest.py</strong><dd><code>Tighten filename validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_api/aihub_api/routes/knowledge/dto/DocumentUploadRequest.py

<ul><li>Added empty filename check and trim logic<br> <li> Updated regex to exclude control chars and separators<br> <li> Removed multi-extension limitation<br> <li> Enforced maximum extension length on file</ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/863/files#diff-11d2691ca4f344f051a14985730802a97388930bfa7a196d8b762ca633ace4e0">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

