### PR TITLE
feat(swiss-ai-hub): Persist user locale server-side

### DIFF
--- a/infra/configs/openwebui/functions/aihub_pipeline.py
+++ b/infra/configs/openwebui/functions/aihub_pipeline.py
@@ -250,22 +250,21 @@ class AuthenticationService:
         self,
         user_name: Annotated[str, "User's name"],
         user_email: Annotated[str, "User's email address"],
-        accept_language: Annotated[str | None, "Accept-Language header value"] = None,
     ) -> Annotated[dict[str, str], "HTTP headers with authentication"]:
-        """Prepare authenticated request headers"""
+        """Prepare authenticated request headers.
+
+        Locale is not forwarded — the API resolves it from the user's persisted preferred_locale.
+        """
         clean_username = urllib.parse.quote(user_name, safe="") if user_name else ""
         signature = self.sign_user_headers(clean_username, user_email)
 
-        headers = {
+        return {
             "Authorization": f"Bearer {self._api_key}",
             "Content-Type": "application/json",
             "X-OpenWebUI-User-Name": clean_username,
             "X-OpenWebUI-User-Email": user_email,
             "X-OpenWebUI-Signature": signature,
         }
-        if accept_language:
-            headers["Accept-Language"] = accept_language
-        return headers
 
 
 # ============================================================================
@@ -1711,9 +1710,7 @@ class Pipe:
                 logger.debug(f"Processing request for {agent_class}.{agent_id}")
                 logger.debug(f"Thread ID: {thread_id}, Display ID: {display_id}")
 
-                # Prepare authentication (forward Accept-Language for localized error messages)
-                accept_language = __request__.headers.get("Accept-Language") if __request__ else None
-                headers = self._auth_service.prepare_headers(__user__["name"], __user__["email"], accept_language)
+                headers = self._auth_service.prepare_headers(__user__["name"], __user__["email"])
                 inject(headers)
 
                 # Convert messages

--- a/infra/deployment/templates/openwebui_functions/aihub_pipeline.py
+++ b/infra/deployment/templates/openwebui_functions/aihub_pipeline.py
@@ -250,22 +250,21 @@ class AuthenticationService:
         self,
         user_name: Annotated[str, "User's name"],
         user_email: Annotated[str, "User's email address"],
-        accept_language: Annotated[str | None, "Accept-Language header value"] = None,
     ) -> Annotated[dict[str, str], "HTTP headers with authentication"]:
-        """Prepare authenticated request headers"""
+        """Prepare authenticated request headers.
+
+        Locale is not forwarded — the API resolves it from the user's persisted preferred_locale.
+        """
         clean_username = urllib.parse.quote(user_name, safe="") if user_name else ""
         signature = self.sign_user_headers(clean_username, user_email)
 
-        headers = {
+        return {
             "Authorization": f"Bearer {self._api_key}",
             "Content-Type": "application/json",
             "X-OpenWebUI-User-Name": clean_username,
             "X-OpenWebUI-User-Email": user_email,
             "X-OpenWebUI-Signature": signature,
         }
-        if accept_language:
-            headers["Accept-Language"] = accept_language
-        return headers
 
 
 # ============================================================================
@@ -1711,9 +1710,7 @@ class Pipe:
                 logger.debug(f"Processing request for {agent_class}.{agent_id}")
                 logger.debug(f"Thread ID: {thread_id}, Display ID: {display_id}")
 
-                # Prepare authentication (forward Accept-Language for localized error messages)
-                accept_language = __request__.headers.get("Accept-Language") if __request__ else None
-                headers = self._auth_service.prepare_headers(__user__["name"], __user__["email"], accept_language)
+                headers = self._auth_service.prepare_headers(__user__["name"], __user__["email"])
                 inject(headers)
 
                 # Convert messages

--- a/packages/api/app/main.py
+++ b/packages/api/app/main.py
@@ -48,7 +48,7 @@ runner.mount(
     AuthProviderController(auth=auth).get_auth_providers(),
     SuiteController(auth=auth).get_suite(),
     MyTenantController(auth=auth).get_my_tenants().get_my_active_tenant().set_my_active_tenant(),
-    MyAccountController(auth=auth).get_my_account().get_my_dashboard().update_my_dashboard(),
+    MyAccountController(auth=auth).get_my_account().get_my_dashboard().update_my_dashboard().update_my_locale(),
     UserController(auth=auth).get_user().get_users(),
     I18nController(auth=auth).get_my_locale(),
     EventController(auth=auth).ws().get_agent_events_in_thread().get_agent_event_timeseries(),

--- a/packages/api/playground/testing/tests/auth/test_bearer_api.py
+++ b/packages/api/playground/testing/tests/auth/test_bearer_api.py
@@ -89,6 +89,7 @@ def expected_user_data():
         "profile_image": None,
         "roles": TEST_USER_ROLES,
         "is_sys_admin": False,
+        "preferred_locale": None,
     }
 
 

--- a/packages/api/playground/testing/tests/auth/test_oauth2_api.py
+++ b/packages/api/playground/testing/tests/auth/test_oauth2_api.py
@@ -133,6 +133,7 @@ def expected_user_data():
         "profile_image": None,
         "roles": TEST_USER_ROLES,
         "is_sys_admin": False,
+        "preferred_locale": None,
     }
 
 

