### PR TITLE
fix(rag): Load Milvus partitions on demand instead of full collection

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,14 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/swiss-ai-hub.iml" filepath="$PROJECT_DIR$/.idea/swiss-ai-hub.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/swiss-ai-hub-agent.iml" filepath="$PROJECT_DIR$/.idea/swiss-ai-hub-agent.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/swiss-ai-hub-api.iml" filepath="$PROJECT_DIR$/.idea/swiss-ai-hub-api.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/swiss-ai-hub-backup.iml" filepath="$PROJECT_DIR$/.idea/swiss-ai-hub-backup.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/swiss-ai-hub-bot.iml" filepath="$PROJECT_DIR$/.idea/swiss-ai-hub-bot.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/swiss-ai-hub-core.iml" filepath="$PROJECT_DIR$/.idea/swiss-ai-hub-core.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/swiss-ai-hub-pipeline.iml" filepath="$PROJECT_DIR$/.idea/swiss-ai-hub-pipeline.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/swiss-ai-hub-process.iml" filepath="$PROJECT_DIR$/.idea/swiss-ai-hub-process.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/swiss-ai-hub-workspace.iml" filepath="$PROJECT_DIR$/.idea/swiss-ai-hub-workspace.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/pyProjectModel.xml
+++ b/.idea/pyProjectModel.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PyProjectModelSettings">
+    <option name="showConfigurationNotification" value="false" />
+    <option name="usePyprojectToml" value="true" />
+  </component>
+</project>

--- a/packages/core/swiss_ai_hub/core/persistence/rag/vectors/stores/partition_aware_milvus_vector_store.py
+++ b/packages/core/swiss_ai_hub/core/persistence/rag/vectors/stores/partition_aware_milvus_vector_store.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from llama_index.core.schema import BaseNode
 from llama_index.core.utils import iter_batch
+from llama_index.core.vector_stores import MetadataFilter, MetadataFilters
 from llama_index.core.vector_stores.types import VectorStoreQuery, VectorStoreQueryMode, VectorStoreQueryResult
 from llama_index.core.vector_stores.utils import node_to_metadata_dict
 from llama_index.vector_stores.milvus import MilvusVectorStore
@@ -65,9 +66,20 @@ class PartitionAwareMilvusVectorStore(MilvusVectorStore):
 
         self._has_manual_partitions: bool | None = None
 
-    def _ensure_collection_loaded(self) -> None:
-        """Lazily load collection into memory on first access. Idempotent — blocks until ready."""
-        self.client.load_collection(collection_name=self.collection_name)
+    def _ensure_collection_loaded(self, partition_names: list[str] | None = None) -> None:
+        """Lazily load partitions (or whole collection if none specified). Idempotent — blocks until ready.
+
+        Loading the full collection on a 1023-partition store is ~54 GB and will not fit
+        in a typical query-node memory budget; always pass partition_names when known.
+        Memory eviction of unused partitions is handled by Milvus itself.
+        """
+        if partition_names:
+            self.client.load_partitions(
+                collection_name=self.collection_name,
+                partition_names=partition_names,
+            )
+        else:
+            self.client.load_collection(collection_name=self.collection_name)
 
     def _check_has_manual_partitions(self) -> bool:
         """Check if collection has 1023 manual partitions (partition_0...partition_1022)."""
@@ -76,19 +88,20 @@ class PartitionAwareMilvusVectorStore(MilvusVectorStore):
             manual_partitions = [p for p in partitions if p.startswith("partition_")]
             self._has_manual_partitions = len(manual_partitions) == MAX_PARTITIONS
 
-        return self._has_manual_partitions
+        return self._has_manual_partitions or False
 
     def add(self, nodes: list[BaseNode], **add_kwargs: Any) -> list[str]:
         """Insert nodes into their hashed partitions (or fallback to base class if no manual partitions)."""
         if not nodes:
             return []
 
