### PR TITLE
feat(swiss-ai-hub): English-only OpenAPI metadata

### DIFF
--- a/packages/api/swiss_ai_hub/api/runners/api_runner.py
+++ b/packages/api/swiss_ai_hub/api/runners/api_runner.py
@@ -12,7 +12,6 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.routing import Mount
 from swiss_ai_hub.core.infrastructure import AIHubSettings
 from swiss_ai_hub.core.routes import Controller
-from swiss_ai_hub.core.routes.tenant_scoped_controller import TenantScopedController
 from swiss_ai_hub.core.runners import Runner
 
 from swiss_ai_hub.api.i18n.api_locale_handler import ApiLocaleHandler
@@ -190,13 +189,16 @@ class ApiRunner(Runner):
         """
         super().mount(*controllers)
 
-        tenant_scoped = [c for c in controllers if isinstance(c, TenantScopedController)]
-        self._api_app.openapi_tags = [
+        existing_tag_names = {tag["name"] for tag in (self._api_app.openapi_tags or [])}
+        new_tags = [
             {
                 "name": ApiLocaleHandler().extract(controller.name, locale="en"),
-                "description": ApiLocaleHandler().extract(controller.description),
+                "description": ApiLocaleHandler().extract(controller.description, locale="en"),
             }
-            for controller in tenant_scoped
+            for controller in controllers
+        ]
+        self._api_app.openapi_tags = (self._api_app.openapi_tags or []) + [
+            tag for tag in new_tags if tag["name"] not in existing_tag_names
         ]
 
         # Pre-populate state with controller references so they're available

--- a/packages/api/swiss_ai_hub/api/services/process_endpoints_discovery_service.py
+++ b/packages/api/swiss_ai_hub/api/services/process_endpoints_discovery_service.py
@@ -20,6 +20,7 @@ from swiss_ai_hub.core.subscribers import ProcessNCSubscriber
 from swiss_ai_hub.core.topic_managers import ProcessTopicManager
 
 from swiss_ai_hub.api.events.event_model_creation_service import EventModelCreationService
+from swiss_ai_hub.api.i18n.api_locale_string import ApiLocaleString
 from swiss_ai_hub.api.i18n.dependencies.use_locale import use_locale
 from swiss_ai_hub.api.routes.process.dto.in_specs.human_in_dto import HumanInDTO
 from swiss_ai_hub.api.routes.process.dto.process_class_dto import ProcessClassDTO
@@ -206,7 +207,7 @@ class ProcessEndpointsDiscoveryService(EndpointsDiscoveryService):
             ),
             methods=["GET"],
             name=get_endpoint_name,
-            tags=["Processes"],
+            tags=[ApiLocaleString.from_i18n_path("api.controllers.process.name").en],
         )
 
         # POST endpoint that accepts form
@@ -221,7 +222,7 @@ class ProcessEndpointsDiscoveryService(EndpointsDiscoveryService):
             ),
             methods=[human_input.method],
             name=post_endpoint_name,
-            tags=["Processes"],
+            tags=[ApiLocaleString.from_i18n_path("api.controllers.process.name").en],
         )
         logger.info(f"Successfully registered endpoints for {process_class}")
 
@@ -256,7 +257,7 @@ class ProcessEndpointsDiscoveryService(EndpointsDiscoveryService):
             ),
             methods=[program_input.method],
             name=post_endpoint_name,
-            tags=["Processes"],
+            tags=[ApiLocaleString.from_i18n_path("api.controllers.process.name").en],
         )
         logger.info(f"Successfully registered endpoints for {process_class}")
 


### PR DESCRIPTION
[openapi-en.webm](https://github.com/user-attachments/assets/53b89697-7838-49be-a88b-c373257ad8ed)

Tag descriptions defaulted to the LocaleHandler default (de) and global controllers (Health, Auth, Tenant Admin, Webhooks, etc.) were not added to openapi_tags at all. Process endpoint discovery also hardcoded tags=["Processes"] while the controller name resolved to "Workflows", producing duplicate Swagger sections (one empty with description, one populated without).

- api_runner.py: extract description with locale="en", iterate all controllers (not just tenant-scoped), append to existing tags.
- process_endpoints_discovery_service.py: tag with the English process controller name, mirroring the agent discovery service.