### PR TITLE
feat(dagster): Backup scheduling and retention (#972)

### DIFF
--- a/infra/deployment/templates/docker-compose.yml.j2
+++ b/infra/deployment/templates/docker-compose.yml.j2
@@ -1212,6 +1212,16 @@ services:
     environment:
       PYTHONUNBUFFERED: 1
       DAGSTER_HOME: /dagster_home
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      MONGO_USERNAME: ${MONGO_USERNAME}
+      MONGO_PASSWORD: ${MONGO_PASSWORD}
+      MILVUS_ROOT_PASSWORD: ${MILVUS_ROOT_PASSWORD}
+      LANGFUSE_CLICKHOUSE_PASSWORD: ${LANGFUSE_CLICKHOUSE_PASSWORD}
+      REDIS_TOKEN: ${REDIS_TOKEN}
+      NATS_TOKEN: ${NATS_TOKEN}
+      S3_STORAGE_ACCESS_KEY: ${S3_STORAGE_ACCESS_KEY}
+      S3_STORAGE_SECRET_KEY: ${S3_STORAGE_SECRET_KEY}
     volumes:
       - {{ global.volume_root }}/backup-dagster-home:/dagster_home
       - ./configs/backup/backup-dagster{{ config_variant_suffix }}.yml:/dagster_home/dagster.yaml:ro
@@ -1229,6 +1239,7 @@ services:
         max-file: 2
     networks:
       - data
+      - storage
 
   {%- if stage != 'dev' %}
   oauth2proxy-backup:

--- a/infra/docker-compose.build.gpu.yml
+++ b/infra/docker-compose.build.gpu.yml
@@ -1024,6 +1024,16 @@ services:
     environment:
       PYTHONUNBUFFERED: 1
       DAGSTER_HOME: /dagster_home
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      MONGO_USERNAME: ${MONGO_USERNAME}
+      MONGO_PASSWORD: ${MONGO_PASSWORD}
+      MILVUS_ROOT_PASSWORD: ${MILVUS_ROOT_PASSWORD}
+      LANGFUSE_CLICKHOUSE_PASSWORD: ${LANGFUSE_CLICKHOUSE_PASSWORD}
+      REDIS_TOKEN: ${REDIS_TOKEN}
+      NATS_TOKEN: ${NATS_TOKEN}
+      S3_STORAGE_ACCESS_KEY: ${S3_STORAGE_ACCESS_KEY}
+      S3_STORAGE_SECRET_KEY: ${S3_STORAGE_SECRET_KEY}
     volumes:
       - ${VOLUME_ROOT:-./.docker-volumes}/backup-dagster-home:/dagster_home
       - ./configs/backup/backup-dagster.build.gpu.yml:/dagster_home/dagster.yaml:ro
@@ -1047,7 +1057,7 @@ services:
       options:
         max-size: 10m
         max-file: 2
-    networks: [data]
+    networks: [data, storage]
   oauth2proxy-backup:
     container_name: oauth2proxy-backup
     image: ghcr.io/bbvch-ai/bbvch-ai/oauth2-proxy:latest

--- a/infra/docker-compose.build.yml
+++ b/infra/docker-compose.build.yml
@@ -1024,6 +1024,16 @@ services:
     environment:
       PYTHONUNBUFFERED: 1
       DAGSTER_HOME: /dagster_home
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      MONGO_USERNAME: ${MONGO_USERNAME}
+      MONGO_PASSWORD: ${MONGO_PASSWORD}
+      MILVUS_ROOT_PASSWORD: ${MILVUS_ROOT_PASSWORD}
+      LANGFUSE_CLICKHOUSE_PASSWORD: ${LANGFUSE_CLICKHOUSE_PASSWORD}
+      REDIS_TOKEN: ${REDIS_TOKEN}
+      NATS_TOKEN: ${NATS_TOKEN}
+      S3_STORAGE_ACCESS_KEY: ${S3_STORAGE_ACCESS_KEY}
+      S3_STORAGE_SECRET_KEY: ${S3_STORAGE_SECRET_KEY}
     volumes:
       - ${VOLUME_ROOT:-./.docker-volumes}/backup-dagster-home:/dagster_home
       - ./configs/backup/backup-dagster.build.yml:/dagster_home/dagster.yaml:ro
@@ -1047,7 +1057,7 @@ services:
       options:
         max-size: 10m
         max-file: 2
-    networks: [data]
+    networks: [data, storage]
   oauth2proxy-backup:
     container_name: oauth2proxy-backup
     image: ghcr.io/bbvch-ai/bbvch-ai/oauth2-proxy:latest

--- a/infra/docker-compose.dev.gpu.yml
+++ b/infra/docker-compose.dev.gpu.yml
@@ -783,6 +783,16 @@ services:
     environment:
       PYTHONUNBUFFERED: 1
       DAGSTER_HOME: /dagster_home
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      MONGO_USERNAME: ${MONGO_USERNAME}
+      MONGO_PASSWORD: ${MONGO_PASSWORD}
+      MILVUS_ROOT_PASSWORD: ${MILVUS_ROOT_PASSWORD}
+      LANGFUSE_CLICKHOUSE_PASSWORD: ${LANGFUSE_CLICKHOUSE_PASSWORD}
+      REDIS_TOKEN: ${REDIS_TOKEN}
+      NATS_TOKEN: ${NATS_TOKEN}
+      S3_STORAGE_ACCESS_KEY: ${S3_STORAGE_ACCESS_KEY}
+      S3_STORAGE_SECRET_KEY: ${S3_STORAGE_SECRET_KEY}
     volumes:
       - ${VOLUME_ROOT:-./.docker-volumes}/backup-dagster-home:/dagster_home
       - ./configs/backup/backup-dagster.dev.gpu.yml:/dagster_home/dagster.yaml:ro
@@ -806,7 +816,7 @@ services:
       options:
         max-size: 10m
         max-file: 2
-    networks: [data]
+    networks: [data, storage]
   backup-webserver:
     container_name: backup-webserver
     build:

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -783,6 +783,16 @@ services:
     environment:
       PYTHONUNBUFFERED: 1
       DAGSTER_HOME: /dagster_home
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      MONGO_USERNAME: ${MONGO_USERNAME}
+      MONGO_PASSWORD: ${MONGO_PASSWORD}
+      MILVUS_ROOT_PASSWORD: ${MILVUS_ROOT_PASSWORD}
+      LANGFUSE_CLICKHOUSE_PASSWORD: ${LANGFUSE_CLICKHOUSE_PASSWORD}
+      REDIS_TOKEN: ${REDIS_TOKEN}
+      NATS_TOKEN: ${NATS_TOKEN}
+      S3_STORAGE_ACCESS_KEY: ${S3_STORAGE_ACCESS_KEY}
+      S3_STORAGE_SECRET_KEY: ${S3_STORAGE_SECRET_KEY}
     volumes:
       - ${VOLUME_ROOT:-./.docker-volumes}/backup-dagster-home:/dagster_home
       - ./configs/backup/backup-dagster.dev.yml:/dagster_home/dagster.yaml:ro
@@ -806,7 +816,7 @@ services:
       options:
         max-size: 10m
         max-file: 2
-    networks: [data]
+    networks: [data, storage]
   backup-webserver:
     container_name: backup-webserver
     build:

--- a/infra/docker-compose.latest.gpu.yml
+++ b/infra/docker-compose.latest.gpu.yml
@@ -1007,6 +1007,16 @@ services:
     environment:
       PYTHONUNBUFFERED: 1
       DAGSTER_HOME: /dagster_home
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      MONGO_USERNAME: ${MONGO_USERNAME}
+      MONGO_PASSWORD: ${MONGO_PASSWORD}
+      MILVUS_ROOT_PASSWORD: ${MILVUS_ROOT_PASSWORD}
+      LANGFUSE_CLICKHOUSE_PASSWORD: ${LANGFUSE_CLICKHOUSE_PASSWORD}
+      REDIS_TOKEN: ${REDIS_TOKEN}
+      NATS_TOKEN: ${NATS_TOKEN}
+      S3_STORAGE_ACCESS_KEY: ${S3_STORAGE_ACCESS_KEY}
+      S3_STORAGE_SECRET_KEY: ${S3_STORAGE_SECRET_KEY}
     volumes:
       - ${VOLUME_ROOT:-./.docker-volumes}/backup-dagster-home:/dagster_home
       - ./configs/backup/backup-dagster.latest.gpu.yml:/dagster_home/dagster.yaml:ro
@@ -1030,7 +1040,7 @@ services:
       options:
         max-size: 10m
         max-file: 2
-    networks: [data]
+    networks: [data, storage]
   oauth2proxy-backup:
     container_name: oauth2proxy-backup
     image: ghcr.io/bbvch-ai/bbvch-ai/oauth2-proxy:latest

--- a/infra/docker-compose.latest.yml
+++ b/infra/docker-compose.latest.yml
@@ -1007,6 +1007,16 @@ services:
     environment:
       PYTHONUNBUFFERED: 1
       DAGSTER_HOME: /dagster_home
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      MONGO_USERNAME: ${MONGO_USERNAME}
+      MONGO_PASSWORD: ${MONGO_PASSWORD}
+      MILVUS_ROOT_PASSWORD: ${MILVUS_ROOT_PASSWORD}
+      LANGFUSE_CLICKHOUSE_PASSWORD: ${LANGFUSE_CLICKHOUSE_PASSWORD}
+      REDIS_TOKEN: ${REDIS_TOKEN}
+      NATS_TOKEN: ${NATS_TOKEN}
+      S3_STORAGE_ACCESS_KEY: ${S3_STORAGE_ACCESS_KEY}
+      S3_STORAGE_SECRET_KEY: ${S3_STORAGE_SECRET_KEY}
     volumes:
       - ${VOLUME_ROOT:-./.docker-volumes}/backup-dagster-home:/dagster_home
       - ./configs/backup/backup-dagster.latest.yml:/dagster_home/dagster.yaml:ro
@@ -1030,7 +1040,7 @@ services:
       options:
         max-size: 10m
         max-file: 2
-    networks: [data]
+    networks: [data, storage]
   oauth2proxy-backup:
     container_name: oauth2proxy-backup
     image: ghcr.io/bbvch-ai/bbvch-ai/oauth2-proxy:latest

--- a/infra/docker-compose.local.gpu.yml
+++ b/infra/docker-compose.local.gpu.yml
@@ -1021,6 +1021,16 @@ services:
     environment:
       PYTHONUNBUFFERED: 1
       DAGSTER_HOME: /dagster_home
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      MONGO_USERNAME: ${MONGO_USERNAME}
+      MONGO_PASSWORD: ${MONGO_PASSWORD}
+      MILVUS_ROOT_PASSWORD: ${MILVUS_ROOT_PASSWORD}
+      LANGFUSE_CLICKHOUSE_PASSWORD: ${LANGFUSE_CLICKHOUSE_PASSWORD}
+      REDIS_TOKEN: ${REDIS_TOKEN}
+      NATS_TOKEN: ${NATS_TOKEN}
+      S3_STORAGE_ACCESS_KEY: ${S3_STORAGE_ACCESS_KEY}
+      S3_STORAGE_SECRET_KEY: ${S3_STORAGE_SECRET_KEY}
     volumes:
       - ${VOLUME_ROOT:-./.docker-volumes}/backup-dagster-home:/dagster_home
       - ./configs/backup/backup-dagster.local.gpu.yml:/dagster_home/dagster.yaml:ro
@@ -1044,7 +1054,7 @@ services:
       options:
         max-size: 10m
         max-file: 2
-    networks: [data]
+    networks: [data, storage]
   oauth2proxy-backup:
     container_name: oauth2proxy-backup
     image: ghcr.io/bbvch-ai/bbvch-ai/oauth2-proxy:latest

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -1021,6 +1021,16 @@ services:
     environment:
       PYTHONUNBUFFERED: 1
       DAGSTER_HOME: /dagster_home
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      MONGO_USERNAME: ${MONGO_USERNAME}
+      MONGO_PASSWORD: ${MONGO_PASSWORD}
+      MILVUS_ROOT_PASSWORD: ${MILVUS_ROOT_PASSWORD}
+      LANGFUSE_CLICKHOUSE_PASSWORD: ${LANGFUSE_CLICKHOUSE_PASSWORD}
+      REDIS_TOKEN: ${REDIS_TOKEN}
+      NATS_TOKEN: ${NATS_TOKEN}
+      S3_STORAGE_ACCESS_KEY: ${S3_STORAGE_ACCESS_KEY}
+      S3_STORAGE_SECRET_KEY: ${S3_STORAGE_SECRET_KEY}
     volumes:
       - ${VOLUME_ROOT:-./.docker-volumes}/backup-dagster-home:/dagster_home
       - ./configs/backup/backup-dagster.local.yml:/dagster_home/dagster.yaml:ro
@@ -1044,7 +1054,7 @@ services:
       options:
         max-size: 10m
         max-file: 2
-    networks: [data]
+    networks: [data, storage]
   oauth2proxy-backup:
     container_name: oauth2proxy-backup
     image: ghcr.io/bbvch-ai/bbvch-ai/oauth2-proxy:latest

--- a/infra/docker-compose.nightly.gpu.yml
+++ b/infra/docker-compose.nightly.gpu.yml
@@ -1007,6 +1007,16 @@ services:
     environment:
       PYTHONUNBUFFERED: 1
       DAGSTER_HOME: /dagster_home
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      MONGO_USERNAME: ${MONGO_USERNAME}
+      MONGO_PASSWORD: ${MONGO_PASSWORD}
+      MILVUS_ROOT_PASSWORD: ${MILVUS_ROOT_PASSWORD}
+      LANGFUSE_CLICKHOUSE_PASSWORD: ${LANGFUSE_CLICKHOUSE_PASSWORD}
+      REDIS_TOKEN: ${REDIS_TOKEN}
+      NATS_TOKEN: ${NATS_TOKEN}
+      S3_STORAGE_ACCESS_KEY: ${S3_STORAGE_ACCESS_KEY}
+      S3_STORAGE_SECRET_KEY: ${S3_STORAGE_SECRET_KEY}
     volumes:
       - ${VOLUME_ROOT:-./.docker-volumes}/backup-dagster-home:/dagster_home
       - ./configs/backup/backup-dagster.nightly.gpu.yml:/dagster_home/dagster.yaml:ro
@@ -1030,7 +1040,7 @@ services:
       options:
         max-size: 10m
         max-file: 2
-    networks: [data]
+    networks: [data, storage]
   oauth2proxy-backup:
     container_name: oauth2proxy-backup
     image: ghcr.io/bbvch-ai/bbvch-ai/oauth2-proxy:latest

--- a/infra/docker-compose.nightly.yml
+++ b/infra/docker-compose.nightly.yml
@@ -1007,6 +1007,16 @@ services:
     environment:
       PYTHONUNBUFFERED: 1
       DAGSTER_HOME: /dagster_home
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      MONGO_USERNAME: ${MONGO_USERNAME}
+      MONGO_PASSWORD: ${MONGO_PASSWORD}
+      MILVUS_ROOT_PASSWORD: ${MILVUS_ROOT_PASSWORD}
+      LANGFUSE_CLICKHOUSE_PASSWORD: ${LANGFUSE_CLICKHOUSE_PASSWORD}
+      REDIS_TOKEN: ${REDIS_TOKEN}
+      NATS_TOKEN: ${NATS_TOKEN}
+      S3_STORAGE_ACCESS_KEY: ${S3_STORAGE_ACCESS_KEY}
+      S3_STORAGE_SECRET_KEY: ${S3_STORAGE_SECRET_KEY}
     volumes:
       - ${VOLUME_ROOT:-./.docker-volumes}/backup-dagster-home:/dagster_home
       - ./configs/backup/backup-dagster.nightly.yml:/dagster_home/dagster.yaml:ro
@@ -1030,7 +1040,7 @@ services:
       options:
         max-size: 10m
         max-file: 2
-    networks: [data]
+    networks: [data, storage]
   oauth2proxy-backup:
     container_name: oauth2proxy-backup
     image: ghcr.io/bbvch-ai/bbvch-ai/oauth2-proxy:latest

--- a/packages/backup/README.md
+++ b/packages/backup/README.md
@@ -7,5 +7,3 @@ Requires the Docker socket (`/var/run/docker.sock`) to discover and manage platf
 `com.docker.compose.project` label.
 
 Dagster UI: <http://localhost:3004>
-
-Currently a placeholder skeleton. The full backup implementation will be added in a follow-up issue.

--- a/packages/backup/pyproject.toml
+++ b/packages/backup/pyproject.toml
@@ -12,10 +12,12 @@ authors = [
 license = "Apache-2.0"
 readme = "README.md"
 dependencies = [
+    "boto3>=1.41.5",
     "dagster>=1.11.2",
     "dagster-webserver>=1.11.2",
     "docker>=7.0",
     "pydantic>=2.10.3",
+    "pydantic-settings>=2.13.1",
 ]
 
 [dependency-groups]

--- a/packages/backup/swiss_ai_hub/backup/container_discovery.py
+++ b/packages/backup/swiss_ai_hub/backup/container_discovery.py
@@ -8,7 +8,7 @@ from docker.models.containers import Container
 
 logger = logging.getLogger(__name__)
 
-_EXCLUDE_PREFIXES = ("backup-", "seaweedfs-", "etcd")
+_EXCLUDE_PREFIXES = ("backup-", "seaweedfs-", "etcd", "traefik")
 
 
 class ContainerDiscovery:

--- a/packages/backup/swiss_ai_hub/backup/dagster/assets/backup_finalize_factory.py
+++ b/packages/backup/swiss_ai_hub/backup/dagster/assets/backup_finalize_factory.py
@@ -1,7 +1,11 @@
 from dagster import AssetExecutionContext, AssetIn, AssetKey, AssetsDefinition, ResourceParam, asset
 
 from swiss_ai_hub.backup.container_discovery import ContainerDiscovery
+from swiss_ai_hub.backup.dagster.partitions import backup_partitions
 from swiss_ai_hub.backup.dagster.types import BackupContext
+from swiss_ai_hub.backup.retention import RetentionService
+from swiss_ai_hub.backup.s3 import BACKUP_PREFIX_RE, S3Manager
+from swiss_ai_hub.backup.settings import BackupSettings
 
 
 def backup_finalize_factory(
@@ -12,12 +16,14 @@ def backup_finalize_factory(
         key=key,
         group_name="backup",
         ins={"session": AssetIn(key=session_key)},
-        description="Restart all previously running containers",
+        description="Restart services and run retention cleanup",
     )
     def backup_finalize(
         context: AssetExecutionContext,
         session: BackupContext,
         container_discovery: ResourceParam[ContainerDiscovery],
+        backup_settings: ResourceParam[BackupSettings],
+        s3_manager: ResourceParam[S3Manager],
     ) -> None:
         context.log.info(
             "Restarting %d previously running containers...",
@@ -26,8 +32,39 @@ def backup_finalize_factory(
         container_discovery.start_all(session.previously_running)
         context.log.info("All containers restarted")
 
+        try:
+            RetentionService.run(s3_manager, backup_settings.BACKUP_RETENTION_DAYS, backup_settings.BACKUP_MINIMUM_KEEP)
+        except Exception as e:
+            context.log.warning("Retention cleanup failed: %s", e)
+
+        _sync_partitions(context, s3_manager)
+
         context.add_output_metadata(
             {"containers_restarted": len(session.previously_running)},
         )
 
     return backup_finalize
+
+
+def _sync_partitions(context: AssetExecutionContext, s3: S3Manager) -> None:
+    """Sync S3 backup prefixes to dynamic partitions for the restore job selector."""
+    s3_prefixes = {p for p in s3.list_prefixes() if BACKUP_PREFIX_RE.match(p)}
+    existing = set(context.instance.get_dynamic_partitions(backup_partitions.name))
+
+    to_add = list(s3_prefixes - existing)
+    to_remove = list(existing - s3_prefixes)
+
+    if to_add:
+        context.instance.add_dynamic_partitions(
+            partitions_def_name=backup_partitions.name,
+            partition_keys=to_add,
+        )
+        context.log.info("Added %d backup partition(s): %s", len(to_add), ", ".join(sorted(to_add)))
+
+    for key in to_remove:
+        context.instance.delete_dynamic_partition(
+            partitions_def_name=backup_partitions.name,
+            partition_key=key,
+        )
+    if to_remove:
+        context.log.info("Removed %d stale partition(s): %s", len(to_remove), ", ".join(sorted(to_remove)))

--- a/packages/backup/swiss_ai_hub/backup/dagster/assets/backup_finalize_factory.py
+++ b/packages/backup/swiss_ai_hub/backup/dagster/assets/backup_finalize_factory.py
@@ -1,3 +1,4 @@
+from botocore.exceptions import ClientError
 from dagster import AssetExecutionContext, AssetIn, AssetKey, AssetsDefinition, ResourceParam, asset
 
 from swiss_ai_hub.backup.container_discovery import ContainerDiscovery
@@ -34,8 +35,8 @@ def backup_finalize_factory(
 
         try:
             RetentionService.run(s3_manager, backup_settings.BACKUP_RETENTION_DAYS, backup_settings.BACKUP_MINIMUM_KEEP)
-        except Exception as e:
-            context.log.warning("Retention cleanup failed: %s", e)
+        except (ClientError, RuntimeError):
+            context.log.warning("Retention cleanup failed", exc_info=True)
 
         _sync_partitions(context, s3_manager)
 

--- a/packages/backup/swiss_ai_hub/backup/dagster/assets/backup_session_factory.py
+++ b/packages/backup/swiss_ai_hub/backup/dagster/assets/backup_session_factory.py
@@ -5,24 +5,37 @@ from dagster import AssetExecutionContext, AssetKey, AssetsDefinition, ResourceP
 from swiss_ai_hub.backup.container_discovery import ContainerDiscovery
 from swiss_ai_hub.backup.dagster.types import BackupContext
 from swiss_ai_hub.backup.models import TIMESTAMP_FORMAT
+from swiss_ai_hub.backup.s3 import S3Manager
 
 
 def backup_session_factory(key: AssetKey) -> AssetsDefinition:
     @asset(key=key, group_name="backup", description="Initialize backup run and stop all managed containers")
     def backup_session(
         context: AssetExecutionContext,
+        s3_manager: ResourceParam[S3Manager],
         container_discovery: ResourceParam[ContainerDiscovery],
     ) -> BackupContext:
         timestamp = datetime.now(UTC).strftime(TIMESTAMP_FORMAT)
+        prefix = timestamp
 
-        context.log.info("Backup session: timestamp=%s", timestamp)
+        existing = s3_manager.count_objects(prefix + "/")
+        if existing > 0:
+            context.log.warning("Purging %d objects from previous attempt at %s/", existing, prefix)
+            s3_manager.delete_recursive(prefix + "/")
+
+        context.log.info(
+            "Backup session: timestamp=%s, dest=s3://%s/%s/",
+            timestamp,
+            s3_manager.bucket,
+            prefix,
+        )
 
         previously_running = container_discovery.stop_all_managed()
 
         context.add_output_metadata(
-            {"timestamp": timestamp, "s3_prefix": timestamp, "containers_stopped": len(previously_running)},
+            {"timestamp": timestamp, "s3_prefix": prefix, "containers_stopped": len(previously_running)},
         )
 
-        return BackupContext(timestamp=timestamp, s3_prefix=timestamp, previously_running=previously_running)
+        return BackupContext(timestamp=timestamp, s3_prefix=prefix, previously_running=previously_running)
 
     return backup_session

--- a/packages/backup/swiss_ai_hub/backup/dagster/definitions.py
+++ b/packages/backup/swiss_ai_hub/backup/dagster/definitions.py
@@ -3,7 +3,8 @@ from dagster import AssetKey, Definitions
 from swiss_ai_hub.backup.dagster.assets.backup_finalize_factory import backup_finalize_factory
 from swiss_ai_hub.backup.dagster.assets.backup_session_factory import backup_session_factory
 from swiss_ai_hub.backup.dagster.jobs.factory import backup_asset_job
-from swiss_ai_hub.backup.dagster.resources.container_discovery_resource import ContainerDiscoveryResource
+from swiss_ai_hub.backup.dagster.resources.factory import backup_resources
+from swiss_ai_hub.backup.dagster.schedules.factory import daily_backup_schedule
 
 
 def backup_definitions() -> Definitions:
@@ -15,13 +16,12 @@ def backup_definitions() -> Definitions:
     backup_assets = [session, finalize]
 
     job = backup_asset_job(backup_assets)
-
-    resources: dict[str, object] = {
-        "container_discovery": ContainerDiscoveryResource(),
-    }
+    schedule = daily_backup_schedule(job)
+    resources = backup_resources()
 
     return Definitions(
         assets=backup_assets,
         jobs=[job],
+        schedules=[schedule],
         resources=resources,
     )

--- a/packages/backup/swiss_ai_hub/backup/dagster/partitions.py
+++ b/packages/backup/swiss_ai_hub/backup/dagster/partitions.py
@@ -1,0 +1,3 @@
+from dagster import DynamicPartitionsDefinition
+
+backup_partitions = DynamicPartitionsDefinition(name="backup_timestamps")

--- a/packages/backup/swiss_ai_hub/backup/dagster/resources/backup_settings_resource.py
+++ b/packages/backup/swiss_ai_hub/backup/dagster/resources/backup_settings_resource.py
@@ -5,4 +5,5 @@ from swiss_ai_hub.backup.settings import BackupSettings
 
 class BackupSettingsResource(ConfigurableResource[BackupSettings]):
     def create_resource(self, context: InitResourceContext) -> BackupSettings:
+        # SecretStr fields have no defaults — pydantic-settings loads them from env at runtime
         return BackupSettings()  # type: ignore[call-arg]

--- a/packages/backup/swiss_ai_hub/backup/dagster/resources/backup_settings_resource.py
+++ b/packages/backup/swiss_ai_hub/backup/dagster/resources/backup_settings_resource.py
@@ -1,0 +1,8 @@
+from dagster import ConfigurableResource, InitResourceContext
+
+from swiss_ai_hub.backup.settings import BackupSettings
+
+
+class BackupSettingsResource(ConfigurableResource[BackupSettings]):
+    def create_resource(self, context: InitResourceContext) -> BackupSettings:
+        return BackupSettings()  # type: ignore[call-arg]

--- a/packages/backup/swiss_ai_hub/backup/dagster/resources/factory.py
+++ b/packages/backup/swiss_ai_hub/backup/dagster/resources/factory.py
@@ -1,11 +1,9 @@
-from dagster._config.pythonic_config import ConfigurableResourceFactory
-
 from swiss_ai_hub.backup.dagster.resources.backup_settings_resource import BackupSettingsResource
 from swiss_ai_hub.backup.dagster.resources.container_discovery_resource import ContainerDiscoveryResource
 from swiss_ai_hub.backup.dagster.resources.s3_manager_resource import S3ManagerResource
 
 
-def backup_resources() -> dict[str, ConfigurableResourceFactory]:
+def backup_resources() -> dict[str, object]:
     settings = BackupSettingsResource()
     return {
         "backup_settings": settings,

--- a/packages/backup/swiss_ai_hub/backup/dagster/resources/factory.py
+++ b/packages/backup/swiss_ai_hub/backup/dagster/resources/factory.py
@@ -1,0 +1,14 @@
+from dagster._config.pythonic_config import ConfigurableResourceFactory
+
+from swiss_ai_hub.backup.dagster.resources.backup_settings_resource import BackupSettingsResource
+from swiss_ai_hub.backup.dagster.resources.container_discovery_resource import ContainerDiscoveryResource
+from swiss_ai_hub.backup.dagster.resources.s3_manager_resource import S3ManagerResource
+
+
+def backup_resources() -> dict[str, ConfigurableResourceFactory]:
+    settings = BackupSettingsResource()
+    return {
+        "backup_settings": settings,
+        "s3_manager": S3ManagerResource(settings=settings),
+        "container_discovery": ContainerDiscoveryResource(),
+    }

--- a/packages/backup/swiss_ai_hub/backup/dagster/resources/s3_manager_resource.py
+++ b/packages/backup/swiss_ai_hub/backup/dagster/resources/s3_manager_resource.py
@@ -1,0 +1,13 @@
+from dagster import ConfigurableResource, InitResourceContext, ResourceDependency
+
+from swiss_ai_hub.backup.s3 import S3Manager
+from swiss_ai_hub.backup.settings import BackupSettings
+
+
+class S3ManagerResource(ConfigurableResource[S3Manager]):
+    settings: ResourceDependency[BackupSettings]
+
+    def create_resource(self, context: InitResourceContext) -> S3Manager:
+        s3 = S3Manager(self.settings)
+        s3.ensure_bucket_exists()
+        return s3

--- a/packages/backup/swiss_ai_hub/backup/dagster/schedules/factory.py
+++ b/packages/backup/swiss_ai_hub/backup/dagster/schedules/factory.py
@@ -1,0 +1,17 @@
+from dagster import RunRequest, ScheduleDefinition, ScheduleEvaluationContext, schedule
+from dagster._core.definitions.job_definition import JobDefinition
+from dagster._core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
+
+
+def daily_backup_schedule(backup_job: JobDefinition | UnresolvedAssetJobDefinition) -> ScheduleDefinition:
+    """Must finish before the pipeline observation schedule (default 2 AM) in aihub_pipeline.
+
+    The backup stops all application containers — if it overlaps with a pipeline
+    job, that job is killed mid-execution.
+    """
+
+    @schedule(cron_schedule="0 1 * * *", job=backup_job, execution_timezone="Europe/Zurich")
+    def daily_backup(context: ScheduleEvaluationContext) -> RunRequest:
+        return RunRequest()
+
+    return daily_backup

--- a/packages/backup/swiss_ai_hub/backup/dagster/schedules/factory.py
+++ b/packages/backup/swiss_ai_hub/backup/dagster/schedules/factory.py
@@ -1,6 +1,12 @@
-from dagster import RunRequest, ScheduleDefinition, ScheduleEvaluationContext, schedule
-from dagster._core.definitions.job_definition import JobDefinition
-from dagster._core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from dagster import JobDefinition, RunRequest, ScheduleEvaluationContext, schedule
+
+if TYPE_CHECKING:
+    from dagster import ScheduleDefinition
+    from dagster._core.definitions.unresolved_asset_job_definition import UnresolvedAssetJobDefinition
 
 
 def daily_backup_schedule(backup_job: JobDefinition | UnresolvedAssetJobDefinition) -> ScheduleDefinition:

--- a/packages/backup/swiss_ai_hub/backup/models.py
+++ b/packages/backup/swiss_ai_hub/backup/models.py
@@ -2,8 +2,24 @@ from enum import StrEnum
 
 from pydantic import BaseModel
 
+BACKUP_SERVICES: tuple[str, ...] = ("PostgreSQL", "Milvus", "Neo4j", "ClickHouse", "Valkey", "NATS")
+
 TIMESTAMP_FORMAT = "%Y-%m-%d_%H-%M-%S"
 TIMESTAMP_LENGTH = 19  # len("YYYY-MM-DD_HH-MM-SS")
+
+SERVICE_TO_ASSET_KEY: dict[str, str] = {
+    "PostgreSQL": "postgres_backup",
+    "Milvus": "milvus_backup",
+    "Neo4j": "neo4j_backup",
+    "ClickHouse": "clickhouse_backup",
+    "Valkey": "valkey_backup",
+    "NATS": "nats_backup",
+}
+
+if set(SERVICE_TO_ASSET_KEY.keys()) != set(BACKUP_SERVICES):
+    raise ValueError(
+        f"SERVICE_TO_ASSET_KEY keys {set(SERVICE_TO_ASSET_KEY.keys())} != BACKUP_SERVICES {set(BACKUP_SERVICES)}"
+    )
 
 
 class ServiceStatus(StrEnum):

--- a/packages/backup/swiss_ai_hub/backup/retention.py
+++ b/packages/backup/swiss_ai_hub/backup/retention.py
@@ -1,0 +1,42 @@
+import logging
+from datetime import UTC, datetime, timedelta
+
+from swiss_ai_hub.backup.s3 import BACKUP_PREFIX_RE, S3Manager
+
+logger = logging.getLogger(__name__)
+
+
+class RetentionService:
+    @staticmethod
+    def run(s3: S3Manager, retention_days: int, minimum_keep: int = 3) -> None:
+        if retention_days <= 0:
+            logger.info("Retention disabled (BACKUP_RETENTION_DAYS=%d)", retention_days)
+            return
+
+        cutoff_date = (datetime.now(UTC) - timedelta(days=retention_days)).strftime("%Y-%m-%d")
+        logger.info("Retention: %d days (cutoff: %s, minimum_keep: %d)", retention_days, cutoff_date, minimum_keep)
+
+        prefixes = s3.list_prefixes()
+        valid_prefixes = sorted(p for p in prefixes if BACKUP_PREFIX_RE.match(p))
+
+        expired = [p for p in valid_prefixes if p[:10] < cutoff_date]
+
+        remaining_after_delete = len(valid_prefixes) - len(expired)
+        if remaining_after_delete < minimum_keep:
+            safe_to_delete = len(valid_prefixes) - minimum_keep
+            if safe_to_delete <= 0:
+                logger.warning(
+                    "Retention: keeping all %d backup(s) (minimum_keep=%d)", len(valid_prefixes), minimum_keep
+                )
+                expired = []
+            else:
+                expired = sorted(expired)[:safe_to_delete]
+
+        expired_set = set(expired)
+
+        for prefix in valid_prefixes:
+            if prefix in expired_set:
+                logger.info("  Deleting: %s (%s)", prefix, prefix[:10])
+                s3.delete_recursive(prefix + "/")
+
+        logger.info("Retention cleanup: done")

--- a/packages/backup/swiss_ai_hub/backup/retention.py
+++ b/packages/backup/swiss_ai_hub/backup/retention.py
@@ -30,7 +30,7 @@ class RetentionService:
                 )
                 expired = []
             else:
-                expired = sorted(expired)[:safe_to_delete]
+                expired = expired[:safe_to_delete]
 
         expired_set = set(expired)
 

--- a/packages/backup/swiss_ai_hub/backup/s3.py
+++ b/packages/backup/swiss_ai_hub/backup/s3.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
+from swiss_ai_hub.backup.settings import BackupSettings
+
+if TYPE_CHECKING:
+    from swiss_ai_hub.backup.models import BackupEntry
+
+logger = logging.getLogger(__name__)
+
+BACKUP_PREFIX_RE = re.compile(r"^\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}$")
+
+_S3_DELETE_BATCH_SIZE = 1000
+
+
+class S3Manager:
+    def __init__(self, settings: BackupSettings) -> None:
+        self._bucket = settings.BACKUP_S3_BUCKET
+        self._client = boto3.client(
+            "s3",
+            endpoint_url=settings.AWS_ENDPOINT_URL,
+            aws_access_key_id=settings.S3_STORAGE_ACCESS_KEY,
+            aws_secret_access_key=settings.S3_STORAGE_SECRET_KEY.get_secret_value(),
+            config=Config(signature_version="s3v4"),
+        )
+
+    @property
+    def bucket(self) -> str:
+        return self._bucket
+
+    def ensure_bucket_exists(self) -> None:
+        """SeaweedFS auto-creates paths on write but skips bucket metadata,
+        which breaks HeadObject. Explicit creation avoids this.
+        """
+        try:
+            self._client.head_bucket(Bucket=self._bucket)
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code not in ("404", "NoSuchBucket"):
+                raise
+            logger.info("Creating S3 bucket: %s", self._bucket)
+            try:
+                self._client.create_bucket(Bucket=self._bucket)
+            except ClientError as create_err:
+                code = create_err.response.get("Error", {}).get("Code", "")
+                if code not in ("BucketAlreadyOwnedByYou", "BucketAlreadyExists", "409"):
+                    raise
+
+    def upload_file(self, local_path: Path, s3_key: str) -> None:
+        logger.info("Uploading %s -> s3://%s/%s", local_path, self._bucket, s3_key)
+        self._client.upload_file(str(local_path), self._bucket, s3_key)
+
+    def download_file(self, s3_key: str, local_path: Path) -> None:
+        logger.info("Downloading s3://%s/%s -> %s", self._bucket, s3_key, local_path)
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        self._client.download_file(self._bucket, s3_key, str(local_path))
+
+    def file_exists(self, s3_key: str) -> bool:
+        try:
+            self._client.head_object(Bucket=self._bucket, Key=s3_key)
+            return True
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code", "") in ("404", "NoSuchKey"):
+                return False
+            raise
+
+    def list_prefixes(self, prefix: str = "") -> list[str]:
+        paginator = self._client.get_paginator("list_objects_v2")
+        prefixes: list[str] = []
+        for page in paginator.paginate(Bucket=self._bucket, Prefix=prefix, Delimiter="/"):
+            for cp in page.get("CommonPrefixes", []):
+                prefixes.append(cp["Prefix"].rstrip("/"))
+        return prefixes
+
+    def list_keys(self, prefix: str) -> list[str]:
+        paginator = self._client.get_paginator("list_objects_v2")
+        keys: list[str] = []
+        for page in paginator.paginate(Bucket=self._bucket, Prefix=prefix):
+            for obj in page.get("Contents", []):
+                keys.append(obj["Key"])
+        return keys
+
+    def count_objects(self, prefix: str) -> int:
+        paginator = self._client.get_paginator("list_objects_v2")
+        count = 0
+        for page in paginator.paginate(Bucket=self._bucket, Prefix=prefix):
+            count += page.get("KeyCount", 0)
+        return count
+
+    def delete_recursive(self, prefix: str) -> None:
+        paginator = self._client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=self._bucket, Prefix=prefix):
+            objects: list[dict[str, str]] = [{"Key": obj["Key"]} for obj in page.get("Contents", [])]
+            for i in range(0, len(objects), _S3_DELETE_BATCH_SIZE):
+                batch = objects[i : i + _S3_DELETE_BATCH_SIZE]
+                response = self._client.delete_objects(Bucket=self._bucket, Delete={"Objects": batch})  # type: ignore[typeddict-item]
+                errors = response.get("Errors", [])
+                if errors:
+                    failed_keys = [e.get("Key", "?") for e in errors]
+                    raise RuntimeError(
+                        f"Failed to delete {len(errors)} object(s) from s3://{self._bucket}/{prefix}: {failed_keys}"
+                    )
+        logger.info("Deleted s3://%s/%s", self._bucket, prefix)
+
+    def resolve_timestamp(self, timestamp: str) -> str:
+        prefixes = self.list_prefixes()
+        if timestamp in prefixes:
+            return timestamp
+        raise ValueError(f"No backup found matching timestamp: {timestamp}")
+
+    def list_backups(self) -> list[BackupEntry]:
+        from swiss_ai_hub.backup.models import BackupEntry
+
+        prefixes = self.list_prefixes()
+        entries: list[BackupEntry] = []
+        for prefix in sorted(prefixes):
+            if not BACKUP_PREFIX_RE.match(prefix):
+                continue
+            file_count = self.count_objects(prefix + "/")
+            entries.append(BackupEntry(prefix=prefix, file_count=file_count))
+        return entries
+
+    def find_latest_backup(self) -> str | None:
+        prefixes = self.list_prefixes()
+        backup_prefixes = sorted(p for p in prefixes if BACKUP_PREFIX_RE.match(p))
+        return backup_prefixes[-1] if backup_prefixes else None

--- a/packages/backup/swiss_ai_hub/backup/settings.py
+++ b/packages/backup/swiss_ai_hub/backup/settings.py
@@ -1,0 +1,45 @@
+from typing import Annotated
+
+from pydantic import Field, SecretStr
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class BackupSettings(BaseSettings):
+    """Field names match the platform-wide .env variable names."""
+
+    model_config = SettingsConfigDict()
+
+    BACKUP_RETENTION_DAYS: Annotated[int, Field(ge=0)] = 7
+    BACKUP_MINIMUM_KEEP: Annotated[int, Field(ge=1)] = 3
+
+    POSTGRES_HOST: str = "postgres"
+    POSTGRES_USER: str = "admin"
+    POSTGRES_PASSWORD: SecretStr
+
+    POSTGRES_FERRETDB_HOST: str = "postgres-ferretdb"
+    MONGO_USERNAME: str = "admin"
+    MONGO_PASSWORD: SecretStr
+
+    MILVUS_HOST: str = "milvus-standalone"
+    MILVUS_PORT: Annotated[int, Field(gt=0)] = 19530
+    MILVUS_ROOT_PASSWORD: SecretStr
+
+    NEO4J_CONTAINER: str = "neo4j"
+
+    CLICKHOUSE_HOST: str = "clickhouse"
+    CLICKHOUSE_PORT: Annotated[int, Field(gt=0)] = 8123
+    CLICKHOUSE_USER: str = "clickhouse"
+    LANGFUSE_CLICKHOUSE_PASSWORD: SecretStr
+
+    VALKEY_HOST: str = "valkey"
+    VALKEY_PORT: Annotated[int, Field(gt=0)] = 6379
+    VALKEY_CONTAINER: str = "valkey"
+    REDIS_TOKEN: SecretStr
+
+    NATS_URL: str = "nats://nats:4222"
+    NATS_TOKEN: SecretStr
+
+    S3_STORAGE_ACCESS_KEY: str = "admin"
+    S3_STORAGE_SECRET_KEY: SecretStr
+    AWS_ENDPOINT_URL: str = "http://seaweedfs-s3:9000"
+    BACKUP_S3_BUCKET: str = "backups"

--- a/packages/backup/tests/test_container_discovery.py
+++ b/packages/backup/tests/test_container_discovery.py
@@ -145,5 +145,6 @@ def test_is_excluded() -> None:
     assert ContainerDiscovery._is_excluded("backup-daemon") is True
     assert ContainerDiscovery._is_excluded("seaweedfs-master") is True
     assert ContainerDiscovery._is_excluded("etcd") is True
+    assert ContainerDiscovery._is_excluded("traefik") is True
     assert ContainerDiscovery._is_excluded("api") is False
     assert ContainerDiscovery._is_excluded("postgres") is False

--- a/packages/backup/tests/test_retention.py
+++ b/packages/backup/tests/test_retention.py
@@ -1,0 +1,134 @@
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+from swiss_ai_hub.backup.retention import RetentionService
+
+FROZEN_NOW = datetime(2026, 2, 18, 12, 0, 0, tzinfo=UTC)
+
+
+def test_retention_deletes_old_backups() -> None:
+    s3 = MagicMock()
+    s3.list_prefixes.return_value = [
+        "2026-01-01_02-00-00",
+        "2026-02-15_02-00-00",
+        "2026-02-16_02-00-00",
+        "2026-02-17_02-00-00",
+        "2026-02-18_02-00-00",
+    ]
+
+    with patch("swiss_ai_hub.backup.retention.datetime") as mock_dt:
+        mock_dt.now.return_value = FROZEN_NOW
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        RetentionService.run(s3, retention_days=7)
+
+    s3.delete_recursive.assert_called_once_with("2026-01-01_02-00-00/")
+
+
+def test_retention_disabled_when_zero() -> None:
+    s3 = MagicMock()
+    RetentionService.run(s3, retention_days=0)
+    s3.list_prefixes.assert_not_called()
+
+
+def test_retention_keeps_backup_on_exact_cutoff_date() -> None:
+    """Backups dated exactly retention_days ago are kept (strict < comparison)."""
+    s3 = MagicMock()
+    s3.list_prefixes.return_value = [
+        "2026-02-11_02-00-00",
+    ]
+
+    with patch("swiss_ai_hub.backup.retention.datetime") as mock_dt:
+        mock_dt.now.return_value = FROZEN_NOW
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        RetentionService.run(s3, retention_days=7)
+
+    s3.delete_recursive.assert_not_called()
+
+
+def test_retention_minimum_keep_prevents_total_wipe() -> None:
+    """When all backups are expired, minimum_keep prevents deleting all of them."""
+    s3 = MagicMock()
+    s3.list_prefixes.return_value = [
+        "2026-01-01_02-00-00",
+        "2026-01-02_02-00-00",
+    ]
+
+    with patch("swiss_ai_hub.backup.retention.datetime") as mock_dt:
+        mock_dt.now.return_value = FROZEN_NOW
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        RetentionService.run(s3, retention_days=7, minimum_keep=3)
+
+    s3.delete_recursive.assert_not_called()
+
+
+def test_retention_minimum_keep_allows_partial_deletion() -> None:
+    """When enough backups remain after deletion, expired ones are still removed."""
+    s3 = MagicMock()
+    s3.list_prefixes.return_value = [
+        "2026-01-01_02-00-00",
+        "2026-01-05_02-00-00",
+        "2026-02-15_02-00-00",
+        "2026-02-16_02-00-00",
+        "2026-02-17_02-00-00",
+    ]
+
+    with patch("swiss_ai_hub.backup.retention.datetime") as mock_dt:
+        mock_dt.now.return_value = FROZEN_NOW
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        RetentionService.run(s3, retention_days=7, minimum_keep=3)
+
+    assert s3.delete_recursive.call_count == 2
+    s3.delete_recursive.assert_any_call("2026-01-01_02-00-00/")
+    s3.delete_recursive.assert_any_call("2026-01-05_02-00-00/")
+
+
+def test_retention_minimum_keep_one_protects_last_backup() -> None:
+    """minimum_keep=1 protects the last remaining backup."""
+    s3 = MagicMock()
+    s3.list_prefixes.return_value = [
+        "2026-01-01_02-00-00",
+    ]
+
+    with patch("swiss_ai_hub.backup.retention.datetime") as mock_dt:
+        mock_dt.now.return_value = FROZEN_NOW
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        RetentionService.run(s3, retention_days=7, minimum_keep=1)
+
+    s3.delete_recursive.assert_not_called()
+
+
+def test_retention_minimum_keep_partial_when_close_to_limit() -> None:
+    """When deleting all expired would violate minimum_keep, only delete oldest ones."""
+    s3 = MagicMock()
+    s3.list_prefixes.return_value = [
+        "2026-01-01_02-00-00",
+        "2026-01-02_02-00-00",
+        "2026-01-03_02-00-00",
+        "2026-02-17_02-00-00",
+    ]
+
+    with patch("swiss_ai_hub.backup.retention.datetime") as mock_dt:
+        mock_dt.now.return_value = FROZEN_NOW
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        RetentionService.run(s3, retention_days=7, minimum_keep=3)
+
+    # 4 backups, 3 expired, minimum_keep=3 -> can only delete 1
+    assert s3.delete_recursive.call_count == 1
+    s3.delete_recursive.assert_called_once_with("2026-01-01_02-00-00/")
+
+
+def test_retention_minimum_keep_exact_boundary_deletes_nothing() -> None:
+    """When total backups == minimum_keep and all expired, nothing is deleted."""
+    s3 = MagicMock()
+    s3.list_prefixes.return_value = [
+        "2026-01-01_02-00-00",
+        "2026-01-02_02-00-00",
+        "2026-01-03_02-00-00",
+    ]
+
+    with patch("swiss_ai_hub.backup.retention.datetime") as mock_dt:
+        mock_dt.now.return_value = FROZEN_NOW
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        RetentionService.run(s3, retention_days=7, minimum_keep=3)
+
+    s3.delete_recursive.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -5285,10 +5285,12 @@ name = "swiss-ai-hub-backup"
 version = "0.273.3"
 source = { editable = "packages/backup" }
 dependencies = [
+    { name = "boto3" },
     { name = "dagster" },
     { name = "dagster-webserver" },
     { name = "docker" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
 ]
 
 [package.dev-dependencies]
@@ -5299,10 +5301,12 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", specifier = ">=1.41.5" },
     { name = "dagster", specifier = ">=1.11.2" },
     { name = "dagster-webserver", specifier = ">=1.11.2" },
     { name = "docker", specifier = ">=7.0" },
     { name = "pydantic", specifier = ">=2.10.3" },
+    { name = "pydantic-settings", specifier = ">=2.13.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- Add daily cron schedule (`0 1 * * *` Europe/Zurich) for automated backup via Dagster
- Add rolling retention policy that deletes backups older than `BACKUP_RETENTION_DAYS` (default 7) while preserving at least `BACKUP_MINIMUM_KEEP` (default 3)
- Add S3Manager for SeaweedFS backup storage, BackupSettings for configuration, and dynamic partition sync for future restore job

## New files
- `settings.py` — `BackupSettings(BaseSettings)` with retention + S3 + service credentials
- `s3.py` — `S3Manager` for listing/deleting backup prefixes in SeaweedFS
- `retention.py` — `RetentionService.run()` with minimum-keep guard
- `schedules/factory.py` — `daily_backup_schedule()` at 1 AM before pipeline observation (2 AM)
- `partitions.py` — `DynamicPartitionsDefinition` for restore job selector
- Resource wrappers (`BackupSettingsResource`, `S3ManagerResource`) + factory

## Modified files
- `backup_finalize_factory.py` — calls retention after container restart + syncs partitions
- `backup_session_factory.py` — uses S3Manager to purge incomplete previous attempts
- `definitions.py` — wires schedule and expanded resources
- `models.py` — adds `BACKUP_SERVICES` and `SERVICE_TO_ASSET_KEY` constants

## Test plan
- [x] 8 retention unit tests covering edge cases (disabled, cutoff boundary, minimum-keep guard, partial deletion)
- [x] All 55 backup package tests pass
- [x] Schedule visible in Dagster UI at `localhost:3004/automation` (verified via browser)

Closes #972