--- a/packages/api/swiss_ai_hub/api/i18n/dependencies/use_locale.py
+++ b/packages/api/swiss_ai_hub/api/i18n/dependencies/use_locale.py
@@ -1,13 +1,34 @@
 from fastapi import Request, WebSocket
+from swiss_ai_hub.core.i18n import LocaleHandler
 
 from swiss_ai_hub.api.i18n.api_locale_handler import ApiLocaleHandler
 from swiss_ai_hub.api.i18n.middleware.i18n_middleware import I18nMiddleware
 
 
 async def use_locale(request: Request) -> ApiLocaleHandler:
+    """Resolves the effective locale for the current request.
+
+    Header-driven `lang`/`locale` always wins (Admin UI sends one per request). When no explicit
+    header is present, fall back to the authenticated user's persisted `preferred_locale` —
+    this is the case for OpenWebUI pipeline calls. Last resort: middleware-extracted value.
+
+    Requires the authenticating Security dependency to be declared before `Depends(use_locale)`
+    in the route signature so `request.state.user` is set in time. AuthHandler.build_identity
+    attaches the identity there.
+    """
+    if request.state.locale_is_explicit:
+        return ApiLocaleHandler(locale=request.state.locale)
+
+    user = getattr(request.state, "user", None)
+    if user is not None and user.preferred_locale in LocaleHandler.LOCALE_WHITE_LIST:
+        return ApiLocaleHandler(locale=user.preferred_locale)
+
     return ApiLocaleHandler(locale=request.state.locale)
 
 
 async def use_locale_ws(request: WebSocket) -> ApiLocaleHandler:
     locale = I18nMiddleware.extract_locale(request.headers, request.path_params, request.query_params)
+    user = getattr(request.state, "user", None)
+    if user is not None and user.preferred_locale in LocaleHandler.LOCALE_WHITE_LIST:
+        locale = user.preferred_locale
     return ApiLocaleHandler(locale=locale)

--- a/packages/api/swiss_ai_hub/api/i18n/middleware/i18n_middleware.py
+++ b/packages/api/swiss_ai_hub/api/i18n/middleware/i18n_middleware.py
@@ -11,28 +11,44 @@ logger = logging.getLogger(__name__)
 
 class I18nMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint):
-        locale = self.extract_locale(request.headers, request.path_params, request.query_params)
+        locale, is_explicit = self.extract_locale_with_source(
+            request.headers, request.path_params, request.query_params
+        )
 
-        logger.debug(f"Setting user locale: {locale}")
+        logger.debug(f"Setting user locale: {locale} (explicit={is_explicit})")
         request.state.locale = locale
+        request.state.locale_is_explicit = is_explicit
 
         return await call_next(request)
 
     @staticmethod
     def extract_locale(headers: Headers, path_params: dict[str, str], query_params: QueryParams) -> str:
