### PR TITLE
fix(ci-cd): Copy README in agent Dockerfile

### DIFF
--- a/packages/agent/app/expert_asking_agent/Dockerfile
+++ b/packages/agent/app/expert_asking_agent/Dockerfile
@@ -25,6 +25,7 @@ COPY pyproject.toml uv.lock ./
 COPY packages/agent/app/${AGENT} ./packages/agent/app/${AGENT}
 COPY packages/agent/swiss_ai_hub ./packages/agent/swiss_ai_hub
 COPY packages/agent/pyproject.toml ./packages/agent/pyproject.toml
+COPY packages/agent/README.md ./packages/agent/README.md
 COPY packages/core ./packages/core
 
 # Install dependencies with cache mount

--- a/packages/agent/app/expert_rag_agent/Dockerfile
+++ b/packages/agent/app/expert_rag_agent/Dockerfile
@@ -25,6 +25,7 @@ COPY pyproject.toml uv.lock ./
 COPY packages/agent/app/${AGENT} ./packages/agent/app/${AGENT}
 COPY packages/agent/swiss_ai_hub ./packages/agent/swiss_ai_hub
 COPY packages/agent/pyproject.toml ./packages/agent/pyproject.toml
+COPY packages/agent/README.md ./packages/agent/README.md
 COPY packages/core ./packages/core
 
 # Install dependencies with cache mount

--- a/packages/agent/app/few_shot_agent/Dockerfile
+++ b/packages/agent/app/few_shot_agent/Dockerfile
@@ -25,6 +25,7 @@ COPY pyproject.toml uv.lock ./
 COPY packages/agent/app/${AGENT} ./packages/agent/app/${AGENT}
 COPY packages/agent/swiss_ai_hub ./packages/agent/swiss_ai_hub
 COPY packages/agent/pyproject.toml ./packages/agent/pyproject.toml
+COPY packages/agent/README.md ./packages/agent/README.md
 COPY packages/core ./packages/core
 
 # Install dependencies with cache mount

--- a/packages/agent/app/llm_wrapping_agent/Dockerfile
+++ b/packages/agent/app/llm_wrapping_agent/Dockerfile
@@ -25,6 +25,7 @@ COPY pyproject.toml uv.lock ./
 COPY packages/agent/app/${AGENT} ./packages/agent/app/${AGENT}
 COPY packages/agent/swiss_ai_hub ./packages/agent/swiss_ai_hub
 COPY packages/agent/pyproject.toml ./packages/agent/pyproject.toml
+COPY packages/agent/README.md ./packages/agent/README.md
 COPY packages/core ./packages/core
 
 # Install dependencies with cache mount

--- a/packages/agent/app/namespace_selection_agent/Dockerfile
+++ b/packages/agent/app/namespace_selection_agent/Dockerfile
@@ -25,6 +25,7 @@ COPY pyproject.toml uv.lock ./
 COPY packages/agent/app/${AGENT} ./packages/agent/app/${AGENT}
 COPY packages/agent/swiss_ai_hub ./packages/agent/swiss_ai_hub
 COPY packages/agent/pyproject.toml ./packages/agent/pyproject.toml
+COPY packages/agent/README.md ./packages/agent/README.md
 COPY packages/core ./packages/core
 
 # Install dependencies with cache mount

--- a/packages/agent/app/rag_agent/Dockerfile
+++ b/packages/agent/app/rag_agent/Dockerfile
@@ -25,6 +25,7 @@ COPY pyproject.toml uv.lock ./
 COPY packages/agent/app/${AGENT} ./packages/agent/app/${AGENT}
 COPY packages/agent/swiss_ai_hub ./packages/agent/swiss_ai_hub
 COPY packages/agent/pyproject.toml ./packages/agent/pyproject.toml
+COPY packages/agent/README.md ./packages/agent/README.md
 COPY packages/core ./packages/core
 
 # Install dependencies with cache mount

--- a/packages/agent/app/retrieval_agent/Dockerfile
+++ b/packages/agent/app/retrieval_agent/Dockerfile
@@ -25,6 +25,7 @@ COPY pyproject.toml uv.lock ./
 COPY packages/agent/app/${AGENT} ./packages/agent/app/${AGENT}
 COPY packages/agent/swiss_ai_hub ./packages/agent/swiss_ai_hub
 COPY packages/agent/pyproject.toml ./packages/agent/pyproject.toml
+COPY packages/agent/README.md ./packages/agent/README.md
 COPY packages/core ./packages/core
 
 # Install dependencies with cache mount


### PR DESCRIPTION
This pull request updates the Dockerfiles for several agents to ensure the `README.md` file from `packages/agent` is included in their build context. This addition helps provide documentation and context within each agent's Docker image. Since README is referenced in pyproject.toml Build fails otherwise