### PR TITLE
fix(swiss-ai-hub): Preserve HITL subclass through WebSocket serialization

### DIFF
--- a/packages/api/CLAUDE.md
+++ b/packages/api/CLAUDE.md
@@ -175,6 +175,13 @@ agent NATS topics. Agents subscribe to thread-specific subjects.
 stores ALL events to MongoDB (audit trail). `WebSocketSender` broadcasts display events to connected WebSocket clients
 in real-time, wrapped in `ContextualizedAgentEvent` (adds agent_class, thread_id, locale context).
 
+**DisplayEvents union** (`sockets/events/server_to_user/contextualized_agent_event.py`): The `DisplayEvents` type alias
+is a discriminated union of all event types the WebSocket can serialize. The `event_discriminator` function walks
+`_parent_event_names` to find the closest match in the union. **When adding a new `ControlAndDisplayEvent` subclass
+(especially HITL subtypes), you MUST add it to the `DisplayEvents` union** — otherwise agent-specific subclasses
+silently downcast to the base class during serialization, and the frontend echoes back the wrong type. See PR #1031 for
+the bug this caused.
+
 **Agents → API** (RPC): `AgentConfigResponder` and `ProcessConfigResponder` serve configuration data via NATS
 request-reply on `aihub.rpc.config.agent.*.*` / `aihub.rpc.config.process.*.*`. Agents fetch their config at runtime
 without needing it baked into event payloads.
@@ -247,6 +254,7 @@ http://localhost:8000/api/v1/active/docs (Swagger).
 - Event models: `packages/api/swiss_ai_hub/api/events/event_model_creation_service.py`
 - RPC responders: `packages/api/swiss_ai_hub/api/rpc/agent_config_responder.py`
 - WebSocket manager: `packages/api/swiss_ai_hub/api/sockets/manager/web_socket_manager.py`
+- DisplayEvents union: `packages/api/swiss_ai_hub/api/sockets/events/server_to_user/contextualized_agent_event.py`
 - i18n: `packages/api/swiss_ai_hub/api/i18n/api_locale_string.py`, `api_locale_handler.py`
 - Test runner: `packages/api/swiss_ai_hub/api/runners/simulation/agent/simulated_agent_api_test_runner.py`
 - Playground: `packages/api/playground/testing/main.py`

