### PR TITLE
fix(ci-cd): Fix CI failures after packages/ rename

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -277,7 +277,7 @@ OTEL_RESOURCE_SERVICE_NAMESPACE='swiss-ai-hub'
 
 # Cloud OTEL (optional)
 OTEL_CLOUD_ENDPOINT='ingest.eu.signoz.cloud:443'
-OTEL_CLOUD_HEADERS='{'signoz-ingestion-key':'XXX'}'
+OTEL_CLOUD_HEADERS='{"signoz-ingestion-key":"XXX"}'
 
 # =============================================================================
 # LOCAL DEVELOPMENT OVERRIDES

--- a/.github/actions/lint_frontend/action.yml
+++ b/.github/actions/lint_frontend/action.yml
@@ -44,7 +44,7 @@ runs:
       working-directory: ${{ inputs.working_directory }}
     - name: Prepare Nuxt
       shell: bash
-      run: pnpm exec nuxi prepare
+      run: pnpm exec nuxi prepare && pnpm exec nuxi prepare .app
       working-directory: ${{ inputs.working_directory }}
     - name: Lint frontend
       uses: reviewdog/action-eslint@v1

--- a/.github/actions/pytest_coverage_comment/action.yml
+++ b/.github/actions/pytest_coverage_comment/action.yml
@@ -8,13 +8,13 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
     - name: Sanitize artifact name
       id: sanitize
       shell: bash
       run: echo "artifact_prefix=$(echo '${{ inputs.working_directory }}' | tr '/'
         '-')" >> "$GITHUB_OUTPUT"
-    - name: Checkout repository
-      uses: actions/checkout@v4
     - name: Download pytest reports
       uses: actions/download-artifact@v4
       with:

--- a/.github/actions/pytest_coverage_comment/action.yml
+++ b/.github/actions/pytest_coverage_comment/action.yml
@@ -8,17 +8,22 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Sanitize artifact name
+      id: sanitize
+      shell: bash
+      run: echo "artifact_prefix=$(echo '${{ inputs.working_directory }}' | tr '/'
+        '-')" >> "$GITHUB_OUTPUT"
     - name: Checkout repository
       uses: actions/checkout@v4
     - name: Download pytest reports
       uses: actions/download-artifact@v4
       with:
-        name: ${{ inputs.working_directory }}-pytest-report
+        name: ${{ steps.sanitize.outputs.artifact_prefix }}-pytest-report
         path: ${{ inputs.working_directory }}
     - name: Download coverage reports
       uses: actions/download-artifact@v4
       with:
-        name: ${{ inputs.working_directory }}-coverage-report
+        name: ${{ steps.sanitize.outputs.artifact_prefix }}-coverage-report
         path: ${{ inputs.working_directory }}
     - name: Pytest coverage comment
       uses: MishaKav/pytest-coverage-comment@main

--- a/.github/actions/sonarcloud_scan/action.yml
+++ b/.github/actions/sonarcloud_scan/action.yml
@@ -25,15 +25,15 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Sanitize artifact name
       id: sanitize
       shell: bash
       run: echo "artifact_prefix=$(echo '${{ inputs.working_directory }}' | tr '/'
         '-')" >> "$GITHUB_OUTPUT"
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
     - name: Download Coverage (if exists)
       uses: actions/download-artifact@v4
       if: inputs.report_coverage == 'true'

--- a/.github/actions/sonarcloud_scan/action.yml
+++ b/.github/actions/sonarcloud_scan/action.yml
@@ -25,6 +25,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Sanitize artifact name
+      id: sanitize
+      shell: bash
+      run: echo "artifact_prefix=$(echo '${{ inputs.working_directory }}' | tr '/'
+        '-')" >> "$GITHUB_OUTPUT"
     - name: Checkout
       uses: actions/checkout@v4
       with:
@@ -33,7 +38,7 @@ runs:
       uses: actions/download-artifact@v4
       if: inputs.report_coverage == 'true'
       with:
-        name: ${{ inputs.working_directory }}-coverage-report
+        name: ${{ steps.sanitize.outputs.artifact_prefix }}-coverage-report
         path: ${{ inputs.working_directory }}
     - name: Run SonarCloud Without Coverage
       if: inputs.report_coverage == 'false'

--- a/.github/actions/test_backend/action.yml
+++ b/.github/actions/test_backend/action.yml
@@ -70,13 +70,13 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
     - name: Sanitize artifact name
       id: sanitize
       shell: bash
       run: echo "artifact_prefix=$(echo '${{ inputs.working_directory }}' | tr '/'
         '-')" >> "$GITHUB_OUTPUT"
