### PR TITLE
feat(rag): Make org and personal memory reranking configurable

### DIFF
--- a/packages/agent/app/rag_agent/templates/shared_knowledge_rag.py
+++ b/packages/agent/app/rag_agent/templates/shared_knowledge_rag.py
@@ -9,6 +9,7 @@ from swiss_ai_hub.core.infrastructure import AIHubSettings
 from swiss_ai_hub.core.persistence import MilvusVectorStoreConfig
 
 from swiss_ai_hub.agent.agents.rag_agent import RAGAgentConfig
+from swiss_ai_hub.agent.agents.rag_agent.configs.memory_config import MemoryConfig
 from swiss_ai_hub.agent.agents.rag_agent.configs.reranking_config import RerankingConfig
 from swiss_ai_hub.agent.steps.guards.context_sufficient_guard_step.context_sufficient_guard_step_config import (
     ContextSufficientGuardStepConfig,
@@ -74,7 +75,9 @@ def build() -> RAGAgentConfig:
             ),
         ],
         reranking_config=RerankingConfig(enabled=False),
-        enable_organization_memory=True,
-        enable_user_memory_retrieval=True,
-        enable_user_memory_storage=True,
+        memory=MemoryConfig(
+            enable_organization_memory=True,
+            enable_user_memory_retrieval=True,
+            enable_user_memory_storage=True,
+        ),
     )

--- a/packages/agent/swiss_ai_hub/agent/agents/expert_rag_agent/configs/expert_rag_agent_config.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/expert_rag_agent/configs/expert_rag_agent_config.py
@@ -40,9 +40,6 @@ class ExpertRAGAgentConfig(RAGAgentConfig):
             few_shot_guard_examples=base_form.few_shot_guard_examples,
             system_prompt=base_form.system_prompt,
             context_prompt=base_form.context_prompt,
-            enable_organization_memory=base_form.enable_organization_memory,
-            tenant_namespace=base_form.tenant_namespace,
-            enable_user_memory_retrieval=base_form.enable_user_memory_retrieval,
-            enable_user_memory_storage=base_form.enable_user_memory_storage,
+            memory=base_form.memory,
             expert_escalation=ExpertEscalationConfig.as_form(),
         )

--- a/packages/agent/swiss_ai_hub/agent/agents/expert_rag_agent/expert_rag_agent.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/expert_rag_agent/expert_rag_agent.py
@@ -202,6 +202,7 @@ class ExpertRAGAgent(Agent):
     async def retrieve_user_memory_step(
         self,
         event: UserMessageEvent | RAGStartEvent,
+        agent_config: ExpertRAGAgentConfig,
         memory: AgentMemory,
     ) -> RetrieveUserMemoryEvent:
         """Retrieve user memories for personalized context."""
@@ -211,7 +212,7 @@ class ExpertRAGAgent(Agent):
             user_id=event.user.id,
             limit=10,
             threshold=0.5,
-            rerank=True,
+            rerank=agent_config.memory.rerank_user_memory,
         )
 
         return RetrieveUserMemoryEvent.from_memory_search_result(memory_result)
@@ -232,12 +233,12 @@ class ExpertRAGAgent(Agent):
         query = event.user_query
         memory_result = await memory.search_organization_memory(
             query=query,
-            tenant_id=agent_config.tenant_id,
-            tenant_namespace=agent_config.tenant_namespace,
+            tenant_id=agent_config.memory.tenant_id,
+            tenant_namespace=agent_config.memory.tenant_namespace,
             user_id=None,
             limit=10,
             threshold=0.5,
-            rerank=True,
+            rerank=agent_config.memory.rerank_organization_memory,
         )
 
         return RetrieveOrganizationMemoryEvent.from_memory_search_result(memory_result)
@@ -260,7 +261,7 @@ class ExpertRAGAgent(Agent):
         chat_history = user_message_event.messages
 
         # Add user memory first (more personal context)
-        if agent_config.enable_user_memory_retrieval and user_memory_event is not None:
+        if agent_config.memory.enable_user_memory_retrieval and user_memory_event is not None:
             chat_history = extend_chat_history_with_user_memory(
                 chat_history=chat_history,
                 memories=user_memory_event.memories,
@@ -270,7 +271,7 @@ class ExpertRAGAgent(Agent):
             )
 
         # Add organization memory second (broader context)