-        self._ensure_collection_loaded()
-
         if not self._check_has_manual_partitions():
+            self._ensure_collection_loaded()
             return super().add(nodes, **add_kwargs)
 
         by_namespace = self._group_nodes_by_namespace(nodes)
+        partition_names = [get_partition_name_for_namespace(ns) for ns in by_namespace]
+        self._ensure_collection_loaded(partition_names=partition_names)
 
         all_ids: list[str] = []
         for namespace, ns_nodes in by_namespace.items():
@@ -153,16 +166,18 @@ class PartitionAwareMilvusVectorStore(MilvusVectorStore):
         - add(): Just set partition_name= per batch
         - query(): Just set partition_names= in kwargs
         """
-        self._ensure_collection_loaded()
-
         # Backward compatibility: fallback to base class if no manual partitions
         if not self._check_has_manual_partitions():
+            self._ensure_collection_loaded()
             return super().query(query, **kwargs)
 
-        namespaces = self._extract_namespaces_from_filters(query)
+        namespaces = self._extract_namespaces_from_query(query)
+        partition_names: list[str] | None = None
         if namespaces:
             partition_names = get_partition_names_for_namespaces(namespaces=namespaces)
             kwargs["milvus_partition_names"] = partition_names
+
+        self._ensure_collection_loaded(partition_names=partition_names)
 
         # HYBRID mode workaround: base class doesn't pass kwargs, so handle it ourselves
         if query.mode == VectorStoreQueryMode.HYBRID:
@@ -185,20 +200,22 @@ class PartitionAwareMilvusVectorStore(MilvusVectorStore):
         nodes, similarities, ids = self._hybrid_search(query, string_expr, output_fields, **kwargs)
         return VectorStoreQueryResult(nodes=nodes, similarities=similarities, ids=ids)
 
-    def _extract_namespaces_from_filters(self, query: VectorStoreQuery) -> list[str]:
+    def _extract_namespaces_from_query(self, query: VectorStoreQuery) -> list[str]:
         """Extract namespace values from query filters (handles 2-level nesting)."""
         if not query.filters or not hasattr(query.filters, "filters"):
             return []
+        filters: MetadataFilters = query.filters
+        return self._extract_namespaces_from_metadata_filters(filters)
 
+    def _extract_namespaces_from_metadata_filters(self, filters: MetadataFilters) -> list[str]:
         namespaces: list[str] = []
-        for filter_item in query.filters.filters:
+        for filter_item in filters:
             if self._is_namespace_filter(filter_item):
                 namespaces.append(filter_item.value)
             elif hasattr(filter_item, "filters"):
                 for nested in filter_item.filters:
                     if self._is_namespace_filter(nested):
                         namespaces.append(nested.value)
-
         return namespaces
 
     @staticmethod
@@ -273,23 +290,28 @@ class PartitionAwareMilvusVectorStore(MilvusVectorStore):
     def get_nodes(
         self,
         node_ids: list[str] | None = None,
-        filters: Any = None,
+        filters: MetadataFilters | None = None,
         **kwargs: Any,
     ) -> list[BaseNode]:
-        self._ensure_collection_loaded()
+        partition_names: list[str] | None = None
+        if filters is not None:
+            namespaces = self._extract_namespaces_from_metadata_filters(filters)
+            if namespaces:
+                partition_names = get_partition_names_for_namespaces(namespaces=namespaces)
+        self._ensure_collection_loaded(partition_names)
         return super().get_nodes(node_ids=node_ids, filters=filters, **kwargs)
 
     def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
         """
         Delete nodes associated with a ref_doc_id, scoped to a specific partition.
         """
-        self._ensure_collection_loaded()
-
         # Backward compatibility: fallback to base class if no manual partitions
         if not self._check_has_manual_partitions():
+            self._ensure_collection_loaded()
             return super().delete(ref_doc_id)
 
-        partition_name = delete_kwargs.get("partition_name")
+        partition_name: str = delete_kwargs.get("partition_name")
+        self._ensure_collection_loaded([partition_name] if partition_name else None)
         doc_ids = [ref_doc_id] if not isinstance(ref_doc_id, list) else ref_doc_id
         doc_ids_expr = ['"' + entry + '"' for entry in doc_ids]
 

--- a/packages/core/swiss_ai_hub/core/persistence/rag/vectors/stores/partition_aware_milvus_vector_store.py
+++ b/packages/core/swiss_ai_hub/core/persistence/rag/vectors/stores/partition_aware_milvus_vector_store.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from llama_index.core.schema import BaseNode
 from llama_index.core.utils import iter_batch
-from llama_index.core.vector_stores import MetadataFilter, MetadataFilters
+from llama_index.core.vector_stores import MetadataFilters
 from llama_index.core.vector_stores.types import VectorStoreQuery, VectorStoreQueryMode, VectorStoreQueryResult
 from llama_index.core.vector_stores.utils import node_to_metadata_dict
 from llama_index.vector_stores.milvus import MilvusVectorStore
@@ -88,7 +88,7 @@ class PartitionAwareMilvusVectorStore(MilvusVectorStore):
             manual_partitions = [p for p in partitions if p.startswith("partition_")]
             self._has_manual_partitions = len(manual_partitions) == MAX_PARTITIONS
 
-        return self._has_manual_partitions or False
+        return self._has_manual_partitions
 
     def add(self, nodes: list[BaseNode], **add_kwargs: Any) -> list[str]:
         """Insert nodes into their hashed partitions (or fallback to base class if no manual partitions)."""
@@ -204,12 +204,11 @@ class PartitionAwareMilvusVectorStore(MilvusVectorStore):
         """Extract namespace values from query filters (handles 2-level nesting)."""
         if not query.filters or not hasattr(query.filters, "filters"):
             return []
-        filters: MetadataFilters = query.filters
-        return self._extract_namespaces_from_metadata_filters(filters)
+        return self._extract_namespaces_from_metadata_filters(query.filters)
 
     def _extract_namespaces_from_metadata_filters(self, filters: MetadataFilters) -> list[str]:
         namespaces: list[str] = []
-        for filter_item in filters:
+        for filter_item in filters.filters:
             if self._is_namespace_filter(filter_item):
                 namespaces.append(filter_item.value)
             elif hasattr(filter_item, "filters"):
@@ -310,7 +309,7 @@ class PartitionAwareMilvusVectorStore(MilvusVectorStore):
             self._ensure_collection_loaded()
             return super().delete(ref_doc_id)
 
-        partition_name: str = delete_kwargs.get("partition_name")
+        partition_name: str | None = delete_kwargs.get("partition_name")
         self._ensure_collection_loaded([partition_name] if partition_name else None)
         doc_ids = [ref_doc_id] if not isinstance(ref_doc_id, list) else ref_doc_id
         doc_ids_expr = ['"' + entry + '"' for entry in doc_ids]

--- a/packages/core/swiss_ai_hub/core/persistence/rag/vectors/stores/tests/unit/test_partition_aware_milvus_vector_store.py
+++ b/packages/core/swiss_ai_hub/core/persistence/rag/vectors/stores/tests/unit/test_partition_aware_milvus_vector_store.py
@@ -1,0 +1,100 @@
+from llama_index.core.vector_stores import MetadataFilter, MetadataFilters
+from llama_index.core.vector_stores.types import FilterCondition, VectorStoreQuery
+
+from swiss_ai_hub.core.persistence.rag.vectors.node_metadata import NAMESPACE, TYPE
+from swiss_ai_hub.core.persistence.rag.vectors.stores.partition_aware_milvus_vector_store import (
+    PartitionAwareMilvusVectorStore,
+)
+
+
+def _make_store() -> PartitionAwareMilvusVectorStore:
+    """Bypass __init__ — these tests cover pure helpers that don't need a Milvus client."""
+    return PartitionAwareMilvusVectorStore.__new__(PartitionAwareMilvusVectorStore)
+
+
+def test_extract_namespaces_returns_empty_when_query_has_no_filters() -> None:
+    store = _make_store()
+    query = VectorStoreQuery(query_embedding=[0.1, 0.2], similarity_top_k=5)
+
+    assert store._extract_namespaces_from_query(query) == []
+
+
+def test_extract_namespaces_from_flat_filters() -> None:
+    store = _make_store()
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key=NAMESPACE, value="alpha"),
+            MetadataFilter(key=TYPE, value="text"),
+        ],
+        condition=FilterCondition.AND,
+    )
+    query = VectorStoreQuery(query_embedding=[0.1], similarity_top_k=5, filters=filters)
+
+    assert store._extract_namespaces_from_query(query) == ["alpha"]
+
+
+def test_extract_namespaces_from_nested_filters_regression() -> None:
+    """
+    Regression: MetadataFilters is a Pydantic model — iterating it yields field tuples,
+    not filter items. The helper must iterate filters.filters; otherwise no namespace is
+    ever found and query() silently loads the full collection.
+    """
+    store = _make_store()
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilters(
+                filters=[
+                    MetadataFilter(key=NAMESPACE, value="alpha"),
+                    MetadataFilter(key=TYPE, value="text"),
+                ],
+                condition=FilterCondition.AND,
+            ),
+            MetadataFilters(
+                filters=[
+                    MetadataFilter(key=NAMESPACE, value="beta"),
+                    MetadataFilter(key=TYPE, value="text"),
+                ],
+                condition=FilterCondition.AND,
+            ),
+        ],
+        condition=FilterCondition.OR,
+    )
+    query = VectorStoreQuery(query_embedding=[0.1], similarity_top_k=5, filters=filters)
+
+    assert store._extract_namespaces_from_query(query) == ["alpha", "beta"]
+
+
+def test_extract_namespaces_ignores_non_namespace_filters() -> None:
+    store = _make_store()
+    filters = MetadataFilters(
+        filters=[
+            MetadataFilter(key=TYPE, value="text"),
+            MetadataFilter(key="other", value="value"),
+        ],
+        condition=FilterCondition.AND,
+    )
+    query = VectorStoreQuery(query_embedding=[0.1], similarity_top_k=5, filters=filters)
+
+    assert store._extract_namespaces_from_query(query) == []
+
+
+def test_extract_namespaces_ignores_non_string_namespace_values() -> None:
+    store = _make_store()
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key=NAMESPACE, value=["alpha", "beta"])],
+        condition=FilterCondition.AND,
+    )
+    query = VectorStoreQuery(query_embedding=[0.1], similarity_top_k=5, filters=filters)
+
+    assert store._extract_namespaces_from_query(query) == []
+
+
+def test_extract_namespaces_from_metadata_filters_directly() -> None:
+    """get_nodes() calls this helper directly — must accept a MetadataFilters and iterate its inner list."""
+    store = _make_store()
+    filters = MetadataFilters(
+        filters=[MetadataFilter(key=NAMESPACE, value="alpha")],
+        condition=FilterCondition.AND,
+    )
+
+    assert store._extract_namespaces_from_metadata_filters(filters) == ["alpha"]


### PR DESCRIPTION
## Summary
- `PartitionAwareMilvusVectorStore` previously called `load_collection` on every operation. On a 1023-partition store this pulls ~54 GB into query-node memory, far above typical budgets.
- Now passes `partition_names` to `load_partitions` whenever the target partitions are known (from filters / namespaces / `partition_name` kwarg). Milvus handles eviction of unused partitions.
- Also tightens types: `_extract_namespaces_from_filters` split into a query-level and a `MetadataFilters`-level helper; `get_nodes` now scopes load by namespace filters; `delete` scopes load to the targeted partition.