### PR TITLE
chore(ci-cd): Update SonarQube Scanner action to v6

### DIFF
--- a/.github/actions/CLAUDE.md
+++ b/.github/actions/CLAUDE.md
@@ -73,7 +73,7 @@ artifacts from `test_backend`, posts formatted coverage report as PR comment via
 `MishaKav/pytest-coverage-comment@main`.
 
 **sonarcloud_scan**: Downloads `{working_directory}-coverage-report` artifact when `report_coverage: true`. Runs
-`SonarSource/sonarqube-scan-action@v5`. Requires `sonar_token` and `sonar_project_key` inputs. Default organization:
+`SonarSource/sonarqube-scan-action@v6`. Requires `sonar_token` and `sonar_project_key` inputs. Default organization:
 `bbv-ai`.
 
 ## Local vs Remote References

--- a/.github/actions/sonarcloud_scan/action.yml
+++ b/.github/actions/sonarcloud_scan/action.yml
@@ -42,7 +42,7 @@ runs:
         path: ${{ inputs.working_directory }}
     - name: Run SonarCloud Without Coverage
       if: inputs.report_coverage == 'false'
-      uses: SonarSource/sonarqube-scan-action@2f77a1ec69fb1d595b06f35ab27e97605bdef703  # v5.3.2
+      uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602  # v6.0.0
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         SONAR_TOKEN: ${{ inputs.sonar_token }}
@@ -53,7 +53,7 @@ runs:
           -Dsonar.organization=${{ inputs.sonar_organization }}
     - name: Run SonarCloud With Coverage
       if: inputs.report_coverage == 'true'
-      uses: SonarSource/sonarqube-scan-action@2f77a1ec69fb1d595b06f35ab27e97605bdef703  # v5.3.2
+      uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602  # v6.0.0
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         SONAR_TOKEN: ${{ inputs.sonar_token }}


### PR DESCRIPTION
Updates `SonarSource/sonarqube-scan-action` from v5.3.2 to v6.0.0. v5 is no longer supported and is flagged with a security vulnerability (CI deprecation warning, see https://community.sonarsource.com/gha-v6-update).

## Changes
- Bump both references in `.github/actions/sonarcloud_scan/action.yml` to the v6.0.0 commit SHA (`fd88b7d7ccbaefd23d8f36f73b59db7a3d246602`), keeping the repo's SHA-pinning policy (#1216).
- Update `.github/actions/CLAUDE.md` to reference `@v6`.

Closes #1398