### PR TITLE
fix(swiss-ai-hub): Bump starlette off vulnerable 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,10 @@ package = false
 # needs libpq-dev to compile). We only use the Neo4j provider (see
 # packages/core/.../mem0/mem0_settings.py), so drop apache-age-python entirely.
 override-dependencies = ["apache-age-python ; sys_platform == 'never'"]
+# Security floor: starlette 1.0.0 has a known vulnerability, fixed in 1.0.1. starlette is
+# only a transitive dependency (fastapi, mcp, sse-starlette, dagster-graphql), so pin the
+# lower bound to the first fixed release to stop the resolver selecting the affected version.
+constraint-dependencies = ["starlette>=1.0.1"]
 
 [tool.uv.workspace]
 members = [

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,7 @@ members = [
     "swiss-ai-hub-sysadmin-api",
     "swiss-ai-hub-workspace",
 ]
+constraints = [{ name = "starlette", specifier = ">=1.0.1" }]
 overrides = [{ name = "apache-age-python", marker = "sys_platform == 'never'" }]
 
 [[package]]
@@ -5491,14 +5492,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `starlette` 1.0.0 has a known security vulnerability (fixed in 1.0.1). It is only a transitive dependency (fastapi, mcp, sse-starlette, dagster-graphql).
- Bumped the locked version to **1.1.0** via `uv lock --upgrade-package starlette`.
- Added a `constraint-dependencies = ["starlette>=1.0.1"]` floor under `[tool.uv]` so the resolver can never select the affected 1.0.0 again, while still allowing the highest compatible patch line.

## Test plan

- [ ] `uv sync --all-packages` installs starlette 1.1.0
- [ ] CI resolves the lockfile without conflicts
- [ ] Core auth/route tests pass (Starlette-touching paths)