### PR TITLE
feat(swiss-ai-hub): Propagate headers to agent

### DIFF
--- a/packages/agent/playground/minimal_workflow/mcp_react_workflow/mcp_react_agent.py
+++ b/packages/agent/playground/minimal_workflow/mcp_react_workflow/mcp_react_agent.py
@@ -59,11 +59,6 @@ class McpReactAgent(Agent):
         run_context: RunContext,
     ) -> McpReasoningEvent:
         """List MCP tools and resources, seed conversation, trigger first reasoning iteration."""
-        # Demo probe (issue #948): the X-AIHub-* headers the API forwarded along the pipeline land
-        # in RunContext under "_aihub_headers" — this is the user identity a real MCP call would attach.
-        aihub_headers = await run_context.get("_aihub_headers")
-        print(f"[init_step] X-AIHub-* identity headers forwarded for MCP calls: {aihub_headers}")
-
         print(f"[init_step] Discovering tools and resources on {mcp_config.url}")
         async with McpClientFactory.create(mcp_config) as mcp_client:
             tools = await mcp_client.list_tools()

--- a/packages/agent/playground/minimal_workflow/mcp_react_workflow/mcp_react_agent.py
+++ b/packages/agent/playground/minimal_workflow/mcp_react_workflow/mcp_react_agent.py
@@ -59,6 +59,11 @@ class McpReactAgent(Agent):
         run_context: RunContext,
     ) -> McpReasoningEvent:
         """List MCP tools and resources, seed conversation, trigger first reasoning iteration."""
+        # Demo probe (issue #948): the X-AIHub-* headers the API forwarded along the pipeline land
+        # in RunContext under "_aihub_headers" — this is the user identity a real MCP call would attach.
+        aihub_headers = await run_context.get("_aihub_headers")
+        print(f"[init_step] X-AIHub-* identity headers forwarded for MCP calls: {aihub_headers}")
+
         print(f"[init_step] Discovering tools and resources on {mcp_config.url}")
         async with McpClientFactory.create(mcp_config) as mcp_client:
             tools = await mcp_client.list_tools()

--- a/packages/agent/playground/testing/tests/test_agent_dispatcher.py
+++ b/packages/agent/playground/testing/tests/test_agent_dispatcher.py
@@ -766,9 +766,7 @@ class TestAgentDispatcherAihubHeaders:
 
     @pytest.mark.asyncio
     async def test_handle_event_stores_aihub_headers_from_message_into_run_context(self, agent_dispatcher, agent_topic):
-        # Keys are lowercased on the way in by NATSMessageHeaders.extract_aihub_headers
-        # (HTTP header normalization). Mirror the production shape here so this test does not
-        # describe a fiction where the dispatcher receives mixed-case keys it never sees in practice.
+        # Keys are lowercased on the way in (see NATSMessageHeaders.extract_aihub_headers).
         start_event = StartEvent()
         start_event._aihub_headers = {"x-aihub-user-token": "tok-from-api"}
         agent_dispatcher.agent.get_steps_waiting_for_event = Mock(return_value=[])
@@ -790,8 +788,7 @@ class TestAgentDispatcherAihubHeaders:
     async def test_handle_event_does_not_persist_aihub_headers_when_message_has_none(
         self, agent_dispatcher, agent_topic
     ):
-        # No headers attached to the event — the key must remain unset so steps don't read stale
-        # tokens from a previous run that may still be in RunContext during early development.
+        # No headers on the event — the key must remain unset.
         start_event = StartEvent()
         agent_dispatcher.agent.get_steps_waiting_for_event = Mock(return_value=[])
 

--- a/packages/agent/playground/testing/tests/test_agent_dispatcher.py
+++ b/packages/agent/playground/testing/tests/test_agent_dispatcher.py
@@ -766,8 +766,11 @@ class TestAgentDispatcherAihubHeaders:
 
     @pytest.mark.asyncio
     async def test_handle_event_stores_aihub_headers_from_message_into_run_context(self, agent_dispatcher, agent_topic):
+        # Keys are lowercased on the way in by NATSMessageHeaders.extract_aihub_headers
+        # (HTTP header normalization). Mirror the production shape here so this test does not
+        # describe a fiction where the dispatcher receives mixed-case keys it never sees in practice.
         start_event = StartEvent()
-        start_event._aihub_headers = {"X-AIHub-User-Token": "tok-from-api"}
+        start_event._aihub_headers = {"x-aihub-user-token": "tok-from-api"}
         agent_dispatcher.agent.get_steps_waiting_for_event = Mock(return_value=[])
 
         mock_tracer = Mock(spec=AgentRunTracer)
@@ -781,7 +784,7 @@ class TestAgentDispatcherAihubHeaders:
 
             run_context = RunContext.for_topic(agent_dispatcher.redis, agent_topic)
             stored = await run_context.get("aihub_headers")
