### PR TITLE
chore(swiss-ai-hub): Clarify license model and fix copyright attribution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,10 +103,10 @@ Code shared by 2+ services belongs in `packages/core`. Service-specific code sta
 - **`packages/api`**: REST API + WebSocket gateway (FastAPI). Apache-2.0.
 - **`packages/sysadmin-api`**: System-administration API — sysadmin-gated tenant lifecycle endpoints (FastAPI,
   proprietary).
-- **`packages/web`**: Frontend UI (Nuxt 3, Vue 3, PrimeVue, Tailwind). Apache-2.0.
+- **`packages/web`**: Frontend UI (Nuxt 3, Vue 3, PrimeVue, Tailwind). AGPL-3.0-or-later.
 - **`packages/sysadmin-web`**: System-administration UI — Nuxt Layer extending `packages/web` (proprietary).
 - **`packages/bot`**: Collaboration platform integrations (MS Teams, Slack).
-- **`packages/backup`**: Centralized backup/restore service (independent Dagster instance).
+- **`packages/backup`**: Centralized backup/restore service (independent Dagster instance). AGPL-3.0-or-later.
 - **`.github/actions`**: Reusable GitHub Actions for CI/CD.
 - **`docs`**: arc42 documentation + ADRs (VitePress).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,4 +117,12 @@ technical/non-technical audiences.
 
 ## ⚖️ License
 
-By contributing to the Swiss AI-Hub, you agree that your contributions will be licensed under the Apache 2.0 License.
+Swiss AI Hub uses a **mixed-license model** — each package carries its own license. Most packages are Apache-2.0; the
+web frontend (`packages/web`) and the backup service (`packages/backup`) are AGPL-3.0-or-later; the `sysadmin-*`
+packages are proprietary. The full per-package matrix is in [`LICENSES.md`](LICENSES.md).
+
+By contributing, you agree that your contribution is licensed under the license of the package it targets, as listed in
+[`LICENSES.md`](LICENSES.md). Contributions are additionally covered by our Contributor License Agreement (CLA), which
+grants bbv Software Services AG the rights needed to sustain this dual-licensed model — including offering the software
+to bbv and its customers under separate commercial terms alongside the open-source distribution. You will be prompted to
+sign the CLA on your first pull request.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2024-2025 bbvch-ai and contributors
+   Copyright 2024-2026 bbv Software Services AG
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSES.md
+++ b/LICENSES.md
@@ -39,3 +39,4 @@ repository purports to summarise or amend any third-party license.
 ## Reference
 
 - Root `LICENSE` — Apache License 2.0 (canonical text).
+- Root `NOTICE` — Apache-2.0 attribution notice (copyright holder + per-license breakdown).

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,15 @@
+Swiss AI Hub
+Copyright 2024-2026 bbv Software Services AG
+
+This product includes software developed by bbv Software Services AG
+(https://www.bbv.ch) and the Swiss AI Hub contributors.
+
+Unless otherwise noted, the contents of this repository are licensed under the
+Apache License, Version 2.0 (see LICENSE). The following parts are distributed
+under different terms:
+
+  - packages/web, packages/backup ........ GNU AGPL v3.0 or later
+  - packages/sysadmin-api, packages/sysadmin-web ... Proprietary, all rights reserved
+
+The per-package LICENSE file is authoritative for everything in that subtree.
+See LICENSES.md for the full per-package matrix and rationale.

--- a/packages/backup/README.md
+++ b/packages/backup/README.md
@@ -43,3 +43,12 @@ ORDER BY c.relkind, c.relname;
 ```
 
 Run this against the `postgres` database on `postgres-ferretdb`. `relkind = 'r'` = tables, `'S'` = sequences.
+
+## License
+
+Copyright (C) 2024-2026 bbv Software Services AG.
+
+AGPL-3.0-or-later — see
+[packages/backup/LICENSE](https://github.com/bbvch-ai/aihub-core/blob/main/packages/backup/LICENSE). For the full
+per-package matrix (root, AGPL, and proprietary packages), see
+[LICENSES.md](https://github.com/bbvch-ai/aihub-core/blob/main/LICENSES.md).

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -408,6 +408,8 @@ environment variables -- Nuxt automatically maps `NUXT_PUBLIC_*` variables to th
 
 ## License
 
+Copyright (C) 2024-2026 bbv Software Services AG.
+
 AGPL-3.0-or-later — see [packages/web/LICENSE](https://github.com/bbvch-ai/aihub-core/blob/main/packages/web/LICENSE).
 For the full per-package matrix (root, AGPL, and proprietary packages), see
 [LICENSES.md](https://github.com/bbvch-ai/aihub-core/blob/main/LICENSES.md).

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@swiss-ai-hub/web",
   "license": "AGPL-3.0-or-later",
+  "author": "bbv Software Services AG (https://www.bbv.ch)",
   "type": "module",
   "version": "0.290.7",
   "description": "Swiss AI Hub - Admin & Management UI (Nuxt 3 layer)",


### PR DESCRIPTION
## Summary

License hygiene pass following a review of the repo's mixed-license model. No code changes — documentation, license metadata, and attribution only.

### Changes

- **`CONTRIBUTING.md`** — the inbound-license clause said contributions are "licensed under the Apache 2.0 License", which was misleading for the AGPL frontend/backup packages and silent on the proprietary `sysadmin-*` packages. Replaced it with the actual per-package mixed-license model and a clause covering the **CLA** that sustains the dual-licensed (open-source + commercial) model.
- **`LICENSE`** — copyright line `2024-2025 bbvch-ai and contributors` → `2024-2026 bbv Software Services AG` (consistent legal entity, current year).
- **AGPL copyright notices** — added `Copyright (C) 2024-2026 bbv Software Services AG` to `packages/web` (README + `package.json` `author`) and `packages/backup` (new README License section), which previously carried the AGPL `LICENSE` file but no copyright notice.
- **`NOTICE`** — new root Apache-2.0 attribution file (§4(d)) with the per-license breakdown; referenced from `LICENSES.md`.
- **`CLAUDE.md`** — fixed a stale label: `packages/web` is **AGPL-3.0-or-later**, not Apache-2.0; also annotated `packages/backup` for consistency.

### Why

The mixed-license model (Apache-2.0 core/SDK, AGPL frontend/backup, proprietary sysadmin) is sound, but the contributor-facing wording and copyright attribution didn't reflect it. These changes make the split clear and the attribution consistent across the repo.

> Note: the dual-licensing model's legal soundness rests on the CLA assigning/granting bbv the rights to relicense all third-party contributions to the AGPL packages. That CLA is being extended separately.

## Test plan

- [ ] Docs/metadata only — no functional changes
- [ ] `LICENSES.md` matrix, `CLAUDE.md`, and per-package labels now agree