### PR TITLE
fix(ci-cd): Make switch-dependencies.py passing its logs

### DIFF
--- a/switch_dependencies.py
+++ b/switch_dependencies.py
@@ -110,8 +110,12 @@ def process_file(pyproject_path: Path, mode: str, remote_tag: str, run_install: 
     if run_install:
         print(f"📦 Running poetry lock for {pyproject_path.parent.name}...")
         result = subprocess.run(["poetry", "lock"], cwd=pyproject_path.parent, capture_output=True, text=True)
+        if result.stdout:
+            print(result.stdout)
         if result.returncode != 0:
-            print(f"❌ Failed to lock dependencies in {pyproject_path.parent}: {result.stderr}")
+            print(f"❌ Failed to lock dependencies in {pyproject_path.parent}")
+            if result.stderr:
+                print(f"stderr: {result.stderr}")
             sys.exit(1)
 
         print(f"📦 Running poetry install for {pyproject_path.parent.name}...")
@@ -122,8 +126,12 @@ def process_file(pyproject_path: Path, mode: str, remote_tag: str, run_install: 
         else:
             result = subprocess.run(["poetry", "install"], cwd=pyproject_path.parent, capture_output=True, text=True)
 
+        if result.stdout:
+            print(result.stdout)
         if result.returncode != 0:
-            print(f"❌ Failed to install dependencies in {pyproject_path.parent}: {result.stderr}")
+            print(f"❌ Failed to install dependencies in {pyproject_path.parent}")
+            if result.stderr:
+                print(f"stderr: {result.stderr}")
             sys.exit(1)
         print(f"✅ Successfully installed dependencies for {pyproject_path.parent.name}")
     else:


### PR DESCRIPTION
### **User description**
This pull request improves the logging and error handling in the `process_file` function within `switch_dependencies.py`. The changes ensure that both standard output and error messages from subprocess commands are displayed more clearly, making debugging easier.


___

### **PR Type**
Enhancement


___

### **Description**
- Print `stdout` from poetry lock and install

- Separate `stderr` printing on errors

- Improved logging clarity for subprocess calls


___

### Diagram Walkthrough


```mermaid
flowchart LR
  nodeStart["Start process_file"]
  nodeLock["Run poetry lock"]
  nodeLockOut["Print stdout (lock)"]
  nodeLockCheck{"lock returncode == 0?"}
  nodeLockErr["Print stderr and exit"]
  nodeInstall["Run poetry install"]
  nodeInstallOut["Print stdout (install)"]
  nodeInstallCheck{"install returncode == 0?"}
  nodeInstallErr["Print stderr and exit"]
  nodeSuccess["Complete process_file"]
  nodeStart --> nodeLock
  nodeLock --> nodeLockOut
  nodeLockOut --> nodeLockCheck
  nodeLockCheck -- "no" --> nodeLockErr
  nodeLockCheck -- "yes" --> nodeInstall
  nodeInstall --> nodeInstallOut
  nodeInstallOut --> nodeInstallCheck
  nodeInstallCheck -- "no" --> nodeInstallErr
  nodeInstallCheck -- "yes" --> nodeSuccess
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>switch_dependencies.py</strong><dd><code>Improve logging for poetry commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

switch_dependencies.py

<ul><li>Added printing of <code>result.stdout</code> after lock and install commands<br> <li> Changed error prints to generic message then print <code>stderr</code> if present<br> <li> Improved visibility of subprocess outputs</ul>


</details>


  </td>
  <td><a href="https://github.com/bbvch-ai/aihub-core/pull/902/files#diff-416c298cac73a8725f95ef0a580437ccd3965c7220eed29b4460bc714c550345">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