-            assert stored == {"X-AIHub-User-Token": "tok-from-api"}
+            assert stored == {"x-aihub-user-token": "tok-from-api"}
 
     @pytest.mark.asyncio
     async def test_handle_event_does_not_persist_aihub_headers_when_message_has_none(

--- a/packages/agent/playground/testing/tests/test_agent_dispatcher.py
+++ b/packages/agent/playground/testing/tests/test_agent_dispatcher.py
@@ -759,3 +759,47 @@ class TestTransformFormkitArrays:
         assert transform_formkit_arrays(123) == 123
         assert transform_formkit_arrays(True) is True
         assert transform_formkit_arrays(None) is None
+
+
+class TestAgentDispatcherAihubHeaders:
+    """RunContext is the authorized place where steps can pick up X-AIHub-* identity headers."""
+
+    @pytest.mark.asyncio
+    async def test_handle_event_stores_aihub_headers_from_message_into_run_context(self, agent_dispatcher, agent_topic):
+        start_event = StartEvent()
+        start_event._aihub_headers = {"X-AIHub-User-Token": "tok-from-api"}
+        agent_dispatcher.agent.get_steps_waiting_for_event = Mock(return_value=[])
+
+        mock_tracer = Mock(spec=AgentRunTracer)
+        mock_tracer.trace_run_start = AsyncMock(return_value=None)
+        agent_dispatcher.agent_run_tracer = mock_tracer
+
+        with patch("swiss_ai_hub.core.dispatcher.base_dispatcher.BaseDispatcher.handle_event") as mock_base_handle:
+            mock_base_handle.return_value = None
+
+            await agent_dispatcher.handle_event(start_event, agent_topic)
+
+            run_context = RunContext.for_topic(agent_dispatcher.redis, agent_topic)
+            stored = await run_context.get("aihub_headers")
+            assert stored == {"X-AIHub-User-Token": "tok-from-api"}
+
+    @pytest.mark.asyncio
+    async def test_handle_event_does_not_persist_aihub_headers_when_message_has_none(
+        self, agent_dispatcher, agent_topic
+    ):
+        # No headers attached to the event — the key must remain unset so steps don't read stale
+        # tokens from a previous run that may still be in RunContext during early development.
+        start_event = StartEvent()
+        agent_dispatcher.agent.get_steps_waiting_for_event = Mock(return_value=[])
+
+        mock_tracer = Mock(spec=AgentRunTracer)
+        mock_tracer.trace_run_start = AsyncMock(return_value=None)
+        agent_dispatcher.agent_run_tracer = mock_tracer
+
+        with patch("swiss_ai_hub.core.dispatcher.base_dispatcher.BaseDispatcher.handle_event") as mock_base_handle:
+            mock_base_handle.return_value = None
+
+            await agent_dispatcher.handle_event(start_event, agent_topic)
+
+            run_context = RunContext.for_topic(agent_dispatcher.redis, agent_topic)
+            assert await run_context.get("aihub_headers") is None

--- a/packages/agent/playground/testing/tests/test_agent_dispatcher.py
+++ b/packages/agent/playground/testing/tests/test_agent_dispatcher.py
@@ -781,7 +781,7 @@ class TestAgentDispatcherAihubHeaders:
             await agent_dispatcher.handle_event(start_event, agent_topic)
 
             run_context = RunContext.for_topic(agent_dispatcher.redis, agent_topic)
-            stored = await run_context.get("aihub_headers")
+            stored = await run_context.get(agent_dispatcher._AIHUB_HEADERS_KEY)
             assert stored == {"x-aihub-user-token": "tok-from-api"}
 
     @pytest.mark.asyncio
@@ -802,4 +802,4 @@ class TestAgentDispatcherAihubHeaders:
             await agent_dispatcher.handle_event(start_event, agent_topic)
 
             run_context = RunContext.for_topic(agent_dispatcher.redis, agent_topic)
-            assert await run_context.get("aihub_headers") is None
+            assert await run_context.get(agent_dispatcher._AIHUB_HEADERS_KEY) is None

--- a/packages/agent/swiss_ai_hub/agent/dispatchers/agent_dispatcher.py
+++ b/packages/agent/swiss_ai_hub/agent/dispatchers/agent_dispatcher.py
@@ -108,16 +108,9 @@ class AgentDispatcher(BaseDispatcher):
         thread_context = ThreadContext.for_topic(self.redis, topic)
         agent_config_dict: dict[str, Any] | None = None
 
-        # Propagate X-AIHub-* request headers (e.g. user identity / on-behalf-of tokens) from the
-        # NATS message into RunContext so downstream steps (notably MCP calls) can act on behalf
-        # of the user. Written on every externally-originated event that carries headers — not
-        # only StartEvent — so HITL/BITL responses re-entering via the API refresh the stored
-        # token rather than reusing a stale one from the run's start. Agent-internal events
-        # (ToolEvent, ChunkEvent, etc.) have no aihub headers on their NATS msg, so the truthy
-        # check skips them and the value already in RunContext is preserved.
-        # Cleared with the rest of RunContext on Stop/Exception below; orphaned runs fall back
-        # to the RunContext TTL (currently 30 days), the same safety net used for the rest of
-        # the run's state.
+        # Propagate X-AIHub-* request headers into RunContext so downstream steps can act on behalf
+        # of the user. Written on every header-carrying event, not only StartEvent, so HITL/BITL
+        # responses refresh the stored token instead of reusing a stale one.
         if event._aihub_headers:
             await run_context.set(self._AIHUB_HEADERS_KEY, event._aihub_headers)
 

--- a/packages/agent/swiss_ai_hub/agent/dispatchers/agent_dispatcher.py
+++ b/packages/agent/swiss_ai_hub/agent/dispatchers/agent_dispatcher.py
@@ -55,6 +55,7 @@ class AgentDispatcher(BaseDispatcher):
     """
 
     _AGENT_CONFIG_KEY = "_agent_config"
+    _AIHUB_HEADERS_KEY = "aihub_headers"
 
     def __init__(
         self,
@@ -106,6 +107,12 @@ class AgentDispatcher(BaseDispatcher):
         run_context = RunContext.for_topic(self.redis, topic)
         thread_context = ThreadContext.for_topic(self.redis, topic)
         agent_config_dict: dict[str, Any] | None = None
+
+        # Propagate transient X-AIHub-* request headers (e.g. user identity / on-behalf-of tokens)
+        # from the NATS message into RunContext so downstream steps (notably MCP calls) can act on
+        # behalf of the user. These are cleared with the rest of RunContext on Stop/Exception.
+        if event._aihub_headers:
+            await run_context.set(self._AIHUB_HEADERS_KEY, event._aihub_headers)
 
         if event.is_start_event:
             event = cast(StartEvent, event)

--- a/packages/agent/swiss_ai_hub/agent/dispatchers/agent_dispatcher.py
+++ b/packages/agent/swiss_ai_hub/agent/dispatchers/agent_dispatcher.py
@@ -108,9 +108,16 @@ class AgentDispatcher(BaseDispatcher):
         thread_context = ThreadContext.for_topic(self.redis, topic)
         agent_config_dict: dict[str, Any] | None = None
 
-        # Propagate transient X-AIHub-* request headers (e.g. user identity / on-behalf-of tokens)
-        # from the NATS message into RunContext so downstream steps (notably MCP calls) can act on
-        # behalf of the user. These are cleared with the rest of RunContext on Stop/Exception.
+        # Propagate X-AIHub-* request headers (e.g. user identity / on-behalf-of tokens) from the
+        # NATS message into RunContext so downstream steps (notably MCP calls) can act on behalf
+        # of the user. Written on every externally-originated event that carries headers — not
+        # only StartEvent — so HITL/BITL responses re-entering via the API refresh the stored
+        # token rather than reusing a stale one from the run's start. Agent-internal events
+        # (ToolEvent, ChunkEvent, etc.) have no aihub headers on their NATS msg, so the truthy
+        # check skips them and the value already in RunContext is preserved.
+        # Cleared with the rest of RunContext on Stop/Exception below; orphaned runs fall back
+        # to the RunContext TTL (currently 30 days), the same safety net used for the rest of
+        # the run's state.
         if event._aihub_headers:
             await run_context.set(self._AIHUB_HEADERS_KEY, event._aihub_headers)
 

--- a/packages/agent/swiss_ai_hub/agent/dispatchers/agent_dispatcher.py
+++ b/packages/agent/swiss_ai_hub/agent/dispatchers/agent_dispatcher.py
@@ -55,7 +55,9 @@ class AgentDispatcher(BaseDispatcher):
     """
 
     _AGENT_CONFIG_KEY = "_agent_config"
-    _AIHUB_HEADERS_KEY = "aihub_headers"
+    # Underscore-prefixed so it cannot collide with a StartEvent field of the same name when
+    # StartEvent.to_context_dict() is later merged into RunContext.
+    _AIHUB_HEADERS_KEY = "_aihub_headers"
 
     def __init__(
         self,
@@ -110,7 +112,8 @@ class AgentDispatcher(BaseDispatcher):
 
         # Propagate X-AIHub-* request headers into RunContext so downstream steps can act on behalf
         # of the user. Written on every header-carrying event, not only StartEvent, so HITL/BITL
-        # responses refresh the stored token instead of reusing a stale one.
+        # responses refresh the stored token instead of reusing a stale one. These are untrusted
+        # client input — a step must validate a header before treating it as an identity claim.
         if event._aihub_headers:
             await run_context.set(self._AIHUB_HEADERS_KEY, event._aihub_headers)
 

--- a/packages/api/swiss_ai_hub/api/routes/openai/openai_controller.py
+++ b/packages/api/swiss_ai_hub/api/routes/openai/openai_controller.py
@@ -16,7 +16,7 @@ from swiss_ai_hub.core.dependencies import use_nats
 from swiss_ai_hub.core.distributor import ExternalAgentEventDistributor, use_external_agent_event_distributor
 from swiss_ai_hub.core.i18n import LocaleHandler
 from swiss_ai_hub.core.routes import TenantScopedController
-from swiss_ai_hub.core.tracing.nats_message_headers import NATSMessageHeaders
+from swiss_ai_hub.core.tracing import NATSMessageHeaders
 
 from swiss_ai_hub.api.i18n.api_locale_string import ApiLocaleString
 from swiss_ai_hub.api.i18n.dependencies.use_locale import use_locale

--- a/packages/api/swiss_ai_hub/api/routes/openai/openai_controller.py
+++ b/packages/api/swiss_ai_hub/api/routes/openai/openai_controller.py
@@ -2,7 +2,7 @@ import logging
 from collections.abc import AsyncIterator
 from typing import Annotated, Literal, Self
 
-from fastapi import Body, Depends, File, Form, Security, UploadFile
+from fastapi import Body, Depends, File, Form, Request, Security, UploadFile
 from nats.aio.client import Client as NATS
 from openai.types import ImagesResponse
 from openai.types.audio import Transcription, TranscriptionVerbose
@@ -16,6 +16,7 @@ from swiss_ai_hub.core.dependencies import use_nats
 from swiss_ai_hub.core.distributor import ExternalAgentEventDistributor, use_external_agent_event_distributor
 from swiss_ai_hub.core.i18n import LocaleHandler
 from swiss_ai_hub.core.routes import TenantScopedController
+from swiss_ai_hub.core.tracing.nats_message_headers import NATSMessageHeaders
 
 from swiss_ai_hub.api.i18n.api_locale_string import ApiLocaleString
 from swiss_ai_hub.api.i18n.dependencies.use_locale import use_locale
@@ -210,6 +211,7 @@ class OpenaiController(TenantScopedController):
         )
         async def chat_completion_with_assistants(
             completion_request: Annotated[ChatCompletionRequest, Body],
+            request: Request,
             nc: Annotated[NATS, Depends(use_nats)],
             usage_limits: Annotated[UsageLimits, Depends(use_usage_limits)],
             external_agent_event_distributor: Annotated[
@@ -226,6 +228,8 @@ class OpenaiController(TenantScopedController):
                 if not AccessChecker.from_user(user).has_access_to_agent(agent_class, agent_id):
                     raise ValueError(f"User {user.id} does not have permission to access model {model_name}")
 
+            aihub_headers = NATSMessageHeaders.extract_aihub_headers(dict(request.headers))
+
             return await OpenaiService.chat_completion_with_assistants(
                 model_name=model_name,
                 chat_completion_request=completion_request,
@@ -234,6 +238,7 @@ class OpenaiController(TenantScopedController):
                 usage_limits=usage_limits,
                 external_agent_event_distributor=external_agent_event_distributor,
                 t=t,
+                aihub_headers=aihub_headers,
             )
 
         return self

--- a/packages/api/swiss_ai_hub/api/routes/openai/openai_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/openai/openai_service.py
@@ -234,6 +234,7 @@ class OpenaiService:
         usage_limits: UsageLimits,
         external_agent_event_distributor: ExternalAgentEventDistributor,
         t: LocaleHandler,
+        aihub_headers: dict[str, str] | None = None,
     ) -> ChatCompletion | StreamingResponse:
         """
         Execute a chat completion request with an LLM or an assistant.
@@ -265,6 +266,7 @@ class OpenaiService:
                 usage_limits=usage_limits,
                 external_agent_event_distributor=external_agent_event_distributor,
                 locale=t.locale,
+                aihub_headers=aihub_headers,
             )
 
         return await OpenaiService.json_assistant(
@@ -276,6 +278,7 @@ class OpenaiService:
             usage_limits=usage_limits,
             external_agent_event_distributor=external_agent_event_distributor,
             locale=t.locale,
+            aihub_headers=aihub_headers,
         )
 
     @staticmethod
@@ -290,6 +293,7 @@ class OpenaiService:
         usage_limits: UsageLimits,
         external_agent_event_distributor: ExternalAgentEventDistributor,
         locale: str | None = None,
+        aihub_headers: dict[str, str] | None = None,
     ):
         thread_id, display_id = OpenaiService._extract_thread_and_display_id(chat_completion_request)
         if thread_id and chat_completion_request.metadata.reconstruct_history:
@@ -311,6 +315,7 @@ class OpenaiService:
             display_id=str_to_object_id(display_id),
             files=files,
             locale=locale,
+            aihub_headers=aihub_headers,
         )
         # Wait until all events are processed
         await resources.stop_signal.wait()
@@ -355,6 +360,7 @@ class OpenaiService:
         usage_limits: UsageLimits,
         external_agent_event_distributor: ExternalAgentEventDistributor,
         locale: str | None = None,
+        aihub_headers: dict[str, str] | None = None,
     ):
         thread_id, display_id = OpenaiService._extract_thread_and_display_id(chat_completion_request)
         if thread_id and chat_completion_request.metadata.reconstruct_history:
@@ -376,6 +382,7 @@ class OpenaiService:
             display_id=str_to_object_id(display_id),
             files=files,
             locale=locale,
+            aihub_headers=aihub_headers,
         )
 
         async def sse_event_generator():

--- a/packages/core/swiss_ai_hub/core/distributor/external_agent_event_distributor.py
+++ b/packages/core/swiss_ai_hub/core/distributor/external_agent_event_distributor.py
@@ -34,12 +34,20 @@ class ExternalAgentEventDistributor:
         self.nc_publisher = NCPublisher(name, nc)
         self.js_publisher = JSPublisher(name, js)
 
-    async def distribute_event(self, external_event: ExternalAgentEvent, user: UserIdentity | None = None):
+    async def distribute_event(
+        self,
+        external_event: ExternalAgentEvent,
+        user: UserIdentity | None = None,
+        aihub_headers: dict[str, str] | None = None,
+    ):
         """
         Entry point for distributing an external event (ExternalAgentEvent) to agents or other systems through NATs.
 
         Validates user's membership in the thread, identifies the event type, and delegates
         to specialized handlers.
+
+        `aihub_headers` carries X-AIHub-* request headers (e.g. user-identity tokens) that must
+        ride along on the NATS message but never enter the event payload or persistence layer.
         """
         thread = ThreadEntity.get_thread_by_id(external_event.thread_id)
 
@@ -62,19 +70,25 @@ class ExternalAgentEventDistributor:
             raise ValueError(f"Received event of unhandled type: {external_event.event.event_name}")
 
         if external_event.event.is_hitl_response_event:
-            await self._handle_human_in_the_loop_response(thread, external_event)
+            await self._handle_human_in_the_loop_response(thread, external_event, aihub_headers)
 
         if external_event.event.is_bitl_response_event:
-            await self._handle_human_in_the_loop_response(thread, external_event)
+            await self._handle_human_in_the_loop_response(thread, external_event, aihub_headers)
 
         # Display the message back to the user who sent it - if it was user-sent
         if external_event.event.is_display_event and user:
-            await self._handle_display_message(external_event, run_id, user)
+            await self._handle_display_message(external_event, run_id, user, aihub_headers)
 
         if external_event.event.is_start_event:
-            await self._handle_start_event(thread, external_event, run_id)
+            await self._handle_start_event(thread, external_event, run_id, aihub_headers)
 
-    async def _handle_start_event(self, thread: ThreadEntity, external_event: ExternalAgentEvent, run_id: str):
+    async def _handle_start_event(
+        self,
+        thread: ThreadEntity,
+        external_event: ExternalAgentEvent,
+        run_id: str,
+        aihub_headers: dict[str, str] | None = None,
+    ):
         """
         Handle a StartEvent from the user.
 
@@ -101,9 +115,15 @@ class ExternalAgentEventDistributor:
                 event_name=event.event_name,
                 event_id=event.event_id,
             )
-            await self.js_publisher.publish_event(event, subject)
+            await self.js_publisher.publish_event(event, subject, extra_headers=aihub_headers)
 
-    async def _handle_display_message(self, external_event: ExternalAgentEvent, run_id: str, user: UserIdentity):
+    async def _handle_display_message(
+        self,
+        external_event: ExternalAgentEvent,
+        run_id: str,
+        user: UserIdentity,
+        aihub_headers: dict[str, str] | None = None,
+    ):
         """
         Handle a DisplayEvent from the user.
 
@@ -122,9 +142,14 @@ class ExternalAgentEventDistributor:
             event_name=external_event.event.event_name,
             event_id=external_event.event.event_id,
         )
-        await self.nc_publisher.publish_event(external_event.event, subject)
+        await self.nc_publisher.publish_event(external_event.event, subject, extra_headers=aihub_headers)
 
-    async def _handle_human_in_the_loop_response(self, thread: ThreadEntity, external_event: ExternalAgentEvent):
+    async def _handle_human_in_the_loop_response(
+        self,
+        thread: ThreadEntity,
+        external_event: ExternalAgentEvent,
+        aihub_headers: dict[str, str] | None = None,
+    ):
         """
         Handle a HumanInTheLoopResponseEvent.
 
@@ -147,4 +172,4 @@ class ExternalAgentEventDistributor:
             event_name=external_event.event.event_name,
             event_id=external_event.event.event_id,
         )
