### PR TITLE
fix(ci-cd): Wrap Claude review job condition in expression syntax

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,11 +14,11 @@ on:
 jobs:
   claude-review:
     if: >-
-      !github.event.pull_request.draft &&
+      ${{ !github.event.pull_request.draft &&
       github.event.sender.type != 'Bot' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
-      github.event.pull_request.author_association)
+      github.event.pull_request.author_association) }}
     runs-on: ubuntu-slim
     timeout-minutes: 20
     permissions:


### PR DESCRIPTION
## Summary

The **Claude Code Review** job was skipped on every pull request, even ones that satisfied all of its gating conditions. The job-level `if` expression started with `!`, which GitHub Actions does not auto-evaluate — so the whole condition silently failed and the job was skipped.

## Changes

- Wrap the `claude-review` job `if` condition in `${{ }}` so it evaluates correctly.

## Test plan

- Verified the bug empirically: PRs #1402 and #1403 satisfied **every** clause (not draft, `User` sender, same-repo head, `MEMBER` author association) yet the job still showed `skipped` in `gh run list --workflow=claude-code-review.yml`.
- Root cause confirmed against [GitHub docs](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution): an `if` expression starting with `!` must be wrapped in `${{ }}` (or escaped), since `!` is reserved YAML notation.
- Counter-example: the sibling `claude.yml` workflow does not lead with `!` and evaluates correctly without a wrapper.
- Full validation requires this to run on a real PR after merge to `main`, since the trigger only fires on `opened` / `ready_for_review`.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>` (see
  [CONTRIBUTING.md](https://github.com/bbvch-ai/aihub-core/blob/main/CONTRIBUTING.md))
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [x] CLA signed — post this exact comment on the PR if the bot hasn't prompted you yet:
  `I have read the CONTRIBUTOR_AGREEMENT and I hereby sign the CLA`
  ([read the agreement](https://github.com/bbvch-ai/aihub-core/blob/main/CONTRIBUTOR_AGREEMENT.md))
- [x] Tests added or updated where relevant (N/A — CI workflow config only)