### PR TITLE
feat(swiss-ai-hub): Tenant path parameter and active tenant resolution

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -169,7 +169,7 @@ them or explicitly accepts the risk.
 
 **WebSocket** — real-time UI:
 
-- Single endpoint: `/api/v1/events/ws`
+- Single endpoint: `/api/v1/{tenant_id}/events/ws`
 - Auth via first message, then read-only from client
 - `WebSocketManager` routes events to connected users by thread participation
 

--- a/.claude/skills/audit-frontend/SKILL.md
+++ b/.claude/skills/audit-frontend/SKILL.md
@@ -273,7 +273,7 @@ ______________________________________________________________________
 1. Check if API is accessible:
 
 ```bash
-curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/api/v1/openapi.json
+curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/api/v1/active/openapi.json
 ```
 
 2. If accessible, compare OpenAPI spec endpoints with `packages/web/swiss_ai_hub_web/sdk/client/sdk.gen.ts`:

--- a/.claude/skills/bot-framework/SKILL.md
+++ b/.claude/skills/bot-framework/SKILL.md
@@ -41,7 +41,7 @@ back to non-streaming (`super().on_message_activity()`).
 ### Request Flow
 
 ```
-1. Azure Bot Service → POST /api/v1/agent/chat/completions/{class}/{id}/json
+1. Azure Bot Service → POST /api/v1/active/agent/chat/completions/{class}/{id}/json
 2. AgentChatController._process_agent_chat_request()
    ├─ RoutesService.get_path(request) → extract URL path
    ├─ bot = AgentChatBot(nc, distributor, agent_class, agent_id, path)

--- a/.claude/skills/debug-frontend/SKILL.md
+++ b/.claude/skills/debug-frontend/SKILL.md
@@ -44,7 +44,7 @@ Use these Playwright MCP tools to gather diagnostic information:
 1. Check `browser_network_requests` for failed API calls
 2. Look at the request URL and response status
 3. Cross-reference with SDK functions in `packages/web/swiss_ai_hub_web/sdk/client/`
-4. Check if the API server is running (`curl http://localhost:8000/api/v1/docs`)
+4. Check if the API server is running (`curl http://localhost:8000/api/v1/active/docs`)
 
 ### Rendering Issues
 

--- a/.claude/skills/generate-sdk/SKILL.md
+++ b/.claude/skills/generate-sdk/SKILL.md
@@ -11,7 +11,7 @@ Regenerate the TypeScript API client from the live OpenAPI specification.
 ## Step 1: Verify API Server Is Running
 
 ```bash
-curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/api/v1/docs
+curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/api/v1/active/docs
 ```
 
 - **200**: Proceed to Step 2
@@ -30,7 +30,7 @@ cd packages/web/swiss_ai_hub_web && pnpm generate-sdk
 ```
 
 This uses the config at `packages/web/swiss_ai_hub_web/openapi-ts.config.ts` to fetch the OpenAPI spec from
-`http://localhost:8000/api/v1/openapi.json` and regenerate TypeScript files into
+`http://localhost:8000/api/v1/active/openapi.json` and regenerate TypeScript files into
 `packages/web/swiss_ai_hub_web/sdk/client/` (`types.gen.ts`, `sdk.gen.ts`, `schemas.gen.ts`, `client.gen.ts`,
 `transformers.gen.ts`).
 

--- a/.claude/skills/pr-demo-video/SKILL.md
+++ b/.claude/skills/pr-demo-video/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr-demo-video
 description: Analyze a screen recording and add a demo section to the current PR on bbvch-ai/aihub-core. Extracts frames with ffmpeg, describes what the video shows using vision, updates the PR body with a Demo section and video description, and checks off matching test plan items. Use when user says 'add demo video to PR', 'add video to PR', 'describe the video', 'add screen recording to PR', or 'pr demo'. Do NOT use for creating the PR itself (use /create-pr), reviewing code (use /review-diff), or recording videos.
-allowed-tools: Bash, Read, Grep, Glob
+allowed-tools: Bash, Read, Grep, Glob, AskUserQuestion
 ---
 
 # PR Demo Video
@@ -34,17 +34,39 @@ echo "$LATEST"
 
 If no recording is found in any default location, ask the user for the path.
 
-## Step 2: Extract Metadata and Frames
+## Step 2: Ask About Key Moments
 
