### PR TITLE
fix(ui): Stop calling defineQuery/defineMutation inside memory factory

### DIFF
--- a/packages/web/swiss_ai_hub_web/components/User/Settings.vue
+++ b/packages/web/swiss_ai_hub_web/components/User/Settings.vue
@@ -34,7 +34,6 @@
 
 <script setup lang="ts">
 import { changeLocale } from '@formkit/vue'
-import { useQueryCache } from '@pinia/colada'
 
 const auth = useAuth()
 const { t, locale, locales } = useI18n()

--- a/packages/web/swiss_ai_hub_web/composables/agent/useAgentClassInstances.ts
+++ b/packages/web/swiss_ai_hub_web/composables/agent/useAgentClassInstances.ts
@@ -1,5 +1,4 @@
 import { type FullAgentInstanceDto, getAgentClassInstances } from '@core/sdk/client'
-import { useQuery } from '@pinia/colada'
 import { minutesToMilliseconds } from 'date-fns'
 import { useRoute } from 'vue-router'
 

--- a/packages/web/swiss_ai_hub_web/composables/agent/useAgentClasses.ts
+++ b/packages/web/swiss_ai_hub_web/composables/agent/useAgentClasses.ts
@@ -1,5 +1,4 @@
 import { type AgentClassDtoReadable, getAgentClasses } from '@core/sdk/client'
-import { useQuery } from '@pinia/colada'
 import { minutesToMilliseconds } from 'date-fns'
 
 export type AgentClassDto = AgentClassDtoReadable

--- a/packages/web/swiss_ai_hub_web/composables/agent/useAgentInstanceThreads.ts
+++ b/packages/web/swiss_ai_hub_web/composables/agent/useAgentInstanceThreads.ts
@@ -1,5 +1,4 @@
 import { getAgentInstanceThreads } from '@core/sdk/client'
-import { useQuery } from '@pinia/colada'
 import { ref, computed } from 'vue'
 import { useRoute } from 'vue-router'
 

--- a/packages/web/swiss_ai_hub_web/composables/agent/useAgentInstances.ts
+++ b/packages/web/swiss_ai_hub_web/composables/agent/useAgentInstances.ts
@@ -1,5 +1,4 @@
 import { type FullAgentInstanceDto, getAllAgentInstances } from '@core/sdk/client'
