### PR TITLE
fix(ui): Prevent UI freeze when editing agent config with empty repeaters

### DIFF
--- a/packages/web/composables/form/useFormKitTransform.ts
+++ b/packages/web/composables/form/useFormKitTransform.ts
@@ -25,8 +25,10 @@ export interface CategorizedElements {
 export type FormElement = Record<string, unknown>
 
 /**
- * Gets a nested value from an object using a dot-separated path.
- * Creates intermediate objects if they don't exist.
+ * Reads a nested array from an object using a dot-separated path. Pure read: never
+ * mutates `obj` (it is called from a render-time `:model-value` getter, where a write
+ * into reactive form data would trigger a recursive render loop). Returns an empty array
+ * when any path segment is missing or the value is not an array.
  */
 export function getNestedValue(
   obj: Record<string, unknown>,

--- a/packages/web/composables/form/useFormKitTransform.ts
+++ b/packages/web/composables/form/useFormKitTransform.ts
@@ -33,20 +33,16 @@ export function getNestedValue(
   path: string,
 ): Record<string, unknown>[] {
   const parts = path.split('.')
-  let current: Record<string, unknown> = obj
+  let current: unknown = obj
 
   for (let i = 0; i < parts.length - 1; i++) {
-    const key = parts[i]
-    current[key] ??= {}
-    current = current[key] as Record<string, unknown>
+    if (!current || typeof current !== 'object') return []
+    current = (current as Record<string, unknown>)[parts[i]]
   }
 
-  const lastKey = parts[parts.length - 1]
-  if (!Array.isArray(current[lastKey])) {
-    current[lastKey] = []
-  }
-
-  return current[lastKey] as Record<string, unknown>[]
+  if (!current || typeof current !== 'object') return []
+  const value = (current as Record<string, unknown>)[parts[parts.length - 1]]
+  return Array.isArray(value) ? value as Record<string, unknown>[] : []
 }
 
 /**
@@ -642,12 +638,19 @@ export function seedFormDefaults(
         : {}
       result[name] = seedFormDefaults(groupValue, children)
     }
-    else if (formkitType === 'repeater' && Array.isArray(value)) {
-      result[name] = value.map(item =>
-        item && typeof item === 'object' && !Array.isArray(item)
-          ? seedFormDefaults(item as Record<string, unknown>, children)
-          : item,
-      )
+    else if (formkitType === 'repeater') {
+      if (Array.isArray(value)) {
+        result[name] = value.map(item =>
+          item && typeof item === 'object' && !Array.isArray(item)
+            ? seedFormDefaults(item as Record<string, unknown>, children)
+            : item,
+        )
+      }
+      // Materialise an empty array for untouched repeaters here (load time) rather
+      // than lazily inside the render-time `:model-value` getter, which must stay pure.
+      else if (value === undefined) {
+        result[name] = []
+      }
     }
     else if (!(name in result) && element.value !== undefined) {
       result[name] = element.value

--- a/packages/web/composables/form/useFormKitTransform.ts
+++ b/packages/web/composables/form/useFormKitTransform.ts
@@ -43,7 +43,7 @@ export function getNestedValue(
   }
 
   if (!current || typeof current !== 'object') return []
-  const value = (current as Record<string, unknown>)[parts[parts.length - 1]]
+  const value = (current as Record<string, unknown>)[parts.at(-1)!]
   return Array.isArray(value) ? value as Record<string, unknown>[] : []
 }
 


### PR DESCRIPTION
## Summary

Editing an agent (or process) configuration whose schema contains an *untouched* repeater field (no value in the loaded data) froze the browser tab. The repeater's render-time `:model-value` getter was mutating the reactive form data, triggering Vue's recursive-update guard ("Maximum recursive updates exceeded"). This makes the render path side-effect-free and moves the one necessary write to load time.

## Changes

- **`getNestedValue` is now a pure read.** Removed the in-place mutations (`current[key] ??= {}` and `current[lastKey] = []`) that wrote into `data.value` while it was being read during render. It now traverses safely and returns the existing array, or a throwaway `[]` that is never written back.
- **Added null/type guards** to `getNestedValue` so missing or `null` intermediate path segments (e.g. a nullable group that is `null`) return `[]` gracefully instead of throwing — previously the auto-created intermediates masked this.
- **`seedFormDefaults` materializes the empty array at load time.** Untouched repeaters (`value === undefined`) now get their backing `[]` seeded during `hydrate()`, giving `FormKitRepeater`'s `v-model` a stable array reference without relying on the render-time getter.

## Test plan

- `make test` for `packages/web` is a no-op (no frontend test suite configured), so verification is manual/end-to-end.
- Manually verified: open the agent config edit form for an agent whose schema has a repeater field with no saved value — the form renders without freezing, the repeater shows empty, and items can be added/removed and saved.
- Regression check: configs that already contain repeater items still load, render, and save correctly; nullable groups left disabled remain `null`.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>` (see
  [CONTRIBUTING.md](https://github.com/bbvch-ai/aihub-core/blob/main/CONTRIBUTING.md))
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [ ] CLA signed — post this exact comment on the PR if the bot hasn't prompted you yet:
  `I have read the CONTRIBUTOR_AGREEMENT and I hereby sign the CLA`
  ([read the agreement](https://github.com/bbvch-ai/aihub-core/blob/main/CONTRIBUTOR_AGREEMENT.md))
- [ ] Tests added or updated where relevant (no frontend test harness configured for `packages/web`)