-        locale = I18nMiddleware.get_preferred_locale(
-            headers.get("lang")
-            or headers.get("locale")
-            or headers.get("Accept-Language")
+        locale, _ = I18nMiddleware.extract_locale_with_source(headers, path_params, query_params)
+        return locale
+
+    @staticmethod
+    def extract_locale_with_source(
+        headers: Headers, path_params: dict[str, str], query_params: QueryParams
+    ) -> tuple[str, bool]:
+        """Resolves the locale and reports whether it came from an explicit `lang`/`locale` header.
+
+        An explicit header signals the client wants a specific locale for this request and should
+        take precedence over the user's persisted ``preferred_locale``.
+        """
+        explicit = headers.get("lang") or headers.get("locale")
+        if explicit:
+            return I18nMiddleware.get_preferred_locale(explicit), True
+
+        fallback = (
+            headers.get("Accept-Language")
             or path_params.get("locale")
             or query_params.get("locale")
             or LocaleHandler.DEFAULT_LOCALE
         )
-
+        locale = I18nMiddleware.get_preferred_locale(fallback)
         if locale not in LocaleHandler.LOCALE_WHITE_LIST:
             locale = LocaleHandler.DEFAULT_LOCALE
-
-        return locale
+        return locale, False
 
     @staticmethod
     def get_preferred_locale(accept_language: str) -> str:

--- a/packages/api/swiss_ai_hub/api/routes/my_account/dto/my_locale_dto.py
+++ b/packages/api/swiss_ai_hub/api/routes/my_account/dto/my_locale_dto.py
@@ -1,0 +1,7 @@
+from typing import Annotated
+
+from pydantic import BaseModel, Field
+
+
+class MyLocaleDTO(BaseModel):
+    locale: Annotated[str, Field(description="ISO 639-1 language code: one of 'de', 'en', 'fr', 'it'.")]

--- a/packages/api/swiss_ai_hub/api/routes/my_account/my_account_controller.py
+++ b/packages/api/swiss_ai_hub/api/routes/my_account/my_account_controller.py
@@ -10,6 +10,7 @@ from swiss_ai_hub.core.routes import TenantScopedController
 
 from swiss_ai_hub.api.i18n.api_locale_string import ApiLocaleString
 from swiss_ai_hub.api.i18n.dependencies.use_locale import use_locale
+from swiss_ai_hub.api.routes.my_account.dto.my_locale_dto import MyLocaleDTO
 from swiss_ai_hub.api.routes.my_account.my_account_service import MyAccountService
 from swiss_ai_hub.api.routes.user.dto.dashboard.dashboard_dto import DashboardDTO
 from swiss_ai_hub.api.routes.user.dto.user_with_access_dto import UserWithAccessDTO
@@ -57,6 +58,18 @@ class MyAccountController(TenantScopedController):
         ) -> None:
             """Updates the user's dashboard settings."""
             await MyAccountService.update_user_dashboard(user, dashboard_dto)
+            return None
+
+        return self
+
+    def update_my_locale(self, route: str = "/locale") -> Self:
+        @self.router.put(route, tags=self.tags, status_code=204)
+        async def update_my_locale(
+            locale_dto: Annotated[MyLocaleDTO, Body()],
+            user: Annotated[UserIdentity, Security(self.user_with_permission("aihub.user.?>"))],
+        ) -> None:
+            """Persists the user's preferred UI language."""
+            await MyAccountService.update_user_locale(user, locale_dto.locale)
             return None
 
         return self

--- a/packages/api/swiss_ai_hub/api/routes/my_account/my_account_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/my_account/my_account_service.py
@@ -1,7 +1,9 @@
 from typing import TYPE_CHECKING
 
+from fastapi import HTTPException
 from nats.aio.client import Client as NATS
 from swiss_ai_hub.core.auth.identity.user_identity import UserIdentity
+from swiss_ai_hub.core.auth.keycloak.keycloak_admin_service import KeycloakAdminService
 from swiss_ai_hub.core.i18n import LocaleHandler
 from swiss_ai_hub.core.persistence.user.user_dashboard_entity import Dashboard, DashboardItem, UserDashboardEntity
 
@@ -39,3 +41,13 @@ class MyAccountService:
 
         dashboard = Dashboard(children=dashboard_items, **dashboard_data_dict)
         UserDashboardEntity.set_dashboard(user.id, dashboard)
+
+    @staticmethod
+    async def update_user_locale(user: UserIdentity, locale: str) -> None:
+        """Persists the user's preferred UI language as a Keycloak attribute."""
+        if locale not in LocaleHandler.LOCALE_WHITE_LIST:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Unsupported locale '{locale}'. Allowed: {LocaleHandler.LOCALE_WHITE_LIST}",
+            )
+        await KeycloakAdminService.set_preferred_locale(user.id, locale)

--- a/packages/api/swiss_ai_hub/api/routes/user/dto/user_with_access_dto.py
+++ b/packages/api/swiss_ai_hub/api/routes/user/dto/user_with_access_dto.py
@@ -31,6 +31,10 @@ class Access(BaseModel):
 
 class UserWithAccessDTO(UserDTO):
     access: Annotated[Access, Field(description="User access levels")]
