### PR TITLE
chore(swiss-ai-hub): Resolve open SonarCloud issues for bot core

### DIFF
--- a/packages/bot/swiss_ai_hub/bot/bots/chat/content_extractor.py
+++ b/packages/bot/swiss_ai_hub/bot/bots/chat/content_extractor.py
@@ -210,9 +210,7 @@ class ContentExtractor:
             # PDF files are not supported, return a placeholder
             return Content(text=f"<file name='{file_info.name}'>PDF files are not supported yet</file>", type="text")
 
-        elif file_info.content_type and (
-            file_info.content_type.startswith("text/") or file_info.content_type.startswith("application/")
-        ):
+        elif file_info.content_type and file_info.content_type.startswith(("text/", "application/")):
             try:
                 text = file_info.content_bytes.decode("utf-8", errors="replace")
                 return Content(text=f"<file name='{file_info.name}'>{text}</file>", type="text")

--- a/packages/bot/swiss_ai_hub/bot/persistence/entities/conversation_entity.py
+++ b/packages/bot/swiss_ai_hub/bot/persistence/entities/conversation_entity.py
@@ -192,7 +192,7 @@ class ConversationEntity(Document):
     ) -> Self:
         conversation_id = _clean_conversation_id(conversation_id, bot_id)
         conversation = cls(
-            conversation_id=conversation_id, bot_id=bot_id, messages=messages, last_activity=datetime.utcnow()
+            conversation_id=conversation_id, bot_id=bot_id, messages=messages, last_activity=datetime.now(UTC)
         )
         return conversation.save()
 
@@ -217,7 +217,7 @@ class ConversationEntity(Document):
         if conversation is None:
             conversation = cls.create_conversation(conversation_id, bot_id, [])
         conversation.messages.extend(messages)
-        conversation.last_activity = datetime.utcnow()
+        conversation.last_activity = datetime.now(UTC)
         return conversation.save()
 
     @classmethod

--- a/packages/bot/swiss_ai_hub/bot/routes/bot_in_the_loop/bot_in_the_loop_handler.py
+++ b/packages/bot/swiss_ai_hub/bot/routes/bot_in_the_loop/bot_in_the_loop_handler.py
@@ -61,7 +61,7 @@ class BotInTheLoopHandler:
         else:
             return
 
-    async def _get_slack_ids(self, path: str) -> SlackIds:
+    def _get_slack_ids(self, path: str) -> SlackIds:
         """Get bot_id and team_id using the Slack auth.test API."""
         if path in self.slack_ids_cache:
             return self.slack_ids_cache[path]
@@ -174,7 +174,7 @@ class BotInTheLoopHandler:
     ):
         logger.info(f"[BITL-Handler] Handling Slack BITL request: thread_id={thread_id}, question={question!r}")
 
-        slack_ids = await self._get_slack_ids(self.path)
+        slack_ids = self._get_slack_ids(self.path)
         base_conversation_id = f"{slack_ids.bot_id}:{slack_ids.team_id}:{event.channel_config.channel_id}"
 
         logger.info(


### PR DESCRIPTION
## Summary

- Resolves the **`packages/bot` portion** of the open SonarCloud findings via small, behavior-preserving fixes.
- Part of #1220 — addresses all 4 open Sonar findings reported on `packages/bot` at the time of this PR.

## Changes

### Deprecated API (`datetime.utcnow()`)

- **`conversation_entity.py:195` + `:220`** — `datetime.utcnow()` → `datetime.now(UTC)` in `ConversationEntity.create_conversation` and `ConversationEntity.add_messages_to_conversation`.

`datetime.utcnow()` is deprecated since Python 3.12 — it returns a **naive** datetime, while the rest of `conversation_entity.py` (lines 90, 108, 169) already uses the timezone-aware `datetime.now(UTC)` pattern. Making both write paths consistent matters for the MongoDB TTL index defined on `last_activity` (line 184): mixed naive/aware timestamps stored on the same field can produce subtle inconsistencies for conversation expiry behavior. `UTC` is already imported on line 3.

### Pythonic idiom (chained `startswith`)

- **`content_extractor.py:213`** — `x.startswith("text/") or x.startswith("application/")` → `x.startswith(("text/", "application/"))`. `str.startswith` accepts a tuple of prefixes; the tuple form is a single C-level call instead of two Python-level calls.

### Misleading `async` keyword

- **`bot_in_the_loop_handler.py:64`** — removed `async` from `BotInTheLoopHandler._get_slack_ids`. The function body has no `await`, no `async with`, no `async for`. Both downstream operations — `PathEntity.get_slack_token_by_path` (MongoEngine query, sync) and `SlackUtils.get_slack_ids` (uses `httpx.post`, not `httpx.AsyncClient`) — are synchronous, so the function blocks regardless of its declaration. The `async` signature was making a false non-blocking promise to callers.
- **`bot_in_the_loop_handler.py:177`** — updated the only caller (`_handle_bot_in_the_loop_request_in_slack`): `slack_ids = await self._get_slack_ids(self.path)` → `slack_ids = self._get_slack_ids(self.path)`.

A genuinely-async alternative (wrap blocking calls in `asyncio.to_thread`, or switch to Motor + `httpx.AsyncClient`) would be a larger architectural change touching the whole bot package's persistence/HTTP stack — out of scope for a Sonar-cleanup PR.

## Test plan

- [x] `make -C packages/bot pr-ready` clean (ruff format + lint pass)
- [ ] Local integration tests for `packages/bot` require the dev Docker stack (MongoDB on `localhost:27017`) which isn't running on the dev machine — local run failed with `ServerSelectionTimeoutError`. CI will run them against a live stack.
- [ ] CI lint passes (`Lint Backend (packages/bot)`)
- [ ] CI test pipeline runs (`Test Modules (packages/bot, …)`)
- [ ] SonarCloud confirms the 4 targeted findings on `packages/bot` are resolved
