### PR TITLE
fix(bots): Resolve agent Teams bot Keycloak lookup using email

### DIFF
--- a/packages/bot/CLAUDE.md
+++ b/packages/bot/CLAUDE.md
@@ -13,7 +13,7 @@ packages/bot/                              # SDK framework
 │   ├── bots/
 │   │   ├── chat/
 │   │   │   ├── base_chat_bot.py              # Core base: conversation lifecycle, routing, error handling
-│   │   │   ├── completion_handler.py        # Strategy base + shared static utilities (channel handling, streaming, CRUD)
+│   │   │   ├── completion_handler.py        # Strategy base + shared static utilities (channel handling, streaming, CRUD, user identity resolution)
 │   │   │   ├── content_extractor.py         # Multi-channel file/text extraction (Slack, Teams, generic)
 │   │   │   ├── agent/
 │   │   │   │   ├── agent_chat_bot.py         # NATS-based agent chat (non-streaming)

--- a/packages/bot/playground/testing/tests/test_UserEmailResolution.py
+++ b/packages/bot/playground/testing/tests/test_UserEmailResolution.py
@@ -30,13 +30,16 @@ CONVERSATION_ID = "conversation-1"
 def _make_turn_context(
     *,
     from_name: str,
-    from_id: str = USER_AAD_ID,
+    from_id: str | None = USER_AAD_ID,
     connector_client: object | None = None,
 ) -> TurnContext:
     """Builds a minimal ``TurnContext`` for a single inbound message activity."""
+    from_fields: dict = {"name": from_name}
+    if from_id is not None:
+        from_fields["id"] = from_id
     activity = Activity(
         type="message",
-        from_property=ChannelAccount(id=from_id, name=from_name),
+        from_property=ChannelAccount(**from_fields),
         conversation=ConversationAccount(id=CONVERSATION_ID),
         recipient=ChannelAccount(id="bot-1", name="Assistant"),
     )
@@ -106,6 +109,44 @@ async def test_resolve_email_ignores_non_teams_connector():
     email = await CompletionHandler.resolve_user_email(turn_context)
 
     assert email == RESOLVED_EMAIL
+
+
+@pytest.mark.asyncio
+async def test_resolve_email_skips_connector_when_user_id_missing():
+    """A missing ``from_property.id`` must not trigger a doomed connector lookup."""
+    connector = _teams_connector(RESOLVED_EMAIL)
+    turn_context = _make_turn_context(from_name=RESOLVED_EMAIL, from_id=None, connector_client=connector)
+
+    email = await CompletionHandler.resolve_user_email(turn_context)
+
+    assert email == RESOLVED_EMAIL
+    connector.get_conversation_member.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resolve_user_identity_builds_identity_from_keycloak(monkeypatch):
+    """``resolve_user_identity`` turns a resolved email into a Keycloak-backed identity."""
+    register_fake_keycloak_user(user_id="agent-user-oid", name=DISPLAY_NAME, email=RESOLVED_EMAIL)
+    monkeypatch.setattr(AuthHandler, "get_active_tenant_for_user", AsyncMock(return_value=fake_tenant_identity()))
+    monkeypatch.setattr(UserTenantRoleEntity, "get_roles_for_user_in_tenant", MagicMock(return_value=["admin"]))
+
+    turn_context = _make_turn_context(from_name=DISPLAY_NAME, connector_client=_teams_connector(RESOLVED_EMAIL))
+
+    identity = await CompletionHandler.resolve_user_identity(turn_context)
+
+    assert identity.id == "agent-user-oid"
+    assert identity.email == RESOLVED_EMAIL
+    assert identity.roles == ["admin"]
+    assert identity.is_sys_admin is False
+
+
+@pytest.mark.asyncio
+async def test_resolve_user_identity_raises_when_user_not_in_keycloak():
+    """A resolved email with no matching Keycloak account fails with a clear error."""
+    turn_context = _make_turn_context(from_name="ghost@example.com")
+
+    with pytest.raises(ValueError, match="not found in Keycloak"):
+        await CompletionHandler.resolve_user_identity(turn_context)
 
 
 @pytest.mark.asyncio

