### PR TITLE
#1236 avoid partition-name collision in default_rclone_to_datalake_def…

### DIFF
--- a/packages/pipeline/swiss_ai_hub/pipeline/util/definitions_util.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/util/definitions_util.py
@@ -453,8 +453,6 @@ def default_rclone_to_datalake_definitions(
     """
     encode = resolve_encode_partition_keys(encode_partition_keys)
 
-    rclone_partitions = DynamicPartitionsDefinition(name="rclone_partitions")
-
     # Extract source name from config or from source_remote (e.g., "onedrive:Documents" -> "onedrive")
     # Ensure we always derive a non-empty, stable source_name for asset keys
     if rclone_config and rclone_config.name:
@@ -467,6 +465,8 @@ def default_rclone_to_datalake_definitions(
             source_name = candidate if candidate else "local_fs"
         else:
             source_name = "local_fs"
+
+    rclone_partitions = DynamicPartitionsDefinition(name=f"{datalake_container_name}_{source_name}_rclone_partitions")
 
     pipeline_group = f"{source_name}_to_datalake"
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/bbvch-ai/aihub-core/issues/1236

## Considerations

For consistency with sibling factories, the name is built as:
`"{datalake_container_name}_{source_name}_rclone_partitions"`

...in contrast to:
`"rclone_{source_name}_partitions"` as suggested in the issue.

Examples:
- f"{datalake_container_name}_document_partitions"    # default_definitions
- f"{datalake_container_name}_sharepoint_partitions"  # default_sharepoint_to_datalake_definitions
- f"{datalake_container_name}_local_fs_partitions"    # default_local_filesystem_to_datalake_definitions