-        await self.js_publisher.publish_event(external_event.event, subject)
+        await self.js_publisher.publish_event(external_event.event, subject, extra_headers=aihub_headers)

--- a/packages/core/swiss_ai_hub/core/distributor/external_agent_event_distributor.py
+++ b/packages/core/swiss_ai_hub/core/distributor/external_agent_event_distributor.py
@@ -46,7 +46,9 @@ class ExternalAgentEventDistributor:
         Validates user's membership in the thread, identifies the event type, and delegates
         to specialized handlers.
 
-        `aihub_headers` carries X-AIHub-* request headers on the NATS envelope, forwarded to the agent.
+        `aihub_headers` carries X-AIHub-* request headers onto the control-path NATS envelopes
+        (StartEvent, HITL/BITL responses) so the agent can act on behalf of the user. They are
+        deliberately not forwarded onto display events — see `_handle_display_message`.
         """
         thread = ThreadEntity.get_thread_by_id(external_event.thread_id)
 
@@ -76,7 +78,7 @@ class ExternalAgentEventDistributor:
 
         # Display the message back to the user who sent it - if it was user-sent
         if external_event.event.is_display_event and user:
-            await self._handle_display_message(external_event, run_id, user, aihub_headers)
+            await self._handle_display_message(external_event, run_id, user)
 
         if external_event.event.is_start_event:
             await self._handle_start_event(thread, external_event, run_id, aihub_headers)
@@ -121,7 +123,6 @@ class ExternalAgentEventDistributor:
         external_event: ExternalAgentEvent,
         run_id: str,
         user: UserIdentity,
-        aihub_headers: dict[str, str] | None = None,
     ):
         """
         Handle a DisplayEvent from the user.
@@ -141,7 +142,10 @@ class ExternalAgentEventDistributor:
             event_name=external_event.event.event_name,
             event_id=external_event.event.event_id,
         )
