### PR TITLE
chore(ci-cd): Upgrade web to pnpm 10 + native minimumReleaseAge

### DIFF
--- a/.github/actions/lint_frontend/action.yml
+++ b/.github/actions/lint_frontend/action.yml
@@ -6,7 +6,9 @@ inputs:
     description: GitHub token for authentication
     required: true
   working_directory:
-    description: Working directory for the linter
+    description: Working directory for the linter. Required because corepack resolves
+      the pinned pnpm from this directory's package.json.
+    required: true
   lockfile:
     description: Path to the lockfile
     required: true
@@ -26,7 +28,7 @@ runs:
       # "packageManager" field — single source of truth, no version drift.
       run: |
         npm install -g --ignore-scripts corepack@0.34.7
-        corepack enable
+        corepack enable pnpm
         corepack install
       working-directory: ${{ inputs.working_directory }}
     - name: Get pnpm store path

--- a/.github/actions/lint_frontend/action.yml
+++ b/.github/actions/lint_frontend/action.yml
@@ -19,13 +19,21 @@ runs:
       uses: actions/setup-node@v6
       with:
         node-version: 25.x
-    - name: Install pnpm
+    - name: Install pnpm via corepack
       shell: bash
-      run: npm install -g pnpm
+      # Node 25 no longer bundles corepack; pin it (matches the web
+      # Dockerfile) so CI uses the exact pnpm from package.json's
+      # "packageManager" field — single source of truth, no version drift.
+      run: |
+        npm install -g --ignore-scripts corepack@0.34.7
+        corepack enable
+        corepack install
+      working-directory: ${{ inputs.working_directory }}
     - name: Get pnpm store path
       id: pnpm-store-dir-path
       shell: bash
       run: echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
+      working-directory: ${{ inputs.working_directory }}
     - name: Cache Node Modules
       uses: actions/cache@v4
       id: pnpm-cache

--- a/.github/actions/lint_frontend/action.yml
+++ b/.github/actions/lint_frontend/action.yml
@@ -23,9 +23,6 @@ runs:
         node-version: 25.x
     - name: Install pnpm via corepack
       shell: bash
-      # Node 25 no longer bundles corepack; pin it (matches the web
-      # Dockerfile) so CI uses the exact pnpm from package.json's
-      # "packageManager" field — single source of truth, no version drift.
       run: |
         npm install -g --ignore-scripts corepack@0.34.7
         corepack enable pnpm

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,17 @@
 #      (this is what flooded the repo and burned the Actions budget).
 #
 #   2. NOT bleeding edge. A `cooldown` window holds back freshly published
-#      releases so we never pull a version on its release day. This is a
-#      supply-chain safety measure: most malicious-package incidents are
-#      caught and yanked within days of publication. We trade a short lag
-#      for not being the canary.
+#      releases so we never pull a version on its release day — supply-chain
+#      safety, since most malicious-package incidents are caught and yanked
+#      within days. uv/docker/github-actions use Dependabot `cooldown`. The
+#      WEB npm entry does NOT: Dependabot cooldown is broken with pnpm — it
+#      desyncs package.json from pnpm-lock.yaml, so every grouped PR fails CI
+#      with ERR_PNPM_OUTDATED_LOCKFILE (dependabot-core issues 13165 / 14339).
+#      web uses pnpm-native `minimumReleaseAge` instead
+#      (packages/web/swiss_ai_hub_web/pnpm-workspace.yaml), applied during
+#      both resolution and lockfile generation so it cannot drift. docs/e2e
+#      are also pnpm and still on `cooldown` (same bug) — migrating them is a
+#      tracked follow-up.
 #
 #   3. Low, predictable cadence. `interval: monthly` → one batched PR per
 #      ecosystem per month instead of a weekly stream. CI runs full
@@ -76,10 +83,13 @@ updates:
     directory: /packages/web/swiss_ai_hub_web
     schedule:
       interval: monthly