--- a/packages/api/CLAUDE.md
+++ b/packages/api/CLAUDE.md
@@ -177,10 +177,10 @@ in real-time, wrapped in `ContextualizedAgentEvent` (adds agent_class, thread_id
 
 **DisplayEvents union** (`sockets/events/server_to_user/contextualized_agent_event.py`): The `DisplayEvents` type alias
 is a discriminated union of all event types the WebSocket can serialize. The `event_discriminator` function walks
-`_parent_event_names` to find the closest match in the union. **When adding a new `ControlAndDisplayEvent` subclass
-(especially HITL subtypes), you MUST add it to the `DisplayEvents` union** — otherwise agent-specific subclasses
-silently downcast to the base class during serialization, and the frontend echoes back the wrong type. See PR #1031 for
-the bug this caused.
+`_parent_event_names` to find the closest match in the union. **When adding a new subclass of any event type already in
+the union, you MUST add the subclass to the `DisplayEvents` union too** — otherwise it silently downcasts to the parent
+class during serialization, and the frontend echoes back the wrong type. See PR #1031 for the bug this caused with HITL
+subtypes.
 
 **Agents → API** (RPC): `AgentConfigResponder` and `ProcessConfigResponder` serve configuration data via NATS
 request-reply on `aihub.rpc.config.agent.*.*` / `aihub.rpc.config.process.*.*`. Agents fetch their config at runtime

--- a/packages/api/playground/testing/tests/sockets/test_contextualized_agent_event.py
+++ b/packages/api/playground/testing/tests/sockets/test_contextualized_agent_event.py
@@ -1,0 +1,100 @@
+"""Regression tests for HITL subclass preservation through ContextualizedAgentEvent.
+
+Bug history: PR #841 (2026-01-05) introduced HumanInTheLoop{Input,Confirmation,Chat}RequestEvent
+subclasses but did not add them to the `DisplayEvents` discriminated union in
+`contextualized_agent_event.py`. As a result, any agent-specific HITL subclass fell through
+to the base `HumanInTheLoopRequestEvent` tag and got downcast during WebSocket serialization.
+The frontend then echoed the downgraded event back in its POST body; the agent-side outer
+validator (`FollowUpQuestionResponseEvent.request_event: HumanInTheLoopInputRequestEvent`)
+rejected the base-class instance, silently dropping the message and hanging the run.
+"""
+
+from swiss_ai_hub.core.events.agent import (
+    HumanInTheLoopChatRequestEvent,
+    HumanInTheLoopConfirmationRequestEvent,
+    HumanInTheLoopInputRequestEvent,
+)
+from swiss_ai_hub.core.topic_managers import AgentTopicManager
+from swiss_ai_hub.core.topics import PartialAgentTopic
+
+from swiss_ai_hub.api.sockets.events.server_to_user.contextualized_agent_event import (
+    ContextualizedAgentEvent,
+    DisplayEvents,
+    event_discriminator,
+)
+
+
+class _TestInputRequest(HumanInTheLoopInputRequestEvent):
+    """Stand-in for an agent-specific input-request subclass (e.g. FollowUpQuestionRequestEvent)."""
+
+
+class _TestConfirmationRequest(HumanInTheLoopConfirmationRequestEvent):
+    """Stand-in for an agent-specific confirmation-request subclass."""
+
+
+class _TestChatRequest(HumanInTheLoopChatRequestEvent):
+    """Stand-in for an agent-specific chat-request subclass."""
+
+
+def _make_topic() -> PartialAgentTopic:
+    return PartialAgentTopic(
+        event_type=AgentTopicManager.CONTROL_EVENT,
+        event_name="SomeResponseEvent",
+    )
+
+
+def _wrap(event) -> ContextualizedAgentEvent:
+    return ContextualizedAgentEvent(
+        event_display_name="x",
+        event_display_description="x",
+        agent_class="TestAgent",
+        agent_id="test",
+        thread_id="t",
+        display_id="d",
+        run_id="r",
+        event_type="control_event",
+        event_name=type(event).__name__,
+        event_id="e",
+        event=event,
+    )
+
+
+def test_display_events_union_tags_hitl_subclasses():
+    """All three HITL request subclasses and their responses are in the discriminated union."""
+    valid_tags = {arg.__metadata__[0].tag for arg in DisplayEvents.__args__}
+    assert {
+        "HumanInTheLoopInputRequestEvent",
+        "HumanInTheLoopConfirmationRequestEvent",
+        "HumanInTheLoopChatRequestEvent",
+        "HumanInTheLoopInputResponseEvent",
+        "HumanInTheLoopConfirmationResponseEvent",
+        "HumanInTheLoopChatResponseEvent",
+    }.issubset(valid_tags)
+
+
+def test_input_subclass_discriminator_resolves_to_input_not_base():
+    """An agent-specific Input subclass must map to HumanInTheLoopInputRequestEvent, not the base."""
+    event = _TestInputRequest(question="?", topic=_make_topic())
+    assert event_discriminator(event) == "HumanInTheLoopInputRequestEvent"
+
+
+def test_confirmation_subclass_discriminator_resolves_to_confirmation():
+    event = _TestConfirmationRequest(question="?", topic=_make_topic())
+    assert event_discriminator(event) == "HumanInTheLoopConfirmationRequestEvent"
+
+
+def test_chat_subclass_discriminator_resolves_to_chat():
+    event = _TestChatRequest(question="?", topic=_make_topic())
+    assert event_discriminator(event) == "HumanInTheLoopChatRequestEvent"
+
+
+def test_agent_subclass_preserved_through_contextualized_dump():
+    """ContextualizedAgentEvent.model_dump() must preserve subclass class info in the nested event."""
+    event = _TestInputRequest(question="?", topic=_make_topic())
+    dumped = _wrap(event).model_dump()
+    nested = dumped["event"]
+
+    # The bug was that this was "HumanInTheLoopRequestEvent" (base class).
+    assert nested["_event_name"] == "_TestInputRequest"
+    assert "HumanInTheLoopInputRequestEvent" in nested["_parent_event_names"]
+    assert nested["hitl_type"] == "input"

--- a/packages/api/playground/testing/tests/sockets/test_contextualized_agent_event.py
+++ b/packages/api/playground/testing/tests/sockets/test_contextualized_agent_event.py
@@ -10,9 +10,13 @@ rejected the base-class instance, silently dropping the message and hanging the 
 """
 
 from swiss_ai_hub.core.events.agent import (
+    DisplayEvent,
     HumanInTheLoopChatRequestEvent,
+    HumanInTheLoopChatResponseEvent,
     HumanInTheLoopConfirmationRequestEvent,
+    HumanInTheLoopConfirmationResponseEvent,
     HumanInTheLoopInputRequestEvent,
+    HumanInTheLoopInputResponseEvent,
 )
 from swiss_ai_hub.core.topic_managers import AgentTopicManager
 from swiss_ai_hub.core.topics import PartialAgentTopic
@@ -24,16 +28,28 @@ from swiss_ai_hub.api.sockets.events.server_to_user.contextualized_agent_event i
 )
 
 
-class _TestInputRequest(HumanInTheLoopInputRequestEvent):
+class _FakeInputRequest(HumanInTheLoopInputRequestEvent):
     """Stand-in for an agent-specific input-request subclass (e.g. FollowUpQuestionRequestEvent)."""
 
 
-class _TestConfirmationRequest(HumanInTheLoopConfirmationRequestEvent):
+class _FakeConfirmationRequest(HumanInTheLoopConfirmationRequestEvent):
     """Stand-in for an agent-specific confirmation-request subclass."""
 
 
-class _TestChatRequest(HumanInTheLoopChatRequestEvent):
+class _FakeChatRequest(HumanInTheLoopChatRequestEvent):
     """Stand-in for an agent-specific chat-request subclass."""
+
+
+class _FakeInputResponse(HumanInTheLoopInputResponseEvent):
+    """Stand-in for an agent-specific input-response subclass."""
+
+
+class _FakeConfirmationResponse(HumanInTheLoopConfirmationResponseEvent):
+    """Stand-in for an agent-specific confirmation-response subclass."""
+
+
+class _FakeChatResponse(HumanInTheLoopChatResponseEvent):
+    """Stand-in for an agent-specific chat-response subclass."""
 
 
 def _make_topic() -> PartialAgentTopic:
@@ -43,7 +59,7 @@ def _make_topic() -> PartialAgentTopic:
     )
 
 
-def _wrap(event) -> ContextualizedAgentEvent:
+def _wrap(event: DisplayEvent) -> ContextualizedAgentEvent:
     return ContextualizedAgentEvent(
         event_display_name="x",
         event_display_description="x",
@@ -72,29 +88,57 @@ def test_display_events_union_tags_hitl_subclasses():
     }.issubset(valid_tags)
 
 
-def test_input_subclass_discriminator_resolves_to_input_not_base():
+def test_input_request_subclass_discriminator_resolves_to_input_not_base():
     """An agent-specific Input subclass must map to HumanInTheLoopInputRequestEvent, not the base."""
-    event = _TestInputRequest(question="?", topic=_make_topic())
+    event = _FakeInputRequest(question="?", topic=_make_topic())
     assert event_discriminator(event) == "HumanInTheLoopInputRequestEvent"
 
 
-def test_confirmation_subclass_discriminator_resolves_to_confirmation():
-    event = _TestConfirmationRequest(question="?", topic=_make_topic())
+def test_confirmation_request_subclass_discriminator_resolves_to_confirmation():
+    event = _FakeConfirmationRequest(question="?", topic=_make_topic())
     assert event_discriminator(event) == "HumanInTheLoopConfirmationRequestEvent"
 
 
-def test_chat_subclass_discriminator_resolves_to_chat():
-    event = _TestChatRequest(question="?", topic=_make_topic())
+def test_chat_request_subclass_discriminator_resolves_to_chat():
+    event = _FakeChatRequest(question="?", topic=_make_topic())
     assert event_discriminator(event) == "HumanInTheLoopChatRequestEvent"
+
+
+def test_input_response_subclass_discriminator_resolves_to_input_response():
+    """The response path was the one actually failing in production — HITL response echo from the frontend."""
+    event = _FakeInputResponse(
+        response="answer",
+        request_event=_FakeInputRequest(question="?", topic=_make_topic()),
+        topic=_make_topic(),
+    )
+    assert event_discriminator(event) == "HumanInTheLoopInputResponseEvent"
+
+
+def test_confirmation_response_subclass_discriminator_resolves_to_confirmation_response():
+    event = _FakeConfirmationResponse(
+        response=True,
+        request_event=_FakeConfirmationRequest(question="?", topic=_make_topic()),
+        topic=_make_topic(),
+    )
+    assert event_discriminator(event) == "HumanInTheLoopConfirmationResponseEvent"
+
+
+def test_chat_response_subclass_discriminator_resolves_to_chat_response():
+    event = _FakeChatResponse(
+        response="reply",
+        request_event=_FakeChatRequest(question="?", topic=_make_topic()),
+        topic=_make_topic(),
+    )
+    assert event_discriminator(event) == "HumanInTheLoopChatResponseEvent"
 
 
 def test_agent_subclass_preserved_through_contextualized_dump():
     """ContextualizedAgentEvent.model_dump() must preserve subclass class info in the nested event."""
-    event = _TestInputRequest(question="?", topic=_make_topic())
+    event = _FakeInputRequest(question="?", topic=_make_topic())
     dumped = _wrap(event).model_dump()
     nested = dumped["event"]
 
     # The bug was that this was "HumanInTheLoopRequestEvent" (base class).
-    assert nested["_event_name"] == "_TestInputRequest"
+    assert nested["_event_name"] == "_FakeInputRequest"
     assert "HumanInTheLoopInputRequestEvent" in nested["_parent_event_names"]
     assert nested["hitl_type"] == "input"

--- a/packages/api/playground/testing/tests/sockets/test_contextualized_agent_event.py
+++ b/packages/api/playground/testing/tests/sockets/test_contextualized_agent_event.py
@@ -1,14 +1,3 @@
-"""Regression tests for HITL subclass preservation through ContextualizedAgentEvent.
-
-Bug history: PR #841 (2026-01-05) introduced HumanInTheLoop{Input,Confirmation,Chat}RequestEvent
-subclasses but did not add them to the `DisplayEvents` discriminated union in
-`contextualized_agent_event.py`. As a result, any agent-specific HITL subclass fell through
-to the base `HumanInTheLoopRequestEvent` tag and got downcast during WebSocket serialization.
-The frontend then echoed the downgraded event back in its POST body; the agent-side outer
-validator (`FollowUpQuestionResponseEvent.request_event: HumanInTheLoopInputRequestEvent`)
-rejected the base-class instance, silently dropping the message and hanging the run.
-"""
-
 from swiss_ai_hub.core.events.agent import (
     DisplayEvent,
     HumanInTheLoopChatRequestEvent,

--- a/packages/api/swiss_ai_hub/api/sockets/events/server_to_user/contextualized_agent_event.py
+++ b/packages/api/swiss_ai_hub/api/sockets/events/server_to_user/contextualized_agent_event.py
@@ -26,6 +26,12 @@ from swiss_ai_hub.core.events.agent import (
     GuardAcceptEvent,
     GuardEvent,
     GuardRejectionEvent,
+    HumanInTheLoopChatRequestEvent,
+    HumanInTheLoopChatResponseEvent,
+    HumanInTheLoopConfirmationRequestEvent,
+    HumanInTheLoopConfirmationResponseEvent,
+    HumanInTheLoopInputRequestEvent,
+    HumanInTheLoopInputResponseEvent,
     HumanInTheLoopRequestEvent,
     HumanInTheLoopResponseEvent,
     LimitChatHistoryEvent,
@@ -56,9 +62,15 @@ from swiss_ai_hub.core.persistence.messaging.entities.persisted_agent_event_enti
 DisplayEvents = (
     Annotated[StartEvent, Tag("StartEvent")]
     | Annotated[AgentInTheLoopResponseEvent, Tag("AgentInTheLoopResponseEvent")]
+    | Annotated[HumanInTheLoopInputRequestEvent, Tag("HumanInTheLoopInputRequestEvent")]
+    | Annotated[HumanInTheLoopConfirmationRequestEvent, Tag("HumanInTheLoopConfirmationRequestEvent")]
+    | Annotated[HumanInTheLoopChatRequestEvent, Tag("HumanInTheLoopChatRequestEvent")]
     | Annotated[HumanInTheLoopRequestEvent, Tag("HumanInTheLoopRequestEvent")]
     | Annotated[AgentInTheLoopRequestEvent, Tag("AgentInTheLoopRequestEvent")]
     | Annotated[AgentInTheLoopExceptionEvent, Tag("AgentInTheLoopExceptionEvent")]
+    | Annotated[HumanInTheLoopInputResponseEvent, Tag("HumanInTheLoopInputResponseEvent")]
+    | Annotated[HumanInTheLoopConfirmationResponseEvent, Tag("HumanInTheLoopConfirmationResponseEvent")]
+    | Annotated[HumanInTheLoopChatResponseEvent, Tag("HumanInTheLoopChatResponseEvent")]
     | Annotated[HumanInTheLoopResponseEvent, Tag("HumanInTheLoopResponseEvent")]
     | Annotated[LimitChatHistoryEvent, Tag("LimitChatHistoryEvent")]
     | Annotated[AddMemoryToChatHistoryEvent, Tag("AddMemoryToChatHistoryEvent")]

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -223,6 +223,9 @@ Events are organized by which system they belong to:
 2. Place in `events/agent/`, `events/process/`, or `events/pipeline/` based on scope
 3. Auto-registers on import — no manual registration needed
 4. Do NOT add eager imports to any `__init__.py` — this causes duplicate registration errors
+5. If the event is a `ControlAndDisplayEvent` subclass (HITL, AITL, BITL, semantic, start/stop), add it to the
+   `DisplayEvents` union in `packages/api/.../contextualized_agent_event.py` — otherwise subclasses silently downcast
+   during WebSocket serialization (see `packages/api/CLAUDE.md` → DisplayEvents union)
 
 ## Form System (Form Duality Pattern)
 

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -223,9 +223,9 @@ Events are organized by which system they belong to:
 2. Place in `events/agent/`, `events/process/`, or `events/pipeline/` based on scope
 3. Auto-registers on import — no manual registration needed
 4. Do NOT add eager imports to any `__init__.py` — this causes duplicate registration errors
-5. If the event is a `ControlAndDisplayEvent` subclass (HITL, AITL, BITL, semantic, start/stop), add it to the
-   `DisplayEvents` union in `packages/api/.../contextualized_agent_event.py` — otherwise subclasses silently downcast
-   during WebSocket serialization (see `packages/api/CLAUDE.md` → DisplayEvents union)
+5. If the event subclasses any type already in the `DisplayEvents` union
+   (`packages/api/.../contextualized_agent_event.py`), add the new subclass to the union too — otherwise it silently
+   downcasts during WebSocket serialization (see `packages/api/CLAUDE.md` → DisplayEvents union)
 
 ## Form System (Form Duality Pattern)
 


### PR DESCRIPTION
## Summary

- Add explicit discriminator tags for `HumanInTheLoopInput/Confirmation/Chat` request and response events in the `DisplayEvents` union
- Fixes a bug where agent-specific HITL subclasses were downcast to the base `HumanInTheLoopRequestEvent` during WebSocket serialization, causing the agent-side validator to reject the echoed event and silently hang the run
- Latent since PR #841; exposed by the NamespaceSelectionAgent HITL flow

## Test plan

- [x] New regression tests in `test_contextualized_agent_event.py` verify all three HITL request subclass variants resolve correctly through the discriminator
- [x] Response-side discriminator tests cover the production failure path (HITL response echo from frontend)
- [x] `ContextualizedAgentEvent.model_dump()` preserves subclass `_event_name` and `_parent_event_names`
- [x] All `packages/api` tests pass