### PR TITLE
chore(ci-cd): Bundle Dependabot patches/minors, ignore majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,13 @@
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
 # Dependabot enforces uniqueness on (package-ecosystem, directory, target-branch) —
-# we therefore have ONE entry per ecosystem. Per-update-type routing happens
-# through `groups`: production / development for languages that distinguish
-# them, and a single bundle otherwise.
+# we therefore have ONE entry per ecosystem. To minimize PR noise, each entry
+# defines a single catch-all group that bundles every update type (patch, minor,
+# major) for every package into ONE PR per ecosystem per run.
+#
+# Anything that does not match a group becomes its own PR — which is exactly
+# what happened before when major bumps escaped a `[patch, minor]` group filter.
+# `patterns: ["*"]` + all update-types prevents that escape.
 #
 # We deliberately do NOT apply major/minor/patch labels here. The release
 # workflow (.github/workflows/add-tag.yml) defaults to a patch bump when no
@@ -27,12 +31,9 @@ updates:
       prefix: chore
       include: scope
     groups:
-      python-prod:
-        dependency-type: production
-        update-types: [patch, minor]
-      python-dev:
-        dependency-type: development
-        update-types: [patch, minor]
+      python:
+        patterns: ['*']
+        update-types: [patch, minor, major]
 
   # ============================================================================
   # Frontend (pnpm) — admin/process UI
@@ -48,12 +49,9 @@ updates:
       prefix: chore
       include: scope
     groups:
-      web-prod:
-        dependency-type: production
-        update-types: [patch, minor]
-      web-dev:
-        dependency-type: development
-        update-types: [patch, minor]
+      web:
+        patterns: ['*']
+        update-types: [patch, minor, major]
 
   # ============================================================================
   # Docs site (VitePress, pnpm)
@@ -70,7 +68,8 @@ updates:
       include: scope
     groups:
       docs:
-        update-types: [patch, minor]
+        patterns: ['*']
+        update-types: [patch, minor, major]
 
   # ============================================================================
   # E2E tests (Playwright, pnpm)
@@ -87,7 +86,8 @@ updates:
       include: scope
     groups:
       e2e:
-        update-types: [patch, minor]
+        patterns: ['*']
+        update-types: [patch, minor, major]
 
   # ============================================================================
   # Docker base images — one entry per Dockerfile
@@ -110,7 +110,8 @@ updates:
       include: scope
     groups:
       docker:
-        update-types: [patch, minor]
+        patterns: ['*']
+        update-types: [patch, minor, major]
 
   # ============================================================================
   # GitHub Actions — pinned action versions in workflows + reusable actions
@@ -127,4 +128,5 @@ updates:
       include: scope
     groups:
       github-actions:
+        patterns: ['*']
         update-types: [patch, minor, major]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,22 @@
 ---
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
-# Dependabot enforces uniqueness on (package-ecosystem, directory, target-branch) —
-# we therefore have ONE entry per ecosystem. To minimize PR noise, each entry
-# defines a single catch-all group that bundles every update type (patch, minor,
-# major) for every package into ONE PR per ecosystem per run.
+# Dependabot enforces uniqueness on (package-ecosystem, directory, target-branch).
+# To minimize PR noise, every update entry below defines a single catch-all
+# group (`patterns: ['*']` × all update-types) that bundles every change for
+# that (ecosystem, directory) tuple into ONE PR per run. Some ecosystems have
+# multiple entries (npm covers /packages/web, /docs, /e2e separately; docker
+# uses `directories:` to fan out across each Dockerfile) — each entry produces
+# its own grouped PR.
 #
 # Anything that does not match a group becomes its own PR — which is exactly
-# what happened before when major bumps escaped a `[patch, minor]` group filter.
-# `patterns: ["*"]` + all update-types prevents that escape.
+# what happened before when major bumps escaped a `[patch, minor]` filter.
+# `patterns: ['*']` + all update-types prevents that escape.
+#
+# Escape hatch when a single bad major bump (e.g. nuxt 3→4) blocks the rest of
+# the bundle: comment `@dependabot ignore <dep> major-version` on the PR. The
+# grouped PR will be regenerated without that dep, letting the patches/minors
+# ship while the major is held for a dedicated upgrade.
 #
 # We deliberately do NOT apply major/minor/patch labels here. The release
 # workflow (.github/workflows/add-tag.yml) defaults to a patch bump when no

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,27 +2,21 @@
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
 # Dependabot enforces uniqueness on (package-ecosystem, directory, target-branch).
