### PR TITLE
chore(ci-cd): Drop semver cooldown keys for docker/github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -171,10 +171,10 @@ updates:
       - /infra/deployment/docker/playwright
     schedule:
       interval: monthly
+    # docker/github-actions ecosystems only support cooldown.default-days —
+    # their tags are not semver-decomposable, so semver-*-days are rejected.
     cooldown:
       default-days: 7
-      semver-minor-days: 14
-      semver-patch-days: 7
     open-pull-requests-limit: 5
     labels: [dependencies, docker]
     commit-message:
@@ -200,10 +200,9 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    # github-actions only supports cooldown.default-days (see docker note above).
     cooldown:
       default-days: 7
-      semver-minor-days: 14
-      semver-patch-days: 7
     open-pull-requests-limit: 5
     labels: [dependencies, ci-cd]
     commit-message:


### PR DESCRIPTION
Follow-up to #1284. Dependabot's config validator rejects `semver-minor-days` / `semver-patch-days` under `cooldown` for the **docker** and **github-actions** ecosystems (their tags aren't semver-decomposable). Only `default-days` is supported there.

```
The property '#/updates/4/cooldown/semver-minor-days' is not supported for the package ecosystem 'docker'.
The property '#/updates/4/cooldown/semver-patch-days' is not supported for the package ecosystem 'docker'.
The property '#/updates/5/cooldown/semver-minor-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/5/cooldown/semver-patch-days' is not supported for the package ecosystem 'github-actions'.
```

**Fix:** docker + github-actions now use `cooldown: { default-days: 7 }` only. npm/uv keep the full semver split (valid for those ecosystems). No behavior change beyond making the config parse — a 7-day blanket cooldown still applies to docker/actions.

Same admin-merge path as #1284 if CI is still budget-constrained — single non-code config file.