### PR TITLE
fix(swiss-ai-hub): Stop siloing organization memory by writer agent/user

### DIFF
--- a/packages/agent/swiss_ai_hub/agent/agents/expert_rag_agent/expert_rag_agent.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/expert_rag_agent/expert_rag_agent.py
@@ -231,7 +231,7 @@ class ExpertRAGAgent(Agent):
             query=query,
             tenant_id=agent_config.tenant_id,
             tenant_namespace=agent_config.tenant_namespace,
-            user_id=event.user.id,
+            user_id=None,
             limit=10,
             threshold=0.5,
             rerank=True,

--- a/packages/agent/swiss_ai_hub/agent/agents/rag_agent/rag_agent.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/rag_agent/rag_agent.py
@@ -204,7 +204,7 @@ class RAGAgent(Agent):
             query=query,
             tenant_id=agent_config.tenant_id,
             tenant_namespace=agent_config.tenant_namespace,
-            user_id=event.user.id,
+            user_id=None,
             limit=10,
             threshold=0.5,
             rerank=True,

--- a/packages/core/swiss_ai_hub/core/generative_ai/memory/agent_memory.py
+++ b/packages/core/swiss_ai_hub/core/generative_ai/memory/agent_memory.py
@@ -197,14 +197,15 @@ class AgentMemory:
         departments within a company). If not provided, searches across all memories for the tenant.
         This enables both broad tenant-wide knowledge and department-specific context.
 
-        Organization memory is tenant-scoped and shared across agents and users within the tenant
-        — `user_id` and `agent_id` are intentionally NOT applied as search filters, otherwise a
-        memory written by one agent/user would be invisible to another. Those fields remain on the
-        stored memory's metadata as trace information (who wrote it), but do not partition reads.
-        The `user_id` parameter is kept for caller symmetry with `search_user_memory` but is
-        ignored for filtering.
+        Organization memory is tenant-scoped and shared across agents within the tenant. Filtering
+        by the searching agent (`self.agent_id`) is intentionally NOT applied — otherwise a memory
+        written by one agent would be invisible to another. The writer's `_agent_id` remains on
+        the stored memory's metadata as trace information, but does not partition reads.
+
+        The caller controls `user_id` scoping: pass `None` (the default) for fully shared
+        tenant-wide retrieval; pass a concrete `user_id` only if the caller wants to restrict
+        results to memories written on behalf of that user.
         """
-        _ = user_id
         return await self.mem0service.search(
             query=query,
             owner_id=tenant_id,
@@ -212,7 +213,7 @@ class AgentMemory:
             display_id=display_id,
             run_id=run_id,
             memory_type=MemoryType.ORGANIZATION_MEMORY,
-            user_id=None,
+            user_id=user_id,
             agent_id=None,
             tenant_namespace=tenant_namespace,
             tenant_id=tenant_id,

--- a/packages/core/swiss_ai_hub/core/generative_ai/memory/agent_memory.py
+++ b/packages/core/swiss_ai_hub/core/generative_ai/memory/agent_memory.py
@@ -196,7 +196,15 @@ class AgentMemory:
         Tenant namespace provides additional scoping for multi-tenant scenarios (e.g., different
         departments within a company). If not provided, searches across all memories for the tenant.
         This enables both broad tenant-wide knowledge and department-specific context.
+
+        Organization memory is tenant-scoped and shared across agents and users within the tenant
+        — `user_id` and `agent_id` are intentionally NOT applied as search filters, otherwise a
+        memory written by one agent/user would be invisible to another. Those fields remain on the
+        stored memory's metadata as trace information (who wrote it), but do not partition reads.
+        The `user_id` parameter is kept for caller symmetry with `search_user_memory` but is
+        ignored for filtering.
         """
+        _ = user_id
         return await self.mem0service.search(
             query=query,
             owner_id=tenant_id,
@@ -204,8 +212,8 @@ class AgentMemory:
             display_id=display_id,
             run_id=run_id,
             memory_type=MemoryType.ORGANIZATION_MEMORY,
-            user_id=user_id,
-            agent_id=self.agent_id,
+            user_id=None,
+            agent_id=None,
             tenant_namespace=tenant_namespace,
             tenant_id=tenant_id,
             limit=limit,


### PR DESCRIPTION
## Summary

`AgentMemory.search_organization_memory` was applying two metadata filters that silently broke org-memory sharing:

- `_agent_id = self.agent_id` (hardcoded inside the method) — memory written by `ExpertAskingAgent` was invisible to `ExpertRAGAgent` because the stored `_agent_id` never matched the searcher's.
- `_user_id = event.user.id` (passed by callers) — further siloed the shared org memory per end-user, so technician A's escalation never reached technician B.

This contradicted the class's own docstring: *"tenant-scoped memories shared across users"*.

## Fix

- **`AgentMemory.search_organization_memory`**: stop hardcoding `agent_id=self.agent_id`; pass `agent_id=None` into `mem0_service.search`. Continue to honor the caller's `user_id` parameter (no silent override inside the method — the decision belongs at the call site).
- **`ExpertRAGAgent.retrieve_organization_memory_step`** and **`RAGAgent.retrieve_organization_memory_step`**: pass `user_id=None` instead of `event.user.id`, since the intent is tenant-wide shared retrieval.
- **Write side (`add_organization_memory`)**: unchanged. `_agent_id` and `_user_id` are still stamped on the stored memory as trace metadata (who wrote it); they just no longer gate reads.
- **`OrganizationMemory` (admin/API path)**: unchanged. Its `agent_id`/`user_id` filter parameters are already opt-in and default to `None`.

Net result: org memory is now partitioned only by `_tenant_id` (+ optional `_tenant_namespace`), which is the documented contract.

## Test plan

- [x] Start the dev stack, trigger an expert escalation so `ExpertAskingAgent` stores an org memory, then ask the same question via `ExpertRAGAgent` → the stored fact appears in the retrieval context (the scenario that was broken).
- [x] Same as above but with a **different end-user** in the same tenant → still retrievable (previous `_user_id` silo gone).
- [x] `search_user_memory` cross-user isolation still holds — the user-memory path was not modified (covered by `test_user_memory_isolation` in `test_agent_memory.py`).
- [x] Run `make test` in `packages/core` with the Docker dev stack up to exercise the `slow`/`flaky` integration tests against live Milvus + Neo4j.