-    - name: Checkout Repository
-      uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.github/actions/test_backend/action.yml
+++ b/.github/actions/test_backend/action.yml
@@ -70,6 +70,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Sanitize artifact name
+      id: sanitize
+      shell: bash
+      run: echo "artifact_prefix=$(echo '${{ inputs.working_directory }}' | tr '/'
+        '-')" >> "$GITHUB_OUTPUT"
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Set up Python
@@ -233,12 +238,12 @@ runs:
     - name: Upload Coverage Report
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.working_directory }}-coverage-report
+        name: ${{ steps.sanitize.outputs.artifact_prefix }}-coverage-report
         path: ${{ inputs.working_directory }}/coverage.xml
     - name: Upload Pytest Report
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.working_directory }}-pytest-report
+        name: ${{ steps.sanitize.outputs.artifact_prefix }}-pytest-report
         path: ${{ inputs.working_directory }}/pytest.xml
     - name: Publish Test Results
       uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/analyze-test-pr.yml
+++ b/.github/workflows/analyze-test-pr.yml
@@ -101,7 +101,7 @@ jobs:
           - packages/process
     steps:
       - name: Coverage comment
-        uses: bbvch-ai/swiss-ai-hu./.github/actions/pytest_coverage_comment@main
+        uses: bbvch-ai/aihub-core/.github/actions/pytest_coverage_comment@main
         with:
           working_directory: ${{ matrix.module }}
   sonarcloud-scan:
@@ -139,7 +139,7 @@ jobs:
             report_coverage: 'false'
     steps:
       - name: SonarCloud Scan
-        uses: bbvch-ai/swiss-ai-hu./.github/actions/sonarcloud_scan@main
+        uses: bbvch-ai/aihub-core/.github/actions/sonarcloud_scan@main
         with:
           working_directory: ${{ matrix.folder }}
           sonar_project_key: ${{ matrix.sonar_project_key }}

--- a/.github/workflows/analyze-test-pr.yml
+++ b/.github/workflows/analyze-test-pr.yml
@@ -117,25 +117,25 @@ jobs:
       matrix:
         include:
           - folder: packages/agent
-            sonar_project_key: swiss-ai-hub_agents-core
+            sonar_project_key: aihub-core_agents-core
             report_coverage: 'true'
           - folder: packages/api
-            sonar_project_key: swiss-ai-hub_api-core
+            sonar_project_key: aihub-core_api-core
             report_coverage: 'true'
           - folder: packages/core
-            sonar_project_key: swiss-ai-hub_lib-core
+            sonar_project_key: aihub-core_lib-core
             report_coverage: 'true'
           - folder: packages/pipeline
-            sonar_project_key: swiss-ai-hub_pipelines-core
+            sonar_project_key: aihub-core_pipelines-core
             report_coverage: 'true'
           - folder: packages/bot
-            sonar_project_key: swiss-ai-hub_bot-core
+            sonar_project_key: aihub-core_bot-core
             report_coverage: 'true'
           - folder: packages/process
-            sonar_project_key: swiss-ai-hub_process-core
+            sonar_project_key: aihub-core_process-core
             report_coverage: 'true'
           - folder: packages/web
-            sonar_project_key: swiss-ai-hub_aihub-web
+            sonar_project_key: aihub-core_aihub-web
             report_coverage: 'false'
     steps:
       - name: SonarCloud Scan

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -25,7 +25,7 @@ jobs:
           - packages/process
     steps:
       - name: Lint backend
