### PR TITLE
fix(rag): Render image block URL without Jinja sandbox SecurityError

### DIFF
--- a/packages/agent/swiss_ai_hub/agent/i18n/translations/agent/rag_agent.de.yml
+++ b/packages/agent/swiss_ai_hub/agent/i18n/translations/agent/rag_agent.de.yml
@@ -37,7 +37,7 @@ config:
       \ für den gegebenen Kontext relevant sind.\n\nNachfolgend finden Sie die relevanten\
       \ Dokumente:\n\n<context_documents>\n{% for block in context_blocks %}\n{% if\
       \ block.block_type == 'text' %}\n{{ block.text }}\n{% endif %}\n{% if block.block_type\
-      \ == 'image' %}\n{{ block.url.__str__() | image}}\n{% endif %}\n{% endfor %}\n\
+      \ == 'image' %}\n{{ block.url | string | image}}\n{% endif %}\n{% endfor %}\n\
       </context_documents>\n\nAnweisung: Erstellen Sie anhand der Informationen aus\
       \ den bereitgestellten Dokumenten eine detaillierte und gut strukturierte Antwort\n\
       auf die Frage des Benutzers.\n{% endchat %}\n"

--- a/packages/agent/swiss_ai_hub/agent/i18n/translations/agent/rag_agent.en.yml
+++ b/packages/agent/swiss_ai_hub/agent/i18n/translations/agent/rag_agent.en.yml
@@ -35,7 +35,7 @@ config:
       within these documents provides crucial insights relevant to the given context.\n\
       \nBelow are the relevant documents:\n\n<context_documents>\n{% for block in\
       \ context_blocks %}\n{% if block.block_type == 'text' %}\n{{ block.text }}\n\
-      {% endif %}\n{% if block.block_type == 'image' %}\n{{ block.url.__str__() | image}}\n\
+      {% endif %}\n{% if block.block_type == 'image' %}\n{{ block.url | string | image}}\n\
       {% endif %}\n{% endfor %}\n</context_documents>\n\nInstruction: Using the information\
       \ from the provided documents, generate a detailed and well-structured response\n\
       to the user's question.\n{% endchat %}\n"

--- a/packages/agent/swiss_ai_hub/agent/i18n/translations/agent/rag_agent.fr.yml
+++ b/packages/agent/swiss_ai_hub/agent/i18n/translations/agent/rag_agent.fr.yml
@@ -38,7 +38,7 @@ config:
       \ Le contenu\nde ces documents fournit des informations cruciales pertinentes\
       \ pour le contexte donné.\n\nVoici les documents pertinents :\n\n<context_documents>\n\
       {% for block in context_blocks %}\n{% if block.block_type == 'text' %}\n{{ block.text }}\n\
-      {% endif %}\n{% if block.block_type == 'image' %}\n{{ block.url.__str__() | image}}\n\
+      {% endif %}\n{% if block.block_type == 'image' %}\n{{ block.url | string | image}}\n\
       {% endif %}\n{% endfor %}\n</context_documents>\n\nInstruction : En utilisant\
       \ les informations des documents fournis, générez une réponse détaillée et bien\
       \ structurée\nà la question de l'utilisateur.\n{% endchat %}\n"

--- a/packages/agent/swiss_ai_hub/agent/i18n/translations/agent/rag_agent.it.yml
+++ b/packages/agent/swiss_ai_hub/agent/i18n/translations/agent/rag_agent.it.yml
@@ -37,7 +37,7 @@ config:
       \ fornisce informazioni cruciali rilevanti per il contesto dato.\n\nDi seguito\
       \ sono riportati i documenti pertinenti:\n\n<context_documents>\n{% for block\
       \ in context_blocks %}\n{% if block.block_type == 'text' %}\n{{ block.text }}\n\
-      {% endif %}\n{% if block.block_type == 'image' %}\n{{ block.url.__str__() | image}}\n\
+      {% endif %}\n{% if block.block_type == 'image' %}\n{{ block.url | string | image}}\n\
       {% endif %}\n{% endfor %}\n</context_documents>\n\nIstruzione: Utilizzando le\
       \ informazioni dai documenti forniti, genera una risposta dettagliata e ben\
       \ strutturata\nalla domanda dell'utente.\n{% endchat %}\n"