+    preferred_locale: Annotated[
+        str | None,
+        Field(description="The user's persisted UI language, or null if not yet set."),
+    ] = None
 
     @classmethod
     async def from_user_identity(
@@ -89,4 +93,5 @@ class UserWithAccessDTO(UserDTO):
             roles=valid_roles,
             is_sys_admin=user.is_sys_admin,
             access=access,
+            preferred_locale=user.preferred_locale,
         )

--- a/packages/core/swiss_ai_hub/core/auth/dependencies/auth_handler.py
+++ b/packages/core/swiss_ai_hub/core/auth/dependencies/auth_handler.py
@@ -171,11 +171,16 @@ class AuthHandler(ABC):
         else:
             tenant = await self.get_active_tenant_for_user(user_id)
         roles = UserTenantRoleEntity.get_roles_for_user_in_tenant(user_id, tenant.id)
-        return UserIdentity(
+        preferred_locale = await KeycloakAdminService.get_preferred_locale(user_id)
+        identity = UserIdentity(
             id=user_id,
             name=name,
             email=email,
             roles=roles,
             acting_within_tenant=tenant,
             is_sys_admin=is_sys_admin,
+            preferred_locale=preferred_locale,
         )
+        if request is not None:
+            request.state.user = identity
+        return identity

--- a/packages/core/swiss_ai_hub/core/auth/identity/user_identity.py
+++ b/packages/core/swiss_ai_hub/core/auth/identity/user_identity.py
@@ -18,3 +18,7 @@ class UserIdentity(BaseModel):
     is_sys_admin: Annotated[
         bool, Field(description="Whether the user has the AIHubSysAdmin realm role (from the JWT).")
     ] = False
+    preferred_locale: Annotated[
+        str | None,
+        Field(description="The user's persisted UI language from Keycloak attributes, or None if unset."),
+    ] = None

--- a/packages/core/swiss_ai_hub/core/auth/keycloak/keycloak_admin_service.py
+++ b/packages/core/swiss_ai_hub/core/auth/keycloak/keycloak_admin_service.py
@@ -324,6 +324,30 @@ class KeycloakAdminService:
 
     @staticmethod
     @trace_fn
+    async def get_preferred_locale(user_id: str) -> str | None:
+        """Reads the preferred_locale custom attribute from the Keycloak user."""
+        admin = _create_admin()
+        data = await admin.a_get_user(user_id)
+        user = KeycloakUser.model_validate(data)
+        preferred = user.attributes.get("preferred_locale", [])
+        return preferred[0] if preferred else None
+
+    @staticmethod
+    @trace_fn
+    async def set_preferred_locale(user_id: str, locale: str) -> None:
+        """Writes the preferred_locale custom attribute on the Keycloak user.
+
+        Caller is responsible for validating the locale against ``LocaleHandler.LOCALE_WHITE_LIST``.
+        """
+        admin = _create_admin()
+        user = await admin.a_get_user(user_id)
+        attributes = user.get("attributes", {})
+        attributes["preferred_locale"] = [locale]
+        user["attributes"] = attributes
+        await admin.a_update_user(user_id, user)
+
+    @staticmethod
+    @trace_fn
     async def clear_active_tenant(user_id: str) -> None:
         """Removes the active_tenant_id custom attribute from the Keycloak user.
 

--- a/packages/core/swiss_ai_hub/core/testing/auth_utils/user_mocks.py
+++ b/packages/core/swiss_ai_hub/core/testing/auth_utils/user_mocks.py
@@ -172,6 +172,7 @@ def get_expected_user_data(include_dashboard=True, include_access=True):
         "profile_image": None,
         "roles": list(TEST_USER_ROLES),
         "is_sys_admin": False,
+        "preferred_locale": None,
     }
 
     if include_dashboard:

--- a/packages/web/swiss_ai_hub_web/app.vue
+++ b/packages/web/swiss_ai_hub_web/app.vue
@@ -12,11 +12,32 @@ import 'gridstack/dist/gridstack.min.css'
 import { client } from './sdk/client/client.gen'
 
 const { getToken } = useAuth()
-const { t, locale } = useI18n()
+const { t, locale, setLocale } = useI18n()
 const localePath = useLocalePath()
+const switchLocalePath = useSwitchLocalePath()
+const router = useRouter()
 const route = useRoute()
 const toast = useToast()
 useNotificationPoller()
+
+const { myUser } = useMyUser()
+const { updateMyLocale } = useUpdateMyLocale()
+const localeBootstrapped = ref(false)
+watch(myUser, (user) => {
+  if (!user || localeBootstrapped.value) return
+  localeBootstrapped.value = true
+  const persisted = (user as { preferred_locale?: string | null }).preferred_locale
+  if (persisted && persisted !== locale.value) {
+    setLocale(persisted as never)
+    const target = switchLocalePath(persisted)
+    if (target) router.replace(target)
+  }
+  else if (!persisted) {
+    updateMyLocale({ locale: locale.value }).catch((err) => {
+      console.error('Failed to bootstrap user locale', err)
+    })
+  }
+}, { immediate: true })
 client.setConfig({
   baseURL: '/api/v1',
   auth: async () => {

--- a/packages/web/swiss_ai_hub_web/components/User/Settings.vue
+++ b/packages/web/swiss_ai_hub_web/components/User/Settings.vue
@@ -41,6 +41,7 @@ const { t, locale, locales } = useI18n()
 const queryCache = useQueryCache()
 const switchLocalePath = useSwitchLocalePath()
 const router = useRouter()
+const { updateMyLocale } = useUpdateMyLocale()
 
 const op = ref()
 const toggle = (event: Event) => {
@@ -66,6 +67,9 @@ const selectedLocale = computed({
     if (newValue?.code && newValue.code !== locale.value) {
       op.value.hide()
       changeLocale(newValue.code)
+      updateMyLocale({ locale: newValue.code }).catch((err) => {
+        console.error('Failed to persist user locale', err)
+      })
       router.push(switchLocalePath(newValue.code))
         .then(() => {
           queryCache.invalidateQueries()

--- a/packages/web/swiss_ai_hub_web/composables/user/useMyLocale.ts
+++ b/packages/web/swiss_ai_hub_web/composables/user/useMyLocale.ts
@@ -1,0 +1,17 @@
+import { client } from '@core/sdk/client/client.gen'
+
+export const useUpdateMyLocale = defineMutation(() => {
+  const { tenantId } = useTenant()
+  const { mutateAsync } = useMutation({
+    mutation: async ({ locale }: { locale: string }) => {
+      await client.put({
+        composable: '$fetch',
+        url: '/{tenant_id}/my-account/locale',
+        path: { tenant_id: tenantId.value! },
+        body: { locale },
+        headers: { 'Content-Type': 'application/json' },
+      })
+    },
+  })
+  return { updateMyLocale: mutateAsync }
+})


### PR DESCRIPTION
## Summary
- Adds `preferred_locale` as a Keycloak user attribute (mirrors the existing `active_tenant_id` pattern). Surfaced on `UserIdentity` and on `GET /my-account` for the Admin UI.
- New endpoint `PUT /my-account/locale` writes the canonical value; locale switcher in the Admin UI persists every change, and `app.vue` bootstraps the persisted value from Accept-Language on first login.
- `use_locale` (and `use_locale_ws`) now prefer the user's persisted locale whenever the request lacks an explicit `lang`/`locale` header. Explicit headers from the Admin UI still win for per-request switches. The middleware tracks the source via `request.state.locale_is_explicit`.
- Agent-bound events constructed with `locale=t.locale` (e.g. `routes/event/event_controller.py:71`, `routes/openai/openai_service.py`) automatically pick up the canonical locale.
- Removes the pipeline's `Accept-Language` forwarding from `aihub_pipeline.py` so OpenWebUI calls fall through to the persisted locale.

## Test plan
- [ ] `pnpm generate-sdk` once the API runs locally so `updateMyLocale` lands in the typed client (Admin UI uses a raw `client.put` until then).
- [ ] Fresh Keycloak user with browser `Accept-Language: fr` → Admin UI loads under `/fr/...` and `preferred_locale=fr` lands in Keycloak.
- [ ] Switch to German in the Admin UI settings popover → Keycloak shows `de`; new browser session without an Accept-Language preference still loads in German.
- [ ] Open OpenWebUI; agent thoughts and step descriptions arrive in the user's locale. Inspect a `StartEvent` on NATS to confirm `locale=de`.
- [ ] `make test` in `packages/core` + `packages/api` (4 pre-existing LiteLLM `gpt-oss-120b` model-availability failures are unrelated and present on `main`).