-        await self.nc_publisher.publish_event(external_event.event, subject, extra_headers=aihub_headers)
+        # X-AIHub-* headers are intentionally not forwarded here: display events are
+        # observability-only and never drive agent tool calls, so the credential has no use on
+        # this path and must not be spread to display-event subscribers.
+        await self.nc_publisher.publish_event(external_event.event, subject)
 
     async def _handle_human_in_the_loop_response(
         self,

--- a/packages/core/swiss_ai_hub/core/distributor/external_agent_event_distributor.py
+++ b/packages/core/swiss_ai_hub/core/distributor/external_agent_event_distributor.py
@@ -46,8 +46,10 @@ class ExternalAgentEventDistributor:
         Validates user's membership in the thread, identifies the event type, and delegates
         to specialized handlers.
 
-        `aihub_headers` carries X-AIHub-* request headers (e.g. user-identity tokens) that must
-        ride along on the NATS message but never enter the event payload or persistence layer.
+        `aihub_headers` carries X-AIHub-* request headers (e.g. user-identity tokens) on the
+        NATS message envelope, not in the event payload. ``NATSMessageHeaders.with_aihub_headers``
+        filters to the ``X-AIHub-*`` prefix before publishing, so any non-prefixed header in the
+        dict is dropped on its way out.
         """
         thread = ThreadEntity.get_thread_by_id(external_event.thread_id)
 

--- a/packages/core/swiss_ai_hub/core/distributor/external_agent_event_distributor.py
+++ b/packages/core/swiss_ai_hub/core/distributor/external_agent_event_distributor.py
@@ -46,10 +46,7 @@ class ExternalAgentEventDistributor:
         Validates user's membership in the thread, identifies the event type, and delegates
         to specialized handlers.
 
-        `aihub_headers` carries X-AIHub-* request headers (e.g. user-identity tokens) on the
-        NATS message envelope, not in the event payload. ``NATSMessageHeaders.with_aihub_headers``
-        filters to the ``X-AIHub-*`` prefix before publishing, so any non-prefixed header in the
-        dict is dropped on its way out.
+        `aihub_headers` carries X-AIHub-* request headers on the NATS envelope, forwarded to the agent.
         """
         thread = ThreadEntity.get_thread_by_id(external_event.thread_id)
 

--- a/packages/core/swiss_ai_hub/core/events/base_event.py
+++ b/packages/core/swiss_ai_hub/core/events/base_event.py
@@ -62,9 +62,12 @@ class BaseEvent(BaseModel):
 
     _jetstream_sequence: int | None = PrivateAttr(None)
 
-    # Transient X-AIHub-* headers carried by the NATS message that delivered this event.
-    # Not serialized: lives only on the in-memory event during processing so the dispatcher can
-    # lift them into RunContext. Tokens here must never be persisted or logged.
+    # Transient X-AIHub-* headers carried by the NATS message that delivered this event. Keys are
+    # lowercased (see NATSMessageHeaders.extract_aihub_headers). Not serialized: lives only on the
+    # in-memory event for the current delivery — on JetStream replay this is empty, since headers
+    # ride on the message envelope, not the payload. The dispatcher lifts them into RunContext,
+    # which is the durable, authoritative source for downstream steps. Tokens here must never be
+    # persisted or logged.
     _aihub_headers: dict[str, str] | None = PrivateAttr(None)
 
     model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, use_enum_values=True, extra="allow")

--- a/packages/core/swiss_ai_hub/core/events/base_event.py
+++ b/packages/core/swiss_ai_hub/core/events/base_event.py
@@ -62,6 +62,11 @@ class BaseEvent(BaseModel):
 
     _jetstream_sequence: int | None = PrivateAttr(None)
 
+    # Transient X-AIHub-* headers carried by the NATS message that delivered this event.
+    # Not serialized: lives only on the in-memory event during processing so the dispatcher can
+    # lift them into RunContext. Tokens here must never be persisted or logged.
+    _aihub_headers: dict[str, str] | None = PrivateAttr(None)
+
     model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, use_enum_values=True, extra="allow")
 
     def __str__(self):

--- a/packages/core/swiss_ai_hub/core/events/base_event.py
+++ b/packages/core/swiss_ai_hub/core/events/base_event.py
@@ -64,6 +64,8 @@ class BaseEvent(BaseModel):
 
     # X-AIHub-* headers from the NATS message that delivered this event. Set by the subscribers
     # per delivery — not serialized, not durable across JetStream replay. May include tokens.
+    # Untrusted client input: a consumer must validate a value before acting on it (e.g. as an
+    # identity claim) — see NATSMessageHeaders.AIHUB_HEADER_PREFIX.
     _aihub_headers: dict[str, str] | None = PrivateAttr(None)
 
     model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, use_enum_values=True, extra="allow")

--- a/packages/core/swiss_ai_hub/core/events/base_event.py
+++ b/packages/core/swiss_ai_hub/core/events/base_event.py
@@ -62,12 +62,12 @@ class BaseEvent(BaseModel):
 
     _jetstream_sequence: int | None = PrivateAttr(None)
 
-    # Transient X-AIHub-* headers carried by the NATS message that delivered this event. Keys are
-    # lowercased (see NATSMessageHeaders.extract_aihub_headers). Not serialized: lives only on the
-    # in-memory event for the current delivery — on JetStream replay this is empty, since headers
-    # ride on the message envelope, not the payload. The dispatcher lifts them into RunContext,
-    # which is the durable, authoritative source for downstream steps. Tokens here must never be
-    # persisted or logged.
+    # X-AIHub-* headers carried by the NATS message that delivered this event. Populated by the
+    # subscribers (see NATSMessageHeaders.extract_aihub_headers, which lowercases keys). Lives on
+    # the in-memory event for the current delivery only — not part of the Pydantic schema, not
+    # serialized into the JetStream payload, not durable across JetStream replay. The dispatcher
+    # lifts the values into RunContext (Valkey, scoped to the run, cleared on Stop/Exception),
+    # which is the source downstream steps read. Values may include bearer tokens; never log them.
     _aihub_headers: dict[str, str] | None = PrivateAttr(None)
 
     model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, use_enum_values=True, extra="allow")

--- a/packages/core/swiss_ai_hub/core/events/base_event.py
+++ b/packages/core/swiss_ai_hub/core/events/base_event.py
@@ -62,12 +62,8 @@ class BaseEvent(BaseModel):
 
     _jetstream_sequence: int | None = PrivateAttr(None)
 
-    # X-AIHub-* headers carried by the NATS message that delivered this event. Populated by the
-    # subscribers (see NATSMessageHeaders.extract_aihub_headers, which lowercases keys). Lives on
-    # the in-memory event for the current delivery only — not part of the Pydantic schema, not
-    # serialized into the JetStream payload, not durable across JetStream replay. The dispatcher
-    # lifts the values into RunContext (Valkey, scoped to the run, cleared on Stop/Exception),
-    # which is the source downstream steps read. Values may include bearer tokens; never log them.
+    # X-AIHub-* headers from the NATS message that delivered this event. Set by the subscribers
+    # per delivery — not serialized, not durable across JetStream replay. May include tokens.
     _aihub_headers: dict[str, str] | None = PrivateAttr(None)
 
     model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True, use_enum_values=True, extra="allow")

--- a/packages/core/swiss_ai_hub/core/publishers/abstract_publisher.py
+++ b/packages/core/swiss_ai_hub/core/publishers/abstract_publisher.py
@@ -43,5 +43,11 @@ class AbstractPublisher[TEvent: BaseEvent](abc.ABC):
             )
 
     @abc.abstractmethod
-    async def publish_event(self, event: TEvent, subject: str, **kwargs):
+    async def publish_event(
+        self,
+        event: TEvent,
+        subject: str,
+        extra_headers: dict[str, str] | None = None,
+        **kwargs,
+    ):
         pass

--- a/packages/core/swiss_ai_hub/core/publishers/js_publisher.py
+++ b/packages/core/swiss_ai_hub/core/publishers/js_publisher.py
@@ -59,8 +59,10 @@ class JSPublisher(AbstractPublisher[TEvent]):
         This ensures developers can catch configuration issues early and maintain consistent
         event routing conventions.
 