-import { useQuery } from '@pinia/colada'
 import { minutesToMilliseconds } from 'date-fns'
 
 export const useAgentInstances = defineQuery((options?: { online?: boolean }) => {

--- a/packages/web/swiss_ai_hub_web/composables/evaluation/useDataset.ts
+++ b/packages/web/swiss_ai_hub_web/composables/evaluation/useDataset.ts
@@ -1,5 +1,4 @@
 import { type Dataset, getDataset } from '@core/sdk/client'
-import { useQuery } from '@pinia/colada'
 import { minutesToMilliseconds } from 'date-fns'
 
 export const useDataset = defineQuery(() => {

--- a/packages/web/swiss_ai_hub_web/composables/evaluation/useDatasets.ts
+++ b/packages/web/swiss_ai_hub_web/composables/evaluation/useDatasets.ts
@@ -2,7 +2,6 @@ import {
   getDatasets,
   type MinimalDataset,
 } from '@core/sdk/client'
-import { useQuery } from '@pinia/colada'
 import { minutesToMilliseconds } from 'date-fns'
 
 export const useDatasets = defineQuery(() => {

--- a/packages/web/swiss_ai_hub_web/composables/memory/useMemoryFactory.ts
+++ b/packages/web/swiss_ai_hub_web/composables/memory/useMemoryFactory.ts
@@ -10,6 +10,7 @@ import {
   deleteOrganizationMemory,
   deleteAllOrganizationMemories,
 } from '@core/sdk/client'
+import { useMutation, useQuery, useQueryCache } from '@pinia/colada'
 import { minutesToMilliseconds } from 'date-fns'
 import { computed, ref } from 'vue'
 
@@ -55,7 +56,7 @@ export function createMemoryComposables(context: MemoryContext) {
   /**
    * Composable for fetching and paginating memories
    */
-  const useMemories = defineQuery(() => {
+  const useMemories = () => {
     const { tenantId } = useTenant()
     const currentPage = ref(1)
     const pageSize = ref(20)
@@ -155,12 +156,12 @@ export function createMemoryComposables(context: MemoryContext) {
       nextPage,
       prevPage,
     }
-  })
+  }
 
   /**
    * Composable for semantic memory search
    */
-  const useMemorySearch = defineQuery(() => {
+  const useMemorySearch = () => {
     const { tenantId } = useTenant()
     const query = ref<string>('')
     const limit = ref(100)
@@ -219,12 +220,12 @@ export function createMemoryComposables(context: MemoryContext) {
       setSearchQuery,
       clearSearch,
     }
-  })
+  }
 
   /**
    * Composable for updating memory content
    */
-  const useUpdateMemory = defineMutation(() => {
+  const useUpdateMemory = () => {
     const queryCache = useQueryCache()
     const { tenantId } = useTenant()
 
@@ -252,12 +253,12 @@ export function createMemoryComposables(context: MemoryContext) {
     })
 
     return { updateMemory: updateMemoryMutation }
-  })
+  }
 
   /**
    * Composable for deleting memories
    */
-  const useDeleteMemory = defineMutation(() => {
+  const useDeleteMemory = () => {
     const queryCache = useQueryCache()
     const { tenantId } = useTenant()
 
@@ -308,7 +309,7 @@ export function createMemoryComposables(context: MemoryContext) {
       deleteMemory: deleteMemoryMutation,
       deleteAllMemories: deleteAllMemoriesMutation,
     }
-  })
+  }
 
   return {
     useMemories,

--- a/packages/web/swiss_ai_hub_web/composables/memory/useMemoryFactory.ts
+++ b/packages/web/swiss_ai_hub_web/composables/memory/useMemoryFactory.ts
@@ -10,7 +10,6 @@ import {
   deleteOrganizationMemory,
   deleteAllOrganizationMemories,
 } from '@core/sdk/client'
-import { useMutation, useQuery, useQueryCache } from '@pinia/colada'
 import { minutesToMilliseconds } from 'date-fns'
 import { computed, ref } from 'vue'
 

--- a/packages/web/swiss_ai_hub_web/composables/models/useModelsList.ts
+++ b/packages/web/swiss_ai_hub_web/composables/models/useModelsList.ts
@@ -1,5 +1,4 @@
 import { getLitellmModels, type ModelTypeGroupDto } from '@core/sdk/client'
-import { useQuery } from '@pinia/colada'
 import { minutesToMilliseconds } from 'date-fns'
 
 export const useModelsList = defineQuery(() => {

--- a/packages/web/swiss_ai_hub_web/composables/models/useSingleModel.ts
+++ b/packages/web/swiss_ai_hub_web/composables/models/useSingleModel.ts
@@ -1,5 +1,4 @@
 import { getLitellmModel, type ModelDto } from '@core/sdk/client'
-import { useQuery } from '@pinia/colada'
 import { minutesToMilliseconds } from 'date-fns'
 
 export const useSingleModel = () => {

--- a/packages/web/swiss_ai_hub_web/composables/notification/useNotificationPoller.ts
+++ b/packages/web/swiss_ai_hub_web/composables/notification/useNotificationPoller.ts
@@ -1,5 +1,4 @@
 import { getNotifications, type NotificationDto } from '@core/sdk/client'
-import { useQuery, useQueryCache } from '@pinia/colada'
 import { useIntervalFn } from '@vueuse/core'
 import { useToast } from 'primevue/usetoast'
 

--- a/packages/web/swiss_ai_hub_web/composables/process/useProcessClasses.ts
+++ b/packages/web/swiss_ai_hub_web/composables/process/useProcessClasses.ts
@@ -1,5 +1,4 @@
 import { type ProcessClassDtoReadable, getProcessClasses } from '@core/sdk/client'
-import { useQuery } from '@pinia/colada'
 import { minutesToMilliseconds } from 'date-fns'
 
 export type ProcessClassDto = ProcessClassDtoReadable

--- a/packages/web/swiss_ai_hub_web/composables/process/useProcessInstances.ts
+++ b/packages/web/swiss_ai_hub_web/composables/process/useProcessInstances.ts
@@ -1,5 +1,4 @@
 import { type FullProcessInstanceDtoReadable, getAllProcessInstances } from '@core/sdk/client'
-import { useQuery } from '@pinia/colada'
 import { minutesToMilliseconds } from 'date-fns'
 
 export type FullProcessInstanceDto = FullProcessInstanceDtoReadable

--- a/packages/web/swiss_ai_hub_web/composables/thread/useThreadEvents.ts
+++ b/packages/web/swiss_ai_hub_web/composables/thread/useThreadEvents.ts
@@ -1,5 +1,4 @@
 import { getAgentEventsInThread, type ContextualizedAgentEvent } from '@core/sdk/client'
-import { useQuery, useQueryCache } from '@pinia/colada'
 import { useWebSocket } from '@vueuse/core'
 import { minutesToMilliseconds } from 'date-fns'
 import { useRoute } from 'vue-router'

--- a/packages/web/swiss_ai_hub_web/composables/thread/useThreadsInfinite.ts
+++ b/packages/web/swiss_ai_hub_web/composables/thread/useThreadsInfinite.ts
@@ -1,5 +1,4 @@
 import { getUserThreads, type ThreadDto } from '@core/sdk/client'
-import { useInfiniteQuery } from '@pinia/colada'
 
 export const useThreadsInfinite = defineQuery(() => {
   const { tenantId } = useTenant()


### PR DESCRIPTION
## Summary
- `createMemoryComposables` was calling `defineQuery` / `defineMutation` inside the factory body, so a fresh setup function got registered on every component setup. Pinia Colada keys its internal registry by the setup function reference via a `WeakMap`, and the repeated registration ultimately tripped `WeakMap.set` with an invalid key.
- Effect in production (v0.289.21): both `/{locale}/{tenant}/service/user-memories/list` and `/.../organization-memories/list` crashed during Vue setup with `TypeError: Invalid value used as weak map key`. The outer chrome rendered but the list/search components never mounted.
- Convention check: every other composable in `swiss_ai_hub_web/composables` (`useThreads`, `useTenantMemberships`, `useDataset`, ...) declares `defineQuery` at module scope — only the memory factory violated this.

## Fix
- Drop `defineQuery` / `defineMutation` wrappers; expose `useMemories`, `useMemorySearch`, `useUpdateMemory`, `useDeleteMemory` as plain functions that call `useQuery` / `useMutation` directly.
- `useQuery` / `useMutation` are the component-scoped APIs designed for per-call instantiation — appropriate here since the factory is invoked from `<script setup>`.
- Caller API is unchanged (`createMemoryComposables({...})` then `useMemories()` etc.). Cache sharing across components is preserved because the cache key already includes tenant + memory type + operation + filters.