-    cooldown:
-      default-days: 7
-      semver-minor-days: 14
-      semver-patch-days: 7
+    # NO Dependabot cooldown for npm — it is fundamentally broken with pnpm:
+    # cooldown makes Dependabot pin an older version in package.json while the
+    # regenerated pnpm-lock.yaml resolves the newer one, so every grouped PR
+    # fails CI with ERR_PNPM_OUTDATED_LOCKFILE (dependabot-core  # 13165/#14339).
+    # The supply-chain lag is instead enforced NATIVELY by pnpm via
+    # `minimumReleaseAge` in each project's pnpm-workspace.yaml — pnpm applies
+    # it during BOTH resolution and lockfile generation, so no drift.
     open-pull-requests-limit: 5
     labels: [dependencies, frontend]
     commit-message:
@@ -104,6 +114,9 @@ updates:
     directory: /docs
     schedule:
       interval: monthly
+    # TODO: docs is also pnpm — same Dependabot-cooldown-vs-pnpm bug applies.
+    # Out of scope for the web pnpm-10 upgrade; migrate docs to pnpm
+    # `minimumReleaseAge` in a follow-up. Kept here until then.
     cooldown:
       default-days: 7
       semver-minor-days: 14
@@ -132,6 +145,9 @@ updates:
     directory: /e2e
     schedule:
       interval: monthly
+    # TODO: e2e is also pnpm — same Dependabot-cooldown-vs-pnpm bug applies.
+    # Out of scope for the web pnpm-10 upgrade; migrate e2e to pnpm
+    # `minimumReleaseAge` in a follow-up. Kept here until then.
     cooldown:
       default-days: 7
       semver-minor-days: 14

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -86,7 +86,7 @@ updates:
     # NO Dependabot cooldown for npm — it is fundamentally broken with pnpm:
     # cooldown makes Dependabot pin an older version in package.json while the
     # regenerated pnpm-lock.yaml resolves the newer one, so every grouped PR
-    # fails CI with ERR_PNPM_OUTDATED_LOCKFILE (dependabot-core  # 13165/#14339).
+    # fails CI with ERR_PNPM_OUTDATED_LOCKFILE (dependabot-core issues 13165/14339).
     # The supply-chain lag is instead enforced NATIVELY by pnpm via
     # `minimumReleaseAge` in each project's pnpm-workspace.yaml — pnpm applies
     # it during BOTH resolution and lockfile generation, so no drift.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,15 +12,13 @@
 #   2. NOT bleeding edge. A `cooldown` window holds back freshly published
 #      releases so we never pull a version on its release day — supply-chain
 #      safety, since most malicious-package incidents are caught and yanked
-#      within days. uv/docker/github-actions use Dependabot `cooldown`. The
-#      WEB npm entry does NOT: Dependabot cooldown is broken with pnpm — it
-#      desyncs package.json from pnpm-lock.yaml, so every grouped PR fails CI
-#      with ERR_PNPM_OUTDATED_LOCKFILE (dependabot-core issues 13165 / 14339).
-#      web uses pnpm-native `minimumReleaseAge` instead
-#      (packages/web/swiss_ai_hub_web/pnpm-workspace.yaml), applied during
-#      both resolution and lockfile generation so it cannot drift. docs/e2e
-#      are also pnpm and still on `cooldown` (same bug) — migrating them is a
-#      tracked follow-up.
+#      within days. uv/docker/github-actions use Dependabot `cooldown`. ALL
+#      THREE npm entries (web/docs/e2e) do NOT: Dependabot cooldown is broken
+#      with pnpm — it desyncs package.json from pnpm-lock.yaml, so every
+#      grouped PR fails CI with ERR_PNPM_OUTDATED_LOCKFILE (dependabot-core
+#      issues 13165 / 14339). npm uses pnpm-native `minimumReleaseAge` (in
+#      each project's pnpm-workspace.yaml), applied during both resolution
+#      and lockfile generation so it cannot drift.
 #
 #   3. Low, predictable cadence. `interval: monthly` → one batched PR per
 #      ecosystem per month instead of a weekly stream. CI runs full
@@ -114,13 +112,8 @@ updates:
     directory: /docs
     schedule:
       interval: monthly
