### PR TITLE
doc(swiss-ai-hub): Add CLA Clarifications section and fix bbv attribution

### DIFF
--- a/CONTRIBUTOR_AGREEMENT.md
+++ b/CONTRIBUTOR_AGREEMENT.md
@@ -2,8 +2,8 @@
 
 **Version 1.0**
 
-Thank you for your interest in contributing to Swiss AI Hub, an open-source project maintained by BBV Software Services
-AG ("BBV CH", "the Company", "We", or "Us"). This Contributor License Agreement ("Agreement") clarifies the intellectual
+Thank you for your interest in contributing to Swiss AI Hub, an open-source project maintained by bbv Software Services
+AG ("bbv", "the Company", "We", or "Us"). This Contributor License Agreement ("Agreement") clarifies the intellectual
 property rights granted to the Company with respect to Contributions from any person or entity ("You"). This Agreement
 is for Your protection as a Contributor as well as the protection of the Company; it does not change Your rights to use
 Your own Contributions for any other purpose.
@@ -108,7 +108,25 @@ representation in this Agreement inaccurate in any respect.
 
 ______________________________________________________________________
 
-## 8. Governing Law
+## 8. Clarifications
+
+8.1 You retain ownership of all copyrights in Your Contributions. This Agreement grants licenses only and does not
+transfer or assign ownership.
+
+8.2 The licenses granted under this Agreement are non-exclusive, and You remain free to use, license, distribute, and
+otherwise exploit Your Contributions.
+
+8.3 Nothing in this Agreement grants the Company the right to use Your name, likeness, trademarks, or logos for
+endorsement or promotion without separate permission.
+
+8.4 Nothing in this Agreement creates an obligation to make future Contributions, to maintain Contributions, or to
+provide support.
+
+8.5 You retain any moral rights that cannot be waived under applicable law.
+
+______________________________________________________________________
+
+## 9. Governing Law
 
 This Agreement shall be governed by and construed in accordance with the laws of Switzerland, without regard to its
 conflict of laws provisions. Any disputes arising under or in connection with this Agreement shall be subject to the
@@ -116,7 +134,7 @@ exclusive jurisdiction of the courts of Switzerland.
 
 ______________________________________________________________________
 
-## 9. How to Sign
+## 10. How to Sign
 
 You sign this Agreement electronically by commenting the following exact phrase on Your GitHub Pull Request:
 


### PR DESCRIPTION
## Summary

Refines the Contributor License Agreement on `feat/735-add-cla-to-prs` (PR #1318) to address Adrian's legal review and align attribution with the rest of the repo. Stacks onto #1318.

Relates to #735, #1158.

## Changes

- **Add Section 8 (Clarifications)** per Adrian's email in #1158 (points 10.1–10.5), adapted to the agreement's "You/Your" voice:
  - You retain copyright ownership; the Agreement grants licenses only, not assignment.
  - The grant is non-exclusive; You remain free to exploit Your Contributions.
  - No right to use Your name, likeness, trademarks, or logos for endorsement.
  - No obligation to make future Contributions, maintain them, or provide support.
  - You retain non-waivable moral rights.
- Renumber **Governing Law → 9** and **How to Sign → 10** (the "see Section 6" cross-reference is unaffected).
- Fix maintainer name to the official **`bbv Software Services AG`** (was "BBV Software Services AG" / "BBV CH"), matching `LICENSE`, `NOTICE`, and `CONTRIBUTING.md`.

## Why

The sublicensing grant (Section 2) already gives bbv the relicensing rights the dual-license strategy needs. These clarifications make the contributor-protective boundaries explicit, as requested in the #1158 legal review.

## Test plan

Documentation only — verified section numbering is sequential and cross-references resolve.