-        uses: bbvch-ai/swiss-ai-hu./.github/actions/lint_backend@main
+        uses: bbvch-ai/aihub-core/.github/actions/lint_backend@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           working_directory: ${{ matrix.folder }}
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Lint frontend
-        uses: bbvch-ai/swiss-ai-hu./.github/actions/lint_frontend@main
+        uses: bbvch-ai/aihub-core/.github/actions/lint_frontend@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           working_directory: packages/web/swiss_ai_hub_web

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.271.0] - 2026-03-19 - Grand Renaming and Open-Source Restructure
+
+### Changed
+
+- 🏗️ **Repository Layout**: Reorganized all source packages under `packages/` directory — `aihub_lib` → `packages/core`,
+  `aihub_agent` → `packages/agent`, `aihub_api` → `packages/api`, `aihub_bot` → `packages/bot`, `aihub_pipeline` →
+  `packages/pipeline`, `aihub_process` → `packages/process`, `swiss_ai_hub_web` → `packages/web`. Non-code directories
+  moved to conventional locations: `aihub_doc` → `docs`, `aihub_action` → `.github/actions`, `deployment` →
+  `infra/deployment`.
+- 📦 **Python Namespace Packages**: All packages renamed to use `swiss_ai_hub` namespace via `uv_build` — import paths
+  are now `swiss_ai_hub.core`, `swiss_ai_hub.agent`, etc. PyPI names follow as `swiss-ai-hub-core`,
+  `swiss-ai-hub-agent`, etc.
+- 🐍 **snake_case Everywhere**: Renamed all CamelCase Python source files and directories to `snake_case` (e.g.,
+  `ExpertAskingAgent/ExpertAskingAgent.py` → `expert_asking_agent/expert_asking_agent.py`), resolving import ambiguity
+  that previously prevented proper `__init__.py` usage.
+- 📤 **Public Interface via `__init__.py`**: Added lazy `__init__.py` exports (using `TYPE_CHECKING` + `__getattr__`) to
+  all top-level package folders, establishing clear public interfaces. Cross-package imports now go through
+  `__init__.py`; intra-package imports use full module paths.
+- 🔄 **Import Rewrite**: Updated all imports across the entire codebase to follow the new namespace structure and import
+  conventions.
+- 📝 **License Change**: Moved from `LicenseRef-Proprietary` to `Apache-2.0` across all packages.
+- 📚 **Documentation Updates**: Updated all references from old naming conventions (`aihub_doc`, `aihub-core`, etc.) to
+  new names across docs, READMEs, CLAUDE.md files, whitepapers, and configuration files.
+- ⚙️ **Docker & CI Updates**: Updated all Docker Compose files, Dockerfiles, GitHub Actions workflows, and run
+  configurations to reference the new directory structure and package names.
+
+### Added
+
+- 📄 **Architecture Decision Record**: Added ADR documenting the rename and restructure rationale
+  (`docs/arc42/decisions/2026_03_13_rename_and_restructure_for_open_source_release.md`).
+- 🏗️ **`docker-compose.build.yml`**: Added comprehensive build-stage Docker Compose for multi-stack orchestration.
+
+### Removed
+
+- 🗑️ **Old Directory Structure**: Removed all `aihub_*` top-level directories, replaced by `packages/` layout.
+- 🗑️ **Deprecated Test Suites**: Removed outdated test suites for `AgentConfig` and `Form` classes.
+- 🗑️ **Outdated READMEs**: Removed stale README files that were superseded by the restructure.
+
+______________________________________________________________________
+
 ## [v0.270.4] - 2026-03-19 - Enhanced Configuration and Dev Environment Streamlining
 
 ### Changed

--- a/packages/agent/sonar-project.properties
+++ b/packages/agent/sonar-project.properties
@@ -1,7 +1,7 @@
-sonar.projectKey=swiss-ai-hub_agent
+sonar.projectKey=aihub-core_agents-core
 sonar.organization=bbv-ai
 # This is the name and version displayed in the SonarCloud UI.
-sonar.projectName=Swiss AI Hub Agent
+sonar.projectName=Agents Core
 sonar.projectVersion=1.0
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=swiss_ai_hub

--- a/packages/api/sonar-project.properties
+++ b/packages/api/sonar-project.properties
@@ -1,8 +1,8 @@
-sonar.projectKey=swiss-ai-hub_api
+sonar.projectKey=aihub-core_api-core
 sonar.organization=bbv-ai
 
 # This is the name and version displayed in the SonarCloud UI
-sonar.projectName=Swiss AI Hub API
+sonar.projectName=API Core
 sonar.projectVersion=1.0
 
 sonar.sources=swiss_ai_hub

--- a/packages/bot/playground/testing/tests/test_ChatBot.py
+++ b/packages/bot/playground/testing/tests/test_ChatBot.py
@@ -12,6 +12,8 @@ from swiss_ai_hub.core.auth.dependencies.dangerous_development_only_auth_handler
     DangerousDevelopmentOnlyAuthHandler,
 )
 from swiss_ai_hub.core.infrastructure import AIHubSettings, MongoSettings, enable_logging
+from swiss_ai_hub.core.persistence.access.entities.tenant_entity import TenantEntity
+from swiss_ai_hub.core.persistence.access.entities.user_tenant_role_entity import UserTenantRoleEntity
 from swiss_ai_hub.core.persistence.messaging.entities.thread_entity import ThreadEntity
 from swiss_ai_hub.core.persistence.user.user_entity import UserEntity
 from swiss_ai_hub.core.persistence.utils import str_to_object_id
@@ -68,9 +70,21 @@ def setup_test_credentials():
     PathEntity(path=json_path, credentials=test_credentials, system_message="Test system message").save()
     PathEntity(path=stream_path, credentials=test_credentials, system_message="Test system message").save()
 
+    # Create default tenant and assign test user
+    default_tenant = TenantEntity.ensure_default_tenant_exists(name="Test Tenant", access_rules=["aihub.admin.>"])
+    tenant_id = str(default_tenant.id)
+
     # Create test user (looked up via from_property.name in AgentCompletionHandler)
     UserEntity.objects(email=USER_EMAIL).delete()
     UserEntity.create_user(oid="test_user_oid", name="Test User", email=USER_EMAIL)