-    # TODO: docs is also pnpm — same Dependabot-cooldown-vs-pnpm bug applies.
-    # Out of scope for the web pnpm-10 upgrade; migrate docs to pnpm
-    # `minimumReleaseAge` in a follow-up. Kept here until then.
-    cooldown:
-      default-days: 7
-      semver-minor-days: 14
-      semver-patch-days: 7
+    # No npm cooldown — pnpm `minimumReleaseAge` in docs/pnpm-workspace.yaml
+    # enforces the supply-chain lag instead (see web entry above for why).
     open-pull-requests-limit: 5
     labels: [dependencies, docs]
     commit-message:
@@ -145,13 +138,8 @@ updates:
     directory: /e2e
     schedule:
       interval: monthly
-    # TODO: e2e is also pnpm — same Dependabot-cooldown-vs-pnpm bug applies.
-    # Out of scope for the web pnpm-10 upgrade; migrate e2e to pnpm
-    # `minimumReleaseAge` in a follow-up. Kept here until then.
-    cooldown:
-      default-days: 7
-      semver-minor-days: 14
-      semver-patch-days: 7
+    # No npm cooldown — pnpm `minimumReleaseAge` in e2e/pnpm-workspace.yaml
+    # enforces the supply-chain lag instead (see web entry above for why).
     open-pull-requests-limit: 5
     labels: [dependencies, tests]
     commit-message:

--- a/.github/workflows/add-tag.yml
+++ b/.github/workflows/add-tag.yml
@@ -194,12 +194,18 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y jq
+      - name: Setup Node.js
+        # Pin Node 25.x to match the web Dockerfile + lint actions so corepack
+        # bootstraps under the same Node everywhere (true env parity).
+        uses: actions/setup-node@v6
+        with:
+          node-version: 25.x
       - name: Install pnpm via corepack
         # Pin pnpm to package.json's "packageManager" (matches web Dockerfile
         # + lint actions) so the release license-check never drifts pnpm.
         run: |
           npm install -g --ignore-scripts corepack@0.34.7
-          corepack enable
+          corepack enable pnpm
           corepack install
         working-directory: packages/web/swiss_ai_hub_web
       - name: Install uv

--- a/.github/workflows/add-tag.yml
+++ b/.github/workflows/add-tag.yml
@@ -194,7 +194,14 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y jq
-          npm install -g pnpm
+      - name: Install pnpm via corepack
+        # Pin pnpm to package.json's "packageManager" (matches web Dockerfile
+        # + lint actions) so the release license-check never drifts pnpm.
+        run: |
+          npm install -g --ignore-scripts corepack@0.34.7
+          corepack enable
+          corepack install
+        working-directory: packages/web/swiss_ai_hub_web
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/add-tag.yml
+++ b/.github/workflows/add-tag.yml
@@ -264,7 +264,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 10.13.1
+          package_json_file: docs/package.json
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/add-tag.yml
+++ b/.github/workflows/add-tag.yml
@@ -195,14 +195,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y jq
       - name: Setup Node.js
-        # Pin Node 25.x to match the web Dockerfile + lint actions so corepack
-        # bootstraps under the same Node everywhere (true env parity).
         uses: actions/setup-node@v6
         with:
           node-version: 25.x
       - name: Install pnpm via corepack
-        # Pin pnpm to package.json's "packageManager" (matches web Dockerfile
-        # + lint actions) so the release license-check never drifts pnpm.
         run: |
           npm install -g --ignore-scripts corepack@0.34.7
           corepack enable pnpm

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 10.13.1
+          package_json_file: docs/package.json
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -65,8 +65,6 @@ jobs:
         with:
           node-version: 25.x
       - name: Install pnpm via corepack
-        # Pin pnpm to package.json's "packageManager" (matches web Dockerfile
-        # + lint_frontend action) so license-check never drifts pnpm version.
         run: |
           npm install -g --ignore-scripts corepack@0.34.7
           corepack enable pnpm

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -69,7 +69,7 @@ jobs:
         # + lint_frontend action) so license-check never drifts pnpm version.
         run: |
           npm install -g --ignore-scripts corepack@0.34.7
