### PR TITLE
doc(swiss-ai-hub): Enable VitePress dead-link checking and fix dead links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Connect, orchestrate, and monitor best-in-class open-source tools to deliver\
 what cloud AI platforms promise, but where you own every layer.
 
 [![GitHub Release](https://img.shields.io/github/v/release/bbvch-ai/aihub-core?style=flat-square)](https://github.com/bbvch-ai/aihub-core/releases)
-[![License](https://img.shields.io/badge/license-Apache%202.0%20%2F%20AGPL%20%2F%20Proprietary-blue?style=flat-square)](LICENSES.md)
+[![License](https://img.shields.io/badge/license-Apache%202.0%20%2F%20AGPL%20%2F%20Proprietary-blue?style=flat-square)](https://github.com/bbvch-ai/aihub-core/blob/main/LICENSES.md)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13%2B-3776AB?style=flat-square&logo=python&logoColor=white)](https://python.org)
 [![PyPI](https://img.shields.io/pypi/v/swiss-ai-hub-core?style=flat-square&logo=pypi&logoColor=white)](https://pypi.org/project/swiss-ai-hub-core/)
 [![npm](https://img.shields.io/npm/v/@swiss-ai-hub/web?style=flat-square&logo=npm&logoColor=white)](https://www.npmjs.com/package/@swiss-ai-hub/web)
@@ -441,7 +441,7 @@ ______________________________________________________________________
 ## Contributing
 
 Swiss AI-Hub is developed by [bbv Software Services](https://www.bbv.ch) and open to contributions. See
-[CONTRIBUTING.md](CONTRIBUTING.md) for the full guide, or jump in:
+[CONTRIBUTING.md](https://github.com/bbvch-ai/aihub-core/blob/main/CONTRIBUTING.md) for the full guide, or jump in:
 
 |                                                                |                                                              |
 | -------------------------------------------------------------- | ------------------------------------------------------------ |
@@ -455,7 +455,7 @@ Swiss AI Hub uses a **mixed-license model** — each published artifact carries 
 `LICENSE` file is authoritative for its subtree:
 
 - **Apache-2.0** — the platform runtime and shared code (`packages/core`, `agent`, `api`, `bot`, `pipeline`, `process`,
-  and the repository root). See [LICENSE](LICENSE).
+  and the repository root). See [LICENSE](https://github.com/bbvch-ai/aihub-core/blob/main/LICENSE).
 - **AGPL-3.0-or-later** — the frontend (`packages/web`) and backup service (`packages/backup`).
 - **Proprietary — All Rights Reserved** — multi-tenant administration (`packages/sysadmin-api`,
   `packages/sysadmin-web`): no use granted. Public visibility in this repository does not grant any right to use, copy,
@@ -466,7 +466,8 @@ The split is intentional: the backend stays **permissive** so you can build and 
 without any obligation to disclose them, while the **copyleft** components (the UI and the backup service) keep
 improvements flowing back to the community and block proprietary SaaS rehosts.
 
-See [LICENSES.md](LICENSES.md) for the full per-package matrix and rationale.
+See [LICENSES.md](https://github.com/bbvch-ai/aihub-core/blob/main/LICENSES.md) for the full per-package matrix and
+rationale.
 
 ______________________________________________________________________
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -20,7 +20,7 @@ export default withMermaid({
   },
 
   srcExclude: ['public/**/*.md', 'translate-prompt.md'],
-  ignoreDeadLinks: false,
+  ignoreDeadLinks: true,
 
   markdown: {
     config(md) {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -20,7 +20,7 @@ export default withMermaid({
   },
 
   srcExclude: ['public/**/*.md', 'translate-prompt.md'],
-  ignoreDeadLinks: true,
+  ignoreDeadLinks: false,
 
   markdown: {
     config(md) {

--- a/docs/docs/2_platform/11_access_management/1_authentication_setup/index.de.md
+++ b/docs/docs/2_platform/11_access_management/1_authentication_setup/index.de.md
@@ -361,4 +361,4 @@ Frühere Versionen riefen Rollen aus Azure AD über die Microsoft Graph API ab. 
 - ❌ **Kein automatisches Abrufen von Profilbildern** vom Identity Provider
 
 Details finden Sie unter
-[ADR: Lokale Multi-Tenant-Rollenverwaltung](/de/arc42/decisions/2025_12_25_local_role_management).
+[ADR: Lokale Multi-Tenant-Rollenverwaltung](/arc42/decisions/2025_12_25_local_role_management.md).

--- a/docs/docs/2_platform/11_access_management/2_permissions/index.de.md
+++ b/docs/docs/2_platform/11_access_management/2_permissions/index.de.md
@@ -239,4 +239,4 @@ aihub.[user|admin].[resource_type].[resource_category].[resource_identifier]
 - `aihub.user.agent.?>` – Benutzerzugriff auf beliebigen Agenten (Wildcard)
 
 Für weitere Details zu Multi-Tenancy und Zugriffssteuerung siehe die Dokumentation zu
-[Multi-Tenancy-Zugriffssteuerung](/de/docs/16_multi_tenancy/4_access_control/).
+[Multi-Tenancy-Zugriffssteuerung](../../16_multi_tenancy/4_access_control/).

--- a/docs/docs/2_platform/17_slack_teams_integrations/1_setup/index.de.md
+++ b/docs/docs/2_platform/17_slack_teams_integrations/1_setup/index.de.md
@@ -242,5 +242,5 @@ Um die Azure Bot Service-Integration in Ihrem Swiss AI Hub-Deployment zu impleme
 
 Für detaillierte Einrichtungsanweisungen, Fehlerbehebungsleitfäden und erweiterte Konfigurationsoptionen konsultieren
 Sie die [Bot-in-the-Loop-Dokumentation](../../../3_sdk/6_feature_overview/bot-in-the-loop/) für
-Mensch-KI-Kollaborations-Workflows, die [Expert Agents-Dokumentation](../../../5_agents/9_expert_coordinator_agent/) für
+Mensch-KI-Kollaborations-Workflows, die [Expert Agents-Dokumentation](../../5_agents/9_expert_coordinator_agent/) für
 Wissenskonsultationsmuster und den Swiss AI Hub Bot Developer's Guide für Implementierungsdetails.

--- a/docs/docs/2_platform/17_slack_teams_integrations/2_bot_creation_guide/index.de.md
+++ b/docs/docs/2_platform/17_slack_teams_integrations/2_bot_creation_guide/index.de.md
@@ -45,7 +45,7 @@ Details zur automatisierten Einrichtung finden Sie in der [Anleitung zur Azure B
 
 - **[Übersicht über Slack- und Teams-Integrationen](../)** – High-Level-Konzepte und geschäftlicher Nutzen
 - **[Azure Bot Service-Integration](../1_setup/)** – Anleitung zur automatisierten Einrichtung
-- **[Entwicklerhandbuch für Swiss AI Hub Bot](../../../6_code_deep_dive/aihub_bot/)** – Technische
+- **[Entwicklerhandbuch für Swiss AI Hub Bot](../../../6_code_deep_dive/packages/bot/)** – Technische
   Implementierungsdetails
 - **[Bot-in-the-Loop-Dokumentation](../../../3_sdk/6_feature_overview/bot-in-the-loop/)** –
   Mensch-KI-Kollaborations-Workflows
@@ -152,7 +152,7 @@ devtunnel host
 ```
 
 Ein detailliertes Setup für die lokale Entwicklung finden Sie im
-[Entwicklerhandbuch](../../../6_code_deep_dive/aihub_bot/).
+[Entwicklerhandbuch](../../../6_code_deep_dive/packages/bot/).
 :::
 
 ### Schritt 4: Client Secret erstellen
@@ -749,8 +749,8 @@ Nach Abschluss der manuellen Bot-Einrichtung:
 2. **Logs überprüfen**: Überprüfen Sie die Anwendungsprotokolle auf Fehler oder Warnungen während der Bot-Interaktionen
 3. **Zusätzliche Funktionen konfigurieren**: Erkunden Sie
    [Bot-in-the-Loop](../../../3_sdk/6_feature_overview/bot-in-the-loop/) für die Zusammenarbeit zwischen Mensch und KI
-4. **Benutzerdefinierte Logik implementieren**: Im [Entwicklerhandbuch](../../../6_code_deep_dive/aihub_bot/) finden Sie
-   Informationen zu benutzerdefinierten Bot-Implementierungen
+4. **Benutzerdefinierte Logik implementieren**: Im [Entwicklerhandbuch](../../../6_code_deep_dive/packages/bot/) finden
+   Sie Informationen zu benutzerdefinierten Bot-Implementierungen
 5. **Leistung überwachen**: Richten Sie Observability und Monitoring für Production-Deployments ein
 
 ______________________________________________________________________

--- a/docs/docs/2_platform/17_slack_teams_integrations/2_bot_creation_guide/index.en.md
+++ b/docs/docs/2_platform/17_slack_teams_integrations/2_bot_creation_guide/index.en.md
@@ -44,7 +44,7 @@ For automated setup details, see the [Azure Bot Service Integration guide](../1_
 
 - **[Slack & Teams Integrations Overview](../)** - High-level concepts and business value
 - **[Azure Bot Service Integration](../1_setup/)** - Automated setup guide
-- **[Swiss AI Hub Bot Developer's Guide](../../../6_code_deep_dive/aihub_bot/)** - Technical implementation details
+- **[Swiss AI Hub Bot Developer's Guide](../../../6_code_deep_dive/packages/bot/)** - Technical implementation details
 - **[Bot-in-the-Loop Documentation](../../../3_sdk/6_feature_overview/bot-in-the-loop/)** - Human-AI collaboration
   workflows
 
@@ -149,7 +149,7 @@ devtunnel host
 # Use the https URL (e.g., https://abc123-8000.devtunnels.ms/api/v1/messages)
 ```
 
-See the [Developer's Guide](../../../6_code_deep_dive/aihub_bot/) for detailed local development setup.
+See the [Developer's Guide](../../../6_code_deep_dive/packages/bot/) for detailed local development setup.
 :::
 
 ### Step 4: Create Client Secret
@@ -738,7 +738,7 @@ After completing the manual bot setup:
 2. **Review Logs**: Check application logs for any errors or warnings during bot interactions
 3. **Configure Additional Features**: Explore [Bot-in-the-Loop](../../../3_sdk/6_feature_overview/bot-in-the-loop/) for
    human-AI collaboration
-4. **Implement Custom Logic**: See the [Developer's Guide](../../../6_code_deep_dive/aihub_bot/) for custom bot
+4. **Implement Custom Logic**: See the [Developer's Guide](../../../6_code_deep_dive/packages/bot/) for custom bot
    implementations
 5. **Monitor Performance**: Set up observability and monitoring for production deployments
 

--- a/docs/docs/2_platform/1_quick_start/1_prerequisites/index.de.md
+++ b/docs/docs/2_platform/1_quick_start/1_prerequisites/index.de.md
@@ -312,7 +312,7 @@ sieben Subdomains, die auf die IP-Adresse Ihres Servers zeigen.
 - Die VM muss ihre eigenen Domainnamen auflösen können (interne DNS-Auflösung)
 - Konfigurieren Sie die Nameserver korrekt, um OAuth-Authentifizierungs-Timeouts zu vermeiden
 
-Siehe [Netzwerkanforderungen](/de/docs/3_deployment_guide/7_network_requirements) für detaillierte DNS-Konfiguration und
+Siehe [Netzwerkanforderungen](../../3_deployment_guide/7_network_requirements/) für detaillierte DNS-Konfiguration und
 Fehlerbehebung.
 :::
 
@@ -377,8 +377,8 @@ ______________________________________________________________________
 
 ## Nächste Schritte
 
-Fahren Sie mit dem [Ein-Befehl-Deployment](/de/docs/2_deployment_guide/2_one_command_deployment) fort, um die Plattform
-mit den aufgezeichneten Konfigurationswerten zu deployen.
+Fahren Sie mit dem [Ein-Befehl-Deployment](../2_one_command_deployment/) fort, um die Plattform mit den aufgezeichneten
+Konfigurationswerten zu deployen.
 
 ```
 ```

--- a/docs/docs/2_platform/1_quick_start/4_your_first_conversation/index.de.md
+++ b/docs/docs/2_platform/1_quick_start/4_your_first_conversation/index.de.md
@@ -24,7 +24,7 @@ Hier ist ein kurzes Video, das Ihnen zeigt, wie Sie zum Chat gelangen:
 
 <video controls="controls" src="../../../../media/platform/your_first_conversation/RAG_Agent-Frontend.webm" type="video/webm" />
 
-Nutzen Sie den Chat wie jeden anderen auch. Eine detaillierte Übersicht aller Chat-Funktionen finden Sie [hier](/de/docs/10_chat_ui/1_feature_overview/).
+Nutzen Sie den Chat wie jeden anderen auch. Eine detaillierte Übersicht aller Chat-Funktionen finden Sie [hier](../../10_chat_ui/1_feature_overview/).
 
 ## Agent
 

--- a/docs/docs/2_platform/20_security/1_authentication/index.de.md
+++ b/docs/docs/2_platform/20_security/1_authentication/index.de.md
@@ -47,7 +47,7 @@ HTTP-Autorisierungs-Header, die mit demselben JWKS-basierten Verifizierungsproze
 Die Autorisierung wird unabhängig von der Authentifizierung implementiert, wodurch eine konsistente Zugriffskontrolle
 ermöglicht wird, unabhängig davon, wie sich Benutzer authentifizieren. Die Plattform evaluiert Berechtigungen für jede
 API-Anfrage basierend auf den zugewiesenen Rollen des Benutzers und dem hierarchischen Berechtigungsmodell, das in den
-[Berechtigungen](/de/docs/11_access_management/2_permissions/) beschrieben ist.
+[Berechtigungen](../../11_access_management/2_permissions/) beschrieben ist.
 
 ### Integration von Unternehmens-Identitätsanbietern
 
@@ -82,7 +82,7 @@ der Benutzer zugreifen kann, basierend auf seinen zugewiesenen Rollen.
 **API-Level-Berechtigungsdurchsetzung:** Jeder API-Endpunkt deklariert seine erforderlichen Berechtigungen. Diese
 Berechtigungen werden automatisch überprüft, bevor die Endpunktlogik ausgeführt wird, wodurch sichergestellt wird, dass
 kein Ressourcenzugriff die Autorisierung umgeht. Die Berechtigungsevaluierung verwendet das hierarchische
-Berechtigungsmodell, das in den [Berechtigungen](/de/docs/11_access_management/2_permissions/) beschrieben ist.
+Berechtigungsmodell, das in den [Berechtigungen](../../11_access_management/2_permissions/) beschrieben ist.
 
 **Dynamische Autorisierung:** Für Operationen, die Laufzeit-Berechtigungsprüfungen erfordern, bietet die Plattform
 programmatischen Zugriff auf das Berechtigungsevaluierungssystem. Dies ermöglicht das Filtern von Ergebnismengen
@@ -103,9 +103,7 @@ Alias des Anbieters gesetzt ist, und leitet den Benutzer direkt zum vorgelagerte
 Keycloaks Login-Theme anzuzeigen.
 
 Dieser Ansatz eliminiert jegliche Frontend-Konfiguration für Identitätsanbieter – das Hinzufügen oder Entfernen eines
-IdP ist eine reine Keycloak-Änderung. Siehe
-[ADR: Dynamic Identity Provider Loading](../../../../arc42/decisions/2026_02_27_dynamic_identity_provider_loading.md)
-für die vollständige Begründung und Implementierungsdetails.
+IdP ist eine reine Keycloak-Änderung.
 
 ### Konfigurieren von Anbieter-Icons
 
@@ -139,9 +137,7 @@ authentifizierte Anfragen an den vorgelagerten Service weitergeleitet werden. Nu
 können auf diese Services zugreifen.
 
 Aufgrund des Split-Horizon-Netzwerks in Docker-Deployments (Container verwenden interne Hostnamen, Browser externe URLs)
-wird die OIDC-Erkennung übersprungen und Endpunkte werden explizit konfiguriert. Siehe
-[ADR: Skip OIDC Discovery for OAuth2 Proxy](../../../../arc42/decisions/2026_02_26_skip_oidc_discovery_for_oauth2_proxy.md)
-für die technische Begründung.
+wird die OIDC-Erkennung übersprungen und Endpunkte werden explizit konfiguriert.
 
 ## Hardening: Keycloak Admin-Konsolenzugriff
 
@@ -191,7 +187,7 @@ Traefik-Dashboard selbst einzuschränken, wenn es in Produktion aktiviert ist.
 
 Keycloak verwaltet Realm-Level-Rollen, die bestimmen, ob ein Benutzer auf die Plattform zugreifen darf. Diese Rollen
 sind grobe Zugangstore – fein granulare Berechtigungen werden lokal von der Plattform verwaltet (siehe
-[Berechtigungen](/de/docs/11_access_management/2_permissions/)).
+[Berechtigungen](../../11_access_management/2_permissions/)).
 
 | Rolle            | Zweck                                                                                                                |
 | ---------------- | -------------------------------------------------------------------------------------------------------------------- |

--- a/docs/docs/2_platform/20_security/1_authentication/index.en.md
+++ b/docs/docs/2_platform/20_security/1_authentication/index.en.md
@@ -93,9 +93,7 @@ initiates the OIDC Authorization Code Flow with `kc_idp_hint` set to the provide
 to the upstream identity provider without showing Keycloak's login theme.
 
 This approach eliminates any frontend configuration for identity providers — adding or removing an IdP is a
-Keycloak-only change. See
-[ADR: Dynamic Identity Provider Loading](../../../../arc42/decisions/2026_02_27_dynamic_identity_provider_loading.md)
-for the full rationale and implementation details.
+Keycloak-only change.
 
 ### Configuring Provider Icons
 
@@ -127,9 +125,7 @@ forwarding authenticated requests to the upstream service. Only users with the `
 services.
 
 Due to the split-horizon networking in Docker deployments (containers use internal hostnames, browsers use external
-URLs), OIDC discovery is skipped and endpoints are configured explicitly. See
-[ADR: Skip OIDC Discovery for OAuth2 Proxy](../../../../arc42/decisions/2026_02_26_skip_oidc_discovery_for_oauth2_proxy.md)
-for the technical rationale.
+URLs), OIDC discovery is skipped and endpoints are configured explicitly.
 
 ## Hardening: Keycloak Admin Console Access
 

--- a/docs/docs/2_platform/21_compliance/2_gdpr/index.de.md
+++ b/docs/docs/2_platform/21_compliance/2_gdpr/index.de.md
@@ -130,8 +130,8 @@ die rollenbasierte Zugriffskontrolle stoppt die Verarbeitung.
 Die Plattform implementiert Datenschutz durch Technikgestaltung (Privacy by Design) mit obligatorischer
 TLS/SSL-Verschlüsselung, standardmäßiger Zugriffsverweigerung (Default-Deny Access Control), automatischem
 Audit-Logging, 30-tägiger Löschung von Ephemeral-Daten und minimaler Datenerfassung. Details finden Sie unter
-[Authentifizierung](/de/docs/20_security/1_authentication/), [Verschlüsselung](/de/docs/20_security/5_data_encryption/)
-und [Zugriffskontrolle](/de/docs/11_access_management/).
+[Authentifizierung](../../20_security/1_authentication/), [Verschlüsselung](../../20_security/5_data_encryption/) und
+[Zugriffskontrolle](../../11_access_management/).
 
 ## Internationale Datenübermittlungen
 
@@ -143,7 +143,7 @@ personenbezogener Daten von der EU in die Schweiz ohne zusätzliche Schutzmaßna
 
 Für Organisationen, die in der Schweiz hosten, vereinfacht dies die Einhaltung sowohl der DSGVO- als auch der Schweizer
 DSG-Anforderungen. Hosting-Konfigurationen finden Sie unter
-[Deployment-Optionen](/de/docs/3_deployment_guide/1_deployment_options/).
+[Deployment-Optionen](../../3_deployment_guide/1_deployment_options/).
 
 ### Übermittlungen in andere Länder
 

--- a/docs/docs/2_platform/3_deployment_guide/1_deployment_options/index.de.md
+++ b/docs/docs/2_platform/3_deployment_guide/1_deployment_options/index.de.md
@@ -13,7 +13,7 @@ bereitgestellt (deployed) werden, die optional Backend-LLM-Ressourcen gemeinsam 
 
 ::: info Multi-Tenancy vs. Multi-Instancing
 Dieses Kapitel beschreibt **Multi-Instancing** (mehrere isolierte Swiss AI Hub-Instanzen). Für **Multi-Tenancy**
-(mehrere organisatorische Grenzen innerhalb einer einzelnen Instanz) siehe [Multi-Tenancy](/de/docs/16_multi_tenancy/).
+(mehrere organisatorische Grenzen innerhalb einer einzelnen Instanz) siehe [Multi-Tenancy](../../16_multi_tenancy/).
 
 Beide Deployment-Modelle sind gültig und dienen unterschiedlichen Zwecken. Multi-Instancing bietet eine harte Isolation zwischen
 Organisationen, während Multi-Tenancy eine logische Trennung innerhalb einer gemeinsam genutzten Plattform-Instanz
@@ -94,7 +94,7 @@ erfordert.
 Selbst eine Fehlkonfiguration des Swiss AI Hubs kann keine Datenlecks zwischen Instanzen verursachen. Admins einer
 Instanz können eine andere Instanz ohne separaten Login weder konfigurieren noch darauf zugreifen.
 
-Für eine logische Trennung innerhalb einer gemeinsam genutzten Plattform verwenden Sie stattdessen [Multi-Tenancy](/de/docs/16_multi_tenancy/).
+Für eine logische Trennung innerhalb einer gemeinsam genutzten Plattform verwenden Sie stattdessen [Multi-Tenancy](../../16_multi_tenancy/).
 :::
 
 ### Geteiltes LLM-Backend
@@ -119,7 +119,7 @@ Daten können nicht zwischen Organisationen austreten. Das Setup erfüllt das Sc
 GDPR-Anforderungen an die Datenisolation und die Schweizer Sicherheitsstandards für den öffentlichen Sektor.
 
 ::: info Multi-Tenancy innerhalb von Instanzen
-Jede Instanz kann auch [Multi-Tenancy](/de/docs/16_multi_tenancy/) nutzen, um logische Grenzen für Abteilungen, Kunden
+Jede Instanz kann auch [Multi-Tenancy](../../16_multi_tenancy/) nutzen, um logische Grenzen für Abteilungen, Kunden
 oder Projekte innerhalb dieser Instanz zu schaffen. Multi-Tenancy bietet flexible Zugriffskontrolle bei gleichzeitiger
 Aufrechterhaltung einer harten Isolation zwischen den Instanzen.
 :::
@@ -278,13 +278,11 @@ ______________________________________________________________________
 
 ## Nächste Schritte
 
-- [Multi-Tenancy](/de/docs/16_multi_tenancy/) – Logische Trennung innerhalb einer einzelnen Instanz
-- [Produktionskonfiguration](/de/docs/deployments/2_production_configuration/) – Konfigurationsanleitung für
-  Produktions-Deployments
-- [Skalierungsüberlegungen](/de/docs/deployments/3_scaling_considerations/) – Skalierung von Instanzen
-- [Backup und Wiederherstellung](/de/docs/deployments/4_backup_and_recovery/) – Backup-Strategien für die
-  Pro-Instanz-Architektur
-- [Updates und Wartung](/de/docs/deployments/6_updates_and_maintenance/) – Verwaltung von Updates über mehrere Instanzen
+- [Multi-Tenancy](../../16_multi_tenancy/) – Logische Trennung innerhalb einer einzelnen Instanz
+- [Produktionskonfiguration](../2_production_configuration/) – Konfigurationsanleitung für Produktions-Deployments
+- [Skalierungsüberlegungen](../3_scaling_considerations/) – Skalierung von Instanzen
+- [Backup und Wiederherstellung](../4_backup_and_recovery/) – Backup-Strategien für die Pro-Instanz-Architektur
+- [Updates und Wartung](../6_updates_and_maintenance/) – Verwaltung von Updates über mehrere Instanzen
 
 ______________________________________________________________________
 
@@ -294,7 +292,7 @@ ______________________________________________________________________
 Nein. Jede Instanz verfügt über einen eigenen, isolierten Satz von Agents und Pipelines. Dieselben Agent-Definitionen
 (Code) können jedoch über mehrere Instanzen hinweg deployed werden. Anpassungen sind instanzspezifisch.
 
-Um Agents innerhalb einer Organisation zu teilen, verwenden Sie [Multi-Tenancy](/de/docs/16_multi_tenancy/), um logische
+Um Agents innerhalb einer Organisation zu teilen, verwenden Sie [Multi-Tenancy](../../16_multi_tenancy/), um logische
 Grenzen innerhalb einer einzelnen Instanz zu schaffen.
 :::
 
@@ -304,7 +302,7 @@ Jede verfügt über separate Datenbanken, Vektor-Stores und Applikationsserver. 
 Datenlecks zwischen Instanzen verursachen. Verwenden Sie dies, wenn Sie absolute Isolation benötigen (z.B. verschiedene
 juristische Einheiten, hochsensible Abteilungen).
 
-**Multi-Tenancy** ([Kapitel 15](/de/docs/16_multi_tenancy/)) bedeutet die Schaffung organisatorischer Grenzen innerhalb
+**Multi-Tenancy** ([Kapitel 15](../../16_multi_tenancy/)) bedeutet die Schaffung organisatorischer Grenzen innerhalb
 einer einzelnen Swiss AI Hub-Instanz. Mehrere Mandanten teilen sich die Infrastruktur, verfügen aber über eine logische
 Trennung durch Zugriffskontrolle. Verwenden Sie dies für Abteilungen, Projekte oder Kunden innerhalb derselben
 Organisation.
@@ -351,20 +349,19 @@ Mitigation: Deployen Sie LiteLLM mit hoher Verfügbarkeit (mehrere Replicas, Loa
 :::
 
 ::: details Wie verwalten Sie Updates über viele Instanzen hinweg?
-Siehe [Updates und Wartung](/de/docs/deployments/6_updates_and_maintenance/) für Strategien wie gestaffelte Rollouts
-(Pilot bis Produktion), Blue-Green Deployments, automatisierte Update-Orchestrierung (Ansible, Kubernetes Operators) und
+Siehe [Updates und Wartung](../6_updates_and_maintenance/) für Strategien wie gestaffelte Rollouts (Pilot bis
+Produktion), Blue-Green Deployments, automatisierte Update-Orchestrierung (Ansible, Kubernetes Operators) und
 instanzspezifische Update-Zeitpläne.
 :::
 
 ## Verwandte Dokumentation
 
-- [Multi-Tenancy](/de/docs/16_multi_tenancy/) – Schaffung organisatorischer Grenzen innerhalb einer Instanz
-- [Kernkomponenten](/de/docs/2_architecture/1_core_components/) – Swiss AI Hub Architektur
-- [Authentifizierung & Autorisierung](/de/docs/11_access_management/1_authentication_setup/) –
+- [Multi-Tenancy](../../16_multi_tenancy/) – Schaffung organisatorischer Grenzen innerhalb einer Instanz
+- [Kernkomponenten](../../2_architecture/1_core_components/) – Swiss AI Hub Architektur
+- [Authentifizierung & Autorisierung](../../11_access_management/1_authentication_setup/) –
   Authentifizierungskonfiguration
-- [Monitoring und Alerting](/de/docs/deployments/5_monitoring_and_alerting/) – Observability für
-  Multi-Instanz-Deployments
-- [Schweizer Datenschutz](/de/docs/21_compliance/3_dsg/) – revDSG-Compliance für den öffentlichen Sektor
+- [Monitoring und Alerting](../5_monitoring_and_alerting/) – Observability für Multi-Instanz-Deployments
+- [Schweizer Datenschutz](../../21_compliance/3_dsg/) – revDSG-Compliance für den öffentlichen Sektor
 
 ```
 ```

--- a/docs/docs/2_platform/3_deployment_guide/5_monitoring_and_alerting/1_log_aggregation/index.de.md
+++ b/docs/docs/2_platform/3_deployment_guide/5_monitoring_and_alerting/1_log_aggregation/index.de.md
@@ -157,6 +157,6 @@ ______________________________________________________________________
 - Erkunden Sie die [SigNoz-Dokumentation](https://signoz.io/docs/) für Abfrage-Builder und Alarmkonfiguration.
 - Lesen Sie die [OpenTelemetry Collector-Dokumentation](https://opentelemetry.io/docs/collector/) für erweiterte
   Konfigurationen.
-- Konfigurieren Sie die [Langfuse LLM Observability](/de/docs/10_chat_ui/10_observability/) für KI-spezifisches
+- Konfigurieren Sie die [Langfuse LLM Observability](../../../10_chat_ui/10_observability/) für KI-spezifisches
   Debugging.
-- Richten Sie die [Kostenverfolgung](/de/docs/14_cost_control/) für die Überwachung der LLM-Nutzung ein.
+- Richten Sie die [Kostenverfolgung](../../../14_cost_control/) für die Überwachung der LLM-Nutzung ein.

--- a/docs/docs/2_platform/3_deployment_guide/6_updates_and_maintenance/index.de.md
+++ b/docs/docs/2_platform/3_deployment_guide/6_updates_and_maintenance/index.de.md
@@ -190,14 +190,14 @@ Framework-Ereignisse aus `event_logs`, und der monatliche `postgres_repack_job` 
 der Festplatte frei. Beide sind gegenseitig exklusiv mit Backups über Dagsters Run-Coordinator-Tag-Concurrency.
 
 Das ist es, was den Postgres-Footprint einer 5 Jahre alten Deployment-Umgebung mit dem einer 3 Monate alten vergleichbar
-hält. Siehe [Backup und Wiederherstellung](/de/docs/4_backup_and_recovery/#continuous-postgres-maintenance) für
+hält. Siehe [Backup und Wiederherstellung](../4_backup_and_recovery/#continuous-postgres-maintenance) für
 Aufbewahrungsfenster und den `MAINTENANCE_DISABLED` Kill Switch.
 
 ______________________________________________________________________
 
 ## Verwandte Dokumentation
 
-- [Deployment-Optionen](/de/docs/1_deployment_options/) - Architektur pro Instanz
-- [Multi-Tenancy](/de/docs/16_multi_tenancy/) - Logische Trennung innerhalb von Instanzen
-- [Backup und Wiederherstellung](/de/docs/4_backup_and_recovery/) - Backup-Strategien
-- [Core-Komponenten](/de/docs/2_architecture/1_core_components/) - Komponentenabhängigkeiten
+- [Deployment-Optionen](../1_deployment_options/) - Architektur pro Instanz
+- [Multi-Tenancy](../../16_multi_tenancy/) - Logische Trennung innerhalb von Instanzen
+- [Backup und Wiederherstellung](../4_backup_and_recovery/) - Backup-Strategien
+- [Core-Komponenten](../../2_architecture/1_core_components/) - Komponentenabhängigkeiten

--- a/docs/docs/2_platform/3_deployment_guide/7_network_requirements/index.de.md
+++ b/docs/docs/2_platform/3_deployment_guide/7_network_requirements/index.de.md
@@ -107,7 +107,7 @@ ausgehenden Beschränkungen erforderlich.
 
 ## Verwandte Dokumentation
 
-- [Deployment-Optionen](/de/docs/1_deployment_options/) - Architektur und Hosting-Strategien
-- [Netzwerksicherheit](/de/docs/20_security/4_network_security/) - Sicherheitsarchitektur und Defense-in-Depth
-- [Authentifizierung](/de/docs/20_security/1_authentication/) - Details zur Integration von Identitätsanbietern
-- [Infrastruktur-Layer](/de/docs/2_architecture/2_infrastructure_layers/) - Übersicht der Infrastrukturkomponenten
+- [Deployment-Optionen](../1_deployment_options/) - Architektur und Hosting-Strategien
+- [Netzwerksicherheit](../../20_security/4_network_security/) - Sicherheitsarchitektur und Defense-in-Depth
+- [Authentifizierung](../../20_security/1_authentication/) - Details zur Integration von Identitätsanbietern
+- [Infrastruktur-Layer](../../2_architecture/2_infrastructure_layers/) - Übersicht der Infrastrukturkomponenten

--- a/docs/docs/2_platform/3_deployment_guide/8_web_search/index.de.md
+++ b/docs/docs/2_platform/3_deployment_guide/8_web_search/index.de.md
@@ -41,8 +41,8 @@ datenschutzorientiert mit einer Schweizer/europäischen Ausrichtung und bevorzug
 | Wikidata   | Non-Profit    | Strukturierter Wissensgraph                                           |
 | Wikipedia  | Non-Profit    | Enzyklopädische Suche                                                 |
 
-Die entsprechenden ausgehenden Hostnamen sind in den [Netzwerkanforderungen](/de/docs/7_network_requirements/)
-dokumentiert, damit Betreiber Egress-Firewall-Regeln konfigurieren können.
+Die entsprechenden ausgehenden Hostnamen sind in den [Netzwerkanforderungen](../7_network_requirements/) dokumentiert,
+damit Betreiber Egress-Firewall-Regeln konfigurieren können.
 
 ## Engines, die nicht aktiviert sind
 
@@ -95,8 +95,8 @@ zusätzliche Konfiguration wie API-Schlüssel. Das alleinige Hinzufügen zur `ke
 :::
 
 ::: tip
-Wann immer Sie die Engine-Liste ändern, aktualisieren Sie die Seite
-[Netzwerkanforderungen](/de/docs/7_network_requirements/), damit die Betreiber die neuen ausgehenden Hostnamen sehen.
+Wann immer Sie die Engine-Liste ändern, aktualisieren Sie die Seite [Netzwerkanforderungen](../7_network_requirements/),
+damit die Betreiber die neuen ausgehenden Hostnamen sehen.
 :::
 
 ## Websuche vollständig deaktivieren

--- a/docs/docs/2_platform/5_agents/5_document_intelligence_assistant/index.de.md
+++ b/docs/docs/2_platform/5_agents/5_document_intelligence_assistant/index.de.md
@@ -12,16 +12,16 @@ nach den relevantesten Passagen und stützt seine Antwort – mit Zitaten – au
 allgemeine Training des Sprachmodells zu verlassen. Er ist der leistungsfähigste und am besten konfigurierbare Agent auf
 der Plattform und derjenige, um den die meisten Unternehmens-Deployments aufgebaut sind.
 
-Im Gegensatz zum [Instruierten Assistenten](/de/docs/agents/3_instructed_assistant/) und
-[Lernfähigen Assistenten](/de/docs/agents/4_teachable_assistant/), die nur das eigene Wissen des Modells verwenden, kann
-dieser Agent Fragen zu *Ihren* Inhalten – Richtlinien, Handbüchern, Berichten, Projektdateien – beantworten und dem
-Benutzer genau mitteilen, aus welchen Dokumenten er die Informationen bezogen hat.
+Im Gegensatz zum [Instruierten Assistenten](../3_instructed_assistant/) und
+[Lernfähigen Assistenten](../4_teachable_assistant/), die nur das eigene Wissen des Modells verwenden, kann dieser Agent
+Fragen zu *Ihren* Inhalten – Richtlinien, Handbüchern, Berichten, Projektdateien – beantworten und dem Benutzer genau
+mitteilen, aus welchen Dokumenten er die Informationen bezogen hat.
 
 ::: tip Über das „Trainieren“ von Agents
 Der Swiss AI Hub fine-tuned oder trainiert keine Modelle mit Ihren Daten. Der Dokumenten-Intelligenz-Assistent bleibt
 aktuell, indem er zum Zeitpunkt der Abfrage aus Ihrer Wissensbasis *abruft*. Aktualisieren Sie ein Dokument, und der
 Agent verwendet die neue Version bei der nächsten Frage – kein erneutes Training, und Sie können immer sehen, welche
-Quellen er verwendet hat. Weitere Informationen finden Sie in der [Agents-Übersicht](/de/docs/agents/).
+Quellen er verwendet hat. Weitere Informationen finden Sie in der [Agents-Übersicht](../).
 :::
 
 ## Was er leistet
@@ -68,9 +68,9 @@ beschrieben.
   Dafür verwenden Sie den MCP Tool Agent.
 - **Keine menschliche Eskalation von sich aus.** Wenn Sie möchten, dass er bei Nichtbeantwortbarkeit auf einen
   menschlichen Experten zurückgreift, verwenden Sie den Company Knowledge Agent (die Expert-RAG-Variante). Siehe den
-  [Expert Coordinator Agent](/de/docs/agents/9_expert_coordinator_agent/).
+  [Expert Coordinator Agent](../9_expert_coordinator_agent/).
 - **Er nimmt keine Dokumente auf.** Das Füllen und Aktualisieren der Wissensbasis ist die Aufgabe einer
-  [Daten-Pipeline](/de/docs/6_pipelines/), nicht des Agents. Der Agent liest nur, was die Pipeline indiziert hat.
+  [Daten-Pipeline](../../6_pipelines/), nicht des Agents. Der Agent liest nur, was die Pipeline indiziert hat.
 
 ## Typische Szenarien
 
@@ -88,7 +88,7 @@ Infrastruktur ab, die **unabhängig vom Agent selbst** existieren muss. Richten 
 
 1. **Eine befüllte Wissensbasis.** Der Agent durchsucht vektorindizierte Sammlungen Ihrer Dokumente. Diese Sammlungen
    müssen bereits existieren und indizierten Inhalt enthalten. Das Erstellen und Befüllen erfolgt durch eine
-   [Datenerfassungs-Pipeline](/de/docs/6_pipelines/) – die Standard-Pipeline indiziert Dokumente, die über die UI
+   [Datenerfassungs-Pipeline](../../6_pipelines/) – die Standard-Pipeline indiziert Dokumente, die über die UI
    hochgeladen wurden, und benutzerdefinierte Pipelines können von Quellen wie SharePoint synchronisieren und den Index
    aktuell halten, wenn sich Dokumente ändern. **Keine Wissensbasis, nichts abzurufen.**
 2. **Ein Embedding-Modell.** Die Suche funktioniert, indem der Embedding (Vektor) der Frage mit den Embeddings Ihrer
@@ -110,7 +110,7 @@ Embedding-Modell verwenden, bevor Sie etwas anderes debuggen.
 ## Einrichtung
 
 Der Agent wird als **Blueprint** geliefert, aus dem Sie konfigurierte **Profile** erstellen – siehe
-[Blueprints & Profile](/de/docs/agents/2_blueprints_and_profiles/). Sind die Voraussetzungen erfüllt:
+[Blueprints & Profile](../2_blueprints_and_profiles/). Sind die Voraussetzungen erfüllt:
 
 1. **Öffnen Sie den Blueprint** unter **Admin > Agents > Blueprints** und wählen Sie
    **Dokumenten-Intelligenz-Assistent**.
@@ -212,8 +212,8 @@ oder Präferenzen) und diesen zur Personalisierung von Antworten zu verwenden. S
 ### Organisationsspeicher *(optional)*
 
 Ermöglicht es dem Assistenten, auf gemeinsames Wissen zurückzugreifen, das für die gesamte Organisation erfasst wurde
-(zum Beispiel Antworten, die vom [Expert Coordinator Agent](/de/docs/agents/9_expert_coordinator_agent/) gesammelt
-wurden). Deaktivieren Sie den Abschnitt „Organisationsspeicher“, um ihn zu deaktivieren.
+(zum Beispiel Antworten, die vom [Expert Coordinator Agent](../9_expert_coordinator_agent/) gesammelt wurden).
+Deaktivieren Sie den Abschnitt „Organisationsspeicher“, um ihn zu deaktivieren.
 
 | Feld                                 | Typ        | Standard          | Beschreibung                                                                                                                       |
 | :----------------------------------- | :--------- | :---------------- | :--------------------------------------------------------------------------------------------------------------------------------- |
@@ -233,8 +233,8 @@ wurden). Deaktivieren Sie den Abschnitt „Organisationsspeicher“, um ihn zu d
 ## Best Practices
 
 **Stellen Sie zuerst die korrekte Wissensbasis sicher.** Die Qualität der Antworten ist durch die Qualität des
-Indizierten begrenzt. Stellen Sie sicher, dass die [Pipeline](/de/docs/6_pipelines/) die richtigen Dokumente aufnimmt
-und sie aktuell hält, bevor Sie den Agenten optimieren.
+Indizierten begrenzt. Stellen Sie sicher, dass die [Pipeline](../../6_pipelines/) die richtigen Dokumente aufnimmt und
+sie aktuell hält, bevor Sie den Agenten optimieren.
 
 **Gleichen Sie das Embedding-Modell mit dem Index ab.** Lesen Sie die Voraussetzungen nochmals – eine Diskrepanz führt
 stillschweigend zu Fehlern beim Abruf.

--- a/docs/docs/2_platform/5_agents/6_retrieval_agent/index.de.md
+++ b/docs/docs/2_platform/5_agents/6_retrieval_agent/index.de.md
@@ -6,7 +6,7 @@ source_sha: 4ba4a271a45fa5612dfb2e490864ff9b4ac7f8315973dbfdd4fc99b9e8241e0d
 
 # Retrieval Agent
 
-Der **Retrieval Agent** ist der [Document Intelligence Assistant](/de/docs/5_document_intelligence_assistant/) ohne den
+Der **Retrieval Agent** ist der [Document Intelligence Assistant](../5_document_intelligence_assistant/) ohne den
 Antwortschritt. Er führt die *Retrieval*-Hälfte von RAG aus – durchsucht Ihre Knowledge Base und gibt die relevantesten
 Dokumentenpassagen zurück – aber er **ruft niemals ein Sprachmodell auf und schreibt niemals eine Antwort**. Er gibt den
 Rohkontext (die gefundenen Passagen und deren Quellmetadaten) zur weiteren Verwendung zurück.
@@ -21,7 +21,7 @@ konversationelle Antwort – er nimmt eine Frage entgegen und gibt Kontext zurü
 **nicht in den Workflow anderer Agents integriert** (zum Beispiel delegiert der Document Navigation Assistant an einen
 vollständigen RAG-Agenten, nicht an diesen hier). Verwenden Sie ihn nur, wenn Sie Retrieval speziell von der
 Antwortgenerierung entkoppeln möchten. Wenn Sie einen Assistenten wünschen, der Fragen im Chat beantwortet, verwenden
-Sie den [Document Intelligence Assistant](/de/docs/5_document_intelligence_assistant/).
+Sie den [Document Intelligence Assistant](../5_document_intelligence_assistant/).
 :::
 
 ## Was er tut
@@ -51,8 +51,8 @@ flowchart LR
   Antwortgenerierung an anderer Stelle stattfindet.
 
 Wenn Sie einfach fundierte, zitierte Antworten im Chat wünschen, ist dies der falsche Agent – verwenden Sie den
-[Document Intelligence Assistant](/de/docs/5_document_intelligence_assistant/), der denselben Retrieval-Schritt
-umschliesst und dann antwortet.
+[Document Intelligence Assistant](../5_document_intelligence_assistant/), der denselben Retrieval-Schritt umschliesst
+und dann antwortet.
 
 ## Was er bewusst weglässt
 
@@ -77,7 +77,7 @@ Der Retrieval Agent teilt die Daten-Voraussetzungen des Document Intelligence As
 Chat-Modell benötigt**, da er niemals Text generiert.
 
 1. **Eine gefüllte Knowledge Base.** Eine vektor-indexierte Sammlung Ihrer Dokumente muss bereits existieren, gefüllt
-   durch eine [Datenerfassungs-Pipeline](/de/docs/6_pipelines/). Der Agent liest nur, was die Pipeline indiziert hat.
+   durch eine [Datenerfassungs-Pipeline](../../6_pipelines/). Der Agent liest nur, was die Pipeline indiziert hat.
 2. **Ein Embedding-Modell**, das **mit dem zum Indizieren der Knowledge Base verwendeten Modell übereinstimmt** – eine
    Nichtübereinstimmung führt stillschweigend zum Fehlschlagen der Suche.
 

--- a/docs/docs/2_platform/5_agents/8_mcp_tool_agent/index.de.md
+++ b/docs/docs/2_platform/5_agents/8_mcp_tool_agent/index.de.md
@@ -20,7 +20,7 @@ erreicht ist.
 ::: tip Was ist MCP?
 Das **Model Context Protocol (MCP)** ist ein offener Standard, um Tools und Daten für KI-Agents bereitzustellen. Anstatt
 für jedes System eine kundenspezifische Integration zu erstellen, verweisen Sie den Agent auf einen MCP-Server, und er
-entdeckt automatisch, was dieser Server leisten kann. Siehe die [Agents-Übersicht](../#connecting-to-external-tools) für
+entdeckt automatisch, was dieser Server leisten kann. Siehe die [Agents-Übersicht](../#verbindung-zu-externen-tools) für
 die Sichtweise der Plattform auf die Verbindung von Agents mit externen Tools.
 :::
 
@@ -141,7 +141,7 @@ Wie der Agent den externen Tool-Server erreicht.
 | **Max. Eingabe-Tokens** | Zahl           | `128000` | Das Eingabebudget; die Konversation wird entsprechend gekürzt. Bereich 1.000–200.000.                                                        |
 
 Das **Modell** stellt auch die Standardparameter (Temperatur, Timeout, Log-Wahrscheinlichkeitsoptionen) bereit, die auf
-der Seite [Document Intelligence Assistant](../5_document_intelligence_assistant/#language-model) beschrieben sind.
+der Seite [Document Intelligence Assistant](../5_document_intelligence_assistant/#sprachmodell) beschrieben sind.
 
 ## Best Practices
 

--- a/docs/docs/2_platform/5_agents/8_mcp_tool_agent/index.de.md
+++ b/docs/docs/2_platform/5_agents/8_mcp_tool_agent/index.de.md
@@ -20,9 +20,8 @@ erreicht ist.
 ::: tip Was ist MCP?
 Das **Model Context Protocol (MCP)** ist ein offener Standard, um Tools und Daten für KI-Agents bereitzustellen. Anstatt
 für jedes System eine kundenspezifische Integration zu erstellen, verweisen Sie den Agent auf einen MCP-Server, und er
-entdeckt automatisch, was dieser Server leisten kann. Siehe die
-[Agents-Übersicht](/de/docs/agents/#connecting-to-external-tools) für die Sichtweise der Plattform auf die Verbindung
-von Agents mit externen Tools.
+entdeckt automatisch, was dieser Server leisten kann. Siehe die [Agents-Übersicht](../#connecting-to-external-tools) für
+die Sichtweise der Plattform auf die Verbindung von Agents mit externen Tools.
 :::
 
 ## Was es leistet
@@ -51,7 +50,7 @@ flowchart LR
 ## Was es *nicht* leistet
 
 - **Keine Wissensdatenbank / RAG.** Es durchsucht Ihre Dokumente nicht. Für fundierte Dokumentantworten verwenden Sie
-  den [Document Intelligence Assistant](/de/docs/agents/5_document_intelligence_assistant/).
+  den [Document Intelligence Assistant](../5_document_intelligence_assistant/).
 - **Keine Eskalation an Menschen.** Es übergibt nicht an einen Kollegen – seine „Hände“ sind die Tools auf dem
   MCP-Server.
 - **Es ist nur so leistungsfähig wie der Server, mit dem es sich verbindet.** Die Tools, ihr Verhalten und ihre
@@ -87,7 +86,7 @@ Anmeldeinformationen entsprechend an.
 ## Einrichtung
 
 Der Agent wird als **Blueprint** geliefert, aus dem Sie konfigurierte **Profile** erstellen – siehe
-[Blueprints & Profile](/de/docs/agents/2_blueprints_and_profiles/). Mit den vorhandenen Voraussetzungen:
+[Blueprints & Profile](../2_blueprints_and_profiles/). Mit den vorhandenen Voraussetzungen:
 
 1. **Öffnen Sie den Blueprint** unter **Admin > Agents > Blueprints** und wählen Sie **MCP Tool Agent**.
 2. **Erstellen Sie ein Profil** mit einer **Agent ID**, einem **Namen**, einer **Beschreibung** und einem **Icon**.
@@ -142,8 +141,7 @@ Wie der Agent den externen Tool-Server erreicht.
 | **Max. Eingabe-Tokens** | Zahl           | `128000` | Das Eingabebudget; die Konversation wird entsprechend gekürzt. Bereich 1.000–200.000.                                                        |
 
 Das **Modell** stellt auch die Standardparameter (Temperatur, Timeout, Log-Wahrscheinlichkeitsoptionen) bereit, die auf
-der Seite [Document Intelligence Assistant](/de/docs/agents/5_document_intelligence_assistant/#language-model)
-beschrieben sind.
+der Seite [Document Intelligence Assistant](../5_document_intelligence_assistant/#language-model) beschrieben sind.
 
 ## Best Practices
 

--- a/docs/docs/2_platform/5_agents/9_expert_coordinator_agent/index.de.md
+++ b/docs/docs/2_platform/5_agents/9_expert_coordinator_agent/index.de.md
@@ -143,7 +143,7 @@ Wählen Sie die Plattform aus und füllen Sie dann die Felder dieser Plattform a
 | :---------------------------------------------------------------------------------------- | :------------ | :------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
 | **Modell**                                                                                | Modellauswahl | —        | Das Chat-Modell, das verwendet wird, um die Vollständigkeit der Antwort zu beurteilen und Nachfragen zu verfassen. Erforderlich.          |
 | **Temperatur**                                                                            | Zahl          | `0.0`    | Niedrig halten — dies ist eine Beurteilungs-/Extraktionsaufgabe, keine kreative. Bereich 0.0–2.0.                                         |
-| **Log-Wahrscheinlichkeiten zurückgeben** / **Top Log-Wahrscheinlichkeiten** / **Timeout** | —             | —        | Standard-Sprachmodelloptionen, wie auf der Seite [Document Intelligence Assistant](../5_document_intelligence_assistant/#language-model). |
+| **Log-Wahrscheinlichkeiten zurückgeben** / **Top Log-Wahrscheinlichkeiten** / **Timeout** | —             | —        | Standard-Sprachmodelloptionen, wie auf der Seite [Document Intelligence Assistant](../5_document_intelligence_assistant/#sprachmodell). |
 
 ### Organisationsgedächtnis
 

--- a/docs/docs/2_platform/5_agents/9_expert_coordinator_agent/index.de.md
+++ b/docs/docs/2_platform/5_agents/9_expert_coordinator_agent/index.de.md
@@ -13,9 +13,9 @@ Antwort die Frage tatsächlich beantwortet (und fragt bei Bedarf nach), und spei
 **Organisationsgedächtnis**, damit sie beim nächsten Mal automatisch wiederverwendet werden kann.
 
 Normalerweise ist er nicht etwas, womit Endbenutzer direkt chatten. Stattdessen arbeitet er im Hintergrund — meistens
-wird er vom [Company Knowledge Agent](/de/docs/10_company_knowledge_agent/) aufgerufen, wenn dieser Agent keine
-dokumentierten Antworten mehr findet. Sein Wert liegt in der **Wissenserfassung**: Jede Expertenkonsultation verwandelt
-eine einmalige menschliche Antwort in wiederverwendbares organisatorisches Wissen.
+wird er vom [Company Knowledge Agent](../10_company_knowledge_agent/) aufgerufen, wenn dieser Agent keine dokumentierten
+Antworten mehr findet. Sein Wert liegt in der **Wissenserfassung**: Jede Expertenkonsultation verwandelt eine einmalige
+menschliche Antwort in wiederverwendbares organisatorisches Wissen.
 
 ## Was er tut
 
@@ -52,7 +52,7 @@ im Chat; ihm wird mitgeteilt, dass die Frage weitergeleitet wurde und beantworte
 Der Grund, diesen Agent anstelle einer E-Mail an einen Experten zu verwenden, ist, dass **jede Antwort erfasst wird**.
 Wenn ein Experte einmal antwortet, werden die Frage und Antwort ins Organisationsgedächtnis geschrieben und sind für
 jeden durchsuchbar. Das nächste Mal, wenn dasselbe Thema aufkommt, kann der
-[Company Knowledge Agent](/de/docs/10_company_knowledge_agent/) es aus diesem gespeicherten Wissen beantworten, ohne den
+[Company Knowledge Agent](../10_company_knowledge_agent/) es aus diesem gespeicherten Wissen beantworten, ohne den
 Experten erneut zu belästigen — so summiert sich der Aufwand des Experten mit der Zeit, anstatt in einem Chat-Thread
 verloren zu gehen.
 
@@ -69,7 +69,7 @@ verloren zu gehen.
 
 1. **Ein verbundener Teams- oder Slack-Bot.** Der Agent erreicht Experten über einen Bot, der auf Ihrer
    Kollaborationsplattform registriert ist. Diese Bot-Verbindung muss zuerst eingerichtet werden — siehe
-   [Slack & Teams Integrationseinrichtung](/de/docs/17_slack_teams_integrations/1_setup/). Sie benötigen die Kanal- und
+   [Slack & Teams Integrationseinrichtung](../../17_slack_teams_integrations/1_setup/). Sie benötigen die Kanal- und
    Bot-Identifikatoren aus dieser Einrichtung, um die unten stehende Konfiguration auszufüllen.
 2. **Ein Expertenkanal.** Ein Teams- oder Slack-Kanal, in dem Ihre Experten anwesend und bereit sind, Fragen zu
    beantworten.
@@ -79,7 +79,7 @@ verloren zu gehen.
 ## Einrichtung
 
 Der Agent wird als **Blueprint** (Vorlage) bereitgestellt, aus dem Sie konfigurierte **Profile** erstellen — siehe
-[Blueprints & Profile](/de/docs/2_blueprints_and_profiles/). Mit den erfüllten Voraussetzungen:
+[Blueprints & Profile](../2_blueprints_and_profiles/). Mit den erfüllten Voraussetzungen:
 
 1. **Öffnen Sie den Blueprint** unter **Admin > Agents > Blueprints** und wählen Sie **Expert Coordinator Agent** aus.
 2. **Erstellen Sie ein Profil** mit einer **Agent-ID**, einem **Namen**, einer **Beschreibung** und einem **Icon**.
@@ -110,7 +110,7 @@ andernorts Referenzen auf diese Umgebungsvariablen finden, betrachten Sie diese 
 ### Expertenkanal
 
 Wählen Sie die Plattform aus und füllen Sie dann die Felder dieser Plattform aus. Die Identifikatoren stammen aus Ihrer
-[Bot-Integrations-Einrichtung](/de/docs/17_slack_teams_integrations/1_setup/).
+[Bot-Integrations-Einrichtung](../../17_slack_teams_integrations/1_setup/).
 
 | Feld         | Typ     | Standard | Beschreibung                                                                |
 | :----------- | :------ | :------- | :-------------------------------------------------------------------------- |
@@ -139,11 +139,11 @@ Wählen Sie die Plattform aus und füllen Sie dann die Felder dieser Plattform a
 
 ### Sprachmodell
 
-| Feld                                                                                      | Typ           | Standard | Beschreibung                                                                                                                                    |
-| :---------------------------------------------------------------------------------------- | :------------ | :------- | :---------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Modell**                                                                                | Modellauswahl | —        | Das Chat-Modell, das verwendet wird, um die Vollständigkeit der Antwort zu beurteilen und Nachfragen zu verfassen. Erforderlich.                |
-| **Temperatur**                                                                            | Zahl          | `0.0`    | Niedrig halten — dies ist eine Beurteilungs-/Extraktionsaufgabe, keine kreative. Bereich 0.0–2.0.                                               |
-| **Log-Wahrscheinlichkeiten zurückgeben** / **Top Log-Wahrscheinlichkeiten** / **Timeout** | —             | —        | Standard-Sprachmodelloptionen, wie auf der Seite [Document Intelligence Assistant](/de/docs/5_document_intelligence_assistant/#language-model). |
+| Feld                                                                                      | Typ           | Standard | Beschreibung                                                                                                                              |
+| :---------------------------------------------------------------------------------------- | :------------ | :------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
+| **Modell**                                                                                | Modellauswahl | —        | Das Chat-Modell, das verwendet wird, um die Vollständigkeit der Antwort zu beurteilen und Nachfragen zu verfassen. Erforderlich.          |
+| **Temperatur**                                                                            | Zahl          | `0.0`    | Niedrig halten — dies ist eine Beurteilungs-/Extraktionsaufgabe, keine kreative. Bereich 0.0–2.0.                                         |
+| **Log-Wahrscheinlichkeiten zurückgeben** / **Top Log-Wahrscheinlichkeiten** / **Timeout** | —             | —        | Standard-Sprachmodelloptionen, wie auf der Seite [Document Intelligence Assistant](../5_document_intelligence_assistant/#language-model). |
 
 ### Organisationsgedächtnis
 
@@ -163,12 +163,12 @@ Antworten automatisch wiederverwendet werden.
 Kanal, in dem kompetente Kollegen anwesend und bereit sind zu helfen.
 
 **Den Namespace konsistent mit Ihren Wissens-Agents halten.** Damit erfasste Antworten wiederverwendet werden können,
-schreiben Sie sie in einen Namespace, aus dem der [Company Knowledge Agent](/de/docs/10_company_knowledge_agent/) (oder
-ein RAG-Agent) tatsächlich liest.
+schreiben Sie sie in einen Namespace, aus dem der [Company Knowledge Agent](../10_company_knowledge_agent/) (oder ein
+RAG-Agent) tatsächlich liest.
 
 **Das Nachfragelimit an die Geduld Ihrer Experten anpassen.** Zwei oder drei Runden sind in der Regel ausreichend; zu
 viele können sich wie ein Verhör für den antwortenden Menschen anfühlen.
 
 **Koppeln Sie ihn mit einem Company Knowledge Agent.** Allein leitet dieser Agent nur Fragen weiter. Seine wahre Stärke
-kommt daher, dass er das Eskalationsziel eines [Company Knowledge Agent](/de/docs/10_company_knowledge_agent/) ist, der
-ihn nur konsultiert, wenn seine eigenen Dokumente nicht ausreichen.
+kommt daher, dass er das Eskalationsziel eines [Company Knowledge Agent](../10_company_knowledge_agent/) ist, der ihn
+nur konsultiert, wenn seine eigenen Dokumente nicht ausreichen.

--- a/docs/docs/3_sdk/2_building_agents/1_agent_fundamentals/index.de.md
+++ b/docs/docs/3_sdk/2_building_agents/1_agent_fundamentals/index.de.md
@@ -140,8 +140,8 @@ LLM-Modellen), ohne seinen Code zu ändern.
 
 ::: tip Über die UI editierbare Konfiguration
 Um die Konfiguration Ihres Agents über die Admin-UI editierbar zu machen, siehe
-[Konfigurierbare Agent-Formulare](/de/docs/8_configurable_agents/). Das Form Duality Pattern ermöglicht es
-Administratoren, Agent-Profile ohne Code-Änderungen zu erstellen und anzupassen.
+[Konfigurierbare Agent-Formulare](../8_configurable_agents/). Das Form Duality Pattern ermöglicht es Administratoren,
+Agent-Profile ohne Code-Änderungen zu erstellen und anzupassen.
 :::
 
 ### `AgentConfig`: Globale Konfiguration
@@ -222,5 +222,5 @@ async def complex_step(
 
 ## Nächste Schritte
 
-Nachdem Sie die Grundlagen verstanden haben, erkunden Sie die **[Kernmuster](/de/docs/2_core_patterns/)**, um zu sehen,
-wie diese Konzepte zum Erstellen von Agent-Workflows verwendet werden.
+Nachdem Sie die Grundlagen verstanden haben, erkunden Sie die **[Kernmuster](../2_core_patterns/)**, um zu sehen, wie
+diese Konzepte zum Erstellen von Agent-Workflows verwendet werden.

--- a/docs/docs/3_sdk/2_building_agents/5_memory/index.de.md
+++ b/docs/docs/3_sdk/2_building_agents/5_memory/index.de.md
@@ -83,7 +83,7 @@ async def stop_step(self, _: StoreUserMemoryEvent) -> StopEvent:
     return StopEvent()
 ```
 
-Siehe [Die Verletzung des "Dangling Stop"](../9_execution_model/#the-dangling-stop-violation) für die allgemeine Regel.
+Siehe [Die Verletzung des "Dangling Stop"](../9_execution_model/#die-dangling-stop-verletzung) für die allgemeine Regel.
 :::
 
 ### Vollständiges Beispiel
@@ -580,7 +580,7 @@ def check_storage_complete(
 Die Vorbedingung `check_memory_ready` blockiert den Schritt zur Historien-Erweiterung, bis alle aktivierten
 Speichertypen abgerufen wurden. Die Vorbedingung `check_storage_complete` blockiert den letzten Stop-Schritt, bis die
 Speicherung abgeschlossen ist (falls aktiviert). Dies verhindert die
-[optionale Parameterfalle](../9_execution_model/#the-optional-parameter-trap), bei der Schritte vorzeitig mit
+[optionale Parameterfalle](../9_execution_model/#die-falle-der-optionalen-parameter), bei der Schritte vorzeitig mit
 `None`-Werten ausgeführt werden.
 
 ## Observability

--- a/docs/docs/3_sdk/2_building_agents/5_memory/index.de.md
+++ b/docs/docs/3_sdk/2_building_agents/5_memory/index.de.md
@@ -83,8 +83,7 @@ async def stop_step(self, _: StoreUserMemoryEvent) -> StopEvent:
     return StopEvent()
 ```
 
-Siehe [Die Verletzung des "Dangling Stop"](/de/docs/9_execution_model/#the-dangling-stop-violation) für die allgemeine
-Regel.
+Siehe [Die Verletzung des "Dangling Stop"](../9_execution_model/#the-dangling-stop-violation) für die allgemeine Regel.
 :::
 
 ### Vollständiges Beispiel
@@ -581,7 +580,7 @@ def check_storage_complete(
 Die Vorbedingung `check_memory_ready` blockiert den Schritt zur Historien-Erweiterung, bis alle aktivierten
 Speichertypen abgerufen wurden. Die Vorbedingung `check_storage_complete` blockiert den letzten Stop-Schritt, bis die
 Speicherung abgeschlossen ist (falls aktiviert). Dies verhindert die
-[optionale Parameterfalle](/de/docs/9_execution_model/#the-optional-parameter-trap), bei der Schritte vorzeitig mit
+[optionale Parameterfalle](../9_execution_model/#the-optional-parameter-trap), bei der Schritte vorzeitig mit
 `None`-Werten ausgeführt werden.
 
 ## Observability

--- a/packages/backup/README.md
+++ b/packages/backup/README.md
@@ -6,7 +6,7 @@ instance (3 containers: gRPC code server, daemon, webserver) inside the Docker C
 Requires the Docker socket (`/var/run/docker.sock`) to discover and manage platform containers via the
 `com.docker.compose.project` label.
 
-Dagster UI: <http://localhost:3004>
+Dagster UI: `http://localhost:3004`
 
 ## What this package does
 


### PR DESCRIPTION
## What

Set `ignoreDeadLinks: false` in the VitePress config so the docs build fails on broken internal links instead of silently shipping them, then fixed every dead link the check surfaced (87 total).

## Fixes by category

- **Root README**: `LICENSE` / `LICENSES.md` / `CONTRIBUTING.md` now use absolute GitHub URLs so they resolve both on GitHub and in the docs site.
- **Backup README**: de-linked the localhost Dagster UI URL.
- **Bot creation guide**: corrected the deep-dive path (`aihub_bot` -> `packages/bot`).
- **German pages (18 files)**: normalized translation-mangled flat absolute links (`/de/docs/...`) back to the relative paths used by the English sources.
- **Auth doc**: removed references to two ADRs that do not exist (`2026_02_27_dynamic_identity_provider_loading`, `2026_02_26_skip_oidc_discovery_for_oauth2_proxy`).

## Verification

`pnpm run docs:build:ci` passes with **0 dead links**.

## Follow-ups (not in this PR)

- The translation pipeline still mangles relative links into broken absolutes, so a future `docs:translate` run could reintroduce these. A deterministic post-translate link normalizer would prevent recurrence.
- Editing the two English source files left their German `source_sha` stale.