### PR TITLE
fix(ui): Pass tenantId to getDocumentSourceUrl in source view

### DIFF
--- a/packages/web/swiss_ai_hub_web/components/Knowledge/Document/List.vue
+++ b/packages/web/swiss_ai_hub_web/components/Knowledge/Document/List.vue
@@ -94,6 +94,7 @@ import type { DataTableSortEvent } from 'primevue/datatable'
 
 const route = useRoute()
 const { t } = useI18n()
+const { tenantId } = useTenant()
 const { getDocumentSourceUrl } = useDocumentUrl()
 
 const props = defineProps<{
@@ -133,7 +134,7 @@ const handleSort = (event: DataTableSortEvent) => {
 const downloadFile = async (documentId: string) => {
   const database = route.params.db as string
   const namespace = route.params.namespace as string
-  const url = await getDocumentSourceUrl(database, namespace, documentId)
+  const url = await getDocumentSourceUrl(tenantId.value!, database, namespace, documentId)
   window.open(url, '_blank')
 }
 </script>

--- a/packages/web/swiss_ai_hub_web/components/Knowledge/Document/WithNodes.vue
+++ b/packages/web/swiss_ai_hub_web/components/Knowledge/Document/WithNodes.vue
@@ -81,7 +81,7 @@ const openOriginalDocument = async () => {
   if (!document.value?.source) return
 
   try {
-    const url = await getDocumentSourceUrl(props.db, props.namespace, props.documentId)
+    const url = await getDocumentSourceUrl(tenantId.value!, props.db, props.namespace, props.documentId)
     window.open(url, '_blank')
   }
   catch (e) {


### PR DESCRIPTION
## Summary
- `useDocumentUrl.getDocumentSourceUrl(tenantId, database, namespace, documentId)` was being called with only 3 args from both callers, shifting `db` into the `tenant_id` path param.
- The resulting request hit the wrong tenant; `KeycloakAuthHandler` rejected it with 403 ("Access denied"), so the "open original document" button in the admin UI source view always failed.
- Fixed by passing `tenantId` from `useTenant()` as the first argument in `WithNodes.vue` and `List.vue`.

## Test plan
- [ ] Open a chat thread in OpenWebUI, trigger the "Sources" action, click "Open original document" — verify the file opens in a new tab instead of redirecting to the Keycloak login.
- [ ] In `/service/knowledge/<db>/<namespace>`, click the download icon on a document row — verify the original opens.