-          corepack enable
+          corepack enable pnpm
           corepack install
         working-directory: packages/web/swiss_ai_hub_web
       - name: Make license check script executable

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -64,8 +64,14 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 25.x
-      - name: Install pnpm
-        run: npm install -g pnpm
+      - name: Install pnpm via corepack
+        # Pin pnpm to package.json's "packageManager" (matches web Dockerfile
+        # + lint_frontend action) so license-check never drifts pnpm version.
+        run: |
+          npm install -g --ignore-scripts corepack@0.34.7
+          corepack enable
+          corepack install
+        working-directory: packages/web/swiss_ai_hub_web
       - name: Make license check script executable
         run: chmod +x ./generate-license.sh
       - name: Run license check

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+---
+# pnpm settings for the docs (VitePress) project.
+# minimumReleaseAge: replaces Dependabot `cooldown` (broken with pnpm).
+# 10080 = 7 days. See packages/web/swiss_ai_hub_web/pnpm-workspace.yaml for
+# the rationale and the dependabot-core issue references.
+minimumReleaseAge: 10080
+
+# pnpm 10 blocks dependency build scripts by default; esbuild needs its
+# native postinstall for the Vitepress build (asset processing).
+onlyBuiltDependencies: [esbuild]

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,5 +8,6 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0"
-  }
+  },
+  "packageManager": "pnpm@10.20.0+sha512.cf9998222162dd85864d0a8102e7892e7ba4ceadebbf5a31f9c2fce48dfce317a9c53b9f6464d1ef9042cba2e02ae02a9f7c143a2b438cd93c91840f0192b9dd"
 }

--- a/e2e/pnpm-workspace.yaml
+++ b/e2e/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+---
+# pnpm settings for the e2e (Playwright) test project.
+# minimumReleaseAge: replaces Dependabot `cooldown` (broken with pnpm).
+# 10080 = 7 days. See packages/web/swiss_ai_hub_web/pnpm-workspace.yaml for
+# the rationale and the dependabot-core issue references.
+# No onlyBuiltDependencies — pnpm 10 install reports zero blocked scripts
+# for the current dep set (@playwright/test only); browser binaries are
+# fetched separately via `npx playwright install`, not via install scripts.
+minimumReleaseAge: 10080

--- a/packages/web/swiss_ai_hub_web/package.json
+++ b/packages/web/swiss_ai_hub_web/package.json
@@ -39,7 +39,7 @@
     "lint": "(test -f .app/.nuxt/eslint.config.mjs || nuxi prepare .app) && eslint . --fix",
     "generate-sdk": "openapi-ts"
   },
