### PR TITLE
fix(ci-cd): Align root packageManager to pnpm 10.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "swiss-ai-hub-monorepo",
   "private": true,
   "description": "Swiss AI Hub — pnpm workspace root. JS/TS packages live under packages/*. Python packages are managed via uv workspaces (see root pyproject.toml).",
-  "packageManager": "pnpm@9.14.2+sha512.6e2baf77d06b9362294152c851c4f278ede37ab1eba3a55fda317a4a17b209f4dbb973fb250a77abc463a341fcb1f17f17cfa24091c4eb319cda0d9b84278387",
+  "packageManager": "pnpm@10.20.0+sha512.cf9998222162dd85864d0a8102e7892e7ba4ceadebbf5a31f9c2fce48dfce317a9c53b9f6464d1ef9042cba2e02ae02a9f7c143a2b438cd93c91840f0192b9dd",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
## Summary

Fixes the `Deploy Documentation to GitHub Pages` workflow which has been failing since release `v0.290.0` (every run since 2026-05-27).

## Root cause

PR #1304 introduced a new root `package.json` pinning `pnpm@9.14.2`, but the docs workflow uses pnpm 10.20.0 (per `docs/package.json`). pnpm 10 has `manage-package-manager-versions` enabled by default and honors the `packageManager` field of the nearest `package.json`.

When `actions/setup-node@v6.4.0` (with `cache: pnpm`) runs `pnpm store path --silent` **from the workspace root** to determine the cache directory:

1. `pnpm/action-setup` has installed pnpm 10.20.0 (from `docs/package.json`).
2. From the workspace root, pnpm 10 sees the root `packageManager: pnpm@9.14.2` and self-switches to pnpm 9.
3. pnpm 9 returns the legacy `store/v3` layout path.
4. `pnpm install` then runs from `./docs` where the nearest `packageManager` is 10.20.0, so the install populates `store/v10` — not `store/v3`.
5. The post-step tries to save the cache at the path setup-node tracked (`store/v3`), which never existed. `actions/setup-node@v6` raises a `ValidationError` (not a warning), failing the build job and skipping the dependent deploy job.

Comparing run logs:

| Run | `pnpm store path --silent` |
|---|---|
| ✅ v0.289.23 (before PR #1304) | `…/store/v10` |
| ❌ v0.290.0 (after PR #1304)   | `…/store/v3`  |

Failing run: https://github.com/bbvch-ai/aihub-core/actions/runs/26517660452/job/78099363497

## Fix

Bump the root `packageManager` field to `pnpm@10.20.0` (matching `docs/package.json` and `e2e/package.json`). This removes the silent self-switch so the cache path setup-node records matches the directory the install actually populates.

`packages/web` and `packages/sysadmin-web` don't pin a `packageManager`, so they continue to use whatever pnpm is provided to the workflow — pnpm 10 in CI today.

## Test plan

- [ ] After merge, observe the next `deploy-docs` run (release tag) — build job should no longer fail in the Post Setup Node.js step and the deploy job should run.
- [ ] `pnpm install` still works locally from the workspace root (no version skew warnings).