### PR TITLE
fix(ci-cd): Fix regression in action due to slim runner

### DIFF
--- a/.github/workflows/build-agents.yml
+++ b/.github/workflows/build-agents.yml
@@ -36,14 +36,14 @@ jobs:
       - name: Parse agent images from compose-config.yml
         id: parse
         run: |
-          # Extract image names where build == "localbuild" and name ends with "_agent"
-          images=$(python3 -c "
-          import yaml, json
-          with open('infra/deployment/compose-config.yml') as f:
-              config = yaml.safe_load(f)
-          images = [k for k, v in config['image_tags'].items() if isinstance(v, dict) and v.get('build') == 'localbuild' and k.endswith('_agent')]
-          print(json.dumps(images))
-          ")
+          # Extract image names where build == "localbuild" and name ends with "_agent".
+          # yq + jq are both preinstalled on ubuntu-slim; PyYAML is not.
+          images=$(yq -o=json '.' infra/deployment/compose-config.yml \
+            | jq -c '[.image_tags | to_entries[]
+                | select((.value | type) == "object"
+                  and .value.build == "localbuild"
+                  and (.key | endswith("_agent")))
+                | .key]')
           echo "Discovered agents: $images"
           echo "matrix={\"image\":$images}" >> $GITHUB_OUTPUT
   build:

--- a/.github/workflows/build-pipelines.yml
+++ b/.github/workflows/build-pipelines.yml
@@ -36,14 +36,14 @@ jobs:
       - name: Parse pipeline images from compose-config.yml
         id: parse
         run: |
-          # Extract image names where build == "localbuild" and name ends with "_pipeline"
-          images=$(python3 -c "
-          import yaml, json
-          with open('infra/deployment/compose-config.yml') as f:
-              config = yaml.safe_load(f)
-          images = [k for k, v in config['image_tags'].items() if isinstance(v, dict) and v.get('build') == 'localbuild' and k.endswith('_pipeline')]
-          print(json.dumps(images))
-          ")
+          # Extract image names where build == "localbuild" and name ends with "_pipeline".
+          # yq + jq are both preinstalled on ubuntu-slim; PyYAML is not.
+          images=$(yq -o=json '.' infra/deployment/compose-config.yml \
+            | jq -c '[.image_tags | to_entries[]
+                | select((.value | type) == "object"
+                  and .value.build == "localbuild"
+                  and (.key | endswith("_pipeline")))
+                | .key]')
           echo "Discovered pipelines: $images"
           echo "matrix={\"image\":$images}" >> $GITHUB_OUTPUT
   build:

--- a/.github/workflows/set-latest.yml
+++ b/.github/workflows/set-latest.yml
@@ -86,10 +86,16 @@ jobs:
     permissions:
       contents: write
     steps:
+      # The default GITHUB_TOKEN cannot push refs that change .github/workflows
+      # content (it lacks the `workflow` scope, and that scope cannot be granted
+      # to GITHUB_TOKEN). Moving `latest` between release commits typically
+      # changes workflow files, so we authenticate via the SSH deploy key used
+      # by add-tag.yml — deploy keys bypass that restriction.
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.RELEASE_FINALIZE_DEPLOY_KEY }}
       - name: Move latest git tag
         env:
           SOURCE_TAG: ${{ inputs.source_tag }}

--- a/.github/workflows/set-latest.yml
+++ b/.github/workflows/set-latest.yml
@@ -67,18 +67,13 @@ jobs:
           # release tag. Project-managed images published out-of-band (postgres ->
           # pgvector-repack:pg17, playwright -> playwright:v1.58.0-jammy) carry a
           # literal tag and must NOT be retagged here.
-          images=$(python3 -c "
-          import yaml, json
-          with open('infra/deployment/compose-config.yml') as f:
-              config = yaml.safe_load(f)
-          images = [
-              k for k, v in config['image_tags'].items()
-              if isinstance(v, dict)
-              and 'build' in v
-              and v.get('latest') == f'{k}:latest'
-          ]
-          print(json.dumps(images))
-          ")
+          # yq + jq are both preinstalled on ubuntu-slim; PyYAML is not.
+          images=$(yq -o=json '.' infra/deployment/compose-config.yml \
+            | jq -c '[.image_tags | to_entries[]
+                | select((.value | type) == "object"
+                  and (.value | has("build"))
+                  and (.value.latest == .key + ":latest"))
+                | .key]')
           echo "Discovered images: $images"
           echo "matrix={\"image\":$images}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to improve how Docker image names are parsed from `compose-config.yml`. The main change is replacing Python scripts that use PyYAML (which isn't preinstalled) with `yq` and `jq` commands (which are preinstalled), making the workflows more portable and reliable. Additionally, it improves authentication for git operations in the `set-latest.yml` workflow.

**Workflow parsing improvements:**

* Replaced Python+PyYAML parsing with `yq` and `jq` in `.github/workflows/build-agents.yml` for extracting agent image names, ensuring compatibility with the default runner environment.
* Replaced Python+PyYAML parsing with `yq` and `jq` in `.github/workflows/build-pipelines.yml` for extracting pipeline image names, ensuring compatibility with the default runner environment.
* Replaced Python+PyYAML parsing with `yq` and `jq` in `.github/workflows/set-latest.yml` for extracting images to retag, ensuring compatibility with the default runner environment.

**Authentication improvements:**

* Updated `.github/workflows/set-latest.yml` to use an SSH deploy key for git operations, allowing workflow files to be updated when moving the `latest` tag, since the default `GITHUB_TOKEN` lacks the necessary permissions.