--- a/packages/bot/playground/testing/tests/test_UserEmailResolution.py
+++ b/packages/bot/playground/testing/tests/test_UserEmailResolution.py
@@ -1,0 +1,148 @@
+"""Tests for shared user-email / identity resolution in ``CompletionHandler``.
+
+Regression coverage for issue #1314: the agent Teams bot used the Teams *display
+name* (e.g. ``John Doe``) as the Keycloak lookup key, so every user whose display
+name was not literally their email failed with
+``User with email '...' not found in Keycloak``.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from microsoft_agents.activity import Activity, ChannelAccount, ConversationAccount
+from microsoft_agents.activity.teams import TeamsChannelAccount
+from microsoft_agents.hosting.core import TeamsConnectorClient, TurnContext
+from swiss_ai_hub.core.auth.dependencies.auth_handler import AuthHandler
+from swiss_ai_hub.core.persistence.access.entities.user_tenant_role_entity import UserTenantRoleEntity
+from swiss_ai_hub.core.routes import ChatService
+from swiss_ai_hub.core.testing.auth_utils.test_identity import fake_tenant_identity
+from swiss_ai_hub.core.testing.auth_utils.user_mocks import register_fake_keycloak_user
+
+from swiss_ai_hub.bot.bots.chat.agent.agent_completion_handler import AgentCompletionHandler
+from swiss_ai_hub.bot.bots.chat.completion_handler import CompletionHandler
+
+DISPLAY_NAME = "John Doe"
+RESOLVED_EMAIL = "john.doe@example.com"
+USER_AAD_ID = "29:aad-object-id"
+CONVERSATION_ID = "conversation-1"
+
+
+def _make_turn_context(
+    *,
+    from_name: str,
+    from_id: str = USER_AAD_ID,
+    connector_client: object | None = None,
+) -> TurnContext:
+    """Builds a minimal ``TurnContext`` for a single inbound message activity."""
+    activity = Activity(
+        type="message",
+        from_property=ChannelAccount(id=from_id, name=from_name),
+        conversation=ConversationAccount(id=CONVERSATION_ID),
+        recipient=ChannelAccount(id="bot-1", name="Assistant"),
+    )
+    turn_context = TurnContext(MagicMock(), activity)
+    if connector_client is not None:
+        turn_context.turn_state["ConnectorClient"] = connector_client
+    return turn_context
+
+
+def _teams_connector(email: str | None) -> MagicMock:
+    """A fake ``TeamsConnectorClient`` whose ``get_conversation_member`` yields the given email."""
+    # ``TeamsChannelAccount.email`` rejects an explicit ``None``; omit it to model a member
+    # whose email is unknown.
+    account_fields = {"id": USER_AAD_ID, "name": DISPLAY_NAME}
+    if email is not None:
+        account_fields["email"] = email
+    connector = MagicMock(spec=TeamsConnectorClient)
+    connector.get_conversation_member = AsyncMock(return_value=TeamsChannelAccount(**account_fields))
+    return connector
+
+
+@pytest.mark.asyncio
+async def test_resolve_email_uses_teams_connector_for_display_name():
+    """Display name in ``from_property.name`` → email comes from the Teams connector."""
+    connector = _teams_connector(RESOLVED_EMAIL)
+    turn_context = _make_turn_context(from_name=DISPLAY_NAME, connector_client=connector)
+
+    email = await CompletionHandler.resolve_user_email(turn_context)
+
+    assert email == RESOLVED_EMAIL
+    connector.get_conversation_member.assert_awaited_once_with(CONVERSATION_ID, USER_AAD_ID)
+
+
+@pytest.mark.asyncio
+async def test_resolve_email_raises_for_display_name_without_connector():
+    """Issue #1314 symptom: a display name with no connector cannot be resolved."""
+    turn_context = _make_turn_context(from_name=DISPLAY_NAME)
+
+    with pytest.raises(ValueError, match="Could not determine email"):
+        await CompletionHandler.resolve_user_email(turn_context)
+
+
+@pytest.mark.asyncio
+async def test_resolve_email_falls_back_to_name_when_name_is_email():
+    """Emulator / dev channels put an email straight into ``from_property.name``."""
+    turn_context = _make_turn_context(from_name=RESOLVED_EMAIL)
+
+    email = await CompletionHandler.resolve_user_email(turn_context)
+
+    assert email == RESOLVED_EMAIL
+
+
+@pytest.mark.asyncio
+async def test_resolve_email_raises_when_connector_has_no_email():
+    """A Teams account without an email must not mask the display-name failure."""
+    turn_context = _make_turn_context(from_name=DISPLAY_NAME, connector_client=_teams_connector(email=None))
+
+    with pytest.raises(ValueError, match="Could not determine email"):
+        await CompletionHandler.resolve_user_email(turn_context)
+
+
+@pytest.mark.asyncio
+async def test_resolve_email_ignores_non_teams_connector():
+    """A non-Teams connector client is not queried; resolution uses the fallback."""
+    turn_context = _make_turn_context(from_name=RESOLVED_EMAIL, connector_client=MagicMock())
+
+    email = await CompletionHandler.resolve_user_email(turn_context)
+
+    assert email == RESOLVED_EMAIL
+
+
+@pytest.mark.asyncio
+async def test_agent_completion_handler_resolves_display_name_via_connector(monkeypatch):
+    """The agent bot path resolves a Teams display-name activity end-to-end.
+
+    Drives ``AgentCompletionHandler.chat_completion`` with an activity whose
+    ``from_property.name`` is a display name and asserts the identity handed to
+    ``ChatService`` carries the connector-resolved email — the exact scenario that
+    failed before issue #1314 was fixed.
+    """
+    register_fake_keycloak_user(user_id="agent-user-oid", name=DISPLAY_NAME, email=RESOLVED_EMAIL)
+
+    monkeypatch.setattr(CompletionHandler, "get_messages_by_conversation_id", lambda *a, **k: [])
+    monkeypatch.setattr(CompletionHandler, "get_system_message", lambda *a, **k: None)
+    monkeypatch.setattr(AuthHandler, "get_active_tenant_for_user", AsyncMock(return_value=fake_tenant_identity()))
+    monkeypatch.setattr(UserTenantRoleEntity, "get_roles_for_user_in_tenant", MagicMock(return_value=["admin"]))
+
+    captured: dict = {}
+
+    async def _capture_chat_interaction(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr(ChatService, "start_json_chat_interaction", _capture_chat_interaction)
+
+    turn_context = _make_turn_context(from_name=DISPLAY_NAME, connector_client=_teams_connector(RESOLVED_EMAIL))
+
+    await AgentCompletionHandler.chat_completion(
+        turn_context=turn_context,
+        path="/api/v1/agent/chat/completions/Agent/agent-1/json",
+        agent_class="Agent",
+        agent_id="agent-1",
+        nc=MagicMock(),
+        external_agent_event_distributor=MagicMock(),
+        stream=False,
+    )
+
+    assert captured["user"].email == RESOLVED_EMAIL
+    assert captured["user"].id == "agent-user-oid"

--- a/packages/bot/swiss_ai_hub/bot/bots/chat/agent/agent_completion_handler.py
+++ b/packages/bot/swiss_ai_hub/bot/bots/chat/agent/agent_completion_handler.py
@@ -5,13 +5,8 @@ from bson import ObjectId
 from llama_index.core.base.llms.types import ChatMessage, ContentBlock, ImageBlock, MessageRole, TextBlock
 from microsoft_agents.hosting.core import TurnContext
 from nats.aio.client import Client as NATS
-from swiss_ai_hub.core.auth import KeycloakAdminService
-from swiss_ai_hub.core.auth.dependencies.auth_handler import AuthHandler
-from swiss_ai_hub.core.auth.identity.user_identity import UserIdentity
-from swiss_ai_hub.core.auth.realm_roles import SYS_ADMIN_ROLE
 from swiss_ai_hub.core.distributor import ExternalAgentEventDistributor
 from swiss_ai_hub.core.events.agent import ExceptionEvent
-from swiss_ai_hub.core.persistence.access.entities.user_tenant_role_entity import UserTenantRoleEntity
 from swiss_ai_hub.core.routes import ChatService, JsonResources, StreamingResources
 
 from swiss_ai_hub.bot.bots.chat.completion_handler import CompletionHandler
@@ -141,20 +136,7 @@ class AgentCompletionHandler(CompletionHandler):
         chat_messages: list[ChatMessage] = [
             AgentCompletionHandler._message_to_chat_message(message) for message in persisted_messages
         ]
-        keycloak_user = await KeycloakAdminService.find_user_by_email(turn_context.activity.from_property.name)
-        if not keycloak_user:
-            raise ValueError(f"User with email '{turn_context.activity.from_property.name}' not found in Keycloak")
-        realm_roles = await KeycloakAdminService.get_user_realm_roles(keycloak_user.id)
-        is_sys_admin = SYS_ADMIN_ROLE in realm_roles
-        tenant = await AuthHandler.get_active_tenant_for_user(keycloak_user.id)
-        user = UserIdentity(
-            id=keycloak_user.id,
-            name=keycloak_user.name,
-            email=keycloak_user.email,
-            roles=UserTenantRoleEntity.get_roles_for_user_in_tenant(keycloak_user.id, tenant.id),
-            acting_within_tenant=tenant,
-            is_sys_admin=is_sys_admin,
-        )
+        user = await CompletionHandler.resolve_user_identity(turn_context)
         if stream:
             return await ChatService.start_stream_chat_interaction(
                 user=user,

--- a/packages/bot/swiss_ai_hub/bot/bots/chat/completion_handler.py
+++ b/packages/bot/swiss_ai_hub/bot/bots/chat/completion_handler.py
@@ -6,8 +6,14 @@ from collections.abc import AsyncGenerator
 from typing import Any
 
 from microsoft_agents.activity import Activity, ActivityTypes, Entity
-from microsoft_agents.hosting.core import TurnContext
+from microsoft_agents.activity.teams import TeamsChannelAccount
+from microsoft_agents.hosting.core import TeamsConnectorClient, TurnContext
+from swiss_ai_hub.core.auth import KeycloakAdminService
+from swiss_ai_hub.core.auth.dependencies.auth_handler import AuthHandler
+from swiss_ai_hub.core.auth.identity.user_identity import UserIdentity
+from swiss_ai_hub.core.auth.realm_roles import SYS_ADMIN_ROLE
 from swiss_ai_hub.core.i18n import LocaleHandler
+from swiss_ai_hub.core.persistence.access.entities.user_tenant_role_entity import UserTenantRoleEntity
 
 from swiss_ai_hub.bot.bots.chat.content_extractor import ContentExtractor
 from swiss_ai_hub.bot.persistence.entities.conversation_entity import Content, ConversationEntity, Message
@@ -59,6 +65,56 @@ class CompletionHandler:
             content=[Content(text=system_message, type="text")],
             role="system",
             name="system",
+        )
+
+    @staticmethod
+    async def resolve_user_email(turn_context: TurnContext) -> str:
+        """
+        Resolve the user's real email address from a Bot Framework activity.
+
+        Teams stores the *display name* (e.g. `John Doe`) in `from_property.name`, so the email
+        must be fetched from the Teams connector. The display name is only a usable fallback when
+        it already is an email (emulator / dev channels).
+        """
+        user_id = turn_context.activity.from_property.id or "UNKNOWN"
+
+        connector_client = turn_context.turn_state.get("ConnectorClient")
+        if isinstance(connector_client, TeamsConnectorClient):
+            teams_account: TeamsChannelAccount = await connector_client.get_conversation_member(
+                turn_context.activity.conversation.id, user_id
+            )
+            if teams_account.email is not None:
+                return teams_account.email
+
+        fallback = turn_context.activity.from_property.name
+        if fallback and "@" in fallback:
+            return fallback
+
+        raise ValueError(
+            f"Could not determine email for user '{turn_context.activity.from_property.name}'. "
+            "Ensure the user has logged in via OAuth2 before using the bot."
+        )
+
+    @staticmethod
+    async def resolve_user_identity(turn_context: TurnContext) -> UserIdentity:
+        """
+        Resolve the Keycloak-backed identity for the user behind the given activity.
+
+        Shared by every completion handler so the agent and OpenAI bots cannot drift apart.
+        """
+        user_email = await CompletionHandler.resolve_user_email(turn_context)
+        keycloak_user = await KeycloakAdminService.find_user_by_email(user_email)
+        if not keycloak_user:
+            raise ValueError(f"User with email '{user_email}' not found in Keycloak")
+        realm_roles = await KeycloakAdminService.get_user_realm_roles(keycloak_user.id)
+        tenant = await AuthHandler.get_active_tenant_for_user(keycloak_user.id)
+        return UserIdentity(
+            id=keycloak_user.id,
+            name=keycloak_user.name,
+            email=keycloak_user.email,
+            roles=UserTenantRoleEntity.get_roles_for_user_in_tenant(keycloak_user.id, tenant.id),
+            acting_within_tenant=tenant,
+            is_sys_admin=SYS_ADMIN_ROLE in realm_roles,
         )
 
     @staticmethod

--- a/packages/bot/swiss_ai_hub/bot/bots/chat/completion_handler.py
+++ b/packages/bot/swiss_ai_hub/bot/bots/chat/completion_handler.py
@@ -76,10 +76,10 @@ class CompletionHandler:
         must be fetched from the Teams connector. The display name is only a usable fallback when
         it already is an email (emulator / dev channels).
         """
-        user_id = turn_context.activity.from_property.id or "UNKNOWN"
+        user_id = turn_context.activity.from_property.id
 
         connector_client = turn_context.turn_state.get("ConnectorClient")
-        if isinstance(connector_client, TeamsConnectorClient):
+        if user_id and isinstance(connector_client, TeamsConnectorClient):
             teams_account: TeamsChannelAccount = await connector_client.get_conversation_member(
                 turn_context.activity.conversation.id, user_id
             )

--- a/packages/bot/swiss_ai_hub/bot/bots/chat/openai/openai_completion_handler.py
+++ b/packages/bot/swiss_ai_hub/bot/bots/chat/openai/openai_completion_handler.py
@@ -7,8 +7,7 @@ from collections.abc import AsyncGenerator
 from typing import override
 
 import openai
-from microsoft_agents.activity.teams import TeamsChannelAccount
-from microsoft_agents.hosting.core import TeamsConnectorClient, TurnContext
+from microsoft_agents.hosting.core import TurnContext
 from openai import APIStatusError, AsyncStream
 from openai.types.chat import (
     ChatCompletion,
@@ -21,13 +20,8 @@ from openai.types.chat import (
     ChatCompletionUserMessageParam,
 )
 from openai.types.chat.chat_completion_content_part_image_param import ChatCompletionContentPartImageParam, ImageURL
-from swiss_ai_hub.core.auth import KeycloakAdminService
-from swiss_ai_hub.core.auth.dependencies.auth_handler import AuthHandler
-from swiss_ai_hub.core.auth.identity.user_identity import UserIdentity
-from swiss_ai_hub.core.auth.realm_roles import SYS_ADMIN_ROLE
 from swiss_ai_hub.core.i18n import LocaleHandler
 from swiss_ai_hub.core.infrastructure import LiteLLMService
-from swiss_ai_hub.core.persistence.access.entities.user_tenant_role_entity import UserTenantRoleEntity
 
 from swiss_ai_hub.bot.bots.chat.completion_handler import CompletionHandler
 from swiss_ai_hub.bot.persistence.entities.conversation_entity import Content, Message
@@ -113,42 +107,7 @@ class OpenaiCompletionHandler(CompletionHandler):
             OpenaiCompletionHandler._message_to_chat_completion_message_param(message) for message in persisted_messages
         ]
 
-        user_id = turn_context.activity.from_property.id or "UNKNOWN"
-        user_email: str | None = None
-
-        connector_client = turn_context.turn_state.get("ConnectorClient")
-
-        if isinstance(connector_client, TeamsConnectorClient):
-            teams_account: TeamsChannelAccount = await connector_client.get_conversation_member(
-                turn_context.activity.conversation.id, user_id
-            )
-            if teams_account.email is not None:
-                user_email = teams_account.email
-
-        if not user_email:
-            fallback = turn_context.activity.from_property.name
-            if fallback and "@" in fallback:
-                user_email = fallback
-            else:
-                raise ValueError(
-                    f"Could not determine email for user '{turn_context.activity.from_property.name}'. "
-                    "Ensure the user has logged in via OAuth2 before using the bot."
-                )
-
-        keycloak_user = await KeycloakAdminService.find_user_by_email(user_email)
-        if not keycloak_user:
-            raise ValueError(f"User with email '{user_email}' not found in Keycloak")
-        realm_roles = await KeycloakAdminService.get_user_realm_roles(keycloak_user.id)
-        is_sys_admin = SYS_ADMIN_ROLE in realm_roles
-        tenant = await AuthHandler.get_active_tenant_for_user(keycloak_user.id)
-        user = UserIdentity(
-            id=keycloak_user.id,
-            name=keycloak_user.name,
-            email=keycloak_user.email,
-            roles=UserTenantRoleEntity.get_roles_for_user_in_tenant(keycloak_user.id, tenant.id),
-            acting_within_tenant=tenant,
-            is_sys_admin=is_sys_admin,
-        )
+        user = await CompletionHandler.resolve_user_identity(turn_context)
 
         logger.debug(f"Using user identity: {user}")
 


### PR DESCRIPTION
## Summary

Fixes #1314 — the **agent** Teams bot resolved the Keycloak user by passing the Teams **display name** (`activity.from_property.name`, e.g. `John Doe`) to `find_user_by_email()`, so the lookup failed with `ValueError: User with email '...' not found in Keycloak` for every user whose display name is not literally their email.

The **OpenAI** handler already resolved the email correctly via the Teams connector — the two handlers had drifted apart.

## Changes

- **`completion_handler.py`** — Added two shared static helpers on the `CompletionHandler` base class:
  - `resolve_user_email()` — resolves the real email via `TeamsConnectorClient.get_conversation_member()`, falling back to `from_property.name` only when it already is an email (emulator/dev channels), otherwise raising a clear error.
  - `resolve_user_identity()` — chains email resolution → Keycloak lookup → `UserIdentity` construction, so the whole identity-resolution path is shared.
- **`agent_completion_handler.py`** — Replaced the buggy inline lookup with `await CompletionHandler.resolve_user_identity(turn_context)`.
- **`openai_completion_handler.py`** — Replaced its (correct but duplicated) inline block with the same shared call.

Both handlers now go through one code path, so they cannot drift apart again.

## Tests

New `test_UserEmailResolution.py` covers:
- Display name + Teams connector → email from connector (the fix)
- Display name + no connector → `ValueError` (the original bug symptom)
- Email-as-name fallback (emulator/dev channels)
- Teams account with no email → still raises
- Non-Teams connector ignored
- Full agent bot path: `AgentCompletionHandler.chat_completion` with a display-name Teams activity resolves the connector email into the `UserIdentity` handed to `ChatService`

## Verification

- All 6 new tests pass.
- Full bot suite passes (11 passed, 1 flaky deselected) — existing `test_send_message` still works via the email-as-name fallback.
- `ruff check` clean on all modified files.

## Acceptance criteria

- [x] Agent bot resolves the Teams user's email via `TeamsConnectorClient.get_conversation_member()`, with a sane fallback.
- [x] Email-resolution logic is shared between the agent and OpenAI completion handlers (no duplication/drift).
- [x] Tests cover the agent bot path with a Teams activity whose `from_property.name` is a display name.