-Get duration and resolution, then extract one frame every 10 seconds for analysis:
+Before extracting frames, ask the user what the video demonstrates and which moments are most important. Frame
+extraction at fixed intervals is lossy — a 10-second gap can miss a crucial UI state, API response, or transition.
+
+Use AskUserQuestion to ask:
+
+> "What are the key moments or things shown in this video that I should capture in the demo description?"
+
+Provide options based on common demo patterns in this repo (e.g., "API response in Swagger", "Agent chat interaction in
+OpenWebUI", "Admin UI configuration", "Process workflow step"). Allow multi-select and free-text input.
+
+Use the user's answer to:
+
+1. Know what to look for when analyzing frames (so you don't misidentify UI elements)
+2. Ensure every key moment the user mentions appears in the final demo description
+3. Extract additional frames at higher density (fps=1/3) if the video is short, to avoid missing transitions
+
+## Step 3: Extract Metadata and Frames
+
+Get duration and resolution, then extract frames for analysis:
 
 ```bash
 ffmpeg -i "$VIDEO_PATH" 2>&1 | grep -E "Duration|Video|Stream"
 mkdir -p /tmp/video-frames
-ffmpeg -i "$VIDEO_PATH" -vf "fps=1/10" -q:v 2 /tmp/video-frames/frame_%02d.jpg -y
+# For videos under 2 minutes, extract every 3 seconds to catch transitions
+# For longer videos, extract every 10 seconds
+ffmpeg -i "$VIDEO_PATH" -vf "fps=1/3" -q:v 2 /tmp/video-frames/frame_%02d.jpg -y
 ```
 
-## Step 3: Analyze Frames
+If the video is longer than 2 minutes, use `fps=1/10` instead to keep frame count manageable.
+
+## Step 4: Analyze Frames
 
 Read each extracted frame using the Read tool (which supports images). For each frame, note:
 
@@ -53,9 +75,12 @@ Read each extracted frame using the Read tool (which supports images). For each 
 - What data is visible (API responses, network tab, console)
 - What the user is demonstrating
 
+Cross-reference against the key moments from Step 2. If any moment the user mentioned is NOT visible in the extracted
+frames, flag it — the user may need to provide a timestamp or the frame extraction interval was too coarse.
+
 Build a chronological narrative of what the video shows.
 
-## Step 4: Get Current PR
+## Step 5: Get Current PR
 
 Find the PR for the current branch:
 
@@ -63,7 +88,7 @@ Find the PR for the current branch:
 gh pr view --json number,body -R bbvch-ai/aihub-core
 ```
 
-## Step 5: Write the Demo Section
+## Step 6: Write the Demo Section
 
 Format the demo section following this repo's PR body convention:
 
@@ -85,12 +110,12 @@ Key rules:
 - Connect each item to what it PROVES about the feature (e.g., "confirming health is outside tenant scope")
 - Include the full path to the video file so the user can drag-and-drop
 
-## Step 6: Update Test Plan
+## Step 7: Update Test Plan
 
 Read the existing `## Test plan` section. For each checklist item, check if the video visually demonstrates it. If so,
 mark it as checked (`- [x]`). Do NOT uncheck already-checked items.
 
-## Step 7: Update the PR
+## Step 8: Update the PR
 
 Use `gh pr edit` to update the PR body with the new Demo section and updated Test plan:
 
@@ -101,7 +126,7 @@ EOF
 )"
 ```
 
-## Step 8: Remind About Upload
+## Step 9: Remind About Upload
 
 Tell the user to manually upload the video file by dragging it into the PR description on GitHub, since `gh` CLI cannot
 upload video attachments. Include the exact file path for convenience.
@@ -114,3 +139,5 @@ upload video attachments. Include the exact file path for convenience.
   codebase. "API requests return 200" not "added tenant path parameter".
 - **Unchecking test plan items**: Only ADD checkmarks to items the video demonstrates. Never uncheck items that were
   already checked.
+- **Skipping the key moments question**: Always ask the user what the video shows before analyzing frames.
+  Fixed-interval frame extraction misses transitions, and the user knows exactly which moments matter for the PR.

--- a/.claude/skills/pr-demo-video/SKILL.md
+++ b/.claude/skills/pr-demo-video/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: pr-demo-video
+description: Analyze a screen recording and add a demo section to the current PR on bbvch-ai/aihub-core. Extracts frames with ffmpeg, describes what the video shows using vision, updates the PR body with a Demo section and video description, and checks off matching test plan items. Use when user says 'add demo video to PR', 'add video to PR', 'describe the video', 'add screen recording to PR', or 'pr demo'. Do NOT use for creating the PR itself (use /create-pr), reviewing code (use /review-diff), or recording videos.
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# PR Demo Video
+
+Add a demo video description to the current branch's pull request on `bbvch-ai/aihub-core`.
+
+## Step 1: Locate the Video
+
+If the user provides a path, use that. Otherwise find the most recent screen recording:
+
+```bash
+ls -t ~/Videos/Screencasts/*.mp4 | head -1
+```
+
+Screen recordings are stored at `~/Videos/Screencasts/` as `Screencast from YYYY-MM-DD HH-MM-SS.mp4`.
+
+## Step 2: Extract Metadata and Frames
+
+Get duration and resolution, then extract one frame every 10 seconds for analysis:
+
+```bash
+ffmpeg -i "$VIDEO_PATH" 2>&1 | grep -E "Duration|Video|Stream"
+mkdir -p /tmp/video-frames
+ffmpeg -i "$VIDEO_PATH" -vf "fps=1/10" -q:v 2 /tmp/video-frames/frame_%02d.jpg -y
+```
+
+## Step 3: Analyze Frames
+
+Read each extracted frame using the Read tool (which supports images). For each frame, note:
+
+- What URL is visible in the browser address bar
+- What UI elements or pages are shown
+- What data is visible (API responses, network tab, console)
+- What the user is demonstrating
+
+Build a chronological narrative of what the video shows.
+
+## Step 4: Get Current PR
+
+Find the PR for the current branch:
+
+```bash
+gh pr view --json number,body -R bbvch-ai/aihub-core
+```
+
+## Step 5: Write the Demo Section
+
+Format the demo section following this repo's PR body convention:
+
+```markdown
+## Demo
+
+> **Video description:** {One-line summary of what the video demonstrates} ({duration}).
+> 1. {First thing shown} -- {what it proves}
+> 2. {Second thing shown} -- {what it proves}
+> ...
+
+_(Upload video here -- drag `{VIDEO_PATH}` into this text area)_
+```
+
+Key rules:
+
+- Lead with a one-line summary including duration (e.g., "1m24s")
+- Each numbered item describes what is VISIBLE, not what was changed in code
+- Connect each item to what it PROVES about the feature (e.g., "confirming health is outside tenant scope")
+- Include the full path to the video file so the user can drag-and-drop
+
+## Step 6: Update Test Plan
+
+Read the existing `## Test plan` section. For each checklist item, check if the video visually demonstrates it. If so,
+mark it as checked (`- [x]`). Do NOT uncheck already-checked items.
+
+## Step 7: Update the PR
+
+Use `gh pr edit` to update the PR body with the new Demo section and updated Test plan:
+
+```bash
+gh pr edit {PR_NUMBER} --body "$(cat <<'EOF'
+{full updated PR body}
+EOF
+)"
+```
+
+## Step 8: Remind About Upload
+
+Tell the user to manually upload the video file by dragging it into the PR description on GitHub, since `gh` CLI cannot
+upload video attachments. Include the exact file path for convenience.
+
+## Common Mistakes
+
+- **Forgetting the video path hint**: Always include the drag-and-drop instruction with the full file path -- the user
+  needs to upload manually since GitHub CLI can't attach videos.
+- **Over-describing code changes**: The demo section describes what is VISIBLE in the video, not what was changed in the
+  codebase. "API requests return 200" not "added tenant path parameter".
+- **Unchecking test plan items**: Only ADD checkmarks to items the video demonstrates. Never uncheck items that were
+  already checked.

--- a/.claude/skills/pr-demo-video/SKILL.md
+++ b/.claude/skills/pr-demo-video/SKILL.md
@@ -10,13 +10,29 @@ Add a demo video description to the current branch's pull request on `bbvch-ai/a
 
 ## Step 1: Locate the Video
 
-If the user provides a path, use that. Otherwise find the most recent screen recording:
+If the user provides a path, use that. Otherwise, find the most recent screen recording by detecting the OS-specific
+default location:
 
 ```bash
-ls -t ~/Videos/Screencasts/*.mp4 | head -1
+# Detect OS and find screen recordings directory
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  # GNOME/Ubuntu: ~/Videos/Screencasts/
+  CANDIDATES=("$HOME/Videos/Screencasts" "$HOME/Videos" "$HOME/Screencasts")
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  # macOS: ~/Desktop/ or ~/Movies/
+  CANDIDATES=("$HOME/Desktop" "$HOME/Movies")
+else
+  CANDIDATES=("$HOME/Videos" "$HOME/Desktop")
+fi
+
+for dir in "${CANDIDATES[@]}"; do
+  LATEST=$(ls -t "$dir"/*.mp4 "$dir"/*.mov "$dir"/*.webm 2>/dev/null | head -1)
+  [ -n "$LATEST" ] && break
+done
+echo "$LATEST"
 ```
 
-Screen recordings are stored at `~/Videos/Screencasts/` as `Screencast from YYYY-MM-DD HH-MM-SS.mp4`.
+If no recording is found in any default location, ask the user for the path.
 
 ## Step 2: Extract Metadata and Frames
 

--- a/.claude/skills/setup-bot-connection/SKILL.md
+++ b/.claude/skills/setup-bot-connection/SKILL.md
@@ -43,7 +43,7 @@ uv run python swiss_ai_hub/bot/setup_azure_bot.py \
     --resource-group "my-resource-group" \
     --bot-name "ai-hub-bot" \
     --token-url "https://my-domain.com" \
-    --token-path "/api/v1/agent/chat/completions/MyAgent/my_agent_id/json" \
+    --token-path "/api/v1/active/agent/chat/completions/MyAgent/my_agent_id/json" \
     --mongo-connection-string "mongodb://localhost:27017" \
     --tenant-id "your-azure-tenant-id" \
     --system-message "You are {assistant_name}. The user's name is {username}." \
@@ -59,7 +59,7 @@ uv run python swiss_ai_hub/bot/setup_azure_bot.py \
     --resource-group "my-resource-group" \
     --bot-name "ai-hub-slack-bot" \
     --token-url "https://my-domain.com" \
-    --token-path "/api/v1/agent/chat/completions/MyAgent/my_agent_id/json" \
+    --token-path "/api/v1/active/agent/chat/completions/MyAgent/my_agent_id/json" \
     --mongo-connection-string "mongodb://localhost:27017" \
     --slack-token "xoxb-your-slack-bot-token" \
     --system-message "You are {assistant_name}. The user's name is {username}."
@@ -107,7 +107,7 @@ az bot create \
     --name "ai-hub-bot" \
     --resource-group "my-resource-group" \
     --display-name "Swiss AI Hub Bot" \
-    --endpoint "https://your-domain.com/api/v1/agent/chat/completions/MyAgent/my_id/json" \
+    --endpoint "https://your-domain.com/api/v1/active/agent/chat/completions/MyAgent/my_id/json" \
     --location "westeurope" \
     --sku "F0" \
     --tenant-id "<APP_TENANTID>"
@@ -131,9 +131,9 @@ cd packages/bot && uv run python swiss_ai_hub/bot/add_path_entity.py
 from pymongo import MongoClient
 client = MongoClient("mongodb://localhost:27017")
 client["aihub"]["bot_paths"].update_one(
-    {"path": "/api/v1/agent/chat/completions/MyAgent/my_id/json"},
+    {"path": "/api/v1/active/agent/chat/completions/MyAgent/my_id/json"},
     {"$set": {
-        "path": "/api/v1/agent/chat/completions/MyAgent/my_id/json",
+        "path": "/api/v1/active/agent/chat/completions/MyAgent/my_id/json",
         "credentials": {
             "APP_TYPE": "SingleTenant",  # or "MultiTenant" for Slack
             "APP_ID": "<APP_ID>",
@@ -186,7 +186,7 @@ devtunnel port create -p 8001
 devtunnel host
 
 # Output: https://abc123-8001.devtunnels.ms
-# Use as bot endpoint: https://abc123-8001.devtunnels.ms/api/v1/agent/chat/completions/...
+# Use as bot endpoint: https://abc123-8001.devtunnels.ms/api/v1/active/agent/chat/completions/...
 ```
 
 ### Using Bot Framework Emulator (No Azure Required)
@@ -197,7 +197,7 @@ devtunnel host
    cd packages/bot/playground/testing
    uv run python main.py
    ```
-3. Connect emulator to: `http://localhost:8000/api/v1/messages`
+3. Connect emulator to: `http://localhost:8000/api/v1/active/messages`
 4. Leave App ID and Password **empty** for local testing
 5. Send messages and inspect Activity JSON
 

--- a/.env.dev
+++ b/.env.dev
@@ -325,7 +325,7 @@ DAGSTER_HOME='~/.dagster_home'
 # Frontend Development URLs
 AIHUB_FRONTEND_ORIGIN='http://localhost:3333'
 WEBUI_URL='http://localhost:8080'
-WS_ENDPOINT='ws://localhost:8000/api/v1/events/ws'
+WS_ENDPOINT='ws://localhost:8000/api/v1/active/events/ws'
 
 # =============================================================================
 # Optional: Azure Services (for customer data sources)

--- a/.idea/swiss-ai-hub.iml
+++ b/.idea/swiss-ai-hub.iml
@@ -13,6 +13,7 @@
       <excludeFolder url="file://$MODULE_DIR$/local-volumes" />
       <excludeFolder url="file://$MODULE_DIR$/docs/.vitepress/dist" />
       <excludeFolder url="file://$MODULE_DIR$/.venv" />
+      <excludeFolder url="file://$MODULE_DIR$/.claude/worktrees" />
     </content>
     <orderEntry type="jdk" jdkName="uv (swiss-ai-hub)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/docs/arc42/chapters/08_crosscutting_concepts.md
+++ b/docs/arc42/chapters/08_crosscutting_concepts.md
@@ -158,10 +158,10 @@ wrapping them in `asyncio.run()`.
 ## Generated TypeScript SDK
 
 The frontend's API client is generated from the FastAPI server's OpenAPI schema using HeyAPI (`@hey-api/openapi-ts`).
-The generator reads the live schema from `http://localhost:8000/api/v1/openapi.json` and produces type definitions, SDK
-functions (one per endpoint), JSON schemas, and response transformers (for date coercion) into `sdk/client/`. The
-`@hey-api/client-nuxt` plugin configures the generated client to use Nuxt's `$fetch` composable for SSR-compatible
-cookie and header forwarding.
+The generator reads the live schema from `http://localhost:8000/api/v1/active/openapi.json` and produces type
+definitions, SDK functions (one per endpoint), JSON schemas, and response transformers (for date coercion) into
+`sdk/client/`. The `@hey-api/client-nuxt` plugin configures the generated client to use Nuxt's `$fetch` composable for
+SSR-compatible cookie and header forwarding.
 
 Because agent endpoints are registered dynamically at runtime (see chapter 6 (Runtime view), agent discovery), the
 generated SDK's type coverage extends to agent-specific request and response types. When a new agent class is discovered

--- a/docs/arc42/decisions/2025_12_25_local_role_management.md
+++ b/docs/arc42/decisions/2025_12_25_local_role_management.md
@@ -99,8 +99,8 @@ removed entirely. Auth handlers are now standalone classes that validate tokens 
 
 ### Multi-Tenancy
 
-- **Tenant context required** - tenant is identified via `{tenant_id}` URL path parameter (see
-  [ADR: Tenant Path Parameter](2026_03_30_tenant_path_parameter.md))
+- **Tenant header optional** - `x-tenant-id` header identifies the tenant context; defaults to default tenant if not
+  provided
 - **User-tenant isolation** - users can have different roles in different tenants
 - **Tenant-scoped roles** - roles can be system-wide (`tenant_id=None`) or tenant-specific (`tenant_id` set)
 - **Tenant membership required** - users must have at least one role in a tenant to access it (enforced during auth

--- a/docs/arc42/decisions/2025_12_25_local_role_management.md
+++ b/docs/arc42/decisions/2025_12_25_local_role_management.md
@@ -128,5 +128,5 @@ removed entirely. Auth handlers are now standalone classes that validate tokens 
 The tenant resolution mechanism described in this ADR (resolving tenant from the `x-tenant-id` HTTP header with a
 fallback to the default tenant) has been superseded. Tenant context is now provided via a required `{tenant_id}` path
 parameter in the URL (`/api/v1/{tenant_id}/...`). The special value `"active"` resolves to the user's persisted active
-tenant. The `x-tenant-id` header is no longer supported. See
-[ADR: Tenant Path Parameter](2026_03_30_tenant_path_parameter.md) for details.
+tenant. There is no implicit fallback — if no active tenant is set, the request is rejected. The `x-tenant-id` header is
+no longer supported. See [ADR: Tenant Path Parameter](2026_03_30_tenant_path_parameter.md) for details.

--- a/docs/arc42/decisions/2025_12_25_local_role_management.md
+++ b/docs/arc42/decisions/2025_12_25_local_role_management.md
@@ -99,8 +99,8 @@ removed entirely. Auth handlers are now standalone classes that validate tokens 
 
 ### Multi-Tenancy
 
-- **Tenant header optional** - `x-tenant-id` header identifies the tenant context; defaults to default tenant if not
-  provided
+- **Tenant context required** - tenant is identified via `{tenant_id}` URL path parameter (see
+  [ADR: Tenant Path Parameter](2026_03_30_tenant_path_parameter.md))
 - **User-tenant isolation** - users can have different roles in different tenants
 - **Tenant-scoped roles** - roles can be system-wide (`tenant_id=None`) or tenant-specific (`tenant_id` set)
 - **Tenant membership required** - users must have at least one role in a tenant to access it (enforced during auth
@@ -122,3 +122,11 @@ removed entirely. Auth handlers are now standalone classes that validate tokens 
 - **User role migration**: Data in old `UserEntity.roles` field must be migrated to UserTenantRoleEntity
 - **No automatic migration**: Deployments upgrading from previous versions must manually migrate data
 - **Rollback considerations**: UserEntity.roles field removal makes rollback complex; backup database before upgrade
+
+## Update (2026-03-30)
+
+The tenant resolution mechanism described in this ADR (resolving tenant from the `x-tenant-id` HTTP header with a
+fallback to the default tenant) has been superseded. Tenant context is now provided via a required `{tenant_id}` path
+parameter in the URL (`/api/v1/{tenant_id}/...`). The special value `"active"` resolves to the user's persisted active
+tenant. The `x-tenant-id` header is no longer supported. See
+[ADR: Tenant Path Parameter](2026_03_30_tenant_path_parameter.md) for details.

--- a/docs/arc42/decisions/2026_03_30_tenant_path_parameter.md
+++ b/docs/arc42/decisions/2026_03_30_tenant_path_parameter.md
@@ -1,0 +1,47 @@
+# Tenant Identification via URL Path Parameter
+
+## Context
+
+Previously, tenant context was provided via an `x-tenant-id` HTTP header on API requests, with a fallback to a
+system-wide default tenant when the header was omitted. This approach had several limitations: OpenWebUI (the chat
+frontend) cannot set custom HTTP headers on API requests, the tenant context was invisible in URLs making debugging and
+logging harder, and the implicit fallback to a default tenant masked misconfigured clients.
+
+## Decision Drivers
+
+- **URL-level tenant scoping**: Embedding the tenant in the URL makes tenant context explicit and visible in logs,
+  browser history, and monitoring tools. Every request's tenant affiliation is immediately apparent.
+- **OpenWebUI compatibility**: OpenWebUI routes API calls to the backend but cannot inject custom HTTP headers. A path
+  parameter works naturally with OpenWebUI's URL-based routing.
+- **Explicit tenant context in every request**: Removing the implicit default tenant fallback forces clients to
+  explicitly declare which tenant they are operating within, eliminating silent misrouting.
+- **Per-user active tenant**: Users working across multiple tenants need the system to remember which tenant they last
+  selected, rather than always falling back to a global system default.
+
+## Decision
+
+All API routes are now mounted at `/api/v1/{tenant_id}/...` where `{tenant_id}` is a required path parameter. The
+`x-tenant-id` header is no longer supported.
+
+The `{tenant_id}` parameter accepts two formats:
+
+- **Concrete MongoDB ObjectId**: Directly specifies the tenant (e.g., `/api/v1/507f1f77bcf86cd799439011/agents/...`)
+- **`"active"` slug**: Resolves to the authenticated user's persisted active tenant (e.g., `/api/v1/active/agents/...`)
+
+Tenant-scoped routes are mounted via a Starlette `Mount` at `/api/v1/{tenant_id}`, which captures the path parameter
+before FastAPI route resolution. Health endpoints remain outside tenant scope at `/api/v1/health/`.
+
+The active tenant is persisted per user and is never automatically updated during request resolution. It can only be
+changed via a dedicated API endpoint.
+
+## Consequences
+
+- **Frontend uses `/api/v1/active/...`**: The frontend (OpenWebUI, Admin UI) uses the `"active"` slug for all API calls,
+  relying on the backend to resolve the user's current tenant.
+- **Health endpoints separated**: Health checks at `/api/v1/health/` are not tenant-scoped and do not require
+  authentication.
+- **No backward compatibility with header**: The `x-tenant-id` header is fully removed. All clients must migrate to the
+  path parameter approach.
+- **Supersedes previous ADR**: This decision supersedes the tenant resolution mechanism described in
+  [Local Multi-Tenant Role Management](2025_12_25_local_role_management.md), which used the `x-tenant-id` header with a
+  fallback to the default tenant.

--- a/docs/docs/2_platform/11_access_management/1_authentication_setup/index.en.md
+++ b/docs/docs/2_platform/11_access_management/1_authentication_setup/index.en.md
@@ -53,10 +53,12 @@ standard user roles (configurable via `UserSignupSettings`).
 
 ### 3. Tenant Context Resolution
 
-Every authenticated request must have a tenant context:
+Every authenticated request must have a tenant context. The tenant is identified via a required `{tenant_id}` path
+parameter in the URL. All API routes are mounted at `/api/v1/{tenant_id}/...`.
 
 ```python
-# Extract from x-tenant-id header or fall back to default tenant
+# Resolve tenant from {tenant_id} path parameter
+# tenant_id can be a MongoDB ObjectId or the special value "active"
 tenant = TenantIdentity.from_request_for_user(request, user_id)
 
 # Verify user has access to this tenant
@@ -65,8 +67,13 @@ if not roles:
     raise HTTPException(403, "User not assigned to tenant")
 ```
 
-**Tenant Header**: Clients should include `x-tenant-id: <tenant-id>` header in requests. If omitted, the default tenant
-is used.
+**Tenant Path Parameter**: All API requests must include the `{tenant_id}` in the URL path. Two formats are supported:
+
+- **Concrete ID**: `/api/v1/507f1f77bcf86cd799439011/agents/...` — directly specifies the tenant by MongoDB ObjectId
+- **Active slug**: `/api/v1/active/agents/...` — resolves to the user's persisted active tenant
+
+The active tenant is never automatically updated during request resolution. It can only be changed via a dedicated API
+endpoint. Health endpoints remain outside tenant scope at `/api/v1/health/`.
 
 ### 4. UserIdentity Construction
 

--- a/docs/docs/2_platform/18_api/4_dynamic_endpoints/index.en.md
+++ b/docs/docs/2_platform/18_api/4_dynamic_endpoints/index.en.md
@@ -65,13 +65,13 @@ Dynamic endpoints are enabled automatically when you start the Swiss AI Hub with
 For each discovered agent, the system creates endpoints following this pattern:
 
 ```
-POST /api/v1/agents/{agent_class}/{agent_id}/{event_name}
+POST /api/v1/{tenant_id}/agents/{agent_class}/{agent_id}/{event_name}
 ```
 
 **Example**: An agent with class `rag_agent` and ID `customer_support` that accepts `UserMessageEvent` would get:
 
 ```
-POST /api/v1/agents/rag_agent/customer_support/user_message_event
+POST /api/v1/{tenant_id}/agents/rag_agent/customer_support/user_message_event
 ```
 
 ## Process Endpoint Generation
@@ -79,10 +79,10 @@ POST /api/v1/agents/rag_agent/customer_support/user_message_event
 For each discovered process, the system creates endpoints based on the process definition:
 
 ```
-GET  /api/v1/processes/{process_class}/{process_id}/{route}         # Get form
-POST /api/v1/processes/{process_class}/{process_id}/{route}         # Submit form
-GET  /api/v1/processes/{process_class}/{process_id}/{walkthrough_id}/{route}  # Continue process
-POST /api/v1/processes/{process_class}/{process_id}/{walkthrough_id}/{route}  # Submit continuation
+GET  /api/v1/{tenant_id}/processes/{process_class}/{process_id}/{route}         # Get form
+POST /api/v1/{tenant_id}/processes/{process_class}/{process_id}/{route}         # Submit form
+GET  /api/v1/{tenant_id}/processes/{process_class}/{process_id}/{walkthrough_id}/{route}  # Continue process
+POST /api/v1/{tenant_id}/processes/{process_class}/{process_id}/{walkthrough_id}/{route}  # Submit continuation
 ```
 
 ## Available Capabilities
@@ -116,7 +116,7 @@ To begin using dynamic endpoints in your Swiss AI Hub:
 
 1. **Start the Infrastructure**: Ensure NATS and the API gateway are running with the standard Docker Compose setup
 2. **Deploy Agents/Processes**: Any agent or process that connects to NATS will automatically get endpoints
-3. **Discover Endpoints**: Check `/api/v1/docs` to see all dynamically generated endpoints
+3. **Discover Endpoints**: Check `/api/v1/active/docs` to see all dynamically generated endpoints
 4. **Integrate**: Use the standard REST endpoints to integrate with external systems or build custom frontends
 
 The dynamic endpoint system transforms the Swiss AI Hub from a static API into a living, adaptive integration layer that

--- a/docs/docs/2_platform/20_security/1_authentication/index.en.md
+++ b/docs/docs/2_platform/20_security/1_authentication/index.en.md
@@ -83,9 +83,9 @@ different behaviors for different access levels, and validating permissions befo
 ## Dynamic Identity Provider Discovery
 
 The login page dynamically discovers available identity providers from Keycloak at runtime. When a user visits the login
-page, the frontend calls `GET /api/v1/auth-providers/` — an unauthenticated API endpoint that queries the Keycloak Admin
-API using a dedicated, least-privilege service account (`aihub-api-service`) with only the `view-identity-providers`
-permission.
+page, the frontend calls `GET /api/v1/{tenant_id}/auth-providers/` — an unauthenticated API endpoint that queries the
+Keycloak Admin API using a dedicated, least-privilege service account (`aihub-api-service`) with only the
+`view-identity-providers` permission.
 
 The API filters the provider list to only include enabled, visible providers and returns their alias, display name, and
 icon. Results are cached for 5 minutes. The frontend renders a branded login button for each provider. Clicking a button

--- a/docs/docs/2_platform/20_security/1_authentication/index.en.md
+++ b/docs/docs/2_platform/20_security/1_authentication/index.en.md
@@ -83,8 +83,8 @@ different behaviors for different access levels, and validating permissions befo
 ## Dynamic Identity Provider Discovery
 
 The login page dynamically discovers available identity providers from Keycloak at runtime. When a user visits the login
-whatpage, the frontend calls `GET /api/v1/{tenant_id}/auth-providers/` — an unauthenticated API endpoint that queries
-the Keycloak Admin API using a dedicated, least-privilege service account (`aihub-api-service`) with only the
+page, the frontend calls `GET /api/v1/{tenant_id}/auth-providers/` — an unauthenticated API endpoint that queries the
+Keycloak Admin API using a dedicated, least-privilege service account (`aihub-api-service`) with only the
 `view-identity-providers` permission.
 
 The API filters the provider list to only include enabled, visible providers and returns their alias, display name, and

--- a/docs/docs/2_platform/20_security/1_authentication/index.en.md
+++ b/docs/docs/2_platform/20_security/1_authentication/index.en.md
@@ -83,8 +83,8 @@ different behaviors for different access levels, and validating permissions befo
 ## Dynamic Identity Provider Discovery
 
 The login page dynamically discovers available identity providers from Keycloak at runtime. When a user visits the login
-page, the frontend calls `GET /api/v1/{tenant_id}/auth-providers/` — an unauthenticated API endpoint that queries the
-Keycloak Admin API using a dedicated, least-privilege service account (`aihub-api-service`) with only the
+whatpage, the frontend calls `GET /api/v1/{tenant_id}/auth-providers/` — an unauthenticated API endpoint that queries
+the Keycloak Admin API using a dedicated, least-privilege service account (`aihub-api-service`) with only the
 `view-identity-providers` permission.
 
 The API filters the provider list to only include enabled, visible providers and returns their alias, display name, and

--- a/infra/configs/openwebui/functions/aihub_pipeline.py
+++ b/infra/configs/openwebui/functions/aihub_pipeline.py
@@ -17,7 +17,7 @@ Architecture:
 - EventHandler chain processes different AI-Hub event types
 - StreamingStateManager maintains content block state
 - ContentBlock hierarchy (TextBlock, ThinkingBlock, ToolBlock)
-- SSE streaming to /api/v1/agents/classes/{class}/instances/{id}/{event}/stream endpoints
+- SSE streaming to /api/v1/active/agents/classes/{class}/instances/{id}/{event}/stream endpoints
 """
 
 import asyncio
@@ -1072,7 +1072,7 @@ class StreamingService:
         display_id: Annotated[str, "Display identifier"],
     ) -> Annotated[str, "Complete streaming endpoint URL"]:
         """Build streaming endpoint URL"""
-        url = f"{self._base_url}/api/v1/agents/classes/{agent_class}/instances/{agent_id}/{event_name}/stream"
+        url = f"{self._base_url}/api/v1/active/agents/classes/{agent_class}/instances/{agent_id}/{event_name}/stream"
         url += f"?thread_id={thread_id}&display_id={display_id}"
         return url
 
@@ -1341,7 +1341,7 @@ class AgentDiscoveryService:
             }
 
             async with httpx.AsyncClient(timeout=self._timeout, follow_redirects=True) as client:
-                response = await client.get(f"{self._base_url}/api/v1/agents/instances", headers=headers)
+                response = await client.get(f"{self._base_url}/api/v1/active/agents/instances", headers=headers)
                 response.raise_for_status()
                 agents = response.json()
 
@@ -1456,7 +1456,7 @@ class FileProcessingService:
         async with httpx.AsyncClient(timeout=30.0) as client:
             # Step 1: Initiate upload — get presigned URL + file_id
             initiate_url = (
-                f"{self._base_url}/api/v1/agents/classes/{agent_class}/instances/{agent_id}/files/upload/initiate"
+                f"{self._base_url}/api/v1/active/agents/classes/{agent_class}/instances/{agent_id}/files/upload/initiate"
             )
             initiate_resp = await client.post(
                 initiate_url,
@@ -1479,7 +1479,7 @@ class FileProcessingService:
 
             # Step 3: Validate upload
             validate_url = (
-                f"{self._base_url}/api/v1/agents/classes/{agent_class}/instances/{agent_id}/files/upload/validate"
+                f"{self._base_url}/api/v1/active/agents/classes/{agent_class}/instances/{agent_id}/files/upload/validate"
             )
             validate_resp = await client.post(
                 validate_url,
@@ -1668,7 +1668,7 @@ class Pipe:
         try:
             async with httpx.AsyncClient(timeout=self.valves.AIHUB_REQUEST_TIMEOUT) as client:
                 response = await client.get(
-                    f"{self.valves.AIHUB_BASE_URL}/api/v1/threads/{thread_id}/open-chat-hitl",
+                    f"{self.valves.AIHUB_BASE_URL}/api/v1/active/threads/{thread_id}/open-chat-hitl",
                     headers=headers,
                 )
                 if response.status_code == 200:

--- a/infra/configs/openwebui/functions/openai_pipeline.py
+++ b/infra/configs/openwebui/functions/openai_pipeline.py
@@ -143,7 +143,7 @@ class Pipe:
                 timeout=self.valves.AIHUB_REQUEST_TIMEOUT, follow_redirects=True
             ) as client:
                 response = await client.get(
-                    f"{self.valves.AIHUB_BASE_URL}/api/v1/openai/models",
+                    f"{self.valves.AIHUB_BASE_URL}/api/v1/active/openai/models",
                     headers=headers,
                 )
                 response.raise_for_status()
@@ -221,7 +221,7 @@ class Pipe:
             # Start the streaming request
             async with client.stream(
                 "POST",
-                url=f"{self.valves.AIHUB_BASE_URL}/api/v1/openai/chat/completions",
+                url=f"{self.valves.AIHUB_BASE_URL}/api/v1/active/openai/chat/completions",
                 json=payload,
                 headers=headers,
             ) as stream_response:
@@ -309,7 +309,7 @@ class Pipe:
                 timeout=self.valves.AIHUB_REQUEST_TIMEOUT, follow_redirects=True
             ) as client:
                 response = await client.post(
-                    url=f"{self.valves.AIHUB_BASE_URL}/api/v1/openai/chat/completions",
+                    url=f"{self.valves.AIHUB_BASE_URL}/api/v1/active/openai/chat/completions",
                     json=payload,
                     headers=headers,
                 )

--- a/infra/deployment/templates/docker-compose.yml.j2
+++ b/infra/deployment/templates/docker-compose.yml.j2
@@ -1784,7 +1784,7 @@ services:
 
       # --- Model & AI-Hub Connection ---
       MODELS_CACHE_TTL: 60
-      OPENAI_API_BASE_URL: http://{{ 'localhost' if stage == 'dev' else 'api' }}:8000/api/v1/openai
+      OPENAI_API_BASE_URL: http://{{ 'localhost' if stage == 'dev' else 'api' }}:8000/api/v1/active/openai
       OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       TASK_MODEL: {{ default_model }}
       TASK_MODEL_EXTERNAL: {{ default_model }}
@@ -1793,7 +1793,7 @@ services:
 
       # --- Image Generation ---
       IMAGE_GENERATION_MODEL: image-generation
-      IMAGES_OPENAI_API_BASE_URL: http://{{ 'localhost' if stage == 'dev' else 'api' }}:8000/api/v1/openai
+      IMAGES_OPENAI_API_BASE_URL: http://{{ 'localhost' if stage == 'dev' else 'api' }}:8000/api/v1/active/openai
       IMAGES_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       IMAGE_SIZE: 1024x1024
       ENABLE_IMAGE_GENERATION: True
@@ -1801,13 +1801,13 @@ services:
       # --- Audio STT ---
       AUDIO_STT_ENGINE: openai
       AUDIO_STT_MODEL: transcription
-      AUDIO_STT_OPENAI_API_BASE_URL: http://{{ 'localhost' if stage == 'dev' else 'api' }}:8000/api/v1/openai
+      AUDIO_STT_OPENAI_API_BASE_URL: http://{{ 'localhost' if stage == 'dev' else 'api' }}:8000/api/v1/active/openai
       AUDIO_STT_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
 
       # --- Audio TTS ---
       AUDIO_TTS_ENGINE: openai
       AUDIO_TTS_MODEL: speech
-      AUDIO_TTS_OPENAI_API_BASE_URL: http://{{ 'localhost' if stage == 'dev' else 'api' }}:8000/api/v1/openai
+      AUDIO_TTS_OPENAI_API_BASE_URL: http://{{ 'localhost' if stage == 'dev' else 'api' }}:8000/api/v1/active/openai
       AUDIO_TTS_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       AUDIO_TTS_VOICE: alloy
 
@@ -1873,11 +1873,11 @@ services:
       PDF_EXTRACT_IMAGES: True
       RAG_FILE_MAX_COUNT: 4
       CONTENT_EXTRACTION_ENGINE: external
-      EXTERNAL_DOCUMENT_LOADER_URL: http://{{ 'localhost' if stage == 'dev' else 'api' }}:8000/api/v1/parsing
+      EXTERNAL_DOCUMENT_LOADER_URL: http://{{ 'localhost' if stage == 'dev' else 'api' }}:8000/api/v1/active/parsing
       EXTERNAL_DOCUMENT_LOADER_API_KEY: ${SUPERUSER_TOKEN}
       RAG_EMBEDDING_ENGINE: openai
       RAG_EMBEDDING_MODEL: embedding/bge-m3
-      RAG_OPENAI_API_BASE_URL: http://{{ 'localhost' if stage == 'dev' else 'api' }}:8000/api/v1/openai
+      RAG_OPENAI_API_BASE_URL: http://{{ 'localhost' if stage == 'dev' else 'api' }}:8000/api/v1/active/openai
       RAG_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
 
       # --- Web Search ---
@@ -2375,7 +2375,7 @@ services:
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY}
       LANGFUSE_PUBLIC_URL: {{ 'http://localhost:6006' if stage == 'dev' else 'https://langfuse.${DOMAIN}' }}
       LANGFUSE_PROJECT_ID: "aihub-project"
-      AIHUB_OPENAI_API_BASE_URL: http://{{ 'localhost' if stage == 'dev' else 'api' }}:8000/api/v1/openai
+      AIHUB_OPENAI_API_BASE_URL: http://{{ 'localhost' if stage == 'dev' else 'api' }}:8000/api/v1/active/openai
 
 
       # NATs
@@ -2468,7 +2468,7 @@ services:
       OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID}
       OAUTH_AUTHORITY_URL: ${OAUTH_AUTHORITY_URL}
       WEBUI_URL: https://openwebui.${DOMAIN}
-      WS_ENDPOINT: wss://${DOMAIN}/api/v1/events/ws
+      WS_ENDPOINT: wss://${DOMAIN}/api/v1/active/events/ws
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1/"]
       interval: 30s

--- a/infra/deployment/templates/openwebui_functions/aihub_pipeline.py
+++ b/infra/deployment/templates/openwebui_functions/aihub_pipeline.py
@@ -17,7 +17,7 @@ Architecture:
 - EventHandler chain processes different AI-Hub event types
 - StreamingStateManager maintains content block state
 - ContentBlock hierarchy (TextBlock, ThinkingBlock, ToolBlock)
-- SSE streaming to /api/v1/agents/classes/{class}/instances/{id}/{event}/stream endpoints
+- SSE streaming to /api/v1/active/agents/classes/{class}/instances/{id}/{event}/stream endpoints
 """
 
 import asyncio
@@ -1072,7 +1072,7 @@ class StreamingService:
         display_id: Annotated[str, "Display identifier"],
     ) -> Annotated[str, "Complete streaming endpoint URL"]:
         """Build streaming endpoint URL"""
-        url = f"{self._base_url}/api/v1/agents/classes/{agent_class}/instances/{agent_id}/{event_name}/stream"
+        url = f"{self._base_url}/api/v1/active/agents/classes/{agent_class}/instances/{agent_id}/{event_name}/stream"
         url += f"?thread_id={thread_id}&display_id={display_id}"
         return url
 
@@ -1341,7 +1341,7 @@ class AgentDiscoveryService:
             }
 
             async with httpx.AsyncClient(timeout=self._timeout, follow_redirects=True) as client:
-                response = await client.get(f"{self._base_url}/api/v1/agents/instances", headers=headers)
+                response = await client.get(f"{self._base_url}/api/v1/active/agents/instances", headers=headers)
                 response.raise_for_status()
                 agents = response.json()
 
@@ -1456,7 +1456,7 @@ class FileProcessingService:
         async with httpx.AsyncClient(timeout=30.0) as client:
             # Step 1: Initiate upload — get presigned URL + file_id
             initiate_url = (
-                f"{self._base_url}/api/v1/agents/classes/{agent_class}/instances/{agent_id}/files/upload/initiate"
+                f"{self._base_url}/api/v1/active/agents/classes/{agent_class}/instances/{agent_id}/files/upload/initiate"
             )
             initiate_resp = await client.post(
                 initiate_url,
@@ -1479,7 +1479,7 @@ class FileProcessingService:
 
             # Step 3: Validate upload
             validate_url = (
-                f"{self._base_url}/api/v1/agents/classes/{agent_class}/instances/{agent_id}/files/upload/validate"
+                f"{self._base_url}/api/v1/active/agents/classes/{agent_class}/instances/{agent_id}/files/upload/validate"
             )
             validate_resp = await client.post(
                 validate_url,
@@ -1668,7 +1668,7 @@ class Pipe:
         try:
             async with httpx.AsyncClient(timeout=self.valves.AIHUB_REQUEST_TIMEOUT) as client:
                 response = await client.get(
-                    f"{self.valves.AIHUB_BASE_URL}/api/v1/threads/{thread_id}/open-chat-hitl",
+                    f"{self.valves.AIHUB_BASE_URL}/api/v1/active/threads/{thread_id}/open-chat-hitl",
                     headers=headers,
                 )
                 if response.status_code == 200:

--- a/infra/deployment/templates/openwebui_functions/openai_pipeline.py
+++ b/infra/deployment/templates/openwebui_functions/openai_pipeline.py
@@ -143,7 +143,7 @@ class Pipe:
                 timeout=self.valves.AIHUB_REQUEST_TIMEOUT, follow_redirects=True
             ) as client:
                 response = await client.get(
-                    f"{self.valves.AIHUB_BASE_URL}/api/v1/openai/models",
+                    f"{self.valves.AIHUB_BASE_URL}/api/v1/active/openai/models",
                     headers=headers,
                 )
                 response.raise_for_status()
@@ -221,7 +221,7 @@ class Pipe:
             # Start the streaming request
             async with client.stream(
                 "POST",
-                url=f"{self.valves.AIHUB_BASE_URL}/api/v1/openai/chat/completions",
+                url=f"{self.valves.AIHUB_BASE_URL}/api/v1/active/openai/chat/completions",
                 json=payload,
                 headers=headers,
             ) as stream_response:
@@ -309,7 +309,7 @@ class Pipe:
                 timeout=self.valves.AIHUB_REQUEST_TIMEOUT, follow_redirects=True
             ) as client:
                 response = await client.post(
-                    url=f"{self.valves.AIHUB_BASE_URL}/api/v1/openai/chat/completions",
+                    url=f"{self.valves.AIHUB_BASE_URL}/api/v1/active/openai/chat/completions",
                     json=payload,
                     headers=headers,
                 )

--- a/infra/docker-compose.build.gpu.yml
+++ b/infra/docker-compose.build.gpu.yml
@@ -1526,7 +1526,7 @@ services:
 
       # --- Model & AI-Hub Connection ---
       MODELS_CACHE_TTL: 60
-      OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       TASK_MODEL: text-generation/Qwen3-VL-30B-A3B-Instruct-FP8
       TASK_MODEL_EXTERNAL: text-generation/Qwen3-VL-30B-A3B-Instruct-FP8
@@ -1535,7 +1535,7 @@ services:
 
       # --- Image Generation ---
       IMAGE_GENERATION_MODEL: image-generation
-      IMAGES_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      IMAGES_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       IMAGES_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       IMAGE_SIZE: 1024x1024
       ENABLE_IMAGE_GENERATION: true
@@ -1543,13 +1543,13 @@ services:
       # --- Audio STT ---
       AUDIO_STT_ENGINE: openai
       AUDIO_STT_MODEL: transcription
-      AUDIO_STT_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AUDIO_STT_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       AUDIO_STT_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
 
       # --- Audio TTS ---
       AUDIO_TTS_ENGINE: openai
       AUDIO_TTS_MODEL: speech
-      AUDIO_TTS_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AUDIO_TTS_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       AUDIO_TTS_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       AUDIO_TTS_VOICE: alloy
 
@@ -1611,11 +1611,11 @@ services:
       PDF_EXTRACT_IMAGES: true
       RAG_FILE_MAX_COUNT: 4
       CONTENT_EXTRACTION_ENGINE: external
-      EXTERNAL_DOCUMENT_LOADER_URL: http://api:8000/api/v1/parsing
+      EXTERNAL_DOCUMENT_LOADER_URL: http://api:8000/api/v1/active/parsing
       EXTERNAL_DOCUMENT_LOADER_API_KEY: ${SUPERUSER_TOKEN}
       RAG_EMBEDDING_ENGINE: openai
       RAG_EMBEDDING_MODEL: embedding/bge-m3
-      RAG_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      RAG_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       RAG_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
 
       # --- Web Search ---
@@ -2047,7 +2047,7 @@ services:
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY}
       LANGFUSE_PUBLIC_URL: https://langfuse.${DOMAIN}
       LANGFUSE_PROJECT_ID: aihub-project
-      AIHUB_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AIHUB_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
 
       # NATs
       NATS_ENDPOINT: nats://nats:4222
@@ -2129,7 +2129,7 @@ services:
       OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID}
       OAUTH_AUTHORITY_URL: ${OAUTH_AUTHORITY_URL}
       WEBUI_URL: https://openwebui.${DOMAIN}
-      WS_ENDPOINT: wss://${DOMAIN}/api/v1/events/ws
+      WS_ENDPOINT: wss://${DOMAIN}/api/v1/active/events/ws
     healthcheck:
       test: [CMD, curl, -f, http://127.0.0.1/]
       interval: 30s

--- a/infra/docker-compose.build.yml
+++ b/infra/docker-compose.build.yml
@@ -1318,7 +1318,7 @@ services:
 
       # --- Model & AI-Hub Connection ---
       MODELS_CACHE_TTL: 60
-      OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       TASK_MODEL: text-generation/gpt-oss-120b
       TASK_MODEL_EXTERNAL: text-generation/gpt-oss-120b
@@ -1327,7 +1327,7 @@ services:
 
       # --- Image Generation ---
       IMAGE_GENERATION_MODEL: image-generation
-      IMAGES_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      IMAGES_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       IMAGES_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       IMAGE_SIZE: 1024x1024
       ENABLE_IMAGE_GENERATION: true
@@ -1335,13 +1335,13 @@ services:
       # --- Audio STT ---
       AUDIO_STT_ENGINE: openai
       AUDIO_STT_MODEL: transcription
-      AUDIO_STT_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AUDIO_STT_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       AUDIO_STT_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
 
       # --- Audio TTS ---
       AUDIO_TTS_ENGINE: openai
       AUDIO_TTS_MODEL: speech
-      AUDIO_TTS_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AUDIO_TTS_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       AUDIO_TTS_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       AUDIO_TTS_VOICE: alloy
 
@@ -1403,11 +1403,11 @@ services:
       PDF_EXTRACT_IMAGES: true
       RAG_FILE_MAX_COUNT: 4
       CONTENT_EXTRACTION_ENGINE: external
-      EXTERNAL_DOCUMENT_LOADER_URL: http://api:8000/api/v1/parsing
+      EXTERNAL_DOCUMENT_LOADER_URL: http://api:8000/api/v1/active/parsing
       EXTERNAL_DOCUMENT_LOADER_API_KEY: ${SUPERUSER_TOKEN}
       RAG_EMBEDDING_ENGINE: openai
       RAG_EMBEDDING_MODEL: embedding/bge-m3
-      RAG_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      RAG_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       RAG_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
 
       # --- Web Search ---
@@ -1839,7 +1839,7 @@ services:
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY}
       LANGFUSE_PUBLIC_URL: https://langfuse.${DOMAIN}
       LANGFUSE_PROJECT_ID: aihub-project
-      AIHUB_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AIHUB_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
 
       # NATs
       NATS_ENDPOINT: nats://nats:4222
@@ -1921,7 +1921,7 @@ services:
       OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID}
       OAUTH_AUTHORITY_URL: ${OAUTH_AUTHORITY_URL}
       WEBUI_URL: https://openwebui.${DOMAIN}
-      WS_ENDPOINT: wss://${DOMAIN}/api/v1/events/ws
+      WS_ENDPOINT: wss://${DOMAIN}/api/v1/active/events/ws
     healthcheck:
       test: [CMD, curl, -f, http://127.0.0.1/]
       interval: 30s

--- a/infra/docker-compose.dev.gpu.yml
+++ b/infra/docker-compose.dev.gpu.yml
@@ -1275,7 +1275,7 @@ services:
 
       # --- Model & AI-Hub Connection ---
       MODELS_CACHE_TTL: 60
-      OPENAI_API_BASE_URL: http://localhost:8000/api/v1/openai
+      OPENAI_API_BASE_URL: http://localhost:8000/api/v1/active/openai
       OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       TASK_MODEL: text-generation/Qwen3-VL-30B-A3B-Instruct-FP8
       TASK_MODEL_EXTERNAL: text-generation/Qwen3-VL-30B-A3B-Instruct-FP8
@@ -1284,7 +1284,7 @@ services:
 
       # --- Image Generation ---
       IMAGE_GENERATION_MODEL: image-generation
-      IMAGES_OPENAI_API_BASE_URL: http://localhost:8000/api/v1/openai
+      IMAGES_OPENAI_API_BASE_URL: http://localhost:8000/api/v1/active/openai
       IMAGES_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       IMAGE_SIZE: 1024x1024
       ENABLE_IMAGE_GENERATION: true
@@ -1292,13 +1292,13 @@ services:
       # --- Audio STT ---
       AUDIO_STT_ENGINE: openai
       AUDIO_STT_MODEL: transcription
-      AUDIO_STT_OPENAI_API_BASE_URL: http://localhost:8000/api/v1/openai
+      AUDIO_STT_OPENAI_API_BASE_URL: http://localhost:8000/api/v1/active/openai
       AUDIO_STT_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
 
       # --- Audio TTS ---
       AUDIO_TTS_ENGINE: openai
       AUDIO_TTS_MODEL: speech
-      AUDIO_TTS_OPENAI_API_BASE_URL: http://localhost:8000/api/v1/openai
+      AUDIO_TTS_OPENAI_API_BASE_URL: http://localhost:8000/api/v1/active/openai
       AUDIO_TTS_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       AUDIO_TTS_VOICE: alloy
 
@@ -1360,11 +1360,11 @@ services:
       PDF_EXTRACT_IMAGES: true
       RAG_FILE_MAX_COUNT: 4
       CONTENT_EXTRACTION_ENGINE: external
-      EXTERNAL_DOCUMENT_LOADER_URL: http://localhost:8000/api/v1/parsing
+      EXTERNAL_DOCUMENT_LOADER_URL: http://localhost:8000/api/v1/active/parsing
       EXTERNAL_DOCUMENT_LOADER_API_KEY: ${SUPERUSER_TOKEN}
       RAG_EMBEDDING_ENGINE: openai
       RAG_EMBEDDING_MODEL: embedding/bge-m3
-      RAG_OPENAI_API_BASE_URL: http://localhost:8000/api/v1/openai
+      RAG_OPENAI_API_BASE_URL: http://localhost:8000/api/v1/active/openai
       RAG_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
 
       # --- Web Search ---

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -1067,7 +1067,7 @@ services:
 
       # --- Model & AI-Hub Connection ---
       MODELS_CACHE_TTL: 60
-      OPENAI_API_BASE_URL: http://localhost:8000/api/v1/openai
+      OPENAI_API_BASE_URL: http://localhost:8000/api/v1/active/openai
       OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       TASK_MODEL: text-generation/gpt-oss-120b
       TASK_MODEL_EXTERNAL: text-generation/gpt-oss-120b
@@ -1076,7 +1076,7 @@ services:
 
       # --- Image Generation ---
       IMAGE_GENERATION_MODEL: image-generation
-      IMAGES_OPENAI_API_BASE_URL: http://localhost:8000/api/v1/openai
+      IMAGES_OPENAI_API_BASE_URL: http://localhost:8000/api/v1/active/openai
       IMAGES_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       IMAGE_SIZE: 1024x1024
       ENABLE_IMAGE_GENERATION: true
@@ -1084,13 +1084,13 @@ services:
       # --- Audio STT ---
       AUDIO_STT_ENGINE: openai
       AUDIO_STT_MODEL: transcription
-      AUDIO_STT_OPENAI_API_BASE_URL: http://localhost:8000/api/v1/openai
+      AUDIO_STT_OPENAI_API_BASE_URL: http://localhost:8000/api/v1/active/openai
       AUDIO_STT_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
 
       # --- Audio TTS ---
       AUDIO_TTS_ENGINE: openai
       AUDIO_TTS_MODEL: speech
-      AUDIO_TTS_OPENAI_API_BASE_URL: http://localhost:8000/api/v1/openai
+      AUDIO_TTS_OPENAI_API_BASE_URL: http://localhost:8000/api/v1/active/openai
       AUDIO_TTS_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       AUDIO_TTS_VOICE: alloy
 
@@ -1152,11 +1152,11 @@ services:
       PDF_EXTRACT_IMAGES: true
       RAG_FILE_MAX_COUNT: 4
       CONTENT_EXTRACTION_ENGINE: external
-      EXTERNAL_DOCUMENT_LOADER_URL: http://localhost:8000/api/v1/parsing
+      EXTERNAL_DOCUMENT_LOADER_URL: http://localhost:8000/api/v1/active/parsing
       EXTERNAL_DOCUMENT_LOADER_API_KEY: ${SUPERUSER_TOKEN}
       RAG_EMBEDDING_ENGINE: openai
       RAG_EMBEDDING_MODEL: embedding/bge-m3
-      RAG_OPENAI_API_BASE_URL: http://localhost:8000/api/v1/openai
+      RAG_OPENAI_API_BASE_URL: http://localhost:8000/api/v1/active/openai
       RAG_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
 
       # --- Web Search ---

--- a/infra/docker-compose.latest.gpu.yml
+++ b/infra/docker-compose.latest.gpu.yml
@@ -1500,7 +1500,7 @@ services:
 
       # --- Model & AI-Hub Connection ---
       MODELS_CACHE_TTL: 60
-      OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       TASK_MODEL: text-generation/Qwen3-VL-30B-A3B-Instruct-FP8
       TASK_MODEL_EXTERNAL: text-generation/Qwen3-VL-30B-A3B-Instruct-FP8
@@ -1509,7 +1509,7 @@ services:
 
       # --- Image Generation ---
       IMAGE_GENERATION_MODEL: image-generation
-      IMAGES_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      IMAGES_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       IMAGES_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       IMAGE_SIZE: 1024x1024
       ENABLE_IMAGE_GENERATION: true
@@ -1517,13 +1517,13 @@ services:
       # --- Audio STT ---
       AUDIO_STT_ENGINE: openai
       AUDIO_STT_MODEL: transcription
-      AUDIO_STT_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AUDIO_STT_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       AUDIO_STT_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
 
       # --- Audio TTS ---
       AUDIO_TTS_ENGINE: openai
       AUDIO_TTS_MODEL: speech
-      AUDIO_TTS_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AUDIO_TTS_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       AUDIO_TTS_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       AUDIO_TTS_VOICE: alloy
 
@@ -1585,11 +1585,11 @@ services:
       PDF_EXTRACT_IMAGES: true
       RAG_FILE_MAX_COUNT: 4
       CONTENT_EXTRACTION_ENGINE: external
-      EXTERNAL_DOCUMENT_LOADER_URL: http://api:8000/api/v1/parsing
+      EXTERNAL_DOCUMENT_LOADER_URL: http://api:8000/api/v1/active/parsing
       EXTERNAL_DOCUMENT_LOADER_API_KEY: ${SUPERUSER_TOKEN}
       RAG_EMBEDDING_ENGINE: openai
       RAG_EMBEDDING_MODEL: embedding/bge-m3
-      RAG_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      RAG_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       RAG_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
 
       # --- Web Search ---
@@ -2016,7 +2016,7 @@ services:
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY}
       LANGFUSE_PUBLIC_URL: https://langfuse.${DOMAIN}
       LANGFUSE_PROJECT_ID: aihub-project
-      AIHUB_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AIHUB_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
 
       # NATs
       NATS_ENDPOINT: nats://nats:4222
@@ -2096,7 +2096,7 @@ services:
       OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID}
       OAUTH_AUTHORITY_URL: ${OAUTH_AUTHORITY_URL}
       WEBUI_URL: https://openwebui.${DOMAIN}
-      WS_ENDPOINT: wss://${DOMAIN}/api/v1/events/ws
+      WS_ENDPOINT: wss://${DOMAIN}/api/v1/active/events/ws
     healthcheck:
       test: [CMD, curl, -f, http://127.0.0.1/]
       interval: 30s

--- a/infra/docker-compose.latest.yml
+++ b/infra/docker-compose.latest.yml
@@ -1298,7 +1298,7 @@ services:
 
       # --- Model & AI-Hub Connection ---
       MODELS_CACHE_TTL: 60
-      OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       TASK_MODEL: text-generation/gpt-oss-120b
       TASK_MODEL_EXTERNAL: text-generation/gpt-oss-120b
@@ -1307,7 +1307,7 @@ services:
 
       # --- Image Generation ---
       IMAGE_GENERATION_MODEL: image-generation
-      IMAGES_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      IMAGES_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       IMAGES_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       IMAGE_SIZE: 1024x1024
       ENABLE_IMAGE_GENERATION: true
@@ -1315,13 +1315,13 @@ services:
       # --- Audio STT ---
       AUDIO_STT_ENGINE: openai
       AUDIO_STT_MODEL: transcription
-      AUDIO_STT_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AUDIO_STT_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       AUDIO_STT_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
 
       # --- Audio TTS ---
       AUDIO_TTS_ENGINE: openai
       AUDIO_TTS_MODEL: speech
-      AUDIO_TTS_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AUDIO_TTS_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       AUDIO_TTS_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       AUDIO_TTS_VOICE: alloy
 
@@ -1383,11 +1383,11 @@ services:
       PDF_EXTRACT_IMAGES: true
       RAG_FILE_MAX_COUNT: 4
       CONTENT_EXTRACTION_ENGINE: external
-      EXTERNAL_DOCUMENT_LOADER_URL: http://api:8000/api/v1/parsing
+      EXTERNAL_DOCUMENT_LOADER_URL: http://api:8000/api/v1/active/parsing
       EXTERNAL_DOCUMENT_LOADER_API_KEY: ${SUPERUSER_TOKEN}
       RAG_EMBEDDING_ENGINE: openai
       RAG_EMBEDDING_MODEL: embedding/bge-m3
-      RAG_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      RAG_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       RAG_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
 
       # --- Web Search ---
@@ -1814,7 +1814,7 @@ services:
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY}
       LANGFUSE_PUBLIC_URL: https://langfuse.${DOMAIN}
       LANGFUSE_PROJECT_ID: aihub-project
-      AIHUB_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AIHUB_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
 
       # NATs
       NATS_ENDPOINT: nats://nats:4222
@@ -1894,7 +1894,7 @@ services:
       OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID}
       OAUTH_AUTHORITY_URL: ${OAUTH_AUTHORITY_URL}
       WEBUI_URL: https://openwebui.${DOMAIN}
-      WS_ENDPOINT: wss://${DOMAIN}/api/v1/events/ws
+      WS_ENDPOINT: wss://${DOMAIN}/api/v1/active/events/ws
     healthcheck:
       test: [CMD, curl, -f, http://127.0.0.1/]
       interval: 30s

--- a/infra/docker-compose.local.gpu.yml
+++ b/infra/docker-compose.local.gpu.yml
@@ -1525,7 +1525,7 @@ services:
 
       # --- Model & AI-Hub Connection ---
       MODELS_CACHE_TTL: 60
-      OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       TASK_MODEL: text-generation/Qwen3-VL-30B-A3B-Instruct-FP8
       TASK_MODEL_EXTERNAL: text-generation/Qwen3-VL-30B-A3B-Instruct-FP8
@@ -1534,7 +1534,7 @@ services:
 
       # --- Image Generation ---
       IMAGE_GENERATION_MODEL: image-generation
-      IMAGES_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      IMAGES_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       IMAGES_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       IMAGE_SIZE: 1024x1024
       ENABLE_IMAGE_GENERATION: true
@@ -1542,13 +1542,13 @@ services:
       # --- Audio STT ---
       AUDIO_STT_ENGINE: openai
       AUDIO_STT_MODEL: transcription
-      AUDIO_STT_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AUDIO_STT_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       AUDIO_STT_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
 
       # --- Audio TTS ---
       AUDIO_TTS_ENGINE: openai
       AUDIO_TTS_MODEL: speech
-      AUDIO_TTS_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AUDIO_TTS_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       AUDIO_TTS_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       AUDIO_TTS_VOICE: alloy
 
@@ -1610,11 +1610,11 @@ services:
       PDF_EXTRACT_IMAGES: true
       RAG_FILE_MAX_COUNT: 4
       CONTENT_EXTRACTION_ENGINE: external
-      EXTERNAL_DOCUMENT_LOADER_URL: http://api:8000/api/v1/parsing
+      EXTERNAL_DOCUMENT_LOADER_URL: http://api:8000/api/v1/active/parsing
       EXTERNAL_DOCUMENT_LOADER_API_KEY: ${SUPERUSER_TOKEN}
       RAG_EMBEDDING_ENGINE: openai
       RAG_EMBEDDING_MODEL: embedding/bge-m3
-      RAG_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      RAG_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       RAG_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
 
       # --- Web Search ---
@@ -2040,7 +2040,7 @@ services:
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY}
       LANGFUSE_PUBLIC_URL: https://langfuse.${DOMAIN}
       LANGFUSE_PROJECT_ID: aihub-project
-      AIHUB_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AIHUB_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
 
       # NATs
       NATS_ENDPOINT: nats://nats:4222
@@ -2120,7 +2120,7 @@ services:
       OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID}
       OAUTH_AUTHORITY_URL: ${OAUTH_AUTHORITY_URL}
       WEBUI_URL: https://openwebui.${DOMAIN}
-      WS_ENDPOINT: wss://${DOMAIN}/api/v1/events/ws
+      WS_ENDPOINT: wss://${DOMAIN}/api/v1/active/events/ws
     healthcheck:
       test: [CMD, curl, -f, http://127.0.0.1/]
       interval: 30s

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -1317,7 +1317,7 @@ services:
 
       # --- Model & AI-Hub Connection ---
       MODELS_CACHE_TTL: 60
-      OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       TASK_MODEL: text-generation/gpt-oss-120b
       TASK_MODEL_EXTERNAL: text-generation/gpt-oss-120b
@@ -1326,7 +1326,7 @@ services:
 
       # --- Image Generation ---
       IMAGE_GENERATION_MODEL: image-generation
-      IMAGES_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      IMAGES_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       IMAGES_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       IMAGE_SIZE: 1024x1024
       ENABLE_IMAGE_GENERATION: true
@@ -1334,13 +1334,13 @@ services:
       # --- Audio STT ---
       AUDIO_STT_ENGINE: openai
       AUDIO_STT_MODEL: transcription
-      AUDIO_STT_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AUDIO_STT_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       AUDIO_STT_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
 
       # --- Audio TTS ---
       AUDIO_TTS_ENGINE: openai
       AUDIO_TTS_MODEL: speech
-      AUDIO_TTS_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AUDIO_TTS_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       AUDIO_TTS_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       AUDIO_TTS_VOICE: alloy
 
@@ -1402,11 +1402,11 @@ services:
       PDF_EXTRACT_IMAGES: true
       RAG_FILE_MAX_COUNT: 4
       CONTENT_EXTRACTION_ENGINE: external
-      EXTERNAL_DOCUMENT_LOADER_URL: http://api:8000/api/v1/parsing
+      EXTERNAL_DOCUMENT_LOADER_URL: http://api:8000/api/v1/active/parsing
       EXTERNAL_DOCUMENT_LOADER_API_KEY: ${SUPERUSER_TOKEN}
       RAG_EMBEDDING_ENGINE: openai
       RAG_EMBEDDING_MODEL: embedding/bge-m3
-      RAG_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      RAG_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       RAG_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
 
       # --- Web Search ---
@@ -1832,7 +1832,7 @@ services:
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY}
       LANGFUSE_PUBLIC_URL: https://langfuse.${DOMAIN}
       LANGFUSE_PROJECT_ID: aihub-project
-      AIHUB_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AIHUB_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
 
       # NATs
       NATS_ENDPOINT: nats://nats:4222
@@ -1912,7 +1912,7 @@ services:
       OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID}
       OAUTH_AUTHORITY_URL: ${OAUTH_AUTHORITY_URL}
       WEBUI_URL: https://openwebui.${DOMAIN}
-      WS_ENDPOINT: wss://${DOMAIN}/api/v1/events/ws
+      WS_ENDPOINT: wss://${DOMAIN}/api/v1/active/events/ws
     healthcheck:
       test: [CMD, curl, -f, http://127.0.0.1/]
       interval: 30s

--- a/infra/docker-compose.nightly.gpu.yml
+++ b/infra/docker-compose.nightly.gpu.yml
@@ -1501,7 +1501,7 @@ services:
 
       # --- Model & AI-Hub Connection ---
       MODELS_CACHE_TTL: 60
-      OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       TASK_MODEL: text-generation/Qwen3-VL-30B-A3B-Instruct-FP8
       TASK_MODEL_EXTERNAL: text-generation/Qwen3-VL-30B-A3B-Instruct-FP8
@@ -1510,7 +1510,7 @@ services:
 
       # --- Image Generation ---
       IMAGE_GENERATION_MODEL: image-generation
-      IMAGES_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      IMAGES_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       IMAGES_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       IMAGE_SIZE: 1024x1024
       ENABLE_IMAGE_GENERATION: true
@@ -1518,13 +1518,13 @@ services:
       # --- Audio STT ---
       AUDIO_STT_ENGINE: openai
       AUDIO_STT_MODEL: transcription
-      AUDIO_STT_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AUDIO_STT_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       AUDIO_STT_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
 
       # --- Audio TTS ---
       AUDIO_TTS_ENGINE: openai
       AUDIO_TTS_MODEL: speech
-      AUDIO_TTS_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AUDIO_TTS_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       AUDIO_TTS_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       AUDIO_TTS_VOICE: alloy
 
@@ -1586,11 +1586,11 @@ services:
       PDF_EXTRACT_IMAGES: true
       RAG_FILE_MAX_COUNT: 4
       CONTENT_EXTRACTION_ENGINE: external
-      EXTERNAL_DOCUMENT_LOADER_URL: http://api:8000/api/v1/parsing
+      EXTERNAL_DOCUMENT_LOADER_URL: http://api:8000/api/v1/active/parsing
       EXTERNAL_DOCUMENT_LOADER_API_KEY: ${SUPERUSER_TOKEN}
       RAG_EMBEDDING_ENGINE: openai
       RAG_EMBEDDING_MODEL: embedding/bge-m3
-      RAG_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      RAG_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       RAG_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
 
       # --- Web Search ---
@@ -2017,7 +2017,7 @@ services:
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY}
       LANGFUSE_PUBLIC_URL: https://langfuse.${DOMAIN}
       LANGFUSE_PROJECT_ID: aihub-project
-      AIHUB_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AIHUB_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
 
       # NATs
       NATS_ENDPOINT: nats://nats:4222
@@ -2097,7 +2097,7 @@ services:
       OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID}
       OAUTH_AUTHORITY_URL: ${OAUTH_AUTHORITY_URL}
       WEBUI_URL: https://openwebui.${DOMAIN}
-      WS_ENDPOINT: wss://${DOMAIN}/api/v1/events/ws
+      WS_ENDPOINT: wss://${DOMAIN}/api/v1/active/events/ws
     healthcheck:
       test: [CMD, curl, -f, http://127.0.0.1/]
       interval: 30s

--- a/infra/docker-compose.nightly.yml
+++ b/infra/docker-compose.nightly.yml
@@ -1298,7 +1298,7 @@ services:
 
       # --- Model & AI-Hub Connection ---
       MODELS_CACHE_TTL: 60
-      OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       TASK_MODEL: text-generation/gpt-oss-120b
       TASK_MODEL_EXTERNAL: text-generation/gpt-oss-120b
@@ -1307,7 +1307,7 @@ services:
 
       # --- Image Generation ---
       IMAGE_GENERATION_MODEL: image-generation
-      IMAGES_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      IMAGES_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       IMAGES_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       IMAGE_SIZE: 1024x1024
       ENABLE_IMAGE_GENERATION: true
@@ -1315,13 +1315,13 @@ services:
       # --- Audio STT ---
       AUDIO_STT_ENGINE: openai
       AUDIO_STT_MODEL: transcription
-      AUDIO_STT_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AUDIO_STT_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       AUDIO_STT_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
 
       # --- Audio TTS ---
       AUDIO_TTS_ENGINE: openai
       AUDIO_TTS_MODEL: speech
-      AUDIO_TTS_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AUDIO_TTS_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       AUDIO_TTS_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
       AUDIO_TTS_VOICE: alloy
 
@@ -1383,11 +1383,11 @@ services:
       PDF_EXTRACT_IMAGES: true
       RAG_FILE_MAX_COUNT: 4
       CONTENT_EXTRACTION_ENGINE: external
-      EXTERNAL_DOCUMENT_LOADER_URL: http://api:8000/api/v1/parsing
+      EXTERNAL_DOCUMENT_LOADER_URL: http://api:8000/api/v1/active/parsing
       EXTERNAL_DOCUMENT_LOADER_API_KEY: ${SUPERUSER_TOKEN}
       RAG_EMBEDDING_ENGINE: openai
       RAG_EMBEDDING_MODEL: embedding/bge-m3
-      RAG_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      RAG_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       RAG_OPENAI_API_KEY: ${SUPERUSER_TOKEN}
 
       # --- Web Search ---
@@ -1814,7 +1814,7 @@ services:
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY}
       LANGFUSE_PUBLIC_URL: https://langfuse.${DOMAIN}
       LANGFUSE_PROJECT_ID: aihub-project
-      AIHUB_OPENAI_API_BASE_URL: http://api:8000/api/v1/openai
+      AIHUB_OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
 
       # NATs
       NATS_ENDPOINT: nats://nats:4222
@@ -1894,7 +1894,7 @@ services:
       OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID}
       OAUTH_AUTHORITY_URL: ${OAUTH_AUTHORITY_URL}
       WEBUI_URL: https://openwebui.${DOMAIN}
-      WS_ENDPOINT: wss://${DOMAIN}/api/v1/events/ws
+      WS_ENDPOINT: wss://${DOMAIN}/api/v1/active/events/ws
     healthcheck:
       test: [CMD, curl, -f, http://127.0.0.1/]
       interval: 30s

--- a/packages/api/CLAUDE.md
+++ b/packages/api/CLAUDE.md
@@ -199,7 +199,7 @@ All resources stored in `app.state`, accessible via the dependencies listed abov
 **Auth bypass**: `DangerousDevelopmentOnlyAuthHandler` with `DangerousDevelopmentOnlyIdentityProvider`.
 
 **Interactive testing**: `cd playground/testing && python main.py` → http://localhost:8000 (frontend),
-http://localhost:8000/api/v1/docs (Swagger).
+http://localhost:8000/api/v1/active/docs (Swagger).
 
 **Pagination**: `PageNumber` and `PageSize` types in `pagination/`. Services return `tuple[int, list[DTO]]`.
 

--- a/packages/api/CLAUDE.md
+++ b/packages/api/CLAUDE.md
@@ -61,6 +61,11 @@ of endpoints.
 here, otherwise they won't be served. `runner.create_app()` also mounts an MCP server at `/mcp`, making the API
 available as a Claude Code MCP tool for testing.
 
+**Tenant-scoped routing**: All controllers are mounted under `/api/v1/{tenant_id}/` via a Starlette `Mount`. The
+`{tenant_id}` is either a concrete MongoDB ObjectId or `"active"` (resolves to the user's persisted active tenant).
+Health endpoints are separated at `/api/v1/health/` (outside tenant scope). The `{tenant_id}` lives at the Starlette
+level, NOT in FastAPI routes — so it does not appear in the OpenAPI spec and controllers don't need to reference it.
+
 **Commands**: `make run-dev` (uvicorn with hot reload on :8000), `make run-prod` (gunicorn multi-worker).
 
 **Docker**: `Dockerfile` builds the production image using `make run-prod` as entrypoint. End-users can also build their
@@ -165,7 +170,7 @@ without needing it baked into event payloads.
 
 ## WebSocket
 
-- Endpoint: `/api/v1/events/ws` (in `EventController`)
+- Endpoint: `/api/v1/{tenant_id}/events/ws` (in `EventController`)
 - Auth: First message must contain `{"token": "Bearer ..."}` — validated against auth handler
 - Read-only from client: inbound messages after auth are ignored (security)
 - Multi-connection per user: `WebSocketManager` tracks connections per user ID, syncs across tabs/devices

--- a/packages/api/playground/testing/tests/agent/test_agent_api.py
+++ b/packages/api/playground/testing/tests/agent/test_agent_api.py
@@ -31,7 +31,9 @@ async def agent_api_client():
     async with LifespanManager(app) as lifespan:
         runner.create_agent_config_in_db()
 
-        async with AsyncClient(transport=ASGITransport(app=lifespan.app), base_url="http://test/api/v1") as client:
+        async with AsyncClient(
+            transport=ASGITransport(app=lifespan.app), base_url="http://test/api/v1/active"
+        ) as client:
             yield client
 
 

--- a/packages/api/playground/testing/tests/agent/test_agent_api_with_custom_event.py
+++ b/packages/api/playground/testing/tests/agent/test_agent_api_with_custom_event.py
@@ -44,7 +44,9 @@ async def agent_api_client():
     async with LifespanManager(app) as lifespan:
         # Create agent config in database after lifespan starts (database is now connected)
         runner.create_agent_config_in_db()
-        async with AsyncClient(transport=ASGITransport(app=lifespan.app), base_url="http://test/api/v1") as client:
+        async with AsyncClient(
+            transport=ASGITransport(app=lifespan.app), base_url="http://test/api/v1/active"
+        ) as client:
             yield client
 
 

--- a/packages/api/playground/testing/tests/agent/test_agent_file_upload_api.py
+++ b/packages/api/playground/testing/tests/agent/test_agent_file_upload_api.py
@@ -43,7 +43,7 @@ async def client(mock_upload_service):
     app = runner.create_app()
 
     async with LifespanManager(app) as lifespan:
-        async with AsyncClient(transport=ASGITransport(app=lifespan.app), base_url="http://test/api/v1") as c:
+        async with AsyncClient(transport=ASGITransport(app=lifespan.app), base_url="http://test/api/v1/active") as c:
             yield c
 
 

--- a/packages/api/playground/testing/tests/auth/test_bearer_api.py
+++ b/packages/api/playground/testing/tests/auth/test_bearer_api.py
@@ -21,7 +21,7 @@ from swiss_ai_hub.api.routes.my_account.my_account_controller import MyAccountCo
 from swiss_ai_hub.api.runners.api_test_runner import ApiTestRunner
 
 BASE_URL = "http://test"
-USER_ENDPOINT = "/api/v1/my-account"
+USER_ENDPOINT = "/api/v1/active/my-account"
 EXPECTED_USER_FIELDS = ["id", "name", "email", "roles", "profile_image", "favorite_modules"]
 
 

--- a/packages/api/playground/testing/tests/auth/test_oauth2_api.py
+++ b/packages/api/playground/testing/tests/auth/test_oauth2_api.py
@@ -26,7 +26,7 @@ from swiss_ai_hub.api.runners.api_test_runner import ApiTestRunner
 
 # Constants for the tests
 BASE_URL = "http://test"
-USER_ENDPOINT = "/api/v1/my-account"
+USER_ENDPOINT = "/api/v1/active/my-account"
 EXPECTED_USER_FIELDS = ["id", "name", "email"]
 TOKEN_EXPIRY_MINUTES = 10
 

--- a/packages/api/playground/testing/tests/auth_provider/test_auth_provider_api.py
+++ b/packages/api/playground/testing/tests/auth_provider/test_auth_provider_api.py
@@ -11,7 +11,7 @@ from swiss_ai_hub.api.routes.auth_provider.auth_provider_service import AuthProv
 from swiss_ai_hub.api.routes.auth_provider.dto.auth_provider_response import AuthProviderResponse
 from swiss_ai_hub.api.runners.api_test_runner import ApiTestRunner
 
-BASE_ENDPOINT = "/api/v1/auth-providers"
+BASE_ENDPOINT = "/api/v1/active/auth-providers"
 
 
 @pytest.fixture

--- a/packages/api/playground/testing/tests/locale/test_locale_api.py
+++ b/packages/api/playground/testing/tests/locale/test_locale_api.py
@@ -10,7 +10,7 @@ from swiss_ai_hub.api.routes.i18n.i18n_controller import I18nController
 from swiss_ai_hub.api.runners.api_test_runner import ApiTestRunner
 
 BASE_URL = "http://test"
-API_ENDPOINT = "/api/v1/i18n/my-locale"
+API_ENDPOINT = "/api/v1/active/i18n/my-locale"
 DEFAULT_LANG_KEY = "lang"
 
 
@@ -44,7 +44,7 @@ async def api_client():
 )
 @pytest.mark.asyncio
 async def test_get_locale_parametrized(api_client, headers, params, expected_locale):
-    """Test /api/v1/i18n/my-locale with various header and query parameter configurations."""
+    """Test /api/v1/active/i18n/my-locale with various header and query parameter configurations."""
     response = await api_client.get(API_ENDPOINT, headers=headers, params=params)
     assert response.status_code == 200, f"Response: {response.text}"
     data = response.json()

--- a/packages/api/playground/testing/tests/memory/test_memory_api.py
+++ b/packages/api/playground/testing/tests/memory/test_memory_api.py
@@ -22,8 +22,8 @@ from swiss_ai_hub.api.routes.memory.user_memory_controller import UserMemoryCont
 from swiss_ai_hub.api.runners.api_test_runner import ApiTestRunner
 
 BASE_URL = "http://test"
-USER_MEMORIES_ENDPOINT = "/api/v1/user-memories"
-ORG_MEMORIES_ENDPOINT = "/api/v1/organization-memories"
+USER_MEMORIES_ENDPOINT = "/api/v1/active/user-memories"
+ORG_MEMORIES_ENDPOINT = "/api/v1/active/organization-memories"
 
 
 @pytest_asyncio.fixture(scope="module")

--- a/packages/api/playground/testing/tests/notification/test_notification_api.py
+++ b/packages/api/playground/testing/tests/notification/test_notification_api.py
@@ -17,7 +17,7 @@ from swiss_ai_hub.api.routes.notification.notification_controller import Notific
 from swiss_ai_hub.api.runners.api_test_runner import ApiTestRunner
 
 BASE_URL = "http://test"
-NOTIFICATIONS_ENDPOINT = "/api/v1/notifications"
+NOTIFICATIONS_ENDPOINT = "/api/v1/active/notifications"
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/packages/api/playground/testing/tests/openai/test_openai_api.py
+++ b/packages/api/playground/testing/tests/openai/test_openai_api.py
@@ -10,7 +10,7 @@ from swiss_ai_hub.api.routes.openai.openai_controller import OpenaiController
 from swiss_ai_hub.api.runners.api_test_runner import ApiTestRunner
 
 BASE_URL = "http://test"
-MODELS_ENDPOINT = "/api/v1/openai/models"
+MODELS_ENDPOINT = "/api/v1/active/openai/models"
 CHAT_MODEL = "text-generation/gpt-oss-120b"
 EMBEDDING_MODEL = "embedding/bge-m3"
 
@@ -61,7 +61,7 @@ async def test_get_embeddings(api_client):
         "model": EMBEDDING_MODEL,
         "encoding_format": "float",
     }
-    response = await api_client.post("/api/v1/openai/embeddings", json=payload)
+    response = await api_client.post("/api/v1/active/openai/embeddings", json=payload)
     assert response.status_code == 200, f"Response: {response.text}"
     data = response.json()
     assert data.get("object") == "list"
@@ -90,7 +90,7 @@ async def test_chat_completion(api_client):
         "temperature": 0,
         "stream": False,
     }
-    response = await api_client.post("/api/v1/openai/chat/completions", json=payload)
+    response = await api_client.post("/api/v1/active/openai/chat/completions", json=payload)
     assert response.status_code == 200, f"Response: {response.text}"
     data = response.json()
     assert "id" in data

--- a/packages/api/playground/testing/tests/openai/test_openai_with_assistants.py
+++ b/packages/api/playground/testing/tests/openai/test_openai_with_assistants.py
@@ -16,7 +16,7 @@ from swiss_ai_hub.api.runners.simulation.agent.simulated_agent_api_test_runner i
 
 AGENT_CLASS = "test_agent"
 AGENT_ID = "test_agent_1"
-BASE_URL = "http://test/api/v1"
+BASE_URL = "http://test/api/v1/active"
 MODELS_ENDPOINT = "/openai/models"
 COMPLETIONS_ENDPOINT = "/openai/chat/completions"
 

--- a/packages/api/playground/testing/tests/openai/test_usage_limits.py
+++ b/packages/api/playground/testing/tests/openai/test_usage_limits.py
@@ -13,7 +13,7 @@ from swiss_ai_hub.api.routes.openai.openai_controller import OpenaiController
 from swiss_ai_hub.api.runners.api_test_runner import ApiTestRunner
 
 BASE_URL = "http://test"
-CHAT_ENDPOINT = "/api/v1/openai/chat/completions"
+CHAT_ENDPOINT = "/api/v1/active/openai/chat/completions"
 
 
 def _exceeded_status(*, limit: int = 100, current_count: int = 101, period: str = "1d") -> UsageStatus:

--- a/packages/api/playground/testing/tests/process/test_process_api.py
+++ b/packages/api/playground/testing/tests/process/test_process_api.py
@@ -76,7 +76,9 @@ async def process_api_client(setup_process_config_mock):
     app = runner.create_app()
 
     async with LifespanManager(app) as lifespan:
-        async with AsyncClient(transport=ASGITransport(app=lifespan.app), base_url="http://test/api/v1") as client:
+        async with AsyncClient(
+            transport=ASGITransport(app=lifespan.app), base_url="http://test/api/v1/active"
+        ) as client:
             yield client
 
     class_patcher.stop()

--- a/packages/api/playground/testing/tests/threads/test_threads_api.py
+++ b/packages/api/playground/testing/tests/threads/test_threads_api.py
@@ -19,7 +19,7 @@ from swiss_ai_hub.api.runners.simulation.agent.simulated_agent_api_test_runner i
 
 enable_logging()
 
-THREAD_BASE = "/api/v1/threads"
+THREAD_BASE = "/api/v1/active/threads"
 DEFAULT_USER_ID = DangerousDevelopmentOnlyAuthSettings().OID
 
 

--- a/packages/api/playground/testing/tests/token/test_token_api.py
+++ b/packages/api/playground/testing/tests/token/test_token_api.py
@@ -12,7 +12,7 @@ from swiss_ai_hub.core.persistence.access.entities.bearer_token import BearerTok
 from swiss_ai_hub.api.routes.token.token_controller import TokenController
 from swiss_ai_hub.api.runners.api_test_runner import ApiTestRunner
 
-TOKEN_BASE = "/api/v1/tokens"
+TOKEN_BASE = "/api/v1/active/tokens"
 DEFAULT_USER_ID = "1234567890"
 
 

--- a/packages/api/playground/testing/tests/user/test_user_api.py
+++ b/packages/api/playground/testing/tests/user/test_user_api.py
@@ -15,7 +15,7 @@ from swiss_ai_hub.api.routes.my_account.my_account_controller import MyAccountCo
 from swiss_ai_hub.api.runners.api_test_runner import ApiTestRunner
 
 BASE_URL = "http://test"
-USER_ENDPOINT = "/api/v1/my-account"
+USER_ENDPOINT = "/api/v1/active/my-account"
 EXPECTED_USER_FIELDS = ["id", "name", "email"]
 
 

--- a/packages/api/swiss_ai_hub/api/runners/api_runner.py
+++ b/packages/api/swiss_ai_hub/api/runners/api_runner.py
@@ -163,10 +163,10 @@ class ApiRunner(Runner):
 
         self._api_app.openapi_tags = [
             {
-                "name": ApiLocaleHandler().extract(controller.name),
+                "name": ApiLocaleHandler().extract(controller.name, locale="en"),
                 "description": ApiLocaleHandler().extract(controller.description),
             }
-            for controller in controllers
+            for controller in tenant_controllers
         ]
 
         # Pre-populate state with controller references so they're available

--- a/packages/api/swiss_ai_hub/api/runners/api_runner.py
+++ b/packages/api/swiss_ai_hub/api/runners/api_runner.py
@@ -12,6 +12,7 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.routing import Mount
 from swiss_ai_hub.core.infrastructure import AIHubSettings
 from swiss_ai_hub.core.routes import Controller
+from swiss_ai_hub.core.routes.health.health_controller import HealthController
 from swiss_ai_hub.core.runners import Runner
 
 from swiss_ai_hub.api.i18n.api_locale_handler import ApiLocaleHandler
@@ -61,6 +62,7 @@ class ApiRunner(Runner):
         origins: list[str] | None = None,
     ):
         super().__init__(api_path, title, description, origins)
+        self._health_app = FastAPI(title=f"{title} Health", redirect_slashes=True)
 
     @property
     def lifetime_manager(self) -> Callable[[FastAPI], AbstractAsyncContextManager]:
@@ -93,10 +95,15 @@ class ApiRunner(Runner):
                     yield
 
         app = Starlette(
-            routes=[Mount(self.api_path, app=self._api_app), Mount("/mcp", app=mcp_app)],
+            routes=[
+                Mount(self.api_path + "/health", app=self._health_app),
+                Mount(self.api_path + "/{tenant_id}", app=self._api_app),
+                Mount("/mcp", app=mcp_app),
+            ],
             lifespan=combined_lifespan,
         )
 
+        self._health_app.state = app.state
         app.state.api_app = self._api_app
         for controller in self.controllers:
             if isinstance(controller, AgentController):
@@ -138,13 +145,21 @@ class ApiRunner(Runner):
 
     def mount(self, *controllers: Controller) -> Self:
         """
-        Mounts one or more controllers (each subclass of Controller) onto the API application.
-        This attaches the controller's routes under the prefix defined in the controller itself.
+        Mounts one or more controllers onto the API application.
 
-        Also sets the controller references on _api_app.state so they're available for
-        discovery services before create_app() is called.
+        HealthController instances are mounted on a separate app at /api/v1/health
+        (outside the tenant-scoped path). All other controllers are mounted on the
+        main API app under /api/v1/{tenant_id}/.
         """
-        super().mount(*controllers)
+        health_controllers = [c for c in controllers if isinstance(c, HealthController)]
+        tenant_controllers = [c for c in controllers if not isinstance(c, HealthController)]
+
+        for controller in health_controllers:
+            self._health_app.include_router(controller.router)
+            controller._runner = self
+            self.controllers.add(controller)
+
+        super().mount(*tenant_controllers)
 
         self._api_app.openapi_tags = [
             {

--- a/packages/bot/playground/testing/tests/test_ChatBot.py
+++ b/packages/bot/playground/testing/tests/test_ChatBot.py
@@ -76,7 +76,7 @@ def setup_test_credentials():
 
     # Create test user (looked up via from_property.name in AgentCompletionHandler)
     UserEntity.objects(email=USER_EMAIL).delete()
-    UserEntity.create_user(oid="test_user_oid", name="Test User", email=USER_EMAIL)
+    UserEntity.create_user(oid="test_user_oid", name="Test User", email=USER_EMAIL, active_tenant_id=tenant_id)
 
     # Assign user to default tenant with admin role
     UserTenantRoleEntity.create_or_update(

--- a/packages/bot/swiss_ai_hub/bot/bots/chat/agent/agent_completion_handler.py
+++ b/packages/bot/swiss_ai_hub/bot/bots/chat/agent/agent_completion_handler.py
@@ -140,7 +140,7 @@ class AgentCompletionHandler(CompletionHandler):
             AgentCompletionHandler._message_to_chat_message(message) for message in persisted_messages
         ]
         user_entity = UserEntity.by_email(turn_context.activity.from_property.name)
-        tenant = AuthHandler.get_default_tenant_for_user(user_entity.id)
+        tenant = AuthHandler.get_active_tenant_for_user(user_entity.id)
         user = UserIdentity.from_user_entity(user_entity, tenant)
         if stream:
             return await ChatService.start_stream_chat_interaction(

--- a/packages/bot/swiss_ai_hub/bot/bots/chat/openai/openai_completion_handler.py
+++ b/packages/bot/swiss_ai_hub/bot/bots/chat/openai/openai_completion_handler.py
@@ -134,7 +134,7 @@ class OpenaiCompletionHandler(CompletionHandler):
                 )
 
         user_entity = UserEntity.by_email(user_email)
-        tenant = AuthHandler.get_default_tenant_for_user(user_entity.id)
+        tenant = AuthHandler.get_active_tenant_for_user(user_entity.id)
         user = UserIdentity.from_user_entity(user_entity, tenant)
 
         logger.debug(f"Using user identity: {user}")

--- a/packages/core/swiss_ai_hub/core/auth/README.md
+++ b/packages/core/swiss_ai_hub/core/auth/README.md
@@ -28,7 +28,8 @@ The authentication system is built around these main abstractions:
 2. **Token Validation**: Handlers validate tokens against their respective authorities (OAuth2, database tokens, etc.)
 3. **User Resolution**: User data is extracted from token claims (OAuth2) or database lookup (Token auth)
 4. **User Persistence**: User is created or updated in UserEntity via `ensure_user_exists_for_auth()`
-5. **Tenant Resolution**: Tenant context is resolved from `x-tenant-id` header or defaults to default tenant
+5. **Tenant Resolution**: Tenant context is resolved from the `tenant_id` path parameter or defaults to the user's
+   active tenant
 6. **Membership Verification**: User's membership in the tenant is verified via UserTenantRoleEntity
 7. **Identity Creation**: UserIdentity DTO is created with embedded TenantIdentity
 8. **Permission Evaluation**: AccessChecker performs two-stage authorization (tenant + user) based on locally-managed
@@ -133,7 +134,7 @@ The system supports two types of permission checks:
 - **TenantEntity**: Organization/tenant definitions with `access_rules` that define maximum permissions for all users
 - **UserTenantRoleEntity**: Authoritative source for user-tenant-role associations (replaces UserEntity.roles)
 - **RoleEntity**: Role definitions with access rules, can be system-wide (`tenant_id=None`) or tenant-scoped
-- **TenantIdentity**: Resolved from `x-tenant-id` HTTP header, or defaults to default tenant if header absent
+- **TenantIdentity**: Resolved from `tenant_id` path parameter, or defaults to the user's active tenant
 - First user signup automatically gets admin roles in default tenant (configurable via UserSignupSettings)
 
 ## Key Features

--- a/packages/core/swiss_ai_hub/core/auth/README.md
+++ b/packages/core/swiss_ai_hub/core/auth/README.md
@@ -28,8 +28,8 @@ The authentication system is built around these main abstractions:
 2. **Token Validation**: Handlers validate tokens against their respective authorities (OAuth2, database tokens, etc.)
 3. **User Resolution**: User data is extracted from token claims (OAuth2) or database lookup (Token auth)
 4. **User Persistence**: User is created or updated in UserEntity via `ensure_user_exists_for_auth()`
-5. **Tenant Resolution**: Tenant context is resolved from the `tenant_id` path parameter or defaults to the user's
-   active tenant
+5. **Tenant Resolution**: Tenant context is resolved from the `tenant_id` path parameter. The special value `"active"`
+   resolves to the user's persisted active tenant. If no active tenant is set, the request is rejected with a 400 error
 6. **Membership Verification**: User's membership in the tenant is verified via UserTenantRoleEntity
 7. **Identity Creation**: UserIdentity DTO is created with embedded TenantIdentity
 8. **Permission Evaluation**: AccessChecker performs two-stage authorization (tenant + user) based on locally-managed
@@ -134,7 +134,8 @@ The system supports two types of permission checks:
 - **TenantEntity**: Organization/tenant definitions with `access_rules` that define maximum permissions for all users
 - **UserTenantRoleEntity**: Authoritative source for user-tenant-role associations (replaces UserEntity.roles)
 - **RoleEntity**: Role definitions with access rules, can be system-wide (`tenant_id=None`) or tenant-scoped
-- **TenantIdentity**: Resolved from `tenant_id` path parameter, or defaults to the user's active tenant
+- **TenantIdentity**: Resolved from `tenant_id` path parameter. No implicit fallback — an active tenant must be
+  explicitly set
 - First user signup automatically gets admin roles in default tenant (configurable via UserSignupSettings)
 
 ## Key Features

--- a/packages/core/swiss_ai_hub/core/auth/dependencies/auth_handler.py
+++ b/packages/core/swiss_ai_hub/core/auth/dependencies/auth_handler.py
@@ -73,18 +73,21 @@ class AuthHandler(ABC):
         UserEntity.objects(id=user_id).update(set__active_tenant_id=str(default_tenant.id))
         return default_tenant
 
+    ACTIVE_TENANT_SLUG = "active"
+
     @staticmethod
     def resolve_tenant_for_user(request: Request, user_id: str) -> TenantIdentity:
         """
-        Resolve tenant context from request headers and verify user membership.
+        Resolve tenant context from the request path parameter and verify user membership.
 
-        Uses the x-tenant-id header if provided (and updates the user's active tenant).
-        Otherwise falls back to the user's persisted active tenant, then the system default.
+        The tenant_id path parameter is required on all API routes. When set to "active",
+        resolves to the user's persisted active tenant (then the system default).
+        When set to a concrete tenant ID, validates membership and updates the active tenant.
         """
-        tenant_id = request.headers.get("x-tenant-id")
+        tenant_id = request.path_params.get("tenant_id") or request.headers.get("x-tenant-id")
 
-        if not tenant_id:
-            logger.debug("No x-tenant-id header found, falling back to active tenant for user %s", user_id)
+        if not tenant_id or tenant_id == AuthHandler.ACTIVE_TENANT_SLUG:
+            logger.debug("Resolving active tenant for user %s", user_id)
             active_tenant = AuthHandler._resolve_active_tenant(user_id)
             tenant_entity = active_tenant if active_tenant else AuthHandler._fall_back_to_default_tenant(user_id)
             return TenantIdentity.from_tenant_entity(tenant_entity)

--- a/packages/core/swiss_ai_hub/core/auth/dependencies/auth_handler.py
+++ b/packages/core/swiss_ai_hub/core/auth/dependencies/auth_handler.py
@@ -99,6 +99,8 @@ class AuthHandler(ABC):
         When set to a concrete tenant ID, validates membership.
         """
         tenant_id = request.path_params.get("tenant_id")
+        if not tenant_id:
+            raise HTTPException(status_code=400, detail="Missing tenant context")
 
         if tenant_id == AuthHandler.ACTIVE_TENANT_SLUG:
             active_tenant = AuthHandler._resolve_active_tenant(user_id)

--- a/packages/core/swiss_ai_hub/core/auth/dependencies/auth_handler.py
+++ b/packages/core/swiss_ai_hub/core/auth/dependencies/auth_handler.py
@@ -26,12 +26,14 @@ class AuthHandler(ABC):
         """
         pass
 
+    ACTIVE_TENANT_SLUG = "active"
+
     @abstractmethod
     async def authenticate_token(self, token: str, request: Request | None = None) -> UserIdentity:
         """
         Authenticates a user based on a token string.
 
-        When a request is provided, the tenant is resolved from the x-tenant-id header.
+        When a request is provided, the tenant is resolved from the tenant_id path parameter.
         Without a request (e.g., WebSocket connections), falls back to the user's active tenant.
         """
         pass
@@ -45,24 +47,24 @@ class AuthHandler(ABC):
 
         tenant = TenantEntity.get_tenant_by_id(user.active_tenant_id)
         if not tenant:
-            UserEntity.objects(id=user_id).update(set__active_tenant_id=None)
+            UserEntity.objects(id=user_id).update_one(set__active_tenant_id=None)
             return None
 
         roles = UserTenantRoleEntity.get_roles_for_user_in_tenant(user_id, str(tenant.id))
         if not roles:
-            UserEntity.objects(id=user_id).update(set__active_tenant_id=None)
+            UserEntity.objects(id=user_id).update_one(set__active_tenant_id=None)
             return None
 
         return tenant
 
     @staticmethod
-    def _fall_back_to_default_tenant(user_id: str) -> TenantEntity:
-        """Returns the system default tenant, updating the user's active tenant to match."""
+    def _fall_back_to_default_tenant(user_id: str) -> TenantIdentity:
+        """Returns the system default tenant identity without persisting it as active."""
         default_tenant = TenantEntity.get_default_tenant()
         if not default_tenant:
             raise HTTPException(
                 status_code=500,
-                detail="No default tenant configured and no x-tenant-id header provided",
+                detail="No default tenant configured and no tenant could be resolved",
             )
 
         user_roles_in_tenant = UserTenantRoleEntity.get_roles_for_user_in_tenant(user_id, str(default_tenant.id))
@@ -70,28 +72,11 @@ class AuthHandler(ABC):
             logger.warning(f"User {user_id} does not have access to default tenant")
             raise HTTPException(status_code=403, detail="Access denied")
 
-        UserEntity.objects(id=user_id).update(set__active_tenant_id=str(default_tenant.id))
-        return default_tenant
-
-    ACTIVE_TENANT_SLUG = "active"
+        return TenantIdentity.from_tenant_entity(default_tenant)
 
     @staticmethod
-    def resolve_tenant_for_user(request: Request, user_id: str) -> TenantIdentity:
-        """
-        Resolve tenant context from the request path parameter and verify user membership.
-
-        The tenant_id path parameter is required on all API routes. When set to "active",
-        resolves to the user's persisted active tenant (then the system default).
-        When set to a concrete tenant ID, validates membership and updates the active tenant.
-        """
-        tenant_id = request.path_params.get("tenant_id") or request.headers.get("x-tenant-id")
-
-        if not tenant_id or tenant_id == AuthHandler.ACTIVE_TENANT_SLUG:
-            logger.debug("Resolving active tenant for user %s", user_id)
-            active_tenant = AuthHandler._resolve_active_tenant(user_id)
-            tenant_entity = active_tenant if active_tenant else AuthHandler._fall_back_to_default_tenant(user_id)
-            return TenantIdentity.from_tenant_entity(tenant_entity)
-
+    def _resolve_tenant_by_id(tenant_id: str, user_id: str) -> TenantIdentity:
+        """Resolves a concrete tenant ID, validates existence and user membership."""
         tenant_entity = TenantEntity.get_tenant_by_id(tenant_id)
         if not tenant_entity:
             logger.warning(f"Tenant {tenant_id} not found during resolution for user {user_id}")
@@ -103,9 +88,25 @@ class AuthHandler(ABC):
             logger.warning(f"User {user_id} attempted to access tenant {tenant_id_str} without membership")
             raise HTTPException(status_code=403, detail="Access denied")
 
-        UserEntity.objects(id=user_id).update_one(set__active_tenant_id=tenant_id_str)
-
         return TenantIdentity.from_tenant_entity(tenant_entity)
+
+    @staticmethod
+    def resolve_tenant_for_user(request: Request, user_id: str) -> TenantIdentity:
+        """
+        Resolve tenant context from the required tenant_id path parameter.
+
+        When set to "active", resolves to the user's persisted active tenant.
+        When set to a concrete tenant ID, validates membership.
+        """
+        tenant_id = request.path_params.get("tenant_id")
+
+        if tenant_id == AuthHandler.ACTIVE_TENANT_SLUG:
+            active_tenant = AuthHandler._resolve_active_tenant(user_id)
+            if active_tenant:
+                return TenantIdentity.from_tenant_entity(active_tenant)
+            return AuthHandler._fall_back_to_default_tenant(user_id)
+
+        return AuthHandler._resolve_tenant_by_id(tenant_id, user_id)
 
     @staticmethod
     def get_active_tenant_for_user(user_id: str) -> TenantIdentity:
@@ -116,5 +117,6 @@ class AuthHandler(ABC):
         Falls back to the system default tenant if no active tenant is set.
         """
         active_tenant = AuthHandler._resolve_active_tenant(user_id)
-        tenant_entity = active_tenant if active_tenant else AuthHandler._fall_back_to_default_tenant(user_id)
-        return TenantIdentity.from_tenant_entity(tenant_entity)
+        if active_tenant:
+            return TenantIdentity.from_tenant_entity(active_tenant)
+        return AuthHandler._fall_back_to_default_tenant(user_id)

--- a/packages/core/swiss_ai_hub/core/auth/dependencies/auth_handler.py
+++ b/packages/core/swiss_ai_hub/core/auth/dependencies/auth_handler.py
@@ -47,12 +47,18 @@ class AuthHandler(ABC):
         tenant = TenantEntity.get_tenant_by_id(user.active_tenant_id)
         if not tenant:
             UserEntity.objects(id=user_id).update_one(set__active_tenant_id=None)
-            return None
+            raise HTTPException(
+                status_code=400,
+                detail="Your active tenant is no longer accessible. Please select a new tenant.",
+            )
 
         roles = UserTenantRoleEntity.get_roles_for_user_in_tenant(user_id, str(tenant.id))
         if not roles:
             UserEntity.objects(id=user_id).update_one(set__active_tenant_id=None)
-            return None
+            raise HTTPException(
+                status_code=400,
+                detail="Your active tenant is no longer accessible. Please select a new tenant.",
+            )
 
         return tenant
 

--- a/packages/core/swiss_ai_hub/core/auth/dependencies/auth_handler.py
+++ b/packages/core/swiss_ai_hub/core/auth/dependencies/auth_handler.py
@@ -7,6 +7,7 @@ from swiss_ai_hub.core.auth.identity.tenant_identity import TenantIdentity
 from swiss_ai_hub.core.auth.identity.user_identity import UserIdentity
 from swiss_ai_hub.core.persistence.access.entities.tenant_entity import TenantEntity
 from swiss_ai_hub.core.persistence.access.entities.user_tenant_role_entity import UserTenantRoleEntity
+from swiss_ai_hub.core.persistence.user.user_entity import UserEntity
 
 logger = logging.getLogger(__name__)
 
@@ -31,58 +32,86 @@ class AuthHandler(ABC):
         Authenticates a user based on a token string.
 
         When a request is provided, the tenant is resolved from the x-tenant-id header.
-        Without a request (e.g., WebSocket connections), falls back to the default tenant.
+        Without a request (e.g., WebSocket connections), falls back to the user's active tenant.
         """
         pass
+
+    @staticmethod
+    def _resolve_active_tenant(user_id: str) -> TenantEntity | None:
+        """Attempts to resolve the user's persisted active tenant, returning None if invalid."""
+        user = UserEntity.objects(id=user_id).only("active_tenant_id").first()
+        if not user or not user.active_tenant_id:
+            return None
+
+        tenant = TenantEntity.get_tenant_by_id(user.active_tenant_id)
+        if not tenant:
+            UserEntity.objects(id=user_id).update(set__active_tenant_id=None)
+            return None
+
+        roles = UserTenantRoleEntity.get_roles_for_user_in_tenant(user_id, str(tenant.id))
+        if not roles:
+            UserEntity.objects(id=user_id).update(set__active_tenant_id=None)
+            return None
+
+        return tenant
+
+    @staticmethod
+    def _fall_back_to_default_tenant(user_id: str) -> TenantEntity:
+        """Returns the system default tenant, updating the user's active tenant to match."""
+        default_tenant = TenantEntity.get_default_tenant()
+        if not default_tenant:
+            raise HTTPException(
+                status_code=500,
+                detail="No default tenant configured and no x-tenant-id header provided",
+            )
+
+        user_roles_in_tenant = UserTenantRoleEntity.get_roles_for_user_in_tenant(user_id, str(default_tenant.id))
+        if not user_roles_in_tenant:
+            logger.warning(f"User {user_id} does not have access to default tenant")
+            raise HTTPException(status_code=403, detail="Access denied")
+
+        UserEntity.objects(id=user_id).update(set__active_tenant_id=str(default_tenant.id))
+        return default_tenant
 
     @staticmethod
     def resolve_tenant_for_user(request: Request, user_id: str) -> TenantIdentity:
         """
         Resolve tenant context from request headers and verify user membership.
 
-        Extracts the x-tenant-id header and verifies the user has access to that tenant.
-        Falls back to the default tenant if no header is provided.
+        Uses the x-tenant-id header if provided (and updates the user's active tenant).
+        Otherwise falls back to the user's persisted active tenant, then the system default.
         """
         tenant_id = request.headers.get("x-tenant-id")
 
         if not tenant_id:
-            logger.debug("No x-tenant-id header found, falling back to default tenant")
-            tenant_entity = TenantEntity.get_default_tenant()
-            if not tenant_entity:
-                raise HTTPException(
-                    status_code=500,
-                    detail="No default tenant configured and no x-tenant-id header provided",
-                )
-        else:
-            tenant_entity = TenantEntity.get_tenant_by_id(tenant_id)
-            if not tenant_entity:
-                logger.warning(f"Tenant {tenant_id} not found during resolution for user {user_id}")
-                raise HTTPException(status_code=403, detail="Access denied")
+            logger.debug("No x-tenant-id header found, falling back to active tenant for user %s", user_id)
+            active_tenant = AuthHandler._resolve_active_tenant(user_id)
+            tenant_entity = active_tenant if active_tenant else AuthHandler._fall_back_to_default_tenant(user_id)
+            return TenantIdentity.from_tenant_entity(tenant_entity)
 
-        # Verify user has access to this tenant
+        tenant_entity = TenantEntity.get_tenant_by_id(tenant_id)
+        if not tenant_entity:
+            logger.warning(f"Tenant {tenant_id} not found during resolution for user {user_id}")
+            raise HTTPException(status_code=403, detail="Access denied")
+
         tenant_id_str = str(tenant_entity.id)
         user_roles_in_tenant = UserTenantRoleEntity.get_roles_for_user_in_tenant(user_id, tenant_id_str)
         if not user_roles_in_tenant:
             logger.warning(f"User {user_id} attempted to access tenant {tenant_id_str} without membership")
             raise HTTPException(status_code=403, detail="Access denied")
 
+        UserEntity.objects(id=user_id).update_one(set__active_tenant_id=tenant_id_str)
+
         return TenantIdentity.from_tenant_entity(tenant_entity)
 
     @staticmethod
-    def get_default_tenant_for_user(user_id: str) -> TenantIdentity:
+    def get_active_tenant_for_user(user_id: str) -> TenantIdentity:
         """
-        Get the default tenant for a user and verify membership.
+        Get the active tenant for a user and verify membership.
 
         Used for contexts without a request object (e.g., WebSocket connections).
+        Falls back to the system default tenant if no active tenant is set.
         """
-        default_tenant = TenantEntity.get_default_tenant()
-        if not default_tenant:
-            raise HTTPException(status_code=500, detail="Default tenant not configured")
-
-        # Verify user has access to default tenant
-        user_roles_in_tenant = UserTenantRoleEntity.get_roles_for_user_in_tenant(user_id, str(default_tenant.id))
-        if not user_roles_in_tenant:
-            logger.warning(f"User {user_id} does not have access to default tenant")
-            raise HTTPException(status_code=403, detail="Access denied")
-
-        return TenantIdentity.from_tenant_entity(default_tenant)
+        active_tenant = AuthHandler._resolve_active_tenant(user_id)
+        tenant_entity = active_tenant if active_tenant else AuthHandler._fall_back_to_default_tenant(user_id)
+        return TenantIdentity.from_tenant_entity(tenant_entity)

--- a/packages/core/swiss_ai_hub/core/auth/dependencies/auth_handler.py
+++ b/packages/core/swiss_ai_hub/core/auth/dependencies/auth_handler.py
@@ -40,7 +40,6 @@ class AuthHandler(ABC):
 
     @staticmethod
     def _resolve_active_tenant(user_id: str) -> TenantEntity | None:
-        """Attempts to resolve the user's persisted active tenant, returning None if invalid."""
         user = UserEntity.objects(id=user_id).only("active_tenant_id").first()
         if not user or not user.active_tenant_id:
             return None
@@ -59,7 +58,6 @@ class AuthHandler(ABC):
 
     @staticmethod
     def _resolve_tenant_by_id(tenant_id: str, user_id: str) -> TenantIdentity:
-        """Resolves a concrete tenant ID, validates existence and user membership."""
         tenant_entity = TenantEntity.get_tenant_by_id(tenant_id)
         if not tenant_entity:
             logger.warning(f"Tenant {tenant_id} not found during resolution for user {user_id}")
@@ -75,12 +73,6 @@ class AuthHandler(ABC):
 
     @staticmethod
     def resolve_tenant_for_user(request: Request, user_id: str) -> TenantIdentity:
-        """
-        Resolve tenant context from the required tenant_id path parameter.
-
-        When set to "active", resolves to the user's persisted active tenant.
-        When set to a concrete tenant ID, validates membership.
-        """
         tenant_id = request.path_params.get("tenant_id")
         if not tenant_id:
             raise HTTPException(status_code=400, detail="Missing tenant context")
@@ -98,12 +90,6 @@ class AuthHandler(ABC):
 
     @staticmethod
     def get_active_tenant_for_user(user_id: str) -> TenantIdentity:
-        """
-        Get the active tenant for a user and verify membership.
-
-        Used for contexts without a request object (e.g., WebSocket connections, bot integrations).
-        Requires an active tenant to be set — no implicit fallback.
-        """
         active_tenant = AuthHandler._resolve_active_tenant(user_id)
         if active_tenant:
             return TenantIdentity.from_tenant_entity(active_tenant)

--- a/packages/core/swiss_ai_hub/core/auth/dependencies/auth_handler.py
+++ b/packages/core/swiss_ai_hub/core/auth/dependencies/auth_handler.py
@@ -58,23 +58,6 @@ class AuthHandler(ABC):
         return tenant
 
     @staticmethod
-    def _fall_back_to_default_tenant(user_id: str) -> TenantIdentity:
-        """Returns the system default tenant identity without persisting it as active."""
-        default_tenant = TenantEntity.get_default_tenant()
-        if not default_tenant:
-            raise HTTPException(
-                status_code=500,
-                detail="No default tenant configured and no tenant could be resolved",
-            )
-
-        user_roles_in_tenant = UserTenantRoleEntity.get_roles_for_user_in_tenant(user_id, str(default_tenant.id))
-        if not user_roles_in_tenant:
-            logger.warning(f"User {user_id} does not have access to default tenant")
-            raise HTTPException(status_code=403, detail="Access denied")
-
-        return TenantIdentity.from_tenant_entity(default_tenant)
-
-    @staticmethod
     def _resolve_tenant_by_id(tenant_id: str, user_id: str) -> TenantIdentity:
         """Resolves a concrete tenant ID, validates existence and user membership."""
         tenant_entity = TenantEntity.get_tenant_by_id(tenant_id)
@@ -106,7 +89,10 @@ class AuthHandler(ABC):
             active_tenant = AuthHandler._resolve_active_tenant(user_id)
             if active_tenant:
                 return TenantIdentity.from_tenant_entity(active_tenant)
-            return AuthHandler._fall_back_to_default_tenant(user_id)
+            raise HTTPException(
+                status_code=400,
+                detail="No active tenant set. Please select a tenant first.",
+            )
 
         return AuthHandler._resolve_tenant_by_id(tenant_id, user_id)
 
@@ -115,10 +101,13 @@ class AuthHandler(ABC):
         """
         Get the active tenant for a user and verify membership.
 
-        Used for contexts without a request object (e.g., WebSocket connections).
-        Falls back to the system default tenant if no active tenant is set.
+        Used for contexts without a request object (e.g., WebSocket connections, bot integrations).
+        Requires an active tenant to be set — no implicit fallback.
         """
         active_tenant = AuthHandler._resolve_active_tenant(user_id)
         if active_tenant:
             return TenantIdentity.from_tenant_entity(active_tenant)
-        return AuthHandler._fall_back_to_default_tenant(user_id)
+        raise HTTPException(
+            status_code=400,
+            detail="No active tenant set. Please select a tenant first.",
+        )

--- a/packages/core/swiss_ai_hub/core/auth/dependencies/dangerous_development_only_auth_handler/dangerous_development_only_auth_handler.py
+++ b/packages/core/swiss_ai_hub/core/auth/dependencies/dangerous_development_only_auth_handler/dangerous_development_only_auth_handler.py
@@ -60,6 +60,6 @@ class DangerousDevelopmentOnlyAuthHandler(AuthHandler):
             tenant = self.resolve_tenant_for_user(request, user_entity.id)
         else:
             # Fallback for contexts without request
-            tenant = self.get_default_tenant_for_user(user_entity.id)
+            tenant = self.get_active_tenant_for_user(user_entity.id)
 
         return UserIdentity.from_user_entity(user_entity, tenant)

--- a/packages/core/swiss_ai_hub/core/auth/dependencies/dangerous_development_only_auth_handler/tests/test_dangerous_development_only_auth_handler.py
+++ b/packages/core/swiss_ai_hub/core/auth/dependencies/dangerous_development_only_auth_handler/tests/test_dangerous_development_only_auth_handler.py
@@ -81,7 +81,7 @@ def mock_database_operations(monkeypatch: pytest.MonkeyPatch):
         "swiss_ai_hub.core.auth.dependencies.auth_handler.AuthHandler.resolve_tenant_for_user", mock_resolve_tenant
     )
     monkeypatch.setattr(
-        "swiss_ai_hub.core.auth.dependencies.auth_handler.AuthHandler.get_default_tenant_for_user", mock_resolve_tenant
+        "swiss_ai_hub.core.auth.dependencies.auth_handler.AuthHandler.get_active_tenant_for_user", mock_resolve_tenant
     )
 
 

--- a/packages/core/swiss_ai_hub/core/auth/dependencies/keycloak_auth_handler/keycloak_auth_handler.py
+++ b/packages/core/swiss_ai_hub/core/auth/dependencies/keycloak_auth_handler/keycloak_auth_handler.py
@@ -109,7 +109,7 @@ class KeycloakAuthHandler(AuthHandler):
             if request:
                 tenant = self.resolve_tenant_for_user(request, user_entity.id)
             else:
-                tenant = self.get_default_tenant_for_user(user_entity.id)
+                tenant = self.get_active_tenant_for_user(user_entity.id)
 
             return UserIdentity.from_user_entity(user_entity, tenant)
 

--- a/packages/core/swiss_ai_hub/core/auth/dependencies/keycloak_auth_handler/tests/test_keycloak_auth_handler.py
+++ b/packages/core/swiss_ai_hub/core/auth/dependencies/keycloak_auth_handler/tests/test_keycloak_auth_handler.py
@@ -75,7 +75,7 @@ def mock_database_operations(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(
         "swiss_ai_hub.core.auth.identity.user_identity.UserIdentity.from_user_entity", mock_from_user_entity
     )
-    monkeypatch.setattr(AuthHandler, "get_default_tenant_for_user", staticmethod(mock_get_default_tenant))
+    monkeypatch.setattr(AuthHandler, "get_active_tenant_for_user", staticmethod(mock_get_default_tenant))
 
 
 # --- Fixtures ---

--- a/packages/core/swiss_ai_hub/core/auth/dependencies/tests/features/tenant_resolution.feature
+++ b/packages/core/swiss_ai_hub/core/auth/dependencies/tests/features/tenant_resolution.feature
@@ -10,29 +10,29 @@ Feature: Tenant Resolution in Auth Handler
     And user "user-1" is a member of the second tenant with roles "AIHubUser"
     And user "user-2" is a member of the default tenant only with roles "AIHubUser"
 
-  Scenario: Valid x-tenant-id header resolves to specified tenant
-    Given a request with x-tenant-id header set to the second tenant
+  Scenario: Explicit tenant path parameter resolves to specified tenant
+    Given a request with tenant path parameter set to the second tenant
     When the auth handler resolves tenant for user "user-1"
     Then the resolved tenant should be "Acme Corp"
 
-  Scenario: Missing x-tenant-id header falls back to default tenant
-    Given a request without x-tenant-id header
+  Scenario: Active tenant path parameter falls back to active tenant then default
+    Given a request with tenant path parameter set to "active"
     When the auth handler resolves tenant for user "user-1"
     Then the resolved tenant should be "Default Org"
 
   Scenario: Invalid tenant ID returns 403 error
-    Given a request with x-tenant-id header set to "non-existent-tenant-id"
+    Given a request with tenant path parameter set to "non-existent-tenant-id"
     When the auth handler resolves tenant for user "user-1" expecting error
     Then a 403 error should be raised with message "Access denied"
 
   Scenario: User without tenant membership returns 403 error
-    Given a request with x-tenant-id header set to the second tenant
+    Given a request with tenant path parameter set to the second tenant
     When the auth handler resolves tenant for user "user-2" expecting error
     Then a 403 error should be raised with message "Access denied"
 
-  Scenario: No default tenant and no header returns 500 error
+  Scenario: No default tenant and active tenant path parameter returns 500 error
     Given no default tenant exists
-    And a request without x-tenant-id header
+    And a request with tenant path parameter set to "active"
     When the auth handler resolves tenant for user "user-1" expecting error
     Then a 500 error should be raised with message "No default tenant configured"
 
@@ -46,38 +46,38 @@ Feature: Tenant Resolution in Auth Handler
     Then a 403 error should be raised with message "Access denied"
 
   Scenario: Non-existent tenant ID returns generic 403 without leaking information
-    Given a request with x-tenant-id header set to "000000000000000000000000"
+    Given a request with tenant path parameter set to "000000000000000000000000"
     When the auth handler resolves tenant for user "user-1" expecting error
     Then a 403 error should be raised with message "Access denied"
 
   Scenario: Superuser virtual tenant ID cannot be used by regular users
-    Given a request with x-tenant-id header set to "__superuser_tenant__"
+    Given a request with tenant path parameter set to "__superuser_tenant__"
     When the auth handler resolves tenant for user "user-1" expecting error
     Then a 403 error should be raised with message "Access denied"
 
-  Scenario: Active tenant is used when no header provided
+  Scenario: Active tenant is used when path parameter is active
     Given user "user-1" has active tenant set to the second tenant
-    And a request without x-tenant-id header
+    And a request with tenant path parameter set to "active"
     When the auth handler resolves tenant for user "user-1"
     Then the resolved tenant should be "Acme Corp"
 
-  Scenario: Explicit header updates active tenant
+  Scenario: Explicit tenant path parameter updates active tenant
     Given user "user-1" has active tenant set to the default tenant
-    And a request with x-tenant-id header set to the second tenant
+    And a request with tenant path parameter set to the second tenant
     When the auth handler resolves tenant for user "user-1"
     Then the resolved tenant should be "Acme Corp"
     And user "user-1" should have active tenant set to the second tenant
 
   Scenario: Stale active tenant falls back to default
     Given user "user-1" has active tenant set to "000000000000000000000000"
-    And a request without x-tenant-id header
+    And a request with tenant path parameter set to "active"
     When the auth handler resolves tenant for user "user-1"
     Then the resolved tenant should be "Default Org"
     And user "user-1" should have active tenant set to the default tenant
 
   Scenario: Active tenant without membership falls back to default
     Given user "user-2" has active tenant set to the second tenant
-    And a request without x-tenant-id header
+    And a request with tenant path parameter set to "active"
     When the auth handler resolves tenant for user "user-2"
     Then the resolved tenant should be "Default Org"
     And user "user-2" should have active tenant set to the default tenant

--- a/packages/core/swiss_ai_hub/core/auth/dependencies/tests/features/tenant_resolution.feature
+++ b/packages/core/swiss_ai_hub/core/auth/dependencies/tests/features/tenant_resolution.feature
@@ -72,15 +72,25 @@ Feature: Tenant Resolution in Auth Handler
     Given user "user-1" has active tenant set to "000000000000000000000000"
     And a request with tenant path parameter set to "active"
     When the auth handler resolves tenant for user "user-1" expecting error
-    Then a 400 error should be raised with message "No active tenant set"
+    Then a 400 error should be raised with message "Your active tenant is no longer accessible"
 
   Scenario: Active tenant without membership returns 400 error
     Given user "user-2" has active tenant set to the second tenant
     And a request with tenant path parameter set to "active"
     When the auth handler resolves tenant for user "user-2" expecting error
-    Then a 400 error should be raised with message "No active tenant set"
+    Then a 400 error should be raised with message "Your active tenant is no longer accessible"
 
   Scenario: WebSocket context uses active tenant
     Given user "user-1" has active tenant set to the second tenant
     When the auth handler gets active tenant for user "user-1"
     Then the resolved tenant should be "Acme Corp"
+
+  Scenario: WebSocket with stale active tenant returns 400 error
+    Given user "user-1" has active tenant set to "000000000000000000000000"
+    When the auth handler gets active tenant for user "user-1" expecting error
+    Then a 400 error should be raised with message "Your active tenant is no longer accessible"
+
+  Scenario: WebSocket with revoked tenant membership returns 400 error
+    Given user "user-2" has active tenant set to the second tenant
+    When the auth handler gets active tenant for user "user-2" expecting error
+    Then a 400 error should be raised with message "Your active tenant is no longer accessible"

--- a/packages/core/swiss_ai_hub/core/auth/dependencies/tests/features/tenant_resolution.feature
+++ b/packages/core/swiss_ai_hub/core/auth/dependencies/tests/features/tenant_resolution.feature
@@ -36,13 +36,13 @@ Feature: Tenant Resolution in Auth Handler
     When the auth handler resolves tenant for user "user-1" expecting error
     Then a 500 error should be raised with message "No default tenant configured"
 
-  Scenario: Get default tenant for user works without request
-    When the auth handler gets default tenant for user "user-1"
+  Scenario: Get active tenant for user works without request
+    When the auth handler gets active tenant for user "user-1"
     Then the resolved tenant should be "Default Org"
 
-  Scenario: Get default tenant for user without membership returns 403 error
+  Scenario: Get active tenant for user without membership returns 403 error
     Given user "user-no-default" is a member of the second tenant only with roles "AIHubUser"
-    When the auth handler gets default tenant for user "user-no-default" expecting error
+    When the auth handler gets active tenant for user "user-no-default" expecting error
     Then a 403 error should be raised with message "Access denied"
 
   Scenario: Non-existent tenant ID returns generic 403 without leaking information
@@ -54,3 +54,35 @@ Feature: Tenant Resolution in Auth Handler
     Given a request with x-tenant-id header set to "__superuser_tenant__"
     When the auth handler resolves tenant for user "user-1" expecting error
     Then a 403 error should be raised with message "Access denied"
+
+  Scenario: Active tenant is used when no header provided
+    Given user "user-1" has active tenant set to the second tenant
+    And a request without x-tenant-id header
+    When the auth handler resolves tenant for user "user-1"
+    Then the resolved tenant should be "Acme Corp"
+
+  Scenario: Explicit header updates active tenant
+    Given user "user-1" has active tenant set to the default tenant
+    And a request with x-tenant-id header set to the second tenant
+    When the auth handler resolves tenant for user "user-1"
+    Then the resolved tenant should be "Acme Corp"
+    And user "user-1" should have active tenant set to the second tenant
+
+  Scenario: Stale active tenant falls back to default
+    Given user "user-1" has active tenant set to "000000000000000000000000"
+    And a request without x-tenant-id header
+    When the auth handler resolves tenant for user "user-1"
+    Then the resolved tenant should be "Default Org"
+    And user "user-1" should have active tenant set to the default tenant
+
+  Scenario: Active tenant without membership falls back to default
+    Given user "user-2" has active tenant set to the second tenant
+    And a request without x-tenant-id header
+    When the auth handler resolves tenant for user "user-2"
+    Then the resolved tenant should be "Default Org"
+    And user "user-2" should have active tenant set to the default tenant
+
+  Scenario: WebSocket context uses active tenant
+    Given user "user-1" has active tenant set to the second tenant
+    When the auth handler gets active tenant for user "user-1"
+    Then the resolved tenant should be "Acme Corp"

--- a/packages/core/swiss_ai_hub/core/auth/dependencies/tests/features/tenant_resolution.feature
+++ b/packages/core/swiss_ai_hub/core/auth/dependencies/tests/features/tenant_resolution.feature
@@ -15,10 +15,10 @@ Feature: Tenant Resolution in Auth Handler
     When the auth handler resolves tenant for user "user-1"
     Then the resolved tenant should be "Acme Corp"
 
-  Scenario: Active tenant path parameter falls back to active tenant then default
+  Scenario: Active tenant path parameter without active tenant returns 400 error
     Given a request with tenant path parameter set to "active"
-    When the auth handler resolves tenant for user "user-1"
-    Then the resolved tenant should be "Default Org"
+    When the auth handler resolves tenant for user "user-1" expecting error
+    Then a 400 error should be raised with message "No active tenant set"
 
   Scenario: Invalid tenant ID returns 403 error
     Given a request with tenant path parameter set to "non-existent-tenant-id"
@@ -30,20 +30,20 @@ Feature: Tenant Resolution in Auth Handler
     When the auth handler resolves tenant for user "user-2" expecting error
     Then a 403 error should be raised with message "Access denied"
 
-  Scenario: No default tenant and active tenant path parameter returns 500 error
+  Scenario: No active tenant set returns 400 error regardless of default tenant
     Given no default tenant exists
     And a request with tenant path parameter set to "active"
     When the auth handler resolves tenant for user "user-1" expecting error
-    Then a 500 error should be raised with message "No default tenant configured"
+    Then a 400 error should be raised with message "No active tenant set"
 
-  Scenario: Get active tenant for user works without request
+  Scenario: Get active tenant for user without active tenant returns 400 error
+    When the auth handler gets active tenant for user "user-1" expecting error
+    Then a 400 error should be raised with message "No active tenant set"
+
+  Scenario: Get active tenant for user with active tenant set resolves correctly
+    Given user "user-1" has active tenant set to the second tenant
     When the auth handler gets active tenant for user "user-1"
-    Then the resolved tenant should be "Default Org"
-
-  Scenario: Get active tenant for user without membership returns 403 error
-    Given user "user-no-default" is a member of the second tenant only with roles "AIHubUser"
-    When the auth handler gets active tenant for user "user-no-default" expecting error
-    Then a 403 error should be raised with message "Access denied"
+    Then the resolved tenant should be "Acme Corp"
 
   Scenario: Non-existent tenant ID returns generic 403 without leaking information
     Given a request with tenant path parameter set to "000000000000000000000000"
@@ -68,17 +68,17 @@ Feature: Tenant Resolution in Auth Handler
     Then the resolved tenant should be "Acme Corp"
     And user "user-1" should have active tenant set to the default tenant
 
-  Scenario: Stale active tenant falls back to default
+  Scenario: Stale active tenant returns 400 error
     Given user "user-1" has active tenant set to "000000000000000000000000"
     And a request with tenant path parameter set to "active"
-    When the auth handler resolves tenant for user "user-1"
-    Then the resolved tenant should be "Default Org"
+    When the auth handler resolves tenant for user "user-1" expecting error
+    Then a 400 error should be raised with message "No active tenant set"
 
-  Scenario: Active tenant without membership falls back to default
+  Scenario: Active tenant without membership returns 400 error
     Given user "user-2" has active tenant set to the second tenant
     And a request with tenant path parameter set to "active"
-    When the auth handler resolves tenant for user "user-2"
-    Then the resolved tenant should be "Default Org"
+    When the auth handler resolves tenant for user "user-2" expecting error
+    Then a 400 error should be raised with message "No active tenant set"
 
   Scenario: WebSocket context uses active tenant
     Given user "user-1" has active tenant set to the second tenant

--- a/packages/core/swiss_ai_hub/core/auth/dependencies/tests/features/tenant_resolution.feature
+++ b/packages/core/swiss_ai_hub/core/auth/dependencies/tests/features/tenant_resolution.feature
@@ -61,26 +61,24 @@ Feature: Tenant Resolution in Auth Handler
     When the auth handler resolves tenant for user "user-1"
     Then the resolved tenant should be "Acme Corp"
 
-  Scenario: Explicit tenant path parameter updates active tenant
+  Scenario: Explicit tenant path parameter does not update active tenant
     Given user "user-1" has active tenant set to the default tenant
     And a request with tenant path parameter set to the second tenant
     When the auth handler resolves tenant for user "user-1"
     Then the resolved tenant should be "Acme Corp"
-    And user "user-1" should have active tenant set to the second tenant
+    And user "user-1" should have active tenant set to the default tenant
 
   Scenario: Stale active tenant falls back to default
     Given user "user-1" has active tenant set to "000000000000000000000000"
     And a request with tenant path parameter set to "active"
     When the auth handler resolves tenant for user "user-1"
     Then the resolved tenant should be "Default Org"
-    And user "user-1" should have active tenant set to the default tenant
 
   Scenario: Active tenant without membership falls back to default
     Given user "user-2" has active tenant set to the second tenant
     And a request with tenant path parameter set to "active"
     When the auth handler resolves tenant for user "user-2"
     Then the resolved tenant should be "Default Org"
-    And user "user-2" should have active tenant set to the default tenant
 
   Scenario: WebSocket context uses active tenant
     Given user "user-1" has active tenant set to the second tenant

--- a/packages/core/swiss_ai_hub/core/auth/dependencies/tests/test_tenant_resolution.py
+++ b/packages/core/swiss_ai_hub/core/auth/dependencies/tests/test_tenant_resolution.py
@@ -63,11 +63,20 @@ def auth_handler() -> ConcreteAuthHandler:
     return ConcreteAuthHandler()
 
 
-def create_mock_request(headers: dict[str, str] | None = None) -> Request:
-    """Create a mock FastAPI Request with the given headers."""
+def create_mock_request(
+    path_params: dict[str, str] | None = None,
+    headers: dict[str, str] | None = None,
+) -> Request:
+    """Create a mock FastAPI Request with the given path params and headers."""
     headers = headers or {}
     headers_list = [(k.lower().encode("utf8"), v.encode("utf8")) for k, v in headers.items()]
-    scope: dict[str, Any] = {"type": "http", "headers": headers_list, "method": "GET", "path": "/"}
+    scope: dict[str, Any] = {
+        "type": "http",
+        "headers": headers_list,
+        "method": "GET",
+        "path": "/",
+        "path_params": path_params or {},
+    }
     return Request(scope)
 
 
@@ -193,23 +202,17 @@ def set_active_tenant_to_id(cleanup_documents: list[Any], user_id: str, tenant_i
 # --- Given Steps for Request Context ---
 
 
-@given("a request with x-tenant-id header set to the second tenant")
-def request_with_second_tenant_header(context: dict[str, Any]) -> None:
-    """Create a request with x-tenant-id header pointing to the second tenant."""
+@given("a request with tenant path parameter set to the second tenant")
+def request_with_second_tenant_path_param(context: dict[str, Any]) -> None:
+    """Create a request with tenant_id path parameter pointing to the second tenant."""
     tenant = context["second_tenant"]
-    context["request"] = create_mock_request({"x-tenant-id": str(tenant.id)})
+    context["request"] = create_mock_request(path_params={"tenant_id": str(tenant.id)})
 
 
-@given(parsers.parse('a request with x-tenant-id header set to "{tenant_id}"'))
-def request_with_specific_tenant_header(context: dict[str, Any], tenant_id: str) -> None:
-    """Create a request with x-tenant-id header set to a specific value."""
-    context["request"] = create_mock_request({"x-tenant-id": tenant_id})
-
-
-@given("a request without x-tenant-id header")
-def request_without_tenant_header(context: dict[str, Any]) -> None:
-    """Create a request without x-tenant-id header."""
-    context["request"] = create_mock_request()
+@given(parsers.parse('a request with tenant path parameter set to "{tenant_id}"'))
+def request_with_specific_tenant_path_param(context: dict[str, Any], tenant_id: str) -> None:
+    """Create a request with tenant_id path parameter set to a specific value."""
+    context["request"] = create_mock_request(path_params={"tenant_id": tenant_id})
 
 
 @given("no default tenant exists")

--- a/packages/core/swiss_ai_hub/core/auth/dependencies/tests/test_tenant_resolution.py
+++ b/packages/core/swiss_ai_hub/core/auth/dependencies/tests/test_tenant_resolution.py
@@ -13,6 +13,7 @@ from swiss_ai_hub.core.infrastructure.mongo.mongo_settings import MongoSettings
 from swiss_ai_hub.core.persistence.access.entities.role_entity import RoleEntity
 from swiss_ai_hub.core.persistence.access.entities.tenant_entity import TenantEntity
 from swiss_ai_hub.core.persistence.access.entities.user_tenant_role_entity import UserTenantRoleEntity
+from swiss_ai_hub.core.persistence.user.user_entity import UserEntity
 
 scenarios("features/tenant_resolution.feature")
 
@@ -155,6 +156,40 @@ def add_user_to_second_only(cleanup_documents: list[Any], context: dict[str, Any
     add_user_to_second_tenant(cleanup_documents, context, user_id, roles)
 
 
+# --- Active Tenant Steps ---
+
+
+def ensure_user_entity(cleanup_documents: list[Any], user_id: str) -> UserEntity:
+    """Ensure a UserEntity exists for the given user_id."""
+    user = UserEntity.objects(id=user_id).first()
+    if not user:
+        user = UserEntity.create_user(oid=user_id, name=f"Test User {user_id}", email=f"{user_id}@test.local")
+        cleanup_documents.append(user)
+    return user
+
+
+@given(parsers.parse('user "{user_id}" has active tenant set to the second tenant'))
+def set_active_tenant_to_second(cleanup_documents: list[Any], context: dict[str, Any], user_id: str) -> None:
+    """Set a user's active tenant to the second tenant."""
+    user = ensure_user_entity(cleanup_documents, user_id)
+    user.set_active_tenant(str(context["second_tenant"].id))
+
+
+@given(parsers.parse('user "{user_id}" has active tenant set to the default tenant'))
+def set_active_tenant_to_default(cleanup_documents: list[Any], context: dict[str, Any], user_id: str) -> None:
+    """Set a user's active tenant to the default tenant."""
+    user = ensure_user_entity(cleanup_documents, user_id)
+    user.set_active_tenant(str(context["default_tenant"].id))
+
+
+@given(parsers.parse('user "{user_id}" has active tenant set to "{tenant_id}"'))
+def set_active_tenant_to_id(cleanup_documents: list[Any], user_id: str, tenant_id: str) -> None:
+    """Set a user's active tenant to a specific ID (possibly non-existent)."""
+    user = ensure_user_entity(cleanup_documents, user_id)
+    user.active_tenant_id = tenant_id
+    user.save()
+
+
 # --- Given Steps for Request Context ---
 
 
@@ -217,18 +252,18 @@ def resolve_tenant_expect_error(context: dict[str, Any], auth_handler: ConcreteA
                 tenant.save()
 
 
-@when(parsers.parse('the auth handler gets default tenant for user "{user_id}"'))
-def get_default_tenant(context: dict[str, Any], auth_handler: ConcreteAuthHandler, user_id: str) -> None:
-    """Get the default tenant for the given user."""
-    tenant_identity = auth_handler.get_default_tenant_for_user(user_id)
+@when(parsers.parse('the auth handler gets active tenant for user "{user_id}"'))
+def get_active_tenant(context: dict[str, Any], auth_handler: ConcreteAuthHandler, user_id: str) -> None:
+    """Get the active tenant for the given user."""
+    tenant_identity = auth_handler.get_active_tenant_for_user(user_id)
     context["resolved_tenant"] = tenant_identity
 
 
-@when(parsers.parse('the auth handler gets default tenant for user "{user_id}" expecting error'))
-def get_default_tenant_expect_error(context: dict[str, Any], auth_handler: ConcreteAuthHandler, user_id: str) -> None:
-    """Get the default tenant for the given user, expecting an error."""
+@when(parsers.parse('the auth handler gets active tenant for user "{user_id}" expecting error'))
+def get_active_tenant_expect_error(context: dict[str, Any], auth_handler: ConcreteAuthHandler, user_id: str) -> None:
+    """Get the active tenant for the given user, expecting an error."""
     try:
-        auth_handler.get_default_tenant_for_user(user_id)
+        auth_handler.get_active_tenant_for_user(user_id)
         pytest.fail("Expected an HTTPException but none was raised")
     except HTTPException as e:
         context["error"] = e
@@ -252,3 +287,21 @@ def check_error_status_and_message(context: dict[str, Any], status_code: int, ex
     assert error is not None, "No error was captured"
     assert error.status_code == status_code, f"Expected status {status_code}, got {error.status_code}"
     assert expected_message in error.detail, f"Expected message '{expected_message}' in '{error.detail}'"
+
+
+@then(parsers.parse('user "{user_id}" should have active tenant set to the second tenant'))
+def check_active_tenant_is_second(context: dict[str, Any], user_id: str) -> None:
+    """Verify the user's active tenant was updated to the second tenant."""
+    user = UserEntity.objects(id=user_id).only("active_tenant_id").first()
+    expected = str(context["second_tenant"].id)
+    assert user is not None, f"User {user_id} not found"
+    assert user.active_tenant_id == expected, f"Expected active_tenant_id '{expected}', got '{user.active_tenant_id}'"
+
+
+@then(parsers.parse('user "{user_id}" should have active tenant set to the default tenant'))
+def check_active_tenant_is_default(context: dict[str, Any], user_id: str) -> None:
+    """Verify the user's active tenant was updated to the default tenant."""
+    user = UserEntity.objects(id=user_id).only("active_tenant_id").first()
+    expected = str(context["default_tenant"].id)
+    assert user is not None, f"User {user_id} not found"
+    assert user.active_tenant_id == expected, f"Expected active_tenant_id '{expected}', got '{user.active_tenant_id}'"

--- a/packages/core/swiss_ai_hub/core/auth/dependencies/token_auth_handler/test/test_token_auth_handler.py
+++ b/packages/core/swiss_ai_hub/core/auth/dependencies/token_auth_handler/test/test_token_auth_handler.py
@@ -77,10 +77,16 @@ def cleanup_document() -> Generator[list[Any]]:
         doc.delete()
 
 
-def create_dummy_request(headers: dict[str, str]) -> Request:
+def create_dummy_request(headers: dict[str, str], path_params: dict[str, str] | None = None) -> Request:
     """Create and return a dummy FastAPI Request with the given headers."""
     headers_list = [(k.lower().encode("utf8"), v.encode("utf8")) for k, v in headers.items()]
-    scope: dict[str, Any] = {"type": "http", "headers": headers_list, "method": "GET", "path": "/"}
+    scope: dict[str, Any] = {
+        "type": "http",
+        "headers": headers_list,
+        "method": "GET",
+        "path": "/",
+        "path_params": path_params or {},
+    }
     return Request(scope)
 
 
@@ -120,6 +126,7 @@ def insert_token_document(
             validate_roles=False,
         )
         cleanup_document.append(user_tenant_role)
+        token_context["tenant_id"] = str(default_tenant.id)
 
     expiry = datetime.now(UTC) + timedelta(hours=1)
     token_doc = BearerToken.create_new_token(
@@ -183,7 +190,8 @@ async def invoke_token_auth_handler(token_context: dict[str, Any], token_context
     """Invoke the TokenAuthHandler with the token and store the authenticated user."""
     token_str = token_context["token_str"]
     headers = {"Authorization": f"Bearer {token_str}"}
-    request = create_dummy_request(headers)
+    path_params = {"tenant_id": token_context["tenant_id"]} if "tenant_id" in token_context else None
+    request = create_dummy_request(headers, path_params=path_params)
     handler = TokenAuthHandler()
     try:
         security = await HTTPBearer()(request)

--- a/packages/core/swiss_ai_hub/core/auth/dependencies/token_auth_handler/token_auth_handler.py
+++ b/packages/core/swiss_ai_hub/core/auth/dependencies/token_auth_handler/token_auth_handler.py
@@ -51,6 +51,6 @@ class TokenAuthHandler(BearerAuthHandler):
             tenant = self.resolve_tenant_for_user(request, user.id)
         else:
             # Fallback for contexts without request (e.g., WebSocket)
-            tenant = self.get_default_tenant_for_user(user.id)
+            tenant = self.get_active_tenant_for_user(user.id)
 
         return UserIdentity.from_user_entity(user, tenant)

--- a/packages/core/swiss_ai_hub/core/infrastructure/api/ai_hub_settings.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/api/ai_hub_settings.py
@@ -34,7 +34,7 @@ class AIHubSettings(EnvironmentSettings):
             pattern=r"^https?://.*$",
             description="Base URL of AI-Hub's OpenAI-compatible endpoint, used for Langfuse LLM connection",
         ),
-    ] = "http://api:8000/api/v1/openai"
+    ] = "http://api:8000/api/v1/active/openai"
 
     FRONTEND_ORIGIN: Annotated[str, Field(description="Comma separated list of origins to allow CORS")]
 

--- a/packages/core/swiss_ai_hub/core/persistence/access/entities/tenant_entity.py
+++ b/packages/core/swiss_ai_hub/core/persistence/access/entities/tenant_entity.py
@@ -3,6 +3,7 @@ from typing import Self
 
 from bson import ObjectId
 from mongoengine import BooleanField, DateTimeField, Document, ListField, NotUniqueError, StringField
+from mongoengine.connection import get_db
 
 from swiss_ai_hub.core.infrastructure.opentelemetry.tracing.decorators.trace_fn import trace_fn
 
@@ -155,6 +156,13 @@ class TenantEntity(Document):
         # Cascade: remove all user-tenant-role associations and tenant-scoped roles
         UserTenantRoleEntity.objects(tenant_id=tenant_id).delete()
         RoleEntity.objects(tenant_id=tenant_id).delete()
+
+        # Clear active tenant for users who had this as their active tenant
+        # Direct collection access avoids circular import with UserEntity
+        get_db()["users"].update_many(
+            {"active_tenant_id": tenant_id},
+            {"$set": {"active_tenant_id": None}},
+        )
 
         tenant.delete()
         return True

--- a/packages/core/swiss_ai_hub/core/persistence/access/entities/tenant_entity.py
+++ b/packages/core/swiss_ai_hub/core/persistence/access/entities/tenant_entity.py
@@ -3,7 +3,6 @@ from typing import Self
 
 from bson import ObjectId
 from mongoengine import BooleanField, DateTimeField, Document, ListField, NotUniqueError, StringField
-from mongoengine.connection import get_db
 
 from swiss_ai_hub.core.infrastructure.opentelemetry.tracing.decorators.trace_fn import trace_fn
 
@@ -139,10 +138,13 @@ class TenantEntity(Document):
         """
         Deletes a tenant by its ID. Returns True if deleted, False if not found.
 
-        Cascades to delete all associated UserTenantRoleEntity and tenant-scoped RoleEntity records.
+        Cascades to delete all associated UserTenantRoleEntity and tenant-scoped RoleEntity records,
+        and clears the active tenant for affected users.
         The default tenant cannot be deleted - attempting to do so will raise ValueError.
+
+        Uses deferred imports because UserEntity, RoleEntity, and UserTenantRoleEntity all import
+        TenantEntity at module level — importing them here at module level would create circular imports.
         """
-        # Runtime import: TenantEntity ↔ RoleEntity/UserTenantRoleEntity mutual reference for cascade deletes
         from swiss_ai_hub.core.persistence.access.entities.role_entity import RoleEntity
         from swiss_ai_hub.core.persistence.access.entities.user_tenant_role_entity import UserTenantRoleEntity
 
@@ -157,12 +159,9 @@ class TenantEntity(Document):
         UserTenantRoleEntity.objects(tenant_id=tenant_id).delete()
         RoleEntity.objects(tenant_id=tenant_id).delete()
 
-        # Clear active tenant for users who had this as their active tenant
-        # Direct collection access avoids circular import with UserEntity
-        get_db()["users"].update_many(
-            {"active_tenant_id": tenant_id},
-            {"$set": {"active_tenant_id": None}},
-        )
+        from swiss_ai_hub.core.persistence.user.user_entity import UserEntity
+
+        UserEntity.objects(active_tenant_id=tenant_id).update(set__active_tenant_id=None)
 
         tenant.delete()
         return True

--- a/packages/core/swiss_ai_hub/core/persistence/access/entities/user_tenant_role_entity.py
+++ b/packages/core/swiss_ai_hub/core/persistence/access/entities/user_tenant_role_entity.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 from typing import Self
 
 from mongoengine import DateTimeField, Document, ListField, NotUniqueError, StringField
+from mongoengine.connection import get_db
 
 from swiss_ai_hub.core.infrastructure.opentelemetry.tracing.decorators.trace_fn import trace_fn
 
@@ -161,5 +162,12 @@ class UserTenantRoleEntity(Document):
         existing = cls.get_by_user_and_tenant(user_id, tenant_id)
         if existing:
             existing.delete()
+
+            # Clear active tenant if it matches the removed tenant
+            # Direct collection access avoids circular import with UserEntity
+            get_db()["users"].update_one(
+                {"_id": user_id, "active_tenant_id": tenant_id},
+                {"$set": {"active_tenant_id": None}},
+            )
             return True
         return False

--- a/packages/core/swiss_ai_hub/core/persistence/access/entities/user_tenant_role_entity.py
+++ b/packages/core/swiss_ai_hub/core/persistence/access/entities/user_tenant_role_entity.py
@@ -3,7 +3,6 @@ from datetime import UTC, datetime
 from typing import Self
 
 from mongoengine import DateTimeField, Document, ListField, NotUniqueError, StringField
-from mongoengine.connection import get_db
 
 from swiss_ai_hub.core.infrastructure.opentelemetry.tracing.decorators.trace_fn import trace_fn
 
@@ -158,16 +157,18 @@ class UserTenantRoleEntity(Document):
     @classmethod
     @trace_fn
     def remove_user_from_tenant(cls, user_id: str, tenant_id: str) -> bool:
-        """Removes a user from a tenant entirely. Returns True if the association was deleted."""
+        """
+        Removes a user from a tenant entirely. Returns True if the association was deleted.
+
+        Clears the user's active tenant if it matches the removed tenant.
+        Uses a deferred import because UserEntity imports UserTenantRoleEntity at module level.
+        """
         existing = cls.get_by_user_and_tenant(user_id, tenant_id)
         if existing:
             existing.delete()
 
-            # Clear active tenant if it matches the removed tenant
-            # Direct collection access avoids circular import with UserEntity
-            get_db()["users"].update_one(
-                {"_id": user_id, "active_tenant_id": tenant_id},
-                {"$set": {"active_tenant_id": None}},
-            )
+            from swiss_ai_hub.core.persistence.user.user_entity import UserEntity
+
+            UserEntity.objects(id=user_id, active_tenant_id=tenant_id).update_one(set__active_tenant_id=None)
             return True
         return False

--- a/packages/core/swiss_ai_hub/core/persistence/user/user_entity.py
+++ b/packages/core/swiss_ai_hub/core/persistence/user/user_entity.py
@@ -244,6 +244,10 @@ class UserEntity(Document):
                     )
                     logger.info(f"Repaired missing tenant association for user {oid} with roles: {roles_to_assign}")
 
+                if not user.active_tenant_id:
+                    user.set_active_tenant(default_tenant_id)
+                    logger.info(f"Repaired missing active tenant for user {oid}")
+
             return user
         except DoesNotExist:
             pass

--- a/packages/core/swiss_ai_hub/core/persistence/user/user_entity.py
+++ b/packages/core/swiss_ai_hub/core/persistence/user/user_entity.py
@@ -60,6 +60,7 @@ class UserEntity(Document):
     name = StringField(required=True)
     email = StringField(required=True)
     profile_image = StringField(null=True)
+    active_tenant_id = StringField(null=True)
     last_updated = DateTimeField(required=True)
     favorite_modules = ListField(StringField(), default=list)
     dashboard = EmbeddedDocumentField(Dashboard)
@@ -75,6 +76,15 @@ class UserEntity(Document):
                 "Profile image must be a valid http:// or https:// URL. "
                 "Data URLs and base64-encoded images are not allowed."
             )
+
+    @trace_fn
+    def set_active_tenant(self, tenant_id: str) -> None:
+        """Persists the user's active tenant if it changed."""
+        if self.active_tenant_id == tenant_id:
+            return
+        self.active_tenant_id = tenant_id
+        self.last_updated = datetime.now(UTC)
+        self.save()
 
     @staticmethod
     @trace_fn
@@ -266,6 +276,9 @@ class UserEntity(Document):
             tenant_id=str(default_tenant.id),
             roles=roles_to_assign,
         )
+
+        user.active_tenant_id = str(default_tenant.id)
+        user.save()
 
         logger.info(f"Created new user {email} in tenant {default_tenant.name} with roles: {roles_to_assign}")
         return user

--- a/packages/core/swiss_ai_hub/core/persistence/user/user_entity.py
+++ b/packages/core/swiss_ai_hub/core/persistence/user/user_entity.py
@@ -130,15 +130,17 @@ class UserEntity(Document):
 
     @classmethod
     @trace_fn
-    def create_user(cls, oid: str, name: str, email: str, profile_image: str | None = None) -> Self:
-        default_dashboard = cls.create_default_dashboard()
+    def create_user(
+        cls, oid: str, name: str, email: str, profile_image: str | None = None, active_tenant_id: str | None = None
+    ) -> Self:
         user = cls(
             id=oid,
             name=name,
             email=email,
             profile_image=profile_image,
+            active_tenant_id=active_tenant_id,
             favorite_modules=[],
-            dashboard=default_dashboard,
+            dashboard=cls.create_default_dashboard(),
             last_updated=datetime.now(UTC),
         )
         user.save()
@@ -264,17 +266,13 @@ class UserEntity(Document):
             roles_to_assign = settings.regular_user_roles_list
             logger.info(f"Regular user signup, assigning default roles: {roles_to_assign}")
 
-        user = cls(
-            id=oid,
+        user = cls.create_user(
+            oid=oid,
             name=name,
             email=email,
             profile_image=profile_image,
             active_tenant_id=str(default_tenant.id),
-            favorite_modules=[],
-            dashboard=cls.create_default_dashboard(),
-            last_updated=datetime.now(UTC),
         )
-        user.save()
 
         UserTenantRoleEntity.create_or_update(
             user_id=oid,

--- a/packages/core/swiss_ai_hub/core/persistence/user/user_entity.py
+++ b/packages/core/swiss_ai_hub/core/persistence/user/user_entity.py
@@ -264,21 +264,23 @@ class UserEntity(Document):
             roles_to_assign = settings.regular_user_roles_list
             logger.info(f"Regular user signup, assigning default roles: {roles_to_assign}")
 
-        user = cls.create_user(
-            oid=oid,
+        user = cls(
+            id=oid,
             name=name,
             email=email,
             profile_image=profile_image,
+            active_tenant_id=str(default_tenant.id),
+            favorite_modules=[],
+            dashboard=cls.create_default_dashboard(),
+            last_updated=datetime.now(UTC),
         )
+        user.save()
 
         UserTenantRoleEntity.create_or_update(
             user_id=oid,
             tenant_id=str(default_tenant.id),
             roles=roles_to_assign,
         )
-
-        user.active_tenant_id = str(default_tenant.id)
-        user.save()
 
         logger.info(f"Created new user {email} in tenant {default_tenant.name} with roles: {roles_to_assign}")
         return user

--- a/packages/core/swiss_ai_hub/core/routes/controller.py
+++ b/packages/core/swiss_ai_hub/core/routes/controller.py
@@ -135,11 +135,14 @@ class Controller(abc.ABC):
         span.set_attribute("service.controller", self.service_name)
         span.set_attribute("auth.required_permission", required_permission)
 
+        # Tenant context (use resolved tenant, not raw path param which may be "active")
+        span.set_attribute("tenant.id", user.acting_within_tenant.id)
+
         # Path parameters (business context)
         if request.path_params:
             for param_name, param_value in request.path_params.items():
                 if param_name == "tenant_id":
-                    span.set_attribute("tenant.id", str(param_value))
+                    continue
                 elif param_name in ["agent_class", "agent_id", "thread_id", "process_id", "process_class"]:
                     span.set_attribute(f"{param_name.replace('_', '.')}", str(param_value))
                 else:

--- a/packages/core/swiss_ai_hub/core/routes/controller.py
+++ b/packages/core/swiss_ai_hub/core/routes/controller.py
@@ -138,7 +138,9 @@ class Controller(abc.ABC):
         # Path parameters (business context)
         if request.path_params:
             for param_name, param_value in request.path_params.items():
-                if param_name in ["agent_class", "agent_id", "thread_id", "process_id", "process_class"]:
+                if param_name == "tenant_id":
+                    span.set_attribute("tenant.id", str(param_value))
+                elif param_name in ["agent_class", "agent_id", "thread_id", "process_id", "process_class"]:
                     span.set_attribute(f"{param_name.replace('_', '.')}", str(param_value))
                 else:
                     span.set_attribute(f"resource.{param_name}", str(param_value))

--- a/packages/core/swiss_ai_hub/core/testing/auth_utils/tenant_mocks.py
+++ b/packages/core/swiss_ai_hub/core/testing/auth_utils/tenant_mocks.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from swiss_ai_hub.core.auth.dependencies.auth_handler import AuthHandler
 from swiss_ai_hub.core.auth.dependencies.dangerous_development_only_auth_handler.dangerous_development_only_auth_settings import (  # noqa: E501
     DangerousDevelopmentOnlyAuthSettings,
 )
@@ -30,15 +31,16 @@ def _create_mock_tenant() -> MagicMock:
 @pytest.fixture(autouse=True)
 def mock_tenant_entity_autouse():
     """
-    Mock TenantEntity and UserTenantRoleEntity methods for multi-tenant auth in tests.
+    Mock TenantEntity, UserTenantRoleEntity, and AuthHandler tenant resolution for tests.
 
-    This fixture ensures that the DangerousDevelopmentOnlyAuthHandler can resolve
-    tenant context without a real database. It mocks:
+    This fixture ensures that auth handlers can resolve tenant context without a real database.
+    It mocks:
     - TenantEntity.get_default_tenant() → returns a test tenant
     - TenantEntity.get_tenant_by_id() → returns the test tenant for any ID
     - UserTenantRoleEntity.get_roles_for_user_in_tenant() → returns dev roles
     - UserTenantRoleEntity.create_or_update() → no-op returning a mock
     - UserTenantRoleEntity.get_user_ids_in_tenant() → returns the dev user ID
+    - AuthHandler._resolve_active_tenant() → returns the test tenant
     """
     config = DangerousDevelopmentOnlyAuthSettings()
     mock_tenant = _create_mock_tenant()
@@ -56,6 +58,9 @@ def mock_tenant_entity_autouse():
     def mock_get_user_ids_in_tenant(tenant_id):
         return [config.OID]
 
+    def mock_resolve_active_tenant(user_id):
+        return mock_tenant
+
     with (
         patch.object(TenantEntity, "get_default_tenant", return_value=mock_tenant),
         patch.object(TenantEntity, "get_tenant_by_id", return_value=mock_tenant),
@@ -63,5 +68,6 @@ def mock_tenant_entity_autouse():
         patch.object(UserTenantRoleEntity, "get_roles_for_user_in_tenant", side_effect=mock_get_roles),
         patch.object(UserTenantRoleEntity, "create_or_update", side_effect=mock_create_or_update),
         patch.object(UserTenantRoleEntity, "get_user_ids_in_tenant", side_effect=mock_get_user_ids_in_tenant),
+        patch.object(AuthHandler, "_resolve_active_tenant", side_effect=mock_resolve_active_tenant),
     ):
         yield

--- a/packages/web/swiss_ai_hub_web/README.md
+++ b/packages/web/swiss_ai_hub_web/README.md
@@ -132,7 +132,7 @@ export default defineNuxtConfig({
         url: 'http://localhost:8080',
       },
       ws: {
-        endpoint: 'ws://localhost:8000/api/v1/events/ws',
+        endpoint: 'ws://localhost:8000/api/v1/active/events/ws',
       },
     },
   },
@@ -378,13 +378,13 @@ ______________________________________________________________________
 All configuration is provided through `runtimeConfig.public` in `nuxt.config.ts`. In production, override them via
 environment variables -- Nuxt automatically maps `NUXT_PUBLIC_*` variables to the corresponding config keys:
 
-| Config key          | Environment variable             | Default (dev)                          | Description                          |
-| ------------------- | -------------------------------- | -------------------------------------- | ------------------------------------ |
-| `env`               | `NUXT_PUBLIC_ENV`                | `dev`                                  | Environment identifier               |
-| `oidc.clientId`     | `NUXT_PUBLIC_OIDC_CLIENT_ID`     | `aihub-frontend`                       | OIDC client ID for Keycloak          |
-| `oidc.authorityUrl` | `NUXT_PUBLIC_OIDC_AUTHORITY_URL` | `http://localhost:8180/realms/aihub`   | Keycloak realm URL                   |
-| `webui.url`         | `NUXT_PUBLIC_WEBUI_URL`          | `http://localhost:8080`                | Open-WebUI URL (chat link)           |
-| `ws.endpoint`       | `NUXT_PUBLIC_WS_ENDPOINT`        | `ws://localhost:8000/api/v1/events/ws` | WebSocket for real-time agent events |
+| Config key          | Environment variable             | Default (dev)                                 | Description                          |
+| ------------------- | -------------------------------- | --------------------------------------------- | ------------------------------------ |
+| `env`               | `NUXT_PUBLIC_ENV`                | `dev`                                         | Environment identifier               |
+| `oidc.clientId`     | `NUXT_PUBLIC_OIDC_CLIENT_ID`     | `aihub-frontend`                              | OIDC client ID for Keycloak          |
+| `oidc.authorityUrl` | `NUXT_PUBLIC_OIDC_AUTHORITY_URL` | `http://localhost:8180/realms/aihub`          | Keycloak realm URL                   |
+| `webui.url`         | `NUXT_PUBLIC_WEBUI_URL`          | `http://localhost:8080`                       | Open-WebUI URL (chat link)           |
+| `ws.endpoint`       | `NUXT_PUBLIC_WS_ENDPOINT`        | `ws://localhost:8000/api/v1/active/events/ws` | WebSocket for real-time agent events |
 
 ## Peer dependencies
 

--- a/packages/web/swiss_ai_hub_web/app.vue
+++ b/packages/web/swiss_ai_hub_web/app.vue
@@ -16,7 +16,7 @@ const { t, locale } = useI18n()
 const toast = useToast()
 useNotificationPoller()
 client.setConfig({
-  baseURL: '/api/v1',
+  baseURL: '/api/v1/active',
   auth: async () => {
     return await getToken()
   },

--- a/packages/web/swiss_ai_hub_web/layouts/default.vue
+++ b/packages/web/swiss_ai_hub_web/layouts/default.vue
@@ -107,6 +107,7 @@ const breadcrumbItems = computed(() => {
 
 getHealth({
   composable: '$fetch',
+  baseURL: '/api/v1',
 })
   .then((response) => {
     online.value = response.code == 200

--- a/packages/web/swiss_ai_hub_web/openapi-ts.config.ts
+++ b/packages/web/swiss_ai_hub_web/openapi-ts.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@hey-api/openapi-ts'
 
 export default defineConfig({
   // Make sure you have the Backend running when generating a new SDK
-  input: 'http://localhost:8000/api/v1/openapi.json',
+  input: 'http://localhost:8000/api/v1/active/openapi.json',
   output: {
     path: 'sdk/client',
     postProcess: ['prettier', 'eslint'],


### PR DESCRIPTION
## Summary

- Replace `x-tenant-id` HTTP header with a **required `{tenant_id}` path parameter** on every API route via Starlette Mount path (`/api/v1/{tenant_id}/...`)
- Special value `"active"` auto-resolves to the user's persisted `active_tenant_id`, falling back to the system default tenant
- Explicit tenant IDs validate membership and update the user's active tenant
- Health endpoints separated onto their own FastAPI app at `/api/v1/health` (outside tenant scope)
- Zero changes to individual controllers or the OpenAPI spec — the frontend SDK stays unchanged

### Key design decision
`{tenant_id}` is placed in the **Starlette Mount path**, not in FastAPI controller routes. This means it appears in `request.path_params` for all routes automatically but does **not** appear in the OpenAPI spec, so the auto-generated SDK is unaffected.

### Changes by scope
- **packages/core**: Tenant resolution reads from `path_params` (header fallback kept), OTEL span enrichment for `tenant.id`
- **packages/api**: `ApiRunner` adds `/{tenant_id}` to Mount, separates `HealthController` onto `_health_app`
- **packages/web**: SDK base URL → `/api/v1/active`, OpenAPI config updated
- **infra**: All compose files, pipeline functions, and `AIHubSettings` default updated with `/active` segment
- **tests**: 14 BDD tenant resolution scenarios rewritten for path params (all pass), 15 API test files updated

## Demo

> **Video description:** End-to-end walkthrough of the tenant path parameter across health endpoint, Swagger, Admin UI, and OpenWebUI chat (1m12s).
> 1. Health endpoint at `localhost:8000/api/v1/health/` — returns 200 without any tenant segment in the path, confirming health is outside tenant scope
> 2. Swagger docs at `localhost:8000/api/v1/active/docs` — server base URL shows `/api/v1/active`, all API sections listed (Gesundheit, KI-Assistenten, Unterhaltungen, etc.)
> 3. Admin UI agent detail page — "Professional Email Drafter" agent overview loads with DevTools showing all API calls routed through `/api/v1/active/...` returning 200
> 4. Services menu and agents list — navigation works correctly, network tab confirms tenant-scoped SDK requests
> 5. OpenWebUI chat at `localhost:8080` — "Professioneller E-Mail-Verfasser" agent responds with a full German business email template, streaming events visible in DevTools network tab
> 6. Chat follow-up responses stream successfully — continued conversation with the agent works end-to-end through the tenant-scoped API path
> 7. Return to Admin UI agents list — all agent cards render correctly with tenant-scoped API calls confirmed in network tab


https://github.com/user-attachments/assets/706cfbee-d857-4fa9-9f79-5029e7571921



## Test plan
- [x] `make test` in `packages/core` — 14/14 tenant resolution BDD tests pass
- [x] `make test` in `packages/api` — 326 pass, health test fixed
- [x] Health endpoint at `/api/v1/health` returns 200 (no tenant segment)
- [x] OpenAPI docs at `/api/v1/active/docs` render correctly
- [x] Frontend at localhost:3333 loads and all API calls succeed
- [x] Verify OpenWebUI can reach API at `/api/v1/active/openai`