-# To minimize PR noise, every update entry below defines a single catch-all
-# group (`patterns: ['*']` × all update-types) that bundles every change for
-# that (ecosystem, directory) tuple into ONE PR per run. Some ecosystems have
-# multiple entries (npm covers /packages/web, /docs, /e2e separately; docker
-# uses `directories:` to fan out across each Dockerfile) — each entry produces
-# its own grouped PR.
+# Each entry below defines a single catch-all group (`patterns: ['*']`) that
+# bundles every patch and minor bump for that (ecosystem, directory) tuple
+# into ONE PR per run. Some ecosystems span multiple entries (npm covers
+# /packages/web, /docs, /e2e separately; docker uses `directories:` to fan
+# out across each Dockerfile) — each entry produces its own grouped PR.
 #
-# Anything that does not match a group becomes its own PR — which is exactly
-# what happened before when major bumps escaped a `[patch, minor]` filter.
-# `patterns: ['*']` + all update-types prevents that escape.
+# We deliberately ignore major version bumps (`version-update:semver-major`)
+# everywhere. Majors usually require code migration (e.g. nuxt 3→4, vue 2→3,
+# tailwind 3→4) and should be done as a deliberate, isolated upgrade on a
+# feature branch — not as a casual auto-PR riding on a weekly bundle.
 #
-# Escape hatch when a single bad major bump (e.g. nuxt 3→4) blocks the rest of
-# the bundle: comment `@dependabot ignore <dep> major-version` on the PR. The
-# grouped PR will be regenerated without that dep, letting the patches/minors
-# ship while the major is held for a dedicated upgrade.
-#
-# We deliberately do NOT apply major/minor/patch labels here. The release
-# workflow (.github/workflows/add-tag.yml) defaults to a patch bump when no
-# version label is present, and `check-version-label` is bypassed for
-# `dependabot[bot]` PRs. Reviewers can override by adding `minor` or `major`
-# manually before merge if a bump warrants it.
+# We deliberately do NOT apply major/minor/patch labels. The release workflow
+# (.github/workflows/add-tag.yml) defaults to a patch bump when no version
+# label is present, and `check-version-label` is bypassed for `dependabot[bot]`
+# PRs. Reviewers can add `minor` manually if a bump warrants it.
 version: 2
 updates:
   # ============================================================================
@@ -38,10 +32,13 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    ignore:
+      - dependency-name: '*'
+        update-types: [version-update:semver-major]
     groups:
       python:
         patterns: ['*']
-        update-types: [patch, minor, major]
+        update-types: [patch, minor]
 
   # ============================================================================
   # Frontend (pnpm) — admin/process UI
@@ -56,10 +53,13 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    ignore:
+      - dependency-name: '*'
+        update-types: [version-update:semver-major]
     groups:
       web:
         patterns: ['*']
-        update-types: [patch, minor, major]
+        update-types: [patch, minor]
 
   # ============================================================================
   # Docs site (VitePress, pnpm)
@@ -74,10 +74,13 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    ignore:
+      - dependency-name: '*'
+        update-types: [version-update:semver-major]
     groups:
       docs:
         patterns: ['*']
-        update-types: [patch, minor, major]
+        update-types: [patch, minor]
 
   # ============================================================================
   # E2E tests (Playwright, pnpm)
@@ -92,10 +95,13 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    ignore:
+      - dependency-name: '*'
+        update-types: [version-update:semver-major]
     groups:
       e2e:
         patterns: ['*']
-        update-types: [patch, minor, major]
+        update-types: [patch, minor]
 
   # ============================================================================
   # Docker base images — one entry per Dockerfile
@@ -116,10 +122,13 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    ignore:
+      - dependency-name: '*'
+        update-types: [version-update:semver-major]
     groups:
       docker:
         patterns: ['*']
-        update-types: [patch, minor, major]
+        update-types: [patch, minor]
 
   # ============================================================================
   # GitHub Actions — pinned action versions in workflows + reusable actions
@@ -134,7 +143,10 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    ignore:
+      - dependency-name: '*'
+        update-types: [version-update:semver-major]
     groups:
       github-actions:
         patterns: ['*']
-        update-types: [patch, minor, major]
+        update-types: [patch, minor]


### PR DESCRIPTION
## Summary

- Dependabot opened **16 individual PRs** because the previous group config restricted `update-types` to `[patch, minor]`, so every major bump (apexcharts 4→5, vueuse 13→14 ×3, primeuix 1→2, tailwindcss 3→4, types/node 22→25, uuid 11→14, formkit 1→2, lucide-vue-next 0→1, huggingface-hub-cli 0→1, nuxt 3→4) escaped grouping.
- **Ignore major bumps entirely** (`version-update:semver-major` for `*` in every entry). Majors require code migration and should be deliberate, isolated upgrades on a feature branch — not casual auto-PRs.
- Each ecosystem-directory now produces ONE grouped PR per run for patches+minors only.

## Test plan

- [x] YAML lints cleanly (yamlfix-formatted)
- [ ] Wait for CI green
- [ ] After merge: close existing Dependabot PRs (#1121–#1136) — many of those are majors that will not be re-opened; the patch/minor ones (#1125, #1122) will reappear bundled on next run