-        `extra_headers` is forwarded as NATS message headers — used for transient, request-scoped
-        metadata (e.g. X-AIHub-* user-identity headers) that must not be persisted with the event.
+        `extra_headers` is forwarded as NATS message headers — used for request-scoped metadata
+        (e.g. X-AIHub-* user-identity headers) that rides on the envelope, not in the event payload.
+        ``NATSMessageHeaders.with_aihub_headers`` filters to the ``X-AIHub-*`` prefix, so values
+        outside that prefix are dropped before they reach JetStream.
         """
         tracer = get_tracer(__name__)
         with tracer.start_as_current_span(

--- a/packages/core/swiss_ai_hub/core/publishers/js_publisher.py
+++ b/packages/core/swiss_ai_hub/core/publishers/js_publisher.py
@@ -59,10 +59,7 @@ class JSPublisher(AbstractPublisher[TEvent]):
         This ensures developers can catch configuration issues early and maintain consistent
         event routing conventions.
 
-        `extra_headers` is forwarded as NATS message headers — used for request-scoped metadata
-        (e.g. X-AIHub-* user-identity headers) that rides on the envelope, not in the event payload.
-        ``NATSMessageHeaders.with_aihub_headers`` filters to the ``X-AIHub-*`` prefix, so values
-        outside that prefix are dropped before they reach JetStream.
+        `extra_headers` is forwarded as NATS message headers, filtered to the ``X-AIHub-*`` prefix.
         """
         tracer = get_tracer(__name__)
         with tracer.start_as_current_span(

--- a/packages/core/swiss_ai_hub/core/publishers/js_publisher.py
+++ b/packages/core/swiss_ai_hub/core/publishers/js_publisher.py
@@ -45,13 +45,22 @@ class JSPublisher(AbstractPublisher[TEvent]):
             await stream_manager.ensure_stream_exists()
             self._ensured_streams.add(stream_name)
 
-    async def publish_event(self, event: TEvent, subject: str, retries=10):
+    async def publish_event(
+        self,
+        event: TEvent,
+        subject: str,
+        extra_headers: dict[str, str] | None = None,
+        retries: int = 10,
+    ):
         """
         Publishes the given event to the specified JetStream subject, encoding it as JSON.
 
         Logs event details and warns if event type does not match the subject pattern.
         This ensures developers can catch configuration issues early and maintain consistent
         event routing conventions.
+
+        `extra_headers` is forwarded as NATS message headers — used for transient, request-scoped
+        metadata (e.g. X-AIHub-* user-identity headers) that must not be persisted with the event.
         """
         tracer = get_tracer(__name__)
         with tracer.start_as_current_span(
@@ -74,7 +83,13 @@ class JSPublisher(AbstractPublisher[TEvent]):
                 logger.debug(f"{self.name} serialized event: {event.event_name}")
 
                 message_id = str(uuid.uuid4())
-                headers = NATSMessageHeaders().with_trace_context().with_header("Nats-Msg-Id", message_id).to_dict()
+                headers = (
+                    NATSMessageHeaders()
+                    .with_trace_context()
+                    .with_header("Nats-Msg-Id", message_id)
+                    .with_aihub_headers(extra_headers)
+                    .to_dict()
+                )
 
                 for attempt in range(retries):
                     try:

--- a/packages/core/swiss_ai_hub/core/publishers/nc_publisher.py
+++ b/packages/core/swiss_ai_hub/core/publishers/nc_publisher.py
@@ -47,10 +47,7 @@ class NCPublisher(AbstractPublisher[TEvent]):
         Logs details, warns if there's a mismatch between event type and subject pattern,
         and then sends the message through the NATS client.
 
-        `extra_headers` is forwarded as NATS message headers — used for request-scoped metadata
-        (e.g. X-AIHub-* user-identity headers) that rides on the envelope, not in the event payload.
-        ``NATSMessageHeaders.with_aihub_headers`` filters to the ``X-AIHub-*`` prefix, so values
-        outside that prefix are dropped before they reach the broker.
+        `extra_headers` is forwarded as NATS message headers, filtered to the ``X-AIHub-*`` prefix.
         """
         tracer = get_tracer(__name__)
 

--- a/packages/core/swiss_ai_hub/core/publishers/nc_publisher.py
+++ b/packages/core/swiss_ai_hub/core/publishers/nc_publisher.py
@@ -35,12 +35,20 @@ class NCPublisher(AbstractPublisher[TEvent]):
         super().__init__(name, protocol="NATS")
         self.nc = nc
 
-    async def publish_event(self, event: TEvent, subject: str):
+    async def publish_event(
+        self,
+        event: TEvent,
+        subject: str,
+        extra_headers: dict[str, str] | None = None,
+    ):
         """
         Publishes the given event to the specified subject, encoding it as JSON.
 
         Logs details, warns if there's a mismatch between event type and subject pattern,
         and then sends the message through the NATS client.
+
+        `extra_headers` is forwarded as NATS message headers — used for transient, request-scoped
+        metadata (e.g. X-AIHub-* user-identity headers) that must not be persisted with the event.
         """
         tracer = get_tracer(__name__)
 
@@ -61,7 +69,7 @@ class NCPublisher(AbstractPublisher[TEvent]):
                 serialized_event = event.model_dump_json(serialize_as_any=True)
                 logger.debug(f"{self.name} serialized event: {event.event_name}")
 
-                headers = NATSMessageHeaders().with_trace_context().to_dict()
+                headers = NATSMessageHeaders().with_trace_context().with_aihub_headers(extra_headers).to_dict()
 
                 await self.nc.publish(subject, serialized_event.encode(), headers=headers)
 

--- a/packages/core/swiss_ai_hub/core/publishers/nc_publisher.py
+++ b/packages/core/swiss_ai_hub/core/publishers/nc_publisher.py
@@ -47,8 +47,10 @@ class NCPublisher(AbstractPublisher[TEvent]):
         Logs details, warns if there's a mismatch between event type and subject pattern,
         and then sends the message through the NATS client.
 
-        `extra_headers` is forwarded as NATS message headers — used for transient, request-scoped
-        metadata (e.g. X-AIHub-* user-identity headers) that must not be persisted with the event.
+        `extra_headers` is forwarded as NATS message headers — used for request-scoped metadata
+        (e.g. X-AIHub-* user-identity headers) that rides on the envelope, not in the event payload.
+        ``NATSMessageHeaders.with_aihub_headers`` filters to the ``X-AIHub-*`` prefix, so values
+        outside that prefix are dropped before they reach the broker.
         """
         tracer = get_tracer(__name__)
 

--- a/packages/core/swiss_ai_hub/core/publishers/tests/unit/test_publishers_aihub_headers.py
+++ b/packages/core/swiss_ai_hub/core/publishers/tests/unit/test_publishers_aihub_headers.py
@@ -1,0 +1,59 @@
+"""Lock the publisher builder-chain order so a future reorder cannot silently drop X-AIHub-* or
+clobber the trace-context / Nats-Msg-Id headers. The helper itself (``with_aihub_headers``) is
+exhaustively tested in
+``packages/core/swiss_ai_hub/core/tracing/tests/unit/test_nats_message_headers.py`` — these tests
+only exist to pin its integration through the publisher chains."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from swiss_ai_hub.core.events.base_event import BaseEvent
+from swiss_ai_hub.core.publishers.js_publisher import JSPublisher
+from swiss_ai_hub.core.publishers.nc_publisher import NCPublisher
+
+
+@pytest.mark.asyncio
+async def test_js_publisher_threads_extra_headers_into_published_message():
+    """``JSPublisher.publish_event(..., extra_headers=...)`` must merge X-AIHub-* values onto the
+    published NATS headers without clobbering ``Nats-Msg-Id`` (set earlier in the chain)."""
+    js = MagicMock()
+
+    async def publish_async(*_args, **_kwargs):
+        inner = asyncio.Future()
+        inner.set_result(MagicMock(seq=1, stream="test-stream"))
+        return inner
+
+    js.publish_async = AsyncMock(side_effect=publish_async)
+
+    publisher = JSPublisher(name="test", js=js)
+    publisher._ensured_streams.add("anything")  # skip stream creation
+
+    await publisher.publish_event(
+        BaseEvent(),
+        "agent.MyAgent.profile.thread.display.run.controlEvent.BaseEvent.eid",
+        extra_headers={"X-AIHub-User-Token": "tok"},
+    )
+
+    sent_headers = js.publish_async.await_args.kwargs["headers"]
+    assert sent_headers.get("X-AIHub-User-Token") == "tok"
+    assert "Nats-Msg-Id" in sent_headers
+
+
+@pytest.mark.asyncio
+async def test_nc_publisher_threads_extra_headers_into_published_message():
+    """Same contract on the NATS Core (ephemeral) path."""
+    nc = MagicMock()
+    nc.publish = AsyncMock()
+
+    publisher = NCPublisher(name="test", nc=nc)
+
+    await publisher.publish_event(
+        BaseEvent(),
+        "agent.MyAgent.profile.thread.display.run.displayEvent.BaseEvent.eid",
+        extra_headers={"X-AIHub-User-Token": "tok"},
+    )
+
+    sent_headers = nc.publish.await_args.kwargs["headers"]
+    assert sent_headers.get("X-AIHub-User-Token") == "tok"

--- a/packages/core/swiss_ai_hub/core/routes/chat/chat_service.py
+++ b/packages/core/swiss_ai_hub/core/routes/chat/chat_service.py
@@ -192,6 +192,7 @@ class ChatService:
         display_id: ObjectId | None = None,
         files: list[UserUploadedFile] | None = None,
         locale: str | None = None,
+        aihub_headers: dict[str, str] | None = None,
     ) -> StreamingResources:
         """
         Starts a streaming chat interaction and returns the resources for SSE streaming.
@@ -250,7 +251,7 @@ class ChatService:
         logger.debug(f"Subscriber created for subject: {subscriber.subject}")
 
         # Trigger the agent interaction via WebSocket
-        await external_agent_event_distributor.distribute_event(external_event, user)
+        await external_agent_event_distributor.distribute_event(external_event, user, aihub_headers=aihub_headers)
 
         return resources
 
@@ -267,6 +268,7 @@ class ChatService:
         display_id: ObjectId | None = None,
         files: list[UserUploadedFile] | None = None,
         locale: str | None = None,
+        aihub_headers: dict[str, str] | None = None,
     ) -> JsonResources:
         """
         Starts a JSON-based chat interaction, waiting for all events before returning.
@@ -283,7 +285,14 @@ class ChatService:
             locale=locale,
         )
         return await ChatService.start_json_event_interaction(
-            user, agent_class, agent_id, external_event, topic_manager, nc, external_agent_event_distributor
+            user,
+            agent_class,
+            agent_id,
+            external_event,
+            topic_manager,
+            nc,
+            external_agent_event_distributor,
+            aihub_headers=aihub_headers,
         )
 
     @staticmethod
@@ -296,6 +305,7 @@ class ChatService:
         topic_manager: AgentThreadTopicManager,
         nc: NATS,
         external_agent_event_distributor: ExternalAgentEventDistributor,
+        aihub_headers: dict[str, str] | None = None,
     ):
         stop_signal = asyncio.Event()
         chunk_events: list[ChunkEvent | ThoughtEvent] = []
@@ -346,7 +356,7 @@ class ChatService:
         logger.debug(f"Subscriber created for subject: {subscriber.subject}")
 
         # Trigger the agent interaction
-        await external_agent_event_distributor.distribute_event(external_event, user)
+        await external_agent_event_distributor.distribute_event(external_event, user, aihub_headers=aihub_headers)
 
         return resources
 

--- a/packages/core/swiss_ai_hub/core/subscribers/js_subscriber.py
+++ b/packages/core/swiss_ai_hub/core/subscribers/js_subscriber.py
@@ -12,6 +12,7 @@ from swiss_ai_hub.core.infrastructure.opentelemetry.tracing.smart_tracer import 
 from swiss_ai_hub.core.streams.stream_manager import StreamManager
 from swiss_ai_hub.core.subscribers.abstract_subscriber import AbstractSubscriber, TEvent
 from swiss_ai_hub.core.topics import Topic
+from swiss_ai_hub.core.tracing.nats_message_headers import NATSMessageHeaders
 from swiss_ai_hub.core.tracing.nats_trace_context_propagator import NATSTraceContextPropagator
 
 logger = logging.getLogger(__name__)
@@ -122,6 +123,7 @@ class JSSubscriber(AbstractSubscriber[TEvent]):
                 event_data = msg.data
                 event = self.event_cls.deserialize_event(event_data)
                 event._jetstream_sequence = msg.metadata.sequence.stream
+                event._aihub_headers = NATSMessageHeaders.extract_aihub_headers(headers)
 
                 span.update_name(f"{self.name}.receive {event.__class__.__name__}")
                 span.set_attribute("event.type", event.event_name)

--- a/packages/core/swiss_ai_hub/core/subscribers/nc_subscriber.py
+++ b/packages/core/swiss_ai_hub/core/subscribers/nc_subscriber.py
@@ -12,6 +12,7 @@ from opentelemetry import context, trace
 from swiss_ai_hub.core.infrastructure.opentelemetry.tracing.smart_tracer import get_tracer
 from swiss_ai_hub.core.subscribers.abstract_subscriber import AbstractSubscriber, TEvent
 from swiss_ai_hub.core.topics import Topic
+from swiss_ai_hub.core.tracing.nats_message_headers import NATSMessageHeaders
 from swiss_ai_hub.core.tracing.nats_trace_context_propagator import NATSTraceContextPropagator
 
 logger = logging.getLogger(__name__)
@@ -93,6 +94,7 @@ class NCSubscriber(AbstractSubscriber[TEvent]):
                 topic = Topic.from_subject(msg.subject)
                 event_data = msg.data
                 event = self.event_cls.deserialize_event(event_data)
+                event._aihub_headers = NATSMessageHeaders.extract_aihub_headers(headers)
 
                 span.update_name(f"{self.name}.receive {event.__class__.__name__}")
                 span.set_attribute("event.type", event.event_name)

--- a/packages/core/swiss_ai_hub/core/tracing/nats_message_headers.py
+++ b/packages/core/swiss_ai_hub/core/tracing/nats_message_headers.py
@@ -1,4 +1,4 @@
-from typing import Self
+from typing import ClassVar, Self
 
 from swiss_ai_hub.core.tracing.nats_trace_context_propagator import NATSTraceContextPropagator
 
@@ -6,7 +6,12 @@ from swiss_ai_hub.core.tracing.nats_trace_context_propagator import NATSTraceCon
 class NATSMessageHeaders:
     """Helper class for working with NATS message headers in a type-safe way."""
 
-    def __init__(self, headers: dict[str, str] = None):
+    # Prefix used to mark headers that originate from the external request boundary (API, bot, etc.)
+    # and must be forwarded along the agent pipeline so downstream MCP tools can act on behalf of
+    # the originating user. Matching is case-insensitive; canonical form is the value below.
+    AIHUB_HEADER_PREFIX: ClassVar[str] = "X-AIHub-"
+
+    def __init__(self, headers: dict[str, str] | None = None):
         self.headers = headers or {}
 
     def with_trace_context(self) -> Self:
@@ -19,6 +24,28 @@ class NATSMessageHeaders:
         self.headers[key] = value
         return self
 
+    def with_aihub_headers(self, aihub_headers: dict[str, str] | None) -> Self:
+        """
+        Merge X-AIHub-* request headers into the outgoing NATS headers so they propagate to the
+        agent. Tokens and identity carried this way must never be written to persistent stores.
+        """
+        if not aihub_headers:
+            return self
+        for key, value in aihub_headers.items():
+            self.headers[key] = value
+        return self
+
     def to_dict(self) -> dict[str, str]:
         """Get headers as dictionary."""
         return self.headers
+
+    @classmethod
+    def extract_aihub_headers(cls, headers: dict[str, str] | None) -> dict[str, str]:
+        """
+        Pick out the X-AIHub-* entries from a NATS headers dict, preserving their original case.
+        Empty/None input yields an empty dict so callers can unconditionally pass it forward.
+        """
+        if not headers:
+            return {}
+        prefix_lower = cls.AIHUB_HEADER_PREFIX.lower()
+        return {key: value for key, value in headers.items() if key.lower().startswith(prefix_lower)}

--- a/packages/core/swiss_ai_hub/core/tracing/nats_message_headers.py
+++ b/packages/core/swiss_ai_hub/core/tracing/nats_message_headers.py
@@ -42,10 +42,12 @@ class NATSMessageHeaders:
     @classmethod
     def extract_aihub_headers(cls, headers: dict[str, str] | None) -> dict[str, str]:
         """
-        Pick out the X-AIHub-* entries from a NATS headers dict, preserving their original case.
-        Empty/None input yields an empty dict so callers can unconditionally pass it forward.
+        Pick out the X-AIHub-* entries from a headers dict. Keys are returned lowercased to
+        match HTTP header normalization (FastAPI/Starlette already lowercases inbound headers);
+        downstream consumers must read by lowercased key. Empty/None input yields an empty dict
+        so callers can unconditionally pass it forward.
         """
         if not headers:
             return {}
         prefix_lower = cls.AIHUB_HEADER_PREFIX.lower()
-        return {key: value for key, value in headers.items() if key.lower().startswith(prefix_lower)}
+        return {key.lower(): value for key, value in headers.items() if key.lower().startswith(prefix_lower)}

--- a/packages/core/swiss_ai_hub/core/tracing/nats_message_headers.py
+++ b/packages/core/swiss_ai_hub/core/tracing/nats_message_headers.py
@@ -26,19 +26,20 @@ class NATSMessageHeaders:
 
     def with_aihub_headers(self, aihub_headers: dict[str, str] | None) -> Self:
         """
-        Merge X-AIHub-* request headers into the outgoing NATS headers so they propagate to the
-        agent. Tokens and identity carried this way must never be written to persistent stores.
+        Merge ``X-AIHub-*`` request headers into the outgoing NATS headers so they propagate to
+        the agent.
 
-        Trust model: the caller is responsible for ensuring this dict only contains headers from
-        a trusted boundary (controller after auth, internal service). The forwarding is wildcard
-        on the X-AIHub-* prefix — any header in the dict rides through unchanged. Downstream
-        consumers that grant privileges based on these values rely on that filtering happening
-        upstream.
+        Defensively filters by ``AIHUB_HEADER_PREFIX`` (case-insensitive): any non-matching key
+        in the dict is dropped. This enforces the trust boundary inside the method instead of
+        relying on caller discipline — a caller who accidentally passes an arbitrary headers
+        dict cannot leak ``Authorization``, ``Cookie``, etc. onto the NATS envelope.
         """
         if not aihub_headers:
             return self
+        prefix_lower = self.AIHUB_HEADER_PREFIX.lower()
         for key, value in aihub_headers.items():
-            self.headers[key] = value
+            if key.lower().startswith(prefix_lower):
+                self.headers[key] = value
         return self
 
     def to_dict(self) -> dict[str, str]:

--- a/packages/core/swiss_ai_hub/core/tracing/nats_message_headers.py
+++ b/packages/core/swiss_ai_hub/core/tracing/nats_message_headers.py
@@ -8,6 +8,12 @@ class NATSMessageHeaders:
 
     # Headers with this prefix are forwarded along the agent pipeline so downstream tools can act
     # on behalf of the originating user. Matching is case-insensitive.
+    #
+    # SECURITY: X-AIHub-* headers come straight from the (untrusted) HTTP client — no proxy
+    # injects or vouches for them. The prefix filter on both ends only stops unrelated headers
+    # (Authorization, Cookie, ...) from leaking onto the envelope; it is NOT an authenticity
+    # check. Any consumer reading these values (e.g. an on-behalf-of token) MUST validate them
+    # independently and must never treat an X-AIHub-* value as a trusted identity assertion.
     AIHUB_HEADER_PREFIX: ClassVar[str] = "X-AIHub-"
 
     def __init__(self, headers: dict[str, str] | None = None):
@@ -44,7 +50,8 @@ class NATSMessageHeaders:
     def extract_aihub_headers(cls, headers: dict[str, str] | None) -> dict[str, str]:
         """
         Pick out the ``X-AIHub-*`` entries from a headers dict, lowercasing keys so downstream
-        consumers read by a single canonical key.
+        consumers read by a single canonical key. The returned values are untrusted client input
+        — see the ``AIHUB_HEADER_PREFIX`` security note before relying on them.
         """
         if not headers:
             return {}

--- a/packages/core/swiss_ai_hub/core/tracing/nats_message_headers.py
+++ b/packages/core/swiss_ai_hub/core/tracing/nats_message_headers.py
@@ -28,6 +28,12 @@ class NATSMessageHeaders:
         """
         Merge X-AIHub-* request headers into the outgoing NATS headers so they propagate to the
         agent. Tokens and identity carried this way must never be written to persistent stores.
+
+        Trust model: the caller is responsible for ensuring this dict only contains headers from
+        a trusted boundary (controller after auth, internal service). The forwarding is wildcard
+        on the X-AIHub-* prefix — any header in the dict rides through unchanged. Downstream
+        consumers that grant privileges based on these values rely on that filtering happening
+        upstream.
         """
         if not aihub_headers:
             return self

--- a/packages/core/swiss_ai_hub/core/tracing/nats_message_headers.py
+++ b/packages/core/swiss_ai_hub/core/tracing/nats_message_headers.py
@@ -6,9 +6,8 @@ from swiss_ai_hub.core.tracing.nats_trace_context_propagator import NATSTraceCon
 class NATSMessageHeaders:
     """Helper class for working with NATS message headers in a type-safe way."""
 
-    # Prefix used to mark headers that originate from the external request boundary (API, bot, etc.)
-    # and must be forwarded along the agent pipeline so downstream MCP tools can act on behalf of
-    # the originating user. Matching is case-insensitive; canonical form is the value below.
+    # Headers with this prefix are forwarded along the agent pipeline so downstream tools can act
+    # on behalf of the originating user. Matching is case-insensitive.
     AIHUB_HEADER_PREFIX: ClassVar[str] = "X-AIHub-"
 
     def __init__(self, headers: dict[str, str] | None = None):
@@ -26,13 +25,8 @@ class NATSMessageHeaders:
 
     def with_aihub_headers(self, aihub_headers: dict[str, str] | None) -> Self:
         """
-        Merge ``X-AIHub-*`` request headers into the outgoing NATS headers so they propagate to
-        the agent.
-
-        Defensively filters by ``AIHUB_HEADER_PREFIX`` (case-insensitive): any non-matching key
-        in the dict is dropped. This enforces the trust boundary inside the method instead of
-        relying on caller discipline — a caller who accidentally passes an arbitrary headers
-        dict cannot leak ``Authorization``, ``Cookie``, etc. onto the NATS envelope.
+        Merge ``X-AIHub-*`` headers into the outgoing NATS headers, dropping any non-prefixed key
+        so a caller cannot leak ``Authorization``/``Cookie`` onto the envelope.
         """
         if not aihub_headers:
             return self
@@ -49,10 +43,8 @@ class NATSMessageHeaders:
     @classmethod
     def extract_aihub_headers(cls, headers: dict[str, str] | None) -> dict[str, str]:
         """
-        Pick out the X-AIHub-* entries from a headers dict. Keys are returned lowercased to
-        match HTTP header normalization (FastAPI/Starlette already lowercases inbound headers);
-        downstream consumers must read by lowercased key. Empty/None input yields an empty dict
-        so callers can unconditionally pass it forward.
+        Pick out the ``X-AIHub-*`` entries from a headers dict, lowercasing keys so downstream
+        consumers read by a single canonical key.
         """
         if not headers:
             return {}

--- a/packages/core/swiss_ai_hub/core/tracing/tests/unit/test_nats_message_headers.py
+++ b/packages/core/swiss_ai_hub/core/tracing/tests/unit/test_nats_message_headers.py
@@ -54,3 +54,53 @@ class TestExtractAihubHeaders:
         # special characters must round-trip exactly.
         result = NATSMessageHeaders.extract_aihub_headers({"x-aihub-user-token": "AbCd-1234_xyz"})
         assert result == {"x-aihub-user-token": "AbCd-1234_xyz"}
+
+
+class TestWithAihubHeaders:
+    """``with_aihub_headers`` is the egress where headers are placed onto the NATS envelope. It
+    defensively filters by the ``X-AIHub-*`` prefix so a caller who accidentally passes a wider
+    dict (e.g. raw request.headers) cannot leak ``Authorization``/``Cookie``/etc. to NATS."""
+
+    def test_aihub_headers_are_merged_into_outgoing_headers(self):
+        result = NATSMessageHeaders().with_aihub_headers({"X-AIHub-User-Token": "tok"}).to_dict()
+        assert result == {"X-AIHub-User-Token": "tok"}
+
+    def test_non_aihub_headers_are_dropped(self):
+        """Defense in depth: any non-prefixed key must not reach NATS, even if the caller passes it."""
+        result = (
+            NATSMessageHeaders()
+            .with_aihub_headers(
+                {
+                    "Authorization": "Bearer secret",
+                    "Cookie": "session=abc",
+                    "X-AIHub-User-Token": "tok",
+                }
+            )
+            .to_dict()
+        )
+        assert result == {"X-AIHub-User-Token": "tok"}
+
+    def test_prefix_match_is_case_insensitive(self):
+        """Mirrors extract_aihub_headers — both sides of the contract treat the prefix the same way."""
+        result = (
+            NATSMessageHeaders().with_aihub_headers({"x-aihub-user-token": "tok", "X-AIHUB-TENANT": "acme"}).to_dict()
+        )
+        assert result == {"x-aihub-user-token": "tok", "X-AIHUB-TENANT": "acme"}
+
+    def test_none_input_is_a_noop(self):
+        result = NATSMessageHeaders().with_aihub_headers(None).to_dict()
+        assert result == {}
+
+    def test_empty_dict_input_is_a_noop(self):
+        result = NATSMessageHeaders().with_aihub_headers({}).to_dict()
+        assert result == {}
+
+    def test_existing_headers_are_preserved(self):
+        """Filtering must not wipe out other headers set by earlier builder calls (trace context, Nats-Msg-Id)."""
+        result = (
+            NATSMessageHeaders()
+            .with_header("Nats-Msg-Id", "msg-123")
+            .with_aihub_headers({"X-AIHub-User-Token": "tok", "Authorization": "should-drop"})
+            .to_dict()
+        )
+        assert result == {"Nats-Msg-Id": "msg-123", "X-AIHub-User-Token": "tok"}

--- a/packages/core/swiss_ai_hub/core/tracing/tests/unit/test_nats_message_headers.py
+++ b/packages/core/swiss_ai_hub/core/tracing/tests/unit/test_nats_message_headers.py
@@ -1,0 +1,56 @@
+from swiss_ai_hub.core.tracing import NATSMessageHeaders
+
+
+class TestExtractAihubHeaders:
+    """`extract_aihub_headers` is the single ingress where `X-AIHub-*` headers enter the agent
+    pipeline (called from the API controller for HTTP and from both subscribers for NATS). It
+    must filter to the prefix and normalize key casing so downstream consumers can read by a
+    single canonical (lowercase) key regardless of how the originating client cased them."""
+
+    def test_canonical_case_input_is_returned_lowercased(self):
+        result = NATSMessageHeaders.extract_aihub_headers({"X-AIHub-User-Token": "tok"})
+        assert result == {"x-aihub-user-token": "tok"}
+
+    def test_already_lowercase_input_passes_through(self):
+        # Production path: Starlette lowercases HTTP header names before our code sees them.
+        result = NATSMessageHeaders.extract_aihub_headers({"x-aihub-user-token": "tok"})
+        assert result == {"x-aihub-user-token": "tok"}
+
+    def test_uppercase_input_is_returned_lowercased(self):
+        result = NATSMessageHeaders.extract_aihub_headers({"X-AIHUB-USER-TOKEN": "tok"})
+        assert result == {"x-aihub-user-token": "tok"}
+
+    def test_non_aihub_headers_are_filtered_out(self):
+        result = NATSMessageHeaders.extract_aihub_headers(
+            {
+                "Authorization": "Bearer secret",
+                "Content-Type": "application/json",
+                "X-AIHub-User-Token": "tok",
+            }
+        )
+        assert result == {"x-aihub-user-token": "tok"}
+
+    def test_multiple_aihub_headers_are_all_extracted(self):
+        result = NATSMessageHeaders.extract_aihub_headers(
+            {
+                "X-AIHub-User-Token": "tok",
+                "X-AIHub-On-Behalf-Of": "alice@example.com",
+            }
+        )
+        assert result == {
+            "x-aihub-user-token": "tok",
+            "x-aihub-on-behalf-of": "alice@example.com",
+        }
+
+    def test_empty_input_returns_empty_dict(self):
+        # Callers rely on this so they can unconditionally forward the result without a None check.
+        assert NATSMessageHeaders.extract_aihub_headers({}) == {}
+
+    def test_none_input_returns_empty_dict(self):
+        assert NATSMessageHeaders.extract_aihub_headers(None) == {}
+
+    def test_prefix_match_is_case_insensitive_but_value_is_preserved_verbatim(self):
+        # Values must never be transformed — only keys are normalized. Tokens with mixed case or
+        # special characters must round-trip exactly.
+        result = NATSMessageHeaders.extract_aihub_headers({"x-aihub-user-token": "AbCd-1234_xyz"})
+        assert result == {"x-aihub-user-token": "AbCd-1234_xyz"}

--- a/packages/core/swiss_ai_hub/core/tracing/tests/unit/test_nats_message_headers.py
+++ b/packages/core/swiss_ai_hub/core/tracing/tests/unit/test_nats_message_headers.py
@@ -2,10 +2,7 @@ from swiss_ai_hub.core.tracing import NATSMessageHeaders
 
 
 class TestExtractAihubHeaders:
-    """`extract_aihub_headers` is the single ingress where `X-AIHub-*` headers enter the agent
-    pipeline (called from the API controller for HTTP and from both subscribers for NATS). It
-    must filter to the prefix and normalize key casing so downstream consumers can read by a
-    single canonical (lowercase) key regardless of how the originating client cased them."""
+    """`extract_aihub_headers` filters to the X-AIHub-* prefix and lowercases keys."""
 
     def test_canonical_case_input_is_returned_lowercased(self):
         result = NATSMessageHeaders.extract_aihub_headers({"X-AIHub-User-Token": "tok"})
@@ -50,16 +47,13 @@ class TestExtractAihubHeaders:
         assert NATSMessageHeaders.extract_aihub_headers(None) == {}
 
     def test_prefix_match_is_case_insensitive_but_value_is_preserved_verbatim(self):
-        # Values must never be transformed — only keys are normalized. Tokens with mixed case or
-        # special characters must round-trip exactly.
+        # Values must never be transformed — only keys are normalized.
         result = NATSMessageHeaders.extract_aihub_headers({"x-aihub-user-token": "AbCd-1234_xyz"})
         assert result == {"x-aihub-user-token": "AbCd-1234_xyz"}
 
 
 class TestWithAihubHeaders:
-    """``with_aihub_headers`` is the egress where headers are placed onto the NATS envelope. It
-    defensively filters by the ``X-AIHub-*`` prefix so a caller who accidentally passes a wider
-    dict (e.g. raw request.headers) cannot leak ``Authorization``/``Cookie``/etc. to NATS."""
+    """``with_aihub_headers`` places X-AIHub-* headers on the NATS envelope, dropping non-prefixed keys."""
 
     def test_aihub_headers_are_merged_into_outgoing_headers(self):
         result = NATSMessageHeaders().with_aihub_headers({"X-AIHub-User-Token": "tok"}).to_dict()


### PR DESCRIPTION
## Summary

Implements [#948](https://github.com/bbvch-ai/aihub-core/issues/948) — propagates `X-AIHub-*` request headers from the
API boundary through the agent pipeline so downstream steps (notably MCP tool calls in
[#1055](https://github.com/bbvch-ai/aihub-core/issues/1055)) can act on behalf of the originating user.

**Acceptance criteria from #948:**

- [x] Any API header prefixed with `X-AIHub-...` is forwarded to the agent on the NATS message header
- [x] Headers ride on the NATS message envelope, not in the event payload
- [x] Lifted into `RunContext` by `AgentDispatcher` so steps can read them by key (per #948 follow-up comment: *"on NATS
  Message Header not UserMessageEvent and put the headers in the RunContext"*)

## Transport

```
HTTP request
  → OpenaiController.chat_completion_with_assistants
  → NATSMessageHeaders.extract_aihub_headers(dict(request.headers))   # filter + lowercase
  → OpenaiService → ChatService → ExternalAgentEventDistributor.distribute_event(..., aihub_headers=...)
  → JSPublisher/NCPublisher.publish_event(..., extra_headers=...)
  → NATSMessageHeaders.with_aihub_headers(extra_headers)               # filter by X-AIHub-* prefix
  → NATS message headers (envelope, not payload)
  → JSSubscriber/NCSubscriber.message_handler
  → event._aihub_headers = NATSMessageHeaders.extract_aihub_headers(msg.headers)
  → AgentDispatcher.handle_event
  → RunContext.set("_aihub_headers", event._aihub_headers)
```

Only the control path forwards the headers (StartEvent, HITL/BITL responses). Display events are observability-only and
never drive tool calls, so `ExternalAgentEventDistributor._handle_display_message` deliberately does **not** attach
`X-AIHub-*` headers.

## Trust boundary

Both `extract_aihub_headers` (read side) and `with_aihub_headers` (write side) filter by the `X-AIHub-` prefix
(case-insensitive). Defense in depth: a caller who passes a wider headers dict cannot leak `Authorization`/`Cookie`/etc.
through either end.

**Inbound trust:** `X-AIHub-*` headers originate from the untrusted HTTP client — no proxy injects or vouches for them,
and the prefix filter is *not* an authenticity check. Any consumer that reads these values (e.g. an on-behalf-of token
in #1055) MUST validate them independently and must never treat an `X-AIHub-*` value as a trusted identity assertion.
This contract is documented in code on `NATSMessageHeaders.AIHUB_HEADER_PREFIX`, `BaseEvent._aihub_headers`, and the
`AgentDispatcher` RunContext write.

## Token persistence

- **JetStream payload**: token is **not** in the event payload (`_aihub_headers` is a `PrivateAttr`, not serialized).
- **NATS message envelope**: headers ride on the envelope; persisted by JetStream for the stream retention period.
  Reviewed and accepted as an operational tradeoff for this PR.
- **RunContext** (Valkey): copied in by the dispatcher; cleared on `StopEvent`/`ExceptionEvent` via
  `run_context.delete_all()`. Orphaned runs fall back to the existing RunContext TTL (30 days) — same safety net used
  for all other run state, not a new exposure.

## Scope (intentional)

Only `/v1/chat/completions` (via `OpenaiController.chat_completion_with_assistants`) extracts headers in this PR. Other
entry points (bot routes, audio/image endpoints, other controllers) do **not** forward `X-AIHub-*` headers yet.
Consumers that depend on the token being present (e.g. MCP `user_token` auth mode in #1055) only work for
chat-completion-initiated runs today; scheduled, process-initiated, bot-channel, and agent-to-agent runs will not carry
one. Extending coverage is a follow-up.

## Test plan

- [x] `extract_aihub_headers` — 8 unit tests covering prefix matching, key normalization, value preservation, empty/None
  inputs.
- [x] `with_aihub_headers` — 6 unit tests covering merge, prefix-filter drop, case-insensitive matching, empty/None
  inputs, builder-chain preservation.
- [x] `JSSubscriber` / `NCSubscriber` — 4 tests verifying `event._aihub_headers` is populated from the NATS message
  headers (keys lowercased) and non-prefixed entries are dropped on the way in.
- [x] `JSPublisher` / `NCPublisher` — 2 tests verifying `extra_headers` is threaded through the publisher builder chain
  onto the published message without clobbering the `Nats-Msg-Id` / trace-context headers. (Prefix filtering at the
  publisher boundary is covered by the `with_aihub_headers` tests above.)
- [x] `AgentDispatcher` — 2 tests verifying the RunContext write on incoming `_aihub_headers` and no write when absent.