-        if agent_config.enable_organization_memory and org_memory_event is not None:
+        if agent_config.memory.enable_organization_memory and org_memory_event is not None:
             chat_history = extend_chat_history_with_organization_memory(
                 chat_history=chat_history,
                 memories=org_memory_event.memories,

--- a/packages/agent/swiss_ai_hub/agent/agents/rag_agent/configs/memory_config.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/rag_agent/configs/memory_config.py
@@ -1,0 +1,81 @@
+from typing import Annotated, Self
+
+from pydantic import Field
+from swiss_ai_hub.core.form import Checkbox, InputText
+from swiss_ai_hub.core.form.form import Form
+from swiss_ai_hub.core.generative_ai import MemorySettings
+
+from swiss_ai_hub.agent.i18n.agent_locale_string import AgentLocaleString
+
+
+class MemoryConfig(Form):
+    """
+    Configuration for user and organization memory in RAG workflows.
+
+    Supports duality pattern for form rendering and data validation.
+    """
+
+    enable_organization_memory: Annotated[
+        bool | Checkbox,
+        Field(description="Whether to retrieve organization memories (expert knowledge) for context."),
+    ] = True
+    rerank_organization_memory: Annotated[
+        bool | Checkbox,
+        Field(description="Whether to rerank organization memory search results via the configured reranker."),
+    ] = True
+    tenant_id: Annotated[
+        str,
+        Field(description="Tenant ID for organization memory scoping."),
+    ] = Field(default_factory=lambda: MemorySettings().DEFAULT_TENANT_ID)
+    tenant_namespace: Annotated[
+        str | InputText | None,
+        Field(description="Tenant namespace for department-level memory isolation. Uses default if None."),
+    ] = None
+
+    enable_user_memory_retrieval: Annotated[
+        bool | Checkbox,
+        Field(description="Whether to retrieve user-specific memories for personalized context."),
+    ] = True
+    rerank_user_memory: Annotated[
+        bool | Checkbox,
+        Field(description="Whether to rerank user memory search results via the configured reranker."),
+    ] = True
+    enable_user_memory_storage: Annotated[
+        bool | Checkbox,
+        Field(description="Whether to store new memories from conversations for future retrieval."),
+    ] = True
+
+    @classmethod
+    def as_form(cls) -> Self:
+        """Factory method to create a form-mode MemoryConfig."""
+        return cls(
+            enable_organization_memory=Checkbox(
+                label=AgentLocaleString.from_i18n_path("agent.rag_agent.config.enable_organization_memory.label"),
+                help=AgentLocaleString.from_i18n_path("agent.rag_agent.config.enable_organization_memory.help"),
+                ref="check_organization_memory_enabled",
+            ),
+            rerank_organization_memory=Checkbox(
+                label=AgentLocaleString.from_i18n_path("agent.rag_agent.config.rerank_organization_memory.label"),
+                help=AgentLocaleString.from_i18n_path("agent.rag_agent.config.rerank_organization_memory.help"),
+                condition_if="$get(check_organization_memory_enabled).value",
+            ),
+            tenant_namespace=InputText(
+                label=AgentLocaleString.from_i18n_path("agent.rag_agent.config.tenant_namespace.label"),
+                help=AgentLocaleString.from_i18n_path("agent.rag_agent.config.tenant_namespace.help"),
+                condition_if="$get(check_organization_memory_enabled).value",
+            ),
+            enable_user_memory_retrieval=Checkbox(
+                label=AgentLocaleString.from_i18n_path("agent.rag_agent.config.enable_user_memory_retrieval.label"),
+                help=AgentLocaleString.from_i18n_path("agent.rag_agent.config.enable_user_memory_retrieval.help"),
+                ref="check_user_memory_retrieval_enabled",
+            ),
+            rerank_user_memory=Checkbox(
+                label=AgentLocaleString.from_i18n_path("agent.rag_agent.config.rerank_user_memory.label"),
+                help=AgentLocaleString.from_i18n_path("agent.rag_agent.config.rerank_user_memory.help"),
+                condition_if="$get(check_user_memory_retrieval_enabled).value",
+            ),
+            enable_user_memory_storage=Checkbox(
+                label=AgentLocaleString.from_i18n_path("agent.rag_agent.config.enable_user_memory_storage.label"),
+                help=AgentLocaleString.from_i18n_path("agent.rag_agent.config.enable_user_memory_storage.help"),
+            ),
+        )

--- a/packages/agent/swiss_ai_hub/agent/agents/rag_agent/configs/rag_agent_config.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/rag_agent/configs/rag_agent_config.py
@@ -2,10 +2,11 @@ from typing import Annotated, Self
 
 from pydantic import Field
 from swiss_ai_hub.core.agents import AgentConfig
-from swiss_ai_hub.core.form import Checkbox, InputNumber, InputText, LocaleInput
-from swiss_ai_hub.core.generative_ai import FewShotGuardExample, KnowledgeRetrieverConfig, LLMConfig, MemorySettings
+from swiss_ai_hub.core.form import InputNumber, LocaleInput
+from swiss_ai_hub.core.generative_ai import FewShotGuardExample, KnowledgeRetrieverConfig, LLMConfig
 from swiss_ai_hub.core.i18n import LocaleString
 
+from swiss_ai_hub.agent.agents.rag_agent.configs.memory_config import MemoryConfig
 from swiss_ai_hub.agent.agents.rag_agent.configs.reranking_config import RerankingConfig
 from swiss_ai_hub.agent.i18n.agent_locale_string import AgentLocaleString
 from swiss_ai_hub.agent.steps.guards.context_sufficient_guard_step.context_sufficient_guard_step_config import (
@@ -68,30 +69,10 @@ class RAGAgentConfig(AgentConfig):
             title="Few-Shot Guard Examples",
         ),
     ] = []
