### PR TITLE
chore(swiss-ai-hub): Resolve open SonarCloud issues for packages/agent

### DIFF
--- a/packages/agent/swiss_ai_hub/agent/agents/rag_agent/rag_agent.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/rag_agent/rag_agent.py
@@ -93,7 +93,7 @@ async def context_ready_for_history_limit(
     Precondition for limit_chat_history_with_context_step.
     Allows the step to run when InOrderNodeCombinerEvent is present AND ContextSufficientAcceptEvent is present.
     """
-    return check_context_ready_for_history_limit(context_event, context_sufficient_event)
+    return check_context_ready_for_history_limit(context_sufficient_event)
 
 
 @precondition()

--- a/packages/agent/swiss_ai_hub/agent/dispatchers/agent_dispatcher.py
+++ b/packages/agent/swiss_ai_hub/agent/dispatchers/agent_dispatcher.py
@@ -275,7 +275,6 @@ class AgentDispatcher(BaseDispatcher):
             topic.execution_context_id, step_method.__name__, events_and_kwargs.events
         )
 
-        # Instantiate the agent and run the step
         agent_instance = self.agent()
 
         async with self.agent_run_tracer.trace_step_start(topic, step_method, events_and_kwargs.kwargs) as step_span:
@@ -292,48 +291,45 @@ class AgentDispatcher(BaseDispatcher):
 
             # Always finalize the span so Langfuse receives trace metadata (name, session,
             # user) even for steps that return None (e.g. side-effect-only steps).
-            result_events = None
-            if result:
-                if not isinstance(result, list):
-                    result = [result]
-                result_events = result
-
+            result_events = self._normalize_step_result(result)
             await self.agent_run_tracer.trace_step_stop(step_span, result_events, topic)
 
-            # If the step returns events, publish them
             if result_events:
                 for event in result_events:
-                    if event.is_hitl_request_event:
-                        logger.debug(f"Handling special event: HumanInTheLoopRequestEvent: {event.event_name}")
-                        # Complete the event's topic info
-                        event.topic = AgentInstanceTopic.from_partial_topic(
-                            partial_topic=event.topic,
-                            agent_class=topic.agent_class,
-                            agent_id=topic.agent_id,
-                            run_id=topic.run_id,
-                            thread_id=topic.thread_id,
-                            display_id=topic.display_id,
-                            event_id=event.event_id,
-                        )
+                    await self._handle_step_result_event(event, topic)
 
-                    if event.is_bitl_request_event:
-                        logger.debug(f"Handling special event: BotInTheLoopRequestEvent: {event.event_name}")
-                        # Complete the event's topic info
-                        event.topic = AgentInstanceTopic.from_partial_topic(
-                            partial_topic=event.topic,
-                            agent_class=topic.agent_class,
-                            agent_id=topic.agent_id,
-                            run_id=topic.run_id,
-                            thread_id=topic.thread_id,
-                            display_id=topic.display_id,
-                            event_id=event.event_id,
-                        )
+    @staticmethod
+    def _normalize_step_result(result: Any) -> list[BaseEvent] | None:
+        if not result:
+            return None
+        if not isinstance(result, list):
+            return [result]
+        return result
 
-                    if event.is_aitl_request_event:
-                        logger.debug(f"Handling special event: AgentInTheLoopRequestEvent: {event.event_name}")
-                        await self.trigger_agent_in_the_loop(event, topic)
+    @staticmethod
+    def _complete_request_event_topic(event: BaseEvent, topic: AgentInstanceTopic) -> None:
+        if event.is_hitl_request_event:
+            logger.debug(f"Handling special event: HumanInTheLoopRequestEvent: {event.event_name}")
+        elif event.is_bitl_request_event:
+            logger.debug(f"Handling special event: BotInTheLoopRequestEvent: {event.event_name}")
+        else:
+            return
+        event.topic = AgentInstanceTopic.from_partial_topic(
+            partial_topic=event.topic,
+            agent_class=topic.agent_class,
+            agent_id=topic.agent_id,
+            run_id=topic.run_id,
+            thread_id=topic.thread_id,
+            display_id=topic.display_id,
+            event_id=event.event_id,
+        )
 
-                    await self.publish_event(event, topic)
+    async def _handle_step_result_event(self, event: BaseEvent, topic: AgentInstanceTopic) -> None:
+        self._complete_request_event_topic(event, topic)
+        if event.is_aitl_request_event:
+            logger.debug(f"Handling special event: AgentInTheLoopRequestEvent: {event.event_name}")
+            await self.trigger_agent_in_the_loop(cast(AgentInTheLoopRequestEvent, event), topic)
+        await self.publish_event(event, topic)
 
     @override
     async def publish_event(

--- a/packages/agent/swiss_ai_hub/agent/mcp/__init__.py
+++ b/packages/agent/swiss_ai_hub/agent/mcp/__init__.py
@@ -23,14 +23,17 @@ __all__ = [
     "to_tool_events",
 ]
 
+_MCP_RESOURCE_SCHEMAS_MODULE = "swiss_ai_hub.agent.mcp.mcp_resource_schemas"
+_MCP_TOOL_SCHEMAS_MODULE = "swiss_ai_hub.agent.mcp.mcp_tool_schemas"
+
 _LAZY_IMPORTS = {
     "McpClientFactory": "swiss_ai_hub.agent.mcp.mcp_client_factory",
-    "execute_resource_read": "swiss_ai_hub.agent.mcp.mcp_resource_schemas",
-    "fetch_static_resources": "swiss_ai_hub.agent.mcp.mcp_resource_schemas",
-    "resource_read_tool_schema": "swiss_ai_hub.agent.mcp.mcp_resource_schemas",
-    "execute_single_tool_call": "swiss_ai_hub.agent.mcp.mcp_tool_schemas",
-    "to_openai_tool_schemas": "swiss_ai_hub.agent.mcp.mcp_tool_schemas",
-    "to_tool_events": "swiss_ai_hub.agent.mcp.mcp_tool_schemas",
+    "execute_resource_read": _MCP_RESOURCE_SCHEMAS_MODULE,
+    "fetch_static_resources": _MCP_RESOURCE_SCHEMAS_MODULE,
+    "resource_read_tool_schema": _MCP_RESOURCE_SCHEMAS_MODULE,
+    "execute_single_tool_call": _MCP_TOOL_SCHEMAS_MODULE,
+    "to_openai_tool_schemas": _MCP_TOOL_SCHEMAS_MODULE,
+    "to_tool_events": _MCP_TOOL_SCHEMAS_MODULE,
 }
 
 

--- a/packages/agent/swiss_ai_hub/agent/rag/preconditions.py
+++ b/packages/agent/swiss_ai_hub/agent/rag/preconditions.py
@@ -39,7 +39,6 @@ def check_is_no_answer_response(event: AgentInTheLoop.response) -> bool:
 
 
 def check_context_ready_for_history_limit(
-    context_event: InOrderNodeCombinerEvent,
     context_sufficient_event: ContextSufficientAcceptEvent | None,
 ) -> bool:
     """Check if context is ready for history limiting (RAGAgent version)."""

--- a/packages/agent/swiss_ai_hub/agent/runners/multiprocess_agent_runner.py
+++ b/packages/agent/swiss_ai_hub/agent/runners/multiprocess_agent_runner.py
@@ -58,6 +58,11 @@ class MultiprocessAgentRunner:
             multiprocessing.set_start_method("fork")
 
     @staticmethod
+    async def _stop_runner_if_present(runner: AgentRunner | None) -> None:
+        if runner and hasattr(runner, "stop"):
+            await runner.stop()
+
+    @staticmethod
     def _process_runner(
         process_index: int,
         agent_type: type[Agent],
@@ -66,7 +71,7 @@ class MultiprocessAgentRunner:
     ):
         """Static method that runs in each process to initialize and run an agent."""
 
-        runner = None
+        runner: AgentRunner | None = None
         stop_loop = asyncio.Event()
         shutdown_task: asyncio.Task | None = None
 
@@ -75,14 +80,12 @@ class MultiprocessAgentRunner:
             if asyncio.get_event_loop().is_running():
                 shutdown_task = asyncio.create_task(shutdown_runner())
             else:
-                # If no event loop is running, just set the event
                 stop_loop.set()
 
         async def shutdown_runner():
             """Gracefully shutdown the runner"""
             logger.info(f"Process {process_index}: Received shutdown signal, stopping runner...")
-            if runner and hasattr(runner, "stop"):
-                await runner.stop()
+            await MultiprocessAgentRunner._stop_runner_if_present(runner)
             stop_loop.set()
 
         signal.signal(signal.SIGTERM, signal_handler)
@@ -99,24 +102,21 @@ class MultiprocessAgentRunner:
                 locale_paths=locale_paths,
             )
 
-            # Start the runner
             await runner.start()
 
             try:
-                # Wait until we're signaled to stop
                 await stop_loop.wait()
             except KeyboardInterrupt:
                 logger.info(f"Process {process_index}: Received KeyboardInterrupt")
             except Exception as e:
                 logger.exception(f"Process {process_index}: Error while running: {e}")
             finally:
-                # Ensure proper cleanup
                 if shutdown_task is not None:
                     logger.info(f"Process {process_index}: Waiting for shutdown task to complete")
                     await shutdown_task
-                if runner and hasattr(runner, "stop") and not stop_loop.is_set():
+                if not stop_loop.is_set():
                     logger.info(f"Process {process_index}: Stopping runner in finally block")
-                    await runner.stop()
+                    await MultiprocessAgentRunner._stop_runner_if_present(runner)
 
         try:
             asyncio.run(_run_agent())

--- a/packages/agent/swiss_ai_hub/agent/tracing/agent_run_tracer.py
+++ b/packages/agent/swiss_ai_hub/agent/tracing/agent_run_tracer.py
@@ -92,7 +92,7 @@ class AgentRunTracer:
             elif isinstance(arg, ListOfSize):
                 input_values[name] = [ev.model_dump() for ev in arg]
             elif isinstance(arg, EventDisplayer):
-                pass # EventDisplayer args are intentionally excluded from tracing
+                pass  # EventDisplayer args are intentionally excluded from tracing
             elif isinstance(arg, BaseModel):
                 input_values[name] = arg.model_dump()
             else:

--- a/packages/agent/swiss_ai_hub/agent/tracing/agent_run_tracer.py
+++ b/packages/agent/swiss_ai_hub/agent/tracing/agent_run_tracer.py
@@ -92,7 +92,7 @@ class AgentRunTracer:
             elif isinstance(arg, ListOfSize):
                 input_values[name] = [ev.model_dump() for ev in arg]
             elif isinstance(arg, EventDisplayer):
-                pass
+                pass # EventDisplayer args are intentionally excluded from tracing
             elif isinstance(arg, BaseModel):
                 input_values[name] = arg.model_dump()
             else:


### PR DESCRIPTION
## Summary

- Resolves the **`packages/agent` portion** of the open SonarCloud findings via small, behavior-preserving refactors.
- Part of #1220 — does **not** close the ticket, since SonarCloud findings in other scopes (e.g. `packages/api`) are still open and will be addressed in follow-up PRs.

## Changes

- **`agent_dispatcher.py`** — extracted three private helpers (`_normalize_step_result`, `_complete_request_event_topic`, `_handle_step_result_event`) to flatten step-result handling in `_execute_step` and remove duplication between HITL/BITL topic-completion branches.
- **`mcp/__init__.py`** — introduced `_MCP_RESOURCE_SCHEMAS_MODULE` / `_MCP_TOOL_SCHEMAS_MODULE` constants to dedupe the six identical module-path literals in `_LAZY_IMPORTS`.
- **`multiprocess_agent_runner.py`** — extracted `_stop_runner_if_present` helper to dedupe the runner shutdown pattern across `shutdown_runner` and the `finally` block.
- **`rag/preconditions.py`** + **`rag_agent.py`** — removed unused `context_event` parameter from `check_context_ready_for_history_limit` (the function body never used it; the `_with_expert` variant still takes both params).
- **`tracing/agent_run_tracer.py`** — added inline comment explaining why `EventDisplayer` args are intentionally skipped during tracing.

No public API or architecture changed — refactor is strictly internal.

## Test plan

- [x] Unit tests for affected files pass locally (`test_mcp_resource_schemas.py`, `test_agent_dispatcher.py`, `test_agent_run_tracer.py` — 57/57 green)
- [x] CI runs the full agent + process test suites against the live dev stack
- [x] CI lint + SonarCloud verifies the targeted findings are resolved on `packages/agent`
