### PR TITLE
fix(ci-cd): Restore deploy key for release finalize-release job

### DIFF
--- a/.github/workflows/add-tag.yml
+++ b/.github/workflows/add-tag.yml
@@ -264,10 +264,17 @@ jobs:
       - sync-docs
     runs-on: ubuntu-latest
     steps:
+      # Authenticate via a deploy key (not the default GITHUB_TOKEN) because this
+      # job amends the merge commit and force-pushes it to `main`. The `main`
+      # branch is protected (PR-only, required status checks, no force-push), and
+      # GITHUB_TOKEN cannot bypass those rules. The deploy key stored in
+      # PRIVATE_SSH_KEY is registered with bypass permissions, so pushes from
+      # this step are accepted.
       - name: Checkout the repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
       - name: Download changelog (if any)
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/add-tag.yml
+++ b/.github/workflows/add-tag.yml
@@ -268,13 +268,13 @@ jobs:
       # job amends the merge commit and force-pushes it to `main`. The `main`
       # branch is protected (PR-only, required status checks, no force-push), and
       # GITHUB_TOKEN cannot bypass those rules. The deploy key stored in
-      # PRIVATE_SSH_KEY is registered with bypass permissions, so pushes from
-      # this step are accepted.
+      # RELEASE_FINALIZE_DEPLOY_KEY is registered with bypass permissions, so
+      # pushes from this step are accepted.
       - name: Checkout the repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
+          ssh-key: ${{ secrets.RELEASE_FINALIZE_DEPLOY_KEY }}
       - name: Download changelog (if any)
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- Re-introduces the deploy key (`secrets.PRIVATE_SSH_KEY`) on the `finalize-release` job's checkout step in `.github/workflows/add-tag.yml`.
- Adds a comment explaining **why** the deploy key is required so a future cleanup does not strip it again.

## Why this is needed
The release workflow [run #25316365909](https://github.com/bbvch-ai/aihub-core/actions/runs/25316365909/job/74215047258) failed at the `Commit Artifacts & Finalize Tag` step with:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - 15 of 15 required status checks are expected.
remote: - Cannot force-push to this branch
```

The `finalize-release` job amends the merge commit (changelog + license report + version bump + docker compose regeneration) and **force-pushes it back to `main`**. `main` is a protected branch — the default `GITHUB_TOKEN` cannot bypass those rules.

PR #1052 (commit `7cd7593c`) removed the SSH-based authentication everywhere. For most jobs that was correct (they only need read access), but `finalize-release` specifically requires bypass, so SSH must be restored just there.

## Scope
- Only the `finalize-release` checkout is changed — all other jobs continue using `GITHUB_TOKEN`.
- No restoration of SSH in `analyze-test-pr.yml`, `test-backup-e2e.yml`, or `test_backend/action.yml` — those jobs succeeded in the failing run, indicating they do not need the deploy key.

## Test plan
- [ ] After merge, observe the next release run (triggered by the next merged PR to `main`).
- [ ] `finalize-release` job pushes the amended commit to `main` successfully.
- [ ] `vX.Y.Z` and `nightly` tags are created and pushed.
- [ ] No regression in earlier jobs (`compute-and-initial-tag`, `changelog`, `license-report`, `sync-docs`).