--- a/packages/core/swiss_ai_hub/core/generative_ai/retrieval/tests/unit/test_combine_nodes_in_order.py
+++ b/packages/core/swiss_ai_hub/core/generative_ai/retrieval/tests/unit/test_combine_nodes_in_order.py
@@ -56,7 +56,7 @@ def custom_prompt():
 {{ block.text }}
 {% endif %}
 {% if block.block_type == 'image' %}
-{{ block.url.__str__() | image}}
+{{ block.url | string | image}}
 {% endif %}
 {% endfor %}
         """
@@ -156,3 +156,33 @@ def _(the_result, docstring):
     expected = "\n".join(line.rstrip() for line in docstring.strip().splitlines())
     actual = "\n".join(line.rstrip() for line in the_result.blocks[0].text.strip().splitlines())
     assert actual == expected, f"\nExpected:\n{expected}\n\nBut got:\n{actual}\n"
+
+
+def test_image_block_renders_without_sandbox_security_error():
+    """Regression: the context prompt must render an image block whose ``url`` is a
+    pydantic ``AnyUrl`` without tripping the Jinja ``SandboxedEnvironment``.
+
+    The previous ``{{ block.url.__str__() | image }}`` raised
+    ``jinja2.exceptions.SecurityError: access to attribute '__str__' of 'AnyUrl'
+    object is unsafe`` because the sandbox forbids dunder access. ``| string``
+    converts via a trusted filter instead.
+    """
+    from llama_index.core.base.llms.types import ImageBlock
+    from llama_index.core.prompts import RichPromptTemplate
+    from pydantic import AnyUrl
+
+    template = (
+        '{% chat role="user" %}\n'
+        "{% for block in context_blocks %}\n"
+        "{% if block.block_type == 'image' %}\n"
+        "{{ block.url | string | image }}\n"
+        "{% endif %}\n"
+        "{% endfor %}\n"
+        "{% endchat %}"
+    )
+    image_block = ImageBlock(url="https://example.com/figure.jpg")
+    assert isinstance(image_block.url, AnyUrl)
+
+    messages = RichPromptTemplate(template_str=template).format_messages(context_blocks=[image_block])
+
+    assert messages

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/guards.de.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/guards.de.yml
@@ -83,7 +83,7 @@ context_sufficient_guard:
     {{ block.text }}
     {% endif %}
     {% if block.block_type == 'image' %}
-    {{ block.url.__str__() | image }}
+    {{ block.url | string | image }}
     {% endif %}
     {% endfor %}
     </message>
@@ -104,7 +104,7 @@ context_sufficient_guard:
     {{ block.text }}
     {% endif %}
     {% if block.block_type == 'image' %}
-    {{ block.url.__str__() | image }}
+    {{ block.url | string | image }}
     {% endif %}
     {% endfor %}
     </Context>

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/guards.en.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/guards.en.yml
@@ -81,7 +81,7 @@ context_sufficient_guard:
     {{ block.text }}
     {% endif %}
     {% if block.block_type == 'image' %}
-    {{ block.url.__str__() | image }}
+    {{ block.url | string | image }}
     {% endif %}
     {% endfor %}
     </message>
@@ -102,7 +102,7 @@ context_sufficient_guard:
     {{ block.text }}
     {% endif %}
     {% if block.block_type == 'image' %}
-    {{ block.url.__str__() | image }}
+    {{ block.url | string | image }}
     {% endif %}
     {% endfor %}
     </Context>

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/guards.fr.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/guards.fr.yml
@@ -83,7 +83,7 @@ context_sufficient_guard:
     {{ block.text }}
     {% endif %}
     {% if block.block_type == 'image' %}
-    {{ block.url.__str__() | image }}
+    {{ block.url | string | image }}
     {% endif %}
     {% endfor %}
     </message>
@@ -104,7 +104,7 @@ context_sufficient_guard:
     {{ block.text }}
     {% endif %}
     {% if block.block_type == 'image' %}
-    {{ block.url.__str__() | image }}
+    {{ block.url | string | image }}
     {% endif %}
     {% endfor %}
     </Context>

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/guards.it.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/guards.it.yml
@@ -84,7 +84,7 @@ context_sufficient_guard:
     {{ block.text }}
     {% endif %}
     {% if block.block_type == 'image' %}
-    {{ block.url.__str__() | image }}
+    {{ block.url | string | image }}
     {% endif %}
     {% endfor %}
     </message>
@@ -105,7 +105,7 @@ context_sufficient_guard:
     {{ block.text }}
     {% endif %}
     {% if block.block_type == 'image' %}
-    {{ block.url.__str__() | image }}
+    {{ block.url | string | image }}
     {% endif %}
     {% endfor %}
     </Contesto>

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.de.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.de.yml
@@ -31,7 +31,7 @@ rag:
     {{ block.text }}
     {% endif %}
     {% if block.block_type == 'image' %}
-    {{ block.url.__str__() | image}}
+    {{ block.url | string | image}}
     {% endif %}
     {% endfor %}
     </context_documents>

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.en.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.en.yml
@@ -30,7 +30,7 @@ rag:
     {{ block.text }}
     {% endif %}
     {% if block.block_type == 'image' %}
-    {{ block.url.__str__() | image}}
+    {{ block.url | string | image}}
     {% endif %}
     {% endfor %}
     </context_documents>

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.fr.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.fr.yml
@@ -30,7 +30,7 @@ rag:
     {{ block.text }}
     {% endif %}
     {% if block.block_type == 'image' %}
-    {{ block.url.__str__() | image}}
+    {{ block.url | string | image}}
     {% endif %}
     {% endfor %}
     </context_documents>

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.it.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.it.yml
@@ -30,7 +30,7 @@ rag:
     {{ block.text }}
     {% endif %}
     {% if block.block_type == 'image' %}
-    {{ block.url.__str__() | image}}
+    {{ block.url | string | image}}
     {% endif %}
     {% endfor %}
     </context_documents>


### PR DESCRIPTION
## What & why

Fixes #1409.

RAG agents crashed on the `order_nodes_by_documents` step for **any query that retrieved an image/figure node**, with:

```
jinja2.exceptions.SecurityError: access to attribute '__str__' of 'AnyUrl' object is unsafe.
```

The context-prompt and context-sufficiency-guard templates rendered figure images with `{{ block.url.__str__() | image }}`. llama-index coerces `ImageBlock.url` to a pydantic `AnyUrl`, and banks renders the template through Jinja2's `SandboxedEnvironment`, which forbids dunder access (`__str__`) on objects — so the explicit call raised a `SecurityError` at render time.

## Change

Replace the blocked dunder call with the trusted `| string` filter: `{{ block.url | string | image }}`. The filter performs the string conversion in sandbox-trusted code rather than via template attribute access.

Applied to every occurrence of the pattern (it is the same latent defect everywhere):

- RAG context prompt — fallback (`lib/prompt.*.yml`) and agent default (`agent/rag_agent.*.yml`), all 4 locales
- Context-sufficiency guard prompts (`lib/guards.*.yml`), all 4 locales (chat-history + context blocks)

Plus a regression test that renders an `AnyUrl`-backed `ImageBlock` through `RichPromptTemplate` and asserts no `SecurityError` (the existing BDD scenarios only exercised text nodes, so the image branch was never covered).

## Notes for the reviewer

- **Existing profiles**: because `context_prompt` is a per-profile configurable field, profiles already saved with the old default carry the broken template frozen in MongoDB — they need a re-save (or a config migration) to pick up this fix. Flagging in case we want a follow-up migration.
- **Not the full image story**: this fixes the template-render crash only. A second, distinct bug (#1412) then surfaces at the token-counting stage, where the figure is downloaded from the unreachable public S3 endpoint. #1412 proposes inlining the image bytes via the internal S3 client, which would supersede this template change. Kept separate per the issue split; happy to fold them together if you'd prefer one PR.

## Testing

- `pytest` on the touched areas (core i18n / guards / retrieval): **43 passed** (incl. new regression test).
- Agent rag/expert-rag suites: unchanged vs. base (the 8 failures are pre-existing and require local infra; identical before and after this change).
