### PR TITLE
fix(ci-cd): Keep latest tagging action in sync with compose files

### DIFF
--- a/.github/workflows/set-latest.yml
+++ b/.github/workflows/set-latest.yml
@@ -1,3 +1,42 @@
+# =============================================================================
+# Set Latest Tag on Images
+# =============================================================================
+#
+# PURPOSE:
+#   Promotes a release tag to "latest" for both Git and Docker images.
+#   This action retags an existing versioned release (e.g., v1.2.3) as "latest"
+#   so that docker-compose.latest.yml deployments pull the promoted version.
+#
+# USAGE:
+#   Trigger manually via workflow_dispatch, providing the source tag to promote.
+#   Example: source_tag = "v1.2.3" will tag that commit and its images as "latest"
+#
+# IMAGE SELECTION (automatically synced with compose-config.yml):
+#   Images are dynamically discovered from deployment/compose-config.yml.
+#   The selection identifies custom application images we build ourselves:
+#
+#   PATTERN MATCHED - entries with per-stage map structure:
+#     api:
+#       build: localbuild
+#       local: api:latest
+#       nightly: api:nightly
+#       latest: api:latest          # <-- "latest" key present = included
+#
+#   PATTERN NOT MATCHED - simple string values (third-party infrastructure):
+#     postgres: pgvector:pg17       # No map structure = excluded
+#     valkey: valkey:8.0.5          # These are external images we don't build
+#     milvus: milvus:v2.6.7
+#
+#   The yq query selects entries where:
+#     1. The value is a map (type == "!!map") - not a simple string
+#     2. The map contains a "latest" key - confirms it's deployed to latest stage
+#
+#   Result: api, bot, web, dagster, and all *_agent/*_pipeline images are
+#   automatically included. Adding a new agent or pipeline to compose-config.yml
+#   with the standard map structure will automatically include it here.
+#
+# =============================================================================
+
 name: Set latest Tag on Images
 
 on:
@@ -8,6 +47,34 @@ on:
         required: true
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Discover which images to retag by parsing compose-config.yml
+  # ---------------------------------------------------------------------------
+  discover-images:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.parse.outputs.matrix }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Parse custom app images from compose-config.yml
+        id: parse
+        run: |
+          # Extract image names where value is a map with a "latest" key
+          images=$(yq -o=json '
+            .image_tags
+            | to_entries
+            | map(select(.value | type == "!!map" and has("latest")))
+            | map(.key)
+          ' deployment/compose-config.yml)
+
+          echo "Discovered images: $images"
+          echo "matrix={\"image\":$images}" >> $GITHUB_OUTPUT
+
+  # ---------------------------------------------------------------------------
+  # Move the "latest" git tag to point to the source tag's commit
+  # ---------------------------------------------------------------------------
   retag-git:
     runs-on: ubuntu-latest
     permissions:
@@ -37,25 +104,19 @@ jobs:
           git push origin refs/tags/latest --force
           echo "Moved 'latest' tag to same commit as $SOURCE_TAG"
 
+  # ---------------------------------------------------------------------------
+  # Retag Docker images: pull source tag, push as "latest" and "{tag}-latest"
+  # ---------------------------------------------------------------------------
   retag-docker:
     runs-on: ubuntu-latest
-    needs: retag-git
+    needs: [discover-images, retag-git]
     permissions:
       packages: write
       contents: read
 
     strategy:
-      matrix:
-        image:
-          - api
-          - bot
-          - web
-          - dagster
-          - llm_wrapping_agent
-          - default_rag_pipeline
-          - rag_agent
-          - expert_rag_agent
-          - expert_asking_agent
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover-images.outputs.matrix) }}
 
     steps:
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/set-latest.yml
+++ b/.github/workflows/set-latest.yml
@@ -115,7 +115,6 @@ jobs:
       contents: read
 
     strategy:
-      fail-fast: false
       matrix: ${{ fromJson(needs.discover-images.outputs.matrix) }}
 
     steps:

--- a/.github/workflows/set-latest.yml
+++ b/.github/workflows/set-latest.yml
@@ -27,9 +27,9 @@
 #     valkey: valkey:8.0.5          # These are external images we don't build
 #     milvus: milvus:v2.6.7
 #
-#   The yq query selects entries where:
-#     1. The value is a map (type == "!!map") - not a simple string
-#     2. The map contains a "latest" key - confirms it's deployed to latest stage
+#   The Python script selects entries where:
+#     1. The value is a dict (not a simple string)
+#     2. The dict contains a "latest" key - confirms it's deployed to latest stage
 #
 #   Result: api, bot, web, dagster, and all *_agent/*_pipeline images are
 #   automatically included. Adding a new agent or pipeline to compose-config.yml
@@ -61,13 +61,14 @@ jobs:
       - name: Parse custom app images from compose-config.yml
         id: parse
         run: |
