### PR TITLE
fix(deploy): Drop apache-age-python peer-dependency

### DIFF
--- a/.github/workflows/build-agents.yml
+++ b/.github/workflows/build-agents.yml
@@ -49,8 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: discover-agents
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.discover-agents.outputs.matrix) }}
-    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -86,3 +86,21 @@ jobs:
           file: ./packages/agent/app/${{ matrix.image }}/Dockerfile
           github_token: ${{ secrets.GITHUB_TOKEN }}
           secondary_tag: ${{ github.event_name == 'repository_dispatch' && 'nightly' || github.event.inputs.secondary_tag }}
+  # ---------------------------------------------------------------------------
+  # Aggregate matrix results: fail the workflow if any agent build failed
+  # ---------------------------------------------------------------------------
+  build-summary:
+    runs-on: ubuntu-latest
+    needs: build
+    if: always() && needs.build.result != 'skipped'
+    steps:
+      - name: Check matrix results
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: |-
+          echo "Aggregate build result: $BUILD_RESULT"
+          if [ "$BUILD_RESULT" != "success" ]; then
+            echo "::error::One or more agent builds failed"
+            exit 1
+          fi
+          echo "All agent builds succeeded"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ dev = [
 
 [tool.uv]
 package = false
+# mem0ai[graph] 1.0.11 transitively pulls apache-age-python -> psycopg2 (source-only,
+# needs libpq-dev to compile). We only use the Neo4j provider (see
+# packages/core/.../mem0/mem0_settings.py), so drop apache-age-python entirely.
+override-dependencies = ["apache-age-python ; sys_platform == 'never'"]
 
 [tool.uv.workspace]
 members = [

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ members = [
     "swiss-ai-hub-process",
     "swiss-ai-hub-workspace",
 ]
+overrides = [{ name = "apache-age-python", marker = "sys_platform == 'never'" }]
 
 [[package]]
 name = "adlfs"
@@ -192,7 +193,7 @@ name = "antlr4-tools"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "install-jdk" },
+    { name = "install-jdk", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b8/7c/6033a383b196b885476210ba6ba72b501c439508ea81f1560a94ea116834/antlr4_tools-0.2.2.tar.gz", hash = "sha256:8af6fba512fc168e48eb93690ed21bdbe8848ed812d12b365d9d259a26ad6ba3", size = 6177, upload-time = "2025-04-27T16:43:22.593Z" }
 wheels = [
@@ -216,8 +217,8 @@ name = "apache-age-python"
 version = "0.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "antlr4-tools" },
-    { name = "psycopg2" },
+    { name = "antlr4-tools", marker = "sys_platform != 'win32'" },
+    { name = "psycopg2", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/ae/506bf1e134103a32df3084e7a1ee0dc85e6a36412bfc485be23f26cfe26a/apache_age_python-0.0.6-py3-none-any.whl", hash = "sha256:d3986dc46dff1b03420061dad8e5fc0f855d1a8befb5a328fa60c595aa7813f2", size = 23009, upload-time = "2023-07-15T04:48:05.722Z" },
@@ -3132,7 +3133,7 @@ wheels = [
 
 [package.optional-dependencies]
 graph = [
-    { name = "apache-age-python" },
+    { name = "apache-age-python", marker = "sys_platform == 'never'" },
     { name = "kuzu" },
     { name = "langchain-aws" },
     { name = "langchain-memgraph" },
@@ -4472,9 +4473,6 @@ name = "psycopg2"
 version = "2.9.12"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/bc/f66df707ed1aec949fbf24e4460e4f4277a7ba23cdadb3965bb1f634ddb9/psycopg2-2.9.12.tar.gz", hash = "sha256:1dedb1c7a1d8552c4a6044c6b1c41a52e6a8e2d144af83eccac758076b1b7c15", size = 379683, upload-time = "2026-04-20T23:36:11.013Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/ab/03403779a251ca14a7f1b07a41c7aa735fd451f0aebe4c4f901a231167a4/psycopg2-2.9.12-cp313-cp313-win_amd64.whl", hash = "sha256:3d23e684927d37b95cee9a943f6927b04ae2fdcd056fd0e2a30929ee89fee5a9", size = 2757176, upload-time = "2026-04-20T23:33:23.577Z" },
-]
 
 [[package]]
 name = "psycopg2-binary"


### PR DESCRIPTION
- Drop `apache-age-python` dependency due to unused Neo4j provider and add sys_platform-specific markers to avoid unnecessary installations.
- Adjust build matrix: disable `fail-fast` and refine error handling to fail workflow on any agent build failure.