### PR TITLE
fix(ci-cd): Fix extraction of release notes in github release creation

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -71,14 +71,7 @@ jobs:
           tar -czf "swissaihub-${VERSION}.tar.gz" -C "dist/release/swissaihub-${VERSION}" .
           tar -czf "swissaihub-${VERSION}-gpu.tar.gz" -C "dist/release/swissaihub-${VERSION}-gpu" .
       - name: Extract changelog for this version
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          awk '/^## \['"${VERSION}"'\]/{found=1; next} /^---$/{if(found) exit} found{print}' CHANGELOG.md > release-notes.md
-
-          # If no changelog section found, provide a fallback
-          if [ ! -s release-notes.md ]; then
-            echo "Release ${VERSION}" > release-notes.md
-          fi
+        run: make extract-release-notes TAG="${{ steps.version.outputs.version }}"
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,16 @@ changelog:
 	/bin/bash ./generate-changelog.sh
 	@uv run mdformat --number $$(git ls-files '*.md' | grep -v 'aihub_doc/whitepaper/chapters/')
 
+# Extract release notes for a specific version from CHANGELOG.md (TAG=v0.267.1, OUTPUT=release-notes.md)
+OUTPUT ?= release-notes.md
+extract-release-notes:
+	@awk '/^## \[$(TAG)\]/{found=1; next} found && /^## \[/{exit} found{print}' CHANGELOG.md | sed '/^_\{3,\}/d' > $(OUTPUT)
+	@if [ ! -s $(OUTPUT) ]; then \
+		echo "No changelog section found for $(TAG), using fallback"; \
+		echo "Release $(TAG)" > $(OUTPUT); \
+	fi
+	@echo "Release notes for $(TAG) written to $(OUTPUT) ($$(wc -c < $(OUTPUT)) bytes)"
+
 # Check licenses across all dependencies
 license-check:
 	@echo "Checking licenses..."

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,11 @@ changelog:
 # Extract release notes for a specific version from CHANGELOG.md (TAG=v0.267.1, OUTPUT=release-notes.md)
 OUTPUT ?= release-notes.md
 extract-release-notes:
-	@awk '/^## \[$(TAG)\]/{found=1; next} found && /^## \[/{exit} found{print}' CHANGELOG.md | sed '/^_\{3,\}/d' > $(OUTPUT)
+	@if ! echo "$(TAG)" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$$'; then \
+		echo "ERROR: Invalid TAG format '$(TAG)'. Expected vMAJOR.MINOR.PATCH (e.g. v0.267.1)"; \
+		exit 1; \
+	fi
+	@awk -v ver="$(TAG)" 'index($$0, "## [" ver "]") == 1 {found=1; next} found && /^## \[/{exit} found{print}' CHANGELOG.md | sed '/^_\{3,\}/d' > $(OUTPUT)
 	@if [ ! -s $(OUTPUT) ]; then \
 		echo "No changelog section found for $(TAG), using fallback"; \
 		echo "Release $(TAG)" > $(OUTPUT); \


### PR DESCRIPTION
This pull request refactors the workflow for extracting release notes during the release process by moving the changelog extraction logic from the GitHub Actions workflow into a dedicated Makefile target. This change improves maintainability and reusability of the release notes extraction logic.

**Release workflow improvements:**

* The logic for extracting release notes for a specific version from `CHANGELOG.md` has been moved from inline shell commands in `.github/workflows/create-release.yml` to a new `extract-release-notes` target in the `Makefile`, which uses `awk` and `sed` for processing.
* The GitHub Actions workflow now calls `make extract-release-notes TAG=...` instead of running the extraction logic directly, simplifying the workflow file and centralizing the logic.