-
-    # Organization memory configuration
-    enable_organization_memory: Annotated[
-        bool | Checkbox,
-        Field(description="Whether to retrieve organization memories (expert knowledge) for context."),
-    ] = True
-    tenant_id: Annotated[
-        str,
-        Field(description="Tenant ID for organization memory scoping."),
-    ] = Field(default_factory=lambda: MemorySettings().DEFAULT_TENANT_ID)
-    tenant_namespace: Annotated[
-        str | InputText | None,
-        Field(description="Tenant namespace for department-level memory isolation. Uses default if None."),
-    ] = None
-
-    # User memory configuration
-    enable_user_memory_retrieval: Annotated[
-        bool | Checkbox,
-        Field(description="Whether to retrieve user-specific memories for personalized context."),
-    ] = True
-    enable_user_memory_storage: Annotated[
-        bool | Checkbox,
-        Field(description="Whether to store new memories from conversations for future retrieval."),
-    ] = True
+    memory: Annotated[
+        MemoryConfig,
+        Field(description="Configuration for user and organization memory.", title="Memory"),
+    ] = MemoryConfig()
 
     @classmethod
     def as_form(cls) -> Self:
@@ -125,22 +106,5 @@ class RAGAgentConfig(AgentConfig):
                 help_text=AgentLocaleString.from_i18n_path("agent.rag_agent.config.context_prompt.help"),
                 input_type="textarea",
             ),
-            enable_organization_memory=Checkbox(
-                label=AgentLocaleString.from_i18n_path("agent.rag_agent.config.enable_organization_memory.label"),
-                help=AgentLocaleString.from_i18n_path("agent.rag_agent.config.enable_organization_memory.help"),
-                ref="check_organization_memory_enabled",
-            ),
-            tenant_namespace=InputText(
-                label=AgentLocaleString.from_i18n_path("agent.rag_agent.config.tenant_namespace.label"),
-                help=AgentLocaleString.from_i18n_path("agent.rag_agent.config.tenant_namespace.help"),
-                condition_if="$get(check_organization_memory_enabled).value",
-            ),
-            enable_user_memory_retrieval=Checkbox(
-                label=AgentLocaleString.from_i18n_path("agent.rag_agent.config.enable_user_memory_retrieval.label"),
-                help=AgentLocaleString.from_i18n_path("agent.rag_agent.config.enable_user_memory_retrieval.help"),
-            ),
-            enable_user_memory_storage=Checkbox(
-                label=AgentLocaleString.from_i18n_path("agent.rag_agent.config.enable_user_memory_storage.label"),
-                help=AgentLocaleString.from_i18n_path("agent.rag_agent.config.enable_user_memory_storage.help"),
-            ),
+            memory=MemoryConfig.as_form(),
         )