-  "packageManager": "pnpm@9.14.2+sha512.6e2baf77d06b9362294152c851c4f278ede37ab1eba3a55fda317a4a17b209f4dbb973fb250a77abc463a341fcb1f17f17cfa24091c4eb319cda0d9b84278387",
+  "packageManager": "pnpm@10.20.0+sha512.cf9998222162dd85864d0a8102e7892e7ba4ceadebbf5a31f9c2fce48dfce317a9c53b9f6464d1ef9042cba2e02ae02a9f7c143a2b438cd93c91840f0192b9dd",
   "dependencies": {
     "@formkit/i18n": "^1.7.2",
     "@formkit/nuxt": "^2.0.0",

--- a/packages/web/swiss_ai_hub_web/pnpm-workspace.yaml
+++ b/packages/web/swiss_ai_hub_web/pnpm-workspace.yaml
@@ -4,7 +4,7 @@
 # minimumReleaseAge: supply-chain hardening. pnpm refuses to install any
 # package version published less than this many MINUTES ago (10080 = 7 days).
 # This replaces the Dependabot `cooldown` for npm, which is fundamentally
-# broken with pnpm (dependabot-core #13165 /  # 14339: cooldown desyncs
+# broken with pnpm (dependabot-core issues 13165/14339: cooldown desyncs
 # package.json from pnpm-lock.yaml → ERR_PNPM_OUTDATED_LOCKFILE on every
 # grouped PR). pnpm enforces this natively during BOTH resolution and
 # lockfile generation, so manifest and lockfile can never drift. The window

--- a/packages/web/swiss_ai_hub_web/pnpm-workspace.yaml
+++ b/packages/web/swiss_ai_hub_web/pnpm-workspace.yaml
@@ -1,0 +1,20 @@
+---
+# pnpm settings for the web app (single-package; no `packages:` list needed).
+#
+# minimumReleaseAge: supply-chain hardening. pnpm refuses to install any
+# package version published less than this many MINUTES ago (10080 = 7 days).
+# This replaces the Dependabot `cooldown` for npm, which is fundamentally
+# broken with pnpm (dependabot-core #13165 /  # 14339: cooldown desyncs
+# package.json from pnpm-lock.yaml → ERR_PNPM_OUTDATED_LOCKFILE on every
+# grouped PR). pnpm enforces this natively during BOTH resolution and
+# lockfile generation, so manifest and lockfile can never drift. The window
+# gives malicious-package takedowns time to land before we pull a release.
+minimumReleaseAge: 10080
+# Packages allowed to run install/build scripts. pnpm 10 blocks dependency
+# lifecycle scripts by default; these four need their native/postinstall
+# steps for the Nuxt build + lint toolchain to function.
+onlyBuiltDependencies:
+  - '@parcel/watcher'
+  - esbuild
+  - unrs-resolver
+  - vue-demi


### PR DESCRIPTION
## Why

Dependabot's `cooldown` is **fundamentally broken with pnpm** ([dependabot-core #13165](https://github.com/dependabot/dependabot-core/issues/13165), [#14339](https://github.com/dependabot/dependabot-core/issues/14339), both open/unfixed): cooldown makes Dependabot pin an *older* version in `package.json` while the regenerated `pnpm-lock.yaml` resolves the *newer* one → every grouped web PR fails CI with `ERR_PNPM_OUTDATED_LOCKFILE` (this is why #1290 wouldn't go green). Recreating the PR does not help — it's deterministic.

## Fix

Replace the broken Dependabot cooldown for the **web** npm entry with pnpm's **native `minimumReleaseAge`**, which pnpm enforces during *both* resolution and lockfile generation, so manifest and lockfile structurally cannot drift.

| Change | Detail |
|---|---|
| `packageManager` | `pnpm@9.14.2` → `pnpm@10.20.0` (matches docs project). `lockfileVersion` stays `9.0` — **zero lockfile churn**, validated locally with `pnpm install --frozen-lockfile` under pnpm 10 (passes; the exact gate that failed on #1290) |
| `pnpm-workspace.yaml` (new) | `minimumReleaseAge: 10080` (7-day supply-chain lag) + `onlyBuiltDependencies` (pnpm 10 blocks dep build scripts by default; the 4 listed are required by the Nuxt build/lint toolchain) |
| `dependabot.yml` | Drop `cooldown` from the **web** npm entry only. uv/docker/github-actions keep it. docs/e2e keep it — **tracked follow-up**, same bug |
| CI | Replace unpinned `npm install -g pnpm` (currently resolves to pnpm 11!) with pinned **corepack** in `lint_frontend` action, `lint-pr` license-check, and `add-tag` license-report — CI now uses the exact `packageManager` pin (single source of truth) |
| Docker | **No change** — the web Dockerfile already does `corepack install`, so it auto-follows the `packageManager` bump |

## ⚠️ Branch divergence — important

This targets `main`'s layout (`packages/web/swiss_ai_hub_web/`). The in-flight **`feat/open-source`** branch restructures the frontend into a *root* pnpm workspace (`packages/web/`, root `pnpm-lock.yaml`). When that lands, this work must be carried over to the root-workspace layout (packageManager pin, `pnpm-workspace.yaml` `minimumReleaseAge`/`onlyBuiltDependencies`, and the dependabot npm `directory`). Not auto-portable — flagging so it isn't lost.

## Test plan

- [x] `pnpm install --frozen-lockfile` passes under pnpm 10 (lockfile unchanged, format 9.0 compatible)
- [x] `dependabot.yml` + `pnpm-workspace.yaml` valid YAML; cooldown matrix correct (web npm = none, rest = cooldown)
- [ ] CI green on this PR (`Lint Web` in particular — the previously failing job)