+
+    # Assign user to default tenant with admin role
+    UserTenantRoleEntity.create_or_update(
+        user_id="test_user_oid",
+        tenant_id=tenant_id,
+        roles=["admin"],
+        validate_roles=False,
+    )
 
     yield
 
@@ -79,6 +93,7 @@ def setup_test_credentials():
         PathEntity.objects(path=json_path).delete()
         PathEntity.objects(path=stream_path).delete()
         UserEntity.objects(email=USER_EMAIL).delete()
+        UserTenantRoleEntity.objects(user_id="test_user_oid").delete()
     except Exception:
         # Connection may already be closed, ignore cleanup errors
         pass

--- a/packages/bot/sonar-project.properties
+++ b/packages/bot/sonar-project.properties
@@ -1,7 +1,7 @@
-sonar.projectKey=swiss-ai-hub_bot
+sonar.projectKey=aihub-core_bot-core
 sonar.organization=bbv-ai
 # This is the name and version displayed in the SonarCloud UI
-sonar.projectName=Swiss AI Hub Bot
+sonar.projectName=Bot Core
 sonar.projectVersion=1.0
 sonar.sources=swiss_ai_hub
 sonar.tests=swiss_ai_hub

--- a/packages/core/sonar-project.properties
+++ b/packages/core/sonar-project.properties
@@ -1,8 +1,8 @@
-sonar.projectKey=swiss-ai-hub_core
+sonar.projectKey=aihub-core_lib-core
 sonar.organization=bbv-ai
 
 # This is the name and version displayed in the SonarCloud UI
-sonar.projectName=Swiss AI Hub Core
+sonar.projectName=Lib Core
 sonar.projectVersion=1.0
 
 sonar.sources=swiss_ai_hub

--- a/packages/pipeline/sonar-project.properties
+++ b/packages/pipeline/sonar-project.properties
@@ -1,8 +1,8 @@
-sonar.projectKey=swiss-ai-hub_pipeline
+sonar.projectKey=aihub-core_pipelines-core
 sonar.organization=bbv-ai
 
 # This is the name and version displayed in the SonarCloud UI
-sonar.projectName=Swiss AI Hub Pipeline
+sonar.projectName=Pipelines Core
 sonar.projectVersion=1.0
 
 sonar.sources=swiss_ai_hub

--- a/packages/process/sonar-project.properties
+++ b/packages/process/sonar-project.properties
@@ -1,8 +1,8 @@
-sonar.projectKey=swiss-ai-hub_process
+sonar.projectKey=aihub-core_process-core
 sonar.organization=bbv-ai
 
 # This is the name and version displayed in the SonarCloud UI
-sonar.projectName=Swiss AI Hub Process
+sonar.projectName=Process Core
 sonar.projectVersion=1.0
 
 sonar.sources=swiss_ai_hub

--- a/packages/web/sonar-project.properties
+++ b/packages/web/sonar-project.properties
@@ -1,8 +1,8 @@
-sonar.projectKey=swiss-ai-hub_web
+sonar.projectKey=aihub-core_aihub-web
 sonar.organization=bbv-ai
 
 # This is the name and version displayed in the SonarCloud UI
-sonar.projectName=Swiss AI Hub Web
+sonar.projectName=Web Core
 sonar.projectVersion=1.0
 
 sonar.sources=swiss_ai_hub_web


### PR DESCRIPTION
## Summary

Fixes CI failures introduced by the `packages/` rename in #982:

- **Artifact naming**: `packages/core` produces artifact name `packages/core-coverage-report` which contains `/` — an invalid character. Added `tr '/' '-'` sanitization in all 3 coupled actions (`test_backend`, `pytest_coverage_comment`, `sonarcloud_scan`)
- **`.env.dev` quoting**: Fixed `OTEL_CLOUD_HEADERS` — was using single quotes inside single quotes (`'{'key':'val'}'`), now uses double quotes inside single quotes (`'{"key":"val"}'`)
- **Workflow repo references**: The rename corrupted `bbvch-ai/aihub-core` to `bbvch-ai/swiss-ai-hu.` in `uses:` directives in `lint-pr.yml` and `analyze-test-pr.yml`
- **CHANGELOG**: Added missing v0.271.0 entry (LLM-generated changelog failed due to diff size)

## Test plan

- [ ] CI lint workflow resolves actions correctly
- [ ] CI test workflow produces valid artifact names (`packages-core-coverage-report` instead of `packages/core-coverage-report`)
- [ ] `.env.dev` parses without errors in Docker Compose and uv