--- a/packages/agent/swiss_ai_hub/agent/agents/rag_agent/rag_agent.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/rag_agent/rag_agent.py
@@ -174,6 +174,7 @@ class RAGAgent(Agent):
     async def retrieve_user_memory_step(
         self,
         event: UserMessageEvent | RAGStartEvent,
+        agent_config: RAGAgentConfig,
         memory: AgentMemory,
     ) -> RetrieveUserMemoryEvent:
         """Retrieve user memories for personalized context."""
@@ -183,7 +184,7 @@ class RAGAgent(Agent):
             user_id=event.user.id,
             limit=10,
             threshold=0.5,
-            rerank=True,
+            rerank=agent_config.memory.rerank_user_memory,
         )
 
         return RetrieveUserMemoryEvent.from_memory_search_result(memory_result)
@@ -204,12 +205,12 @@ class RAGAgent(Agent):
         query = event.user_query
         memory_result = await memory.search_organization_memory(
             query=query,
-            tenant_id=agent_config.tenant_id,
-            tenant_namespace=agent_config.tenant_namespace,
+            tenant_id=agent_config.memory.tenant_id,
+            tenant_namespace=agent_config.memory.tenant_namespace,
             user_id=None,
             limit=10,
             threshold=0.5,
-            rerank=True,
+            rerank=agent_config.memory.rerank_organization_memory,
         )
 
         return RetrieveOrganizationMemoryEvent.from_memory_search_result(memory_result)
@@ -232,7 +233,7 @@ class RAGAgent(Agent):
         chat_history = user_message_event.messages
 
         # Add user memory first (more personal context)
-        if agent_config.enable_user_memory_retrieval and user_memory_event is not None:
+        if agent_config.memory.enable_user_memory_retrieval and user_memory_event is not None:
             chat_history = extend_chat_history_with_user_memory(
                 chat_history=chat_history,
                 memories=user_memory_event.memories,
@@ -242,7 +243,7 @@ class RAGAgent(Agent):
             )
 
         # Add organization memory second (broader context)
