### PR TITLE
fix(aihub): Allow empty index_namespaces to retrieve from all namespaces

### DIFF
--- a/aihub_lib/aihub_lib/generative_ai/retrievers/KnowledgeRetrieverConfig.py
+++ b/aihub_lib/aihub_lib/generative_ai/retrievers/KnowledgeRetrieverConfig.py
@@ -17,7 +17,7 @@ class KnowledgeRetrieverConfig(BaseRetrieverConfig):
 
     embed_model: Annotated[EmbeddingModelConfig, Field(description="The embedding model configuration.")]
     vector_store: Annotated[MilvusVectorStoreConfig, Field(description="The vector store configuration.")]
-    index_namespaces: Annotated[list[str], Field(description="The namespaces to retrieve from.", min_length=1)]
+    index_namespaces: Annotated[list[str], Field(description="The namespaces to retrieve from. Empty means all.")]
     retrieve_k: Annotated[int, Field(description="The number of documents to retrieve.", ge=1)]
     query_mode: Annotated[
         VectorStoreQueryMode,

--- a/aihub_lib/aihub_lib/generative_ai/utils/filter_retrievers_by_namespace.py
+++ b/aihub_lib/aihub_lib/generative_ai/utils/filter_retrievers_by_namespace.py
@@ -22,7 +22,7 @@ def filter_retrievers_by_namespace(
             bucket_name = retriever.vector_store.collection_name
             if bucket_name in namespace_map:
                 selected_namespace = namespace_map[bucket_name]
-                if selected_namespace in retriever.index_namespaces:
+                if not retriever.index_namespaces or selected_namespace in retriever.index_namespaces:
                     filtered_retriever = retriever.model_copy(update={"index_namespaces": [selected_namespace]})
                     filtered.append(filtered_retriever)
         else:

--- a/aihub_lib/aihub_lib/generative_ai/utils/retrieve_nodes.py
+++ b/aihub_lib/aihub_lib/generative_ai/utils/retrieve_nodes.py
@@ -26,20 +26,26 @@ def retrieve_nodes(
     if retrieve_k <= 0:
         raise ValueError("retrieve_k must be a positive integer")
 
-    filters = MetadataFilters(
-        filters=[
-            MetadataFilters(
-                filters=[
-                    MetadataFilter(key=NAMESPACE, value=ns),
-                    MetadataFilter(key=TYPE, value=nt),
-                ],
-                condition=FilterCondition.AND,
-            )
-            for ns in index_namespaces
-            for nt in node_types
-        ],
-        condition=FilterCondition.OR,
-    )
+    if index_namespaces:
+        filters = MetadataFilters(
+            filters=[
+                MetadataFilters(
+                    filters=[
+                        MetadataFilter(key=NAMESPACE, value=ns),
+                        MetadataFilter(key=TYPE, value=nt),
+                    ],
+                    condition=FilterCondition.AND,
+                )
+                for ns in index_namespaces
+                for nt in node_types
+            ],
+            condition=FilterCondition.OR,
+        )
+    else:
+        filters = MetadataFilters(
+            filters=[MetadataFilter(key=TYPE, value=nt) for nt in node_types],
+            condition=FilterCondition.OR,
+        )
 
     embedding = embed_model.get_text_embedding(message)
 


### PR DESCRIPTION
### **User description**
## Summary
- Allow `index_namespaces` to be empty in `KnowledgeRetrieverConfig` (removed `min_length=1` constraint)
- Update `filter_retrievers_by_namespace` to pass through namespaces when retriever's `index_namespaces` is empty
- Update `retrieve_nodes` to only filter by `node_types` when `index_namespaces` is empty, retrieving from all namespaces

## Test plan
- [ ] Verify retrieval works with specific namespaces configured
- [ ] Verify retrieval works with empty `index_namespaces` (should retrieve from all namespaces)
- [ ] Verify namespace filtering works correctly when user selects a namespace


___

### **PR Type**
Bug fix


___

### **Description**
- allow empty `index_namespaces` to mean all namespaces

- remove `min_length` constraint in retriever config

- accept empty namespaces in filter function

- use type-only filters when no namespaces provided


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Config["Config: index_namespaces can be empty"] --> Filter["filter_retrievers_by_namespace handles empty list"]
  Filter --> Retrieve["retrieve_nodes branches by namespace presence"]
  Retrieve -- "namespaces present" --> NSFilter["create namespace+type filters"]
  Retrieve -- "no namespaces" --> TypeFilter["create type-only filters"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>KnowledgeRetrieverConfig.py</strong><dd><code>Allow empty namespaces in config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_lib/aihub_lib/generative_ai/retrievers/KnowledgeRetrieverConfig.py

<ul><li>Removed <code>min_length</code> constraint on <code>index_namespaces</code><br> <li> Updated description to clarify empty means all</ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/877/files#diff-0bb4c3c850a70f3c1e797dddbc68b0fe490c0cc830b4dbc45a631e7dd0f0571d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>filter_retrievers_by_namespace.py</strong><dd><code>Handle empty namespaces in filter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_lib/aihub_lib/generative_ai/utils/filter_retrievers_by_namespace.py

<ul><li>Added check for empty <code>index_namespaces</code><br> <li> Preserve retrievers when namespaces list empty</ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/877/files#diff-affc5a41e9da7fc2e093a51797564881f0b96d7e3a2f774e1c74f19f115b2d71">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>retrieve_nodes.py</strong><dd><code>Add empty namespace filtering logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

aihub_lib/aihub_lib/generative_ai/utils/retrieve_nodes.py

<ul><li>Introduced branch for empty <code>index_namespaces</code><br> <li> Use type-only filters when list is empty</ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/877/files#diff-5292af1ceeb7ac239924572fe3d26441b5e57e797f99a881356b9d4cb26834a4">+20/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

