### PR TITLE
fix(aihub): Update release date for v0.262.2 in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -434,7 +434,7 @@ ______________________________________________________________________
 
 ______________________________________________________________________
 
-## [v0.262.2] - YYYY-MM-DD - Introducing the LLM-Powered Whitepaper Generation System
+## [v0.262.2] - 2026-02-17 - Introducing the LLM-Powered Whitepaper Generation System
 
 ### Added
 


### PR DESCRIPTION
This pull request updates the release date for version `v0.262.2` in the `CHANGELOG.md` file to reflect the correct date.

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL437-R437): Changed the release date for version `v0.262.2` from a placeholder (`YYYY-MM-DD`) to `2026-02-17`.