-        if agent_config.enable_organization_memory and org_memory_event is not None:
+        if agent_config.memory.enable_organization_memory and org_memory_event is not None:
             chat_history = extend_chat_history_with_organization_memory(
                 chat_history=chat_history,
                 memories=org_memory_event.memories,

--- a/packages/agent/swiss_ai_hub/agent/agents/rag_agent/tests/test_rag_agent.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/rag_agent/tests/test_rag_agent.py
@@ -41,6 +41,7 @@ from swiss_ai_hub.core.testing import async_test
 from swiss_ai_hub.core.testing.auth_utils import fake_user
 from swiss_ai_hub.core.testing.milvus_vector_store_content import drop_collection, fill_collection
 
+from swiss_ai_hub.agent.agents.rag_agent.configs.memory_config import MemoryConfig
 from swiss_ai_hub.agent.agents.rag_agent.configs.rag_agent_config import RAGAgentConfig
 from swiss_ai_hub.agent.agents.rag_agent.configs.reranking_config import RerankingConfig
 from swiss_ai_hub.agent.agents.rag_agent.events.in_order_node_combiner_event import InOrderNodeCombinerEvent
@@ -166,9 +167,11 @@ def build_rag_agent_config_with_memory(
         number_of_input_tokens=8192,
         context_sufficient_guard=ContextSufficientGuardStepConfig(check_context_sufficiency=False),
         reranking_config=RerankingConfig(enabled=False, reranking_model=reranking_config),
-        enable_organization_memory=True,
-        tenant_id=tenant_id,
-        tenant_namespace=tenant_namespace,
+        memory=MemoryConfig(
+            enable_organization_memory=True,
+            tenant_id=tenant_id,
+            tenant_namespace=tenant_namespace,
+        ),
     )
 
 

--- a/packages/agent/swiss_ai_hub/agent/i18n/translations/agent/rag_agent.de.yml
+++ b/packages/agent/swiss_ai_hub/agent/i18n/translations/agent/rag_agent.de.yml
@@ -49,6 +49,10 @@ config:
     label: Organisationsgedächtnis aktivieren
     help: Ob Organisationserinnerungen (Expertenwissen, das zwischen Benutzern geteilt
       wird) für den Kontext abgerufen werden sollen.
+  rerank_organization_memory:
+    label: Organisationsgedächtnis neu ordnen
+    help: Ergebnisse der Organisationsgedächtnis-Suche mit dem konfigurierten Reranker
+      neu ordnen, um die Relevanz zu erhöhen. Erhöht Latenz und Kosten.
   tenant_namespace:
     label: Mandanten-Namespace
     help: Namespace für die abteilungsspezifische Speicherisolierung. Leer lassen
@@ -57,6 +61,10 @@ config:
     label: Benutzergedächtnis-Abruf aktivieren
     help: Ob benutzerspezifische Erinnerungen für personalisierten Kontext abgerufen
       werden sollen.
+  rerank_user_memory:
+    label: Benutzergedächtnis neu ordnen
+    help: Ergebnisse der Benutzergedächtnis-Suche mit dem konfigurierten Reranker
+      neu ordnen, um die Relevanz zu erhöhen. Erhöht Latenz und Kosten.
   enable_user_memory_storage:
     label: Benutzergedächtnis-Speicherung aktivieren
     help: Ob neue Erinnerungen aus Gesprächen für zukünftigen Abruf gespeichert werden

--- a/packages/agent/swiss_ai_hub/agent/i18n/translations/agent/rag_agent.en.yml
+++ b/packages/agent/swiss_ai_hub/agent/i18n/translations/agent/rag_agent.en.yml
@@ -47,6 +47,10 @@ config:
     label: Enable organization memory
     help: Whether to retrieve organization memories (expert knowledge shared across
       users) for context.
+  rerank_organization_memory:
+    label: Rerank organization memory
+    help: Rerank organization memory search results using the configured reranker
+      for higher relevance. Adds latency and cost.
   tenant_namespace:
     label: Tenant namespace
     help: Namespace for department-level memory isolation. Leave empty for default
@@ -54,6 +58,10 @@ config:
   enable_user_memory_retrieval:
     label: Enable user memory retrieval
     help: Whether to retrieve user-specific memories for personalized context.
+  rerank_user_memory:
+    label: Rerank user memory
+    help: Rerank user memory search results using the configured reranker for higher
+      relevance. Adds latency and cost.
   enable_user_memory_storage:
     label: Enable user memory storage
     help: Whether to store new memories from conversations for future retrieval.

--- a/packages/agent/swiss_ai_hub/agent/i18n/translations/agent/rag_agent.fr.yml
+++ b/packages/agent/swiss_ai_hub/agent/i18n/translations/agent/rag_agent.fr.yml
@@ -50,6 +50,11 @@ config:
     label: Activer la mémoire organisationnelle
     help: Récupérer les mémoires organisationnelles (connaissances d'experts partagées
       entre utilisateurs) pour le contexte.
+  rerank_organization_memory:
+    label: Reclasser la mémoire organisationnelle
+    help: Reclasser les résultats de recherche de mémoire organisationnelle avec le
+      reranker configuré pour une meilleure pertinence. Augmente la latence et le
+      coût.
   tenant_namespace:
     label: Espace de noms du locataire
     help: Espace de noms pour l'isolation de la mémoire au niveau départemental. Laisser
@@ -57,6 +62,10 @@ config:
   enable_user_memory_retrieval:
     label: Activer la récupération de mémoire utilisateur
     help: Récupérer les mémoires spécifiques à l'utilisateur pour un contexte personnalisé.
+  rerank_user_memory:
+    label: Reclasser la mémoire utilisateur
+    help: Reclasser les résultats de recherche de mémoire utilisateur avec le reranker
+      configuré pour une meilleure pertinence. Augmente la latence et le coût.
   enable_user_memory_storage:
     label: Activer le stockage de mémoire utilisateur
     help: Stocker les nouvelles mémoires des conversations pour une récupération future.

--- a/packages/agent/swiss_ai_hub/agent/i18n/translations/agent/rag_agent.it.yml
+++ b/packages/agent/swiss_ai_hub/agent/i18n/translations/agent/rag_agent.it.yml
@@ -49,6 +49,10 @@ config:
     label: Abilita memoria organizzativa
     help: Se recuperare le memorie organizzative (conoscenze esperte condivise tra
       utenti) per il contesto.
+  rerank_organization_memory:
+    label: Riordina memoria organizzativa
+    help: Riordina i risultati della ricerca della memoria organizzativa con il reranker
+      configurato per una maggiore pertinenza. Aumenta la latenza e il costo.
   tenant_namespace:
     label: Namespace del tenant
     help: Namespace per l'isolamento della memoria a livello dipartimentale. Lasciare
@@ -56,6 +60,10 @@ config:
   enable_user_memory_retrieval:
     label: Abilita recupero memoria utente
     help: Se recuperare le memorie specifiche dell'utente per un contesto personalizzato.
+  rerank_user_memory:
+    label: Riordina memoria utente
+    help: Riordina i risultati della ricerca della memoria utente con il reranker
+      configurato per una maggiore pertinenza. Aumenta la latenza e il costo.
   enable_user_memory_storage:
     label: Abilita archiviazione memoria utente
     help: Se archiviare nuove memorie dalle conversazioni per il recupero futuro.

--- a/packages/agent/swiss_ai_hub/agent/rag/preconditions.py
+++ b/packages/agent/swiss_ai_hub/agent/rag/preconditions.py
@@ -58,17 +58,17 @@ def check_context_ready_for_history_limit_with_expert(
 
 def check_organization_memory_enabled(config: RAGAgentConfig) -> bool:
     """Check if organization memory retrieval is enabled in the agent configuration."""
-    return config.enable_organization_memory
+    return config.memory.enable_organization_memory
 
 
 def check_user_memory_retrieval_enabled(config: RAGAgentConfig) -> bool:
     """Check if user memory retrieval is enabled in the agent configuration."""
-    return config.enable_user_memory_retrieval
+    return config.memory.enable_user_memory_retrieval
 
 
 def check_user_memory_storage_enabled(config: RAGAgentConfig) -> bool:
     """Check if user memory storage is enabled in the agent configuration."""
-    return config.enable_user_memory_storage
+    return config.memory.enable_user_memory_storage
 
 
 def check_memory_ready_for_chat_history(
@@ -84,12 +84,12 @@ def check_memory_ready_for_chat_history(
     - If org memory is enabled, wait for org memory event
     - Only execute once when all required events are present
     """
-    if config.enable_user_memory_retrieval and user_memory_event is None:
+    if config.memory.enable_user_memory_retrieval and user_memory_event is None:
         return False
-    if config.enable_organization_memory and org_memory_event is None:
+    if config.memory.enable_organization_memory and org_memory_event is None:
         return False
     # If neither is enabled, return False - step shouldn't run at all
-    return config.enable_user_memory_retrieval or config.enable_organization_memory
+    return config.memory.enable_user_memory_retrieval or config.memory.enable_organization_memory
 
 
 def check_memory_added_to_chat_history(
@@ -103,7 +103,7 @@ def check_memory_added_to_chat_history(
     - If any memory is enabled, wait for memory history event
     - If no memory is enabled, proceed immediately (no wait)
     """
-    if config.enable_user_memory_retrieval or config.enable_organization_memory:
+    if config.memory.enable_user_memory_retrieval or config.memory.enable_organization_memory:
         return memory_history_event is not None
     return True
 
@@ -118,6 +118,6 @@ def check_ready_for_stop(
     Ensures that if memory storage is enabled, we wait for storage to complete
     before emitting the stop event.
     """
-    if config.enable_user_memory_storage:
+    if config.memory.enable_user_memory_storage:
         return store_memory_event is not None
     return True


### PR DESCRIPTION
## Summary

- Introduce `MemoryConfig` sub-form grouping the existing user/org memory fields together with new `rerank_user_memory` and `rerank_organization_memory` toggles (default `True`, conditional on the parent enable flag).
- Thread the rerank flags through `RAGAgent` and `ExpertRAGAgent` memory steps instead of the previous hardcoded `rerank=True`.
- Update preconditions, templates, tests, and en/de/fr/it translations to read from `config.memory.*`.

## Test plan

- [ ] `make test` in `packages/agent` (non-integration suite passes locally; integration tests need the Docker stack)
- [ ] Verify in Admin UI that the new `Memory` group renders with both rerank checkboxes and that they hide when their parent enable flag is off
- [ ] Run a RAG conversation with rerank toggled off and confirm via Langfuse that mem0 rerank spans are absent
- [ ] Repeat the conversation check for an `ExpertRAGAgent` profile