-          # Extract image names where value is a map with a "latest" key
-          images=$(yq -o=json '
-            .image_tags
-            | to_entries
-            | map(select(.value | type == "!!map" and has("latest")))
-            | map(.key)
-          ' deployment/compose-config.yml)
+          # Extract image names where value is a dict with a "latest" key
+          images=$(python3 -c "
+          import yaml, json
+          with open('deployment/compose-config.yml') as f:
+              config = yaml.safe_load(f)
+          images = [k for k, v in config['image_tags'].items() if isinstance(v, dict) and 'latest' in v]
+          print(json.dumps(images))
+          ")
 
           echo "Discovered images: $images"
           echo "matrix={\"image\":$images}" >> $GITHUB_OUTPUT

--- a/.github/workflows/set-latest.yml
+++ b/.github/workflows/set-latest.yml
@@ -15,21 +15,24 @@
 #   Images are dynamically discovered from deployment/compose-config.yml.
 #   The selection identifies custom application images we build ourselves:
 #
-#   PATTERN MATCHED - entries with per-stage map structure:
+#   PATTERN MATCHED - entries with "build: localbuild" (images we build ourselves):
 #     api:
-#       build: localbuild
+#       build: localbuild           # <-- "localbuild" = included
 #       local: api:latest
 #       nightly: api:nightly
-#       latest: api:latest          # <-- "latest" key present = included
+#       latest: api:latest
 #
 #   PATTERN NOT MATCHED - simple string values (third-party infrastructure):
-#     postgres: pgvector:pg17       # No map structure = excluded
-#     valkey: valkey:8.0.5          # These are external images we don't build
-#     milvus: milvus:v2.6.7
+#     postgres: pgvector:pg17       # Simple string = excluded
+#     valkey: valkey:8.0.5
+#
+#   PATTERN NOT MATCHED - dicts without "build: localbuild" (external images):
+#     some_external:
+#       latest: external:v1.0       # No "build: localbuild" = excluded
 #
 #   The Python script selects entries where:
-#     1. The value is a dict (not a simple string)
-#     2. The dict contains a "latest" key - confirms it's deployed to latest stage
+#     - The value is a dict with build == "localbuild"
+#   This ensures only images we build ourselves are retagged, never external images.
 #
 #   Result: api, bot, web, dagster, and all *_agent/*_pipeline images are
 #   automatically included. Adding a new agent or pipeline to compose-config.yml
@@ -61,12 +64,12 @@ jobs:
       - name: Parse custom app images from compose-config.yml
         id: parse
         run: |
-          # Extract image names where value is a dict with a "latest" key
+          # Extract image names where build == "localbuild" (images we build ourselves)
           images=$(python3 -c "
           import yaml, json
           with open('deployment/compose-config.yml') as f:
               config = yaml.safe_load(f)
-          images = [k for k, v in config['image_tags'].items() if isinstance(v, dict) and 'latest' in v]
+          images = [k for k, v in config['image_tags'].items() if isinstance(v, dict) and v.get('build') == 'localbuild']
           print(json.dumps(images))
           ")
 


### PR DESCRIPTION
### **User description**
This pull request improves the workflow for promoting a release tag to "latest" for both Git and Docker images by making the selection of images dynamic and maintainable. The changes automate the discovery of custom application images to retag, ensuring that any new images added to `compose-config.yml` are automatically included in the promotion process. This reduces manual maintenance and risk of oversight.

**Dynamic image discovery and workflow improvements:**

* Added a new `discover-images` job to parse `deployment/compose-config.yml` and dynamically determine which images should be retagged, based on whether their configuration is a map containing a `latest` key. This eliminates the need for a hardcoded image list.
* Updated the `retag-docker` job to depend on the output of the new `discover-images` job, using its dynamically generated image matrix instead of a static list. This ensures the workflow always targets the correct set of images.

**Documentation and maintainability:**

* Added documentation at the top of `.github/workflows/set-latest.yml` explaining the workflow's purpose, usage, and the logic behind image selection, making it easier for future maintainers to understand and extend.


___

### **PR Type**
Enhancement


___

### **Description**
- Add documentation header to set-latest workflow

- Introduce discover-images job for dynamic image matrix

- Update retag-docker to use dynamic matrix

- Remove static image list and unused fail-fast key


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Discover images from compose-config.yml"]
  B["Move 'latest' Git tag"]
  C["Retag Docker images as latest"]
  A -- "matrix output" --> C
  B -- "tag updated" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>set-latest.yml</strong><dd><code>Add dynamic image discovery to CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/set-latest.yml

<ul><li>Added header documentation explaining workflow purpose<br> <li> Introduced discover-images job parsing compose-config.yml<br> <li> Removed static image list and unused 'fail-fast' key<br> <li> Updated retag-docker job to consume dynamic matrix</ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/894/files#diff-7fde6f2bd6eb5243182dba0b0116b957cb33254f06f36782e81e663c15823952">+72/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

