### PR TITLE
fix(ui): Resolve endless spinner on first login

### DIFF
--- a/packages/web/app.vue
+++ b/packages/web/app.vue
@@ -21,19 +21,13 @@ const { getToken } = useAuth()
 const { t, locale } = useI18n()
 const localePath = useLocalePath()
 const route = useRoute()
-const router = useRouter()
 const toast = useToast()
 useNotificationPoller()
 
 // Spinner shown while the home-redirect middleware resolves tenants; it runs
-// before any page mounts, so the page itself can't show it. Cleared on settle.
-const homeResolving = useState<boolean>('home-resolving', () => false)
-router.afterEach(() => {
-  homeResolving.value = false
-})
-router.onError(() => {
-  homeResolving.value = false
-})
+// before any page mounts, so the page itself can't show it. The middleware sets
+// the flag, plugins/home-resolving clears it once navigation settles.
+const homeResolving = useHomeResolving()
 client.setConfig({
   baseURL: '/api/v1',
   auth: async () => {

--- a/packages/web/app.vue
+++ b/packages/web/app.vue
@@ -24,9 +24,8 @@ const route = useRoute()
 const toast = useToast()
 useNotificationPoller()
 
-// Spinner shown while the home-redirect middleware resolves tenants; it runs
-// before any page mounts, so the page itself can't show it. The middleware sets
-// the flag, plugins/home-resolving clears it once navigation settles.
+// Overlay lives at the root, not the page: the home-redirect middleware
+// redirects before any page mounts, so the page can't show it.
 const homeResolving = useHomeResolving()
 client.setConfig({
   baseURL: '/api/v1',

--- a/packages/web/app.vue
+++ b/packages/web/app.vue
@@ -3,6 +3,12 @@
     <NuxtPage />
     <Toast />
     <ConfirmDialog />
+    <div
+      v-if="homeResolving"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-white dark:bg-surface-900"
+    >
+      <ProgressSpinner />
+    </div>
   </NuxtLayout>
 </template>
 
@@ -15,8 +21,23 @@ const { getToken } = useAuth()
 const { t, locale } = useI18n()
 const localePath = useLocalePath()
 const route = useRoute()
+const router = useRouter()
 const toast = useToast()
 useNotificationPoller()
+
+// Full-screen spinner while the home route resolves the user's tenant context
+// and redirects (see middleware/home-redirect.ts). That redirect runs in the
+// navigation-guard pipeline, so the index page never mounts to show its own
+// spinner — this root-level overlay covers the wait. The middleware owns the
+// flag (it is the only thing that knows a home resolution is in flight); we
+// clear it once any navigation settles.
+const homeResolving = useState<boolean>('home-resolving', () => false)
+router.afterEach(() => {
+  homeResolving.value = false
+})
+router.onError(() => {
+  homeResolving.value = false
+})
 client.setConfig({
   baseURL: '/api/v1',
   auth: async () => {

--- a/packages/web/app.vue
+++ b/packages/web/app.vue
@@ -25,12 +25,8 @@ const router = useRouter()
 const toast = useToast()
 useNotificationPoller()
 
-// Full-screen spinner while the home route resolves the user's tenant context
-// and redirects (see middleware/home-redirect.ts). That redirect runs in the
-// navigation-guard pipeline, so the index page never mounts to show its own
-// spinner — this root-level overlay covers the wait. The middleware owns the
-// flag (it is the only thing that knows a home resolution is in flight); we
-// clear it once any navigation settles.
+// Spinner shown while the home-redirect middleware resolves tenants; it runs
+// before any page mounts, so the page itself can't show it. Cleared on settle.
 const homeResolving = useState<boolean>('home-resolving', () => false)
 router.afterEach(() => {
   homeResolving.value = false

--- a/packages/web/composables/useHomeResolving.ts
+++ b/packages/web/composables/useHomeResolving.ts
@@ -1,0 +1,4 @@
+// Shared flag that drives app.vue's spinner overlay while the home-redirect
+// middleware resolves tenants. Uses useState (not createSharedComposable) since
+// the writer is a route middleware, not a component.
+export const useHomeResolving = () => useState<boolean>('home-resolving', () => false)

--- a/packages/web/composables/useHomeResolving.ts
+++ b/packages/web/composables/useHomeResolving.ts
@@ -1,4 +1,2 @@
-// Shared flag that drives app.vue's spinner overlay while the home-redirect
-// middleware resolves tenants. Uses useState (not createSharedComposable) since
-// the writer is a route middleware, not a component.
+// useState, not createSharedComposable: the writer is a route middleware, not a component.
 export const useHomeResolving = () => useState<boolean>('home-resolving', () => false)

--- a/packages/web/middleware/auth.global.ts
+++ b/packages/web/middleware/auth.global.ts
@@ -40,6 +40,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
         await $auth.signinSilent()
       }
       catch {
+        await $auth.removeUser()
         if (import.meta.client && to.fullPath !== '/' && !isAuthPath) {
           sessionStorage.setItem(REDIRECT_KEY, to.fullPath)
         }

--- a/packages/web/middleware/home-redirect.ts
+++ b/packages/web/middleware/home-redirect.ts
@@ -7,8 +7,7 @@ const REDIRECT_KEY = 'aihub_redirect_after_login'
 // Redirect runs in the guard pipeline, not the page: a page-component redirect
 // here can be dropped by an in-flight navigation.
 export default defineNuxtRouteMiddleware(async () => {
-  // Drives the root-level spinner overlay in app.vue while tenants resolve.
-  useState<boolean>('home-resolving', () => false).value = true
+  useHomeResolving().value = true
 
   const localePath = useLocalePath()
 

--- a/packages/web/middleware/home-redirect.ts
+++ b/packages/web/middleware/home-redirect.ts
@@ -1,0 +1,44 @@
+import { getMyTenants } from '@core/sdk/client'
+
+import { useLocalePath } from '#i18n'
+
+const REDIRECT_KEY = 'aihub_redirect_after_login'
+
+/**
+ * Resolves the logged-in user's tenant context and redirects off the index
+ * route. Lives in a route middleware (not the page's setup/onMounted) on
+ * purpose: on first login the index route is reached via an in-app
+ * navigateTo('/') from the auth callback, and redirecting from a page component
+ * fires a *separate* navigation that Vue Router drops while the arrival
+ * navigation is still settling — leaving an endless spinner. Returning
+ * navigateTo() from a middleware is handled inside the guard pipeline as a
+ * redirect of the current navigation, so it is never dropped.
+ *
+ * Returns nothing when the user has no tenants, letting the page render its
+ * "no tenant" message.
+ */
+export default defineNuxtRouteMiddleware(async () => {
+  // Signal the root-level spinner overlay (app.vue) that a home resolution is in
+  // flight — the index page itself never mounts to show one. app.vue clears it
+  // once the navigation settles.
+  useState<boolean>('home-resolving', () => false).value = true
+
+  const localePath = useLocalePath()
+
+  const response = await getMyTenants({ composable: '$fetch' }).catch(() => null)
+  const tenants = response?.tenants ?? []
+  if (!tenants.length) {
+    return
+  }
+
+  const storedRedirect = sessionStorage.getItem(REDIRECT_KEY)
+  sessionStorage.removeItem(REDIRECT_KEY)
+
+  if (storedRedirect && storedRedirect !== '/') {
+    return navigateTo(storedRedirect, { replace: true })
+  }
+  if (tenants.length === 1) {
+    return navigateTo(localePath(`/${tenants[0].id}/service/openai`), { replace: true })
+  }
+  return navigateTo(localePath('/select-tenant'), { replace: true })
+})

--- a/packages/web/middleware/home-redirect.ts
+++ b/packages/web/middleware/home-redirect.ts
@@ -4,23 +4,10 @@ import { useLocalePath } from '#i18n'
 
 const REDIRECT_KEY = 'aihub_redirect_after_login'
 
-/**
- * Resolves the logged-in user's tenant context and redirects off the index
- * route. Lives in a route middleware (not the page's setup/onMounted) on
- * purpose: on first login the index route is reached via an in-app
- * navigateTo('/') from the auth callback, and redirecting from a page component
- * fires a *separate* navigation that Vue Router drops while the arrival
- * navigation is still settling — leaving an endless spinner. Returning
- * navigateTo() from a middleware is handled inside the guard pipeline as a
- * redirect of the current navigation, so it is never dropped.
- *
- * Returns nothing when the user has no tenants, letting the page render its
- * "no tenant" message.
- */
+// Redirect runs in the guard pipeline, not the page: a page-component redirect
+// here can be dropped by an in-flight navigation.
 export default defineNuxtRouteMiddleware(async () => {
-  // Signal the root-level spinner overlay (app.vue) that a home resolution is in
-  // flight — the index page itself never mounts to show one. app.vue clears it
-  // once the navigation settles.
+  // Drives the root-level spinner overlay in app.vue while tenants resolve.
   useState<boolean>('home-resolving', () => false).value = true
 
   const localePath = useLocalePath()

--- a/packages/web/pages/index.vue
+++ b/packages/web/pages/index.vue
@@ -12,9 +12,7 @@
 </template>
 
 <script setup lang="ts">
-// Tenant resolution + redirect happens in the `home-redirect` route middleware
-// (see middleware/home-redirect.ts). This page only renders when the user has
-// no tenants — otherwise the middleware redirects before it mounts.
+// Shown only when the user has no tenants; home-redirect middleware redirects otherwise.
 definePageMeta({ middleware: 'home-redirect' })
 
 const { t } = useI18n()

--- a/packages/web/pages/index.vue
+++ b/packages/web/pages/index.vue
@@ -1,10 +1,6 @@
 <template>
   <div class="flex h-screen items-center justify-center">
-    <ProgressSpinner v-if="tenantsAreLoading" />
-    <div
-      v-else-if="!tenants?.length"
-      class="text-center"
-    >
+    <div class="text-center">
       <h1 class="mb-4 text-2xl font-bold">
         {{ t('tenant.no_tenant_title') }}
       </h1>
@@ -16,44 +12,10 @@
 </template>
 
 <script setup lang="ts">
-import { getMyTenants } from '@core/sdk/client'
-
-const REDIRECT_KEY = 'aihub_redirect_after_login'
+// Tenant resolution + redirect happens in the `home-redirect` route middleware
+// (see middleware/home-redirect.ts). This page only renders when the user has
+// no tenants — otherwise the middleware redirects before it mounts.
+definePageMeta({ middleware: 'home-redirect' })
 
 const { t } = useI18n()
-const localePath = useLocalePath()
-
-const tenantsAreLoading = ref(true)
-const tenants = ref<{ id: string }[] | null>(null)
-
-onMounted(async () => {
-  try {
-    const response = await getMyTenants({ composable: '$fetch' })
-    tenants.value = response.tenants
-
-    if (!response.tenants?.length) {
-      tenantsAreLoading.value = false
-      return
-    }
-
-    const storedRedirect = sessionStorage.getItem(REDIRECT_KEY)
-    sessionStorage.removeItem(REDIRECT_KEY)
-
-    if (storedRedirect && storedRedirect !== '/') {
-      await navigateTo(storedRedirect, { replace: true })
-      return
-    }
-
-    if (response.tenants.length === 1) {
-      const tenant = response.tenants[0]
-      await navigateTo(localePath(`/${tenant.id}/service/openai`), { replace: true })
-      return
-    }
-
-    await navigateTo(localePath('/select-tenant'), { replace: true })
-  }
-  catch {
-    tenantsAreLoading.value = false
-  }
-})
 </script>

--- a/packages/web/plugins/home-resolving.client.ts
+++ b/packages/web/plugins/home-resolving.client.ts
@@ -1,0 +1,14 @@
+// Clears the home-resolving spinner flag once a navigation settles. Lives in a
+// plugin, not app.vue: plugins register before the initial navigation, so this
+// also catches a full page load that lands on (and redirects off) the home route.
+export default defineNuxtPlugin(() => {
+  const router = useRouter()
+  const homeResolving = useHomeResolving()
+
+  router.afterEach(() => {
+    homeResolving.value = false
+  })
+  router.onError(() => {
+    homeResolving.value = false
+  })
+})

--- a/packages/web/plugins/home-resolving.client.ts
+++ b/packages/web/plugins/home-resolving.client.ts
@@ -1,6 +1,5 @@
-// Clears the home-resolving spinner flag once a navigation settles. Lives in a
-// plugin, not app.vue: plugins register before the initial navigation, so this
-// also catches a full page load that lands on (and redirects off) the home route.
+// In a plugin, not app.vue, so afterEach registers before the initial navigation
+// — otherwise a full load landing on the home route never clears the flag.
 export default defineNuxtPlugin(() => {
   const router = useRouter()
   const homeResolving = useHomeResolving()

--- a/packages/web/plugins/oidc-client.ts
+++ b/packages/web/plugins/oidc-client.ts
@@ -42,21 +42,15 @@ export default defineNuxtPlugin(async ({ $i18n, $router }) => {
 
   auth.events.addSilentRenewError(async (error) => {
     console.error('Silent renew error:', error)
-    // The refresh token is rejected (typically: Keycloak invalidated it, e.g.
-    // after a dev-stack restart). Purge the dead session so the stale token
-    // can't poison the next app init, then send the user to login to re-auth.
-    // Without this, the SDK would keep sending unauthenticated requests on the
-    // next navigation — surfacing as 401s downstream.
+    // Refresh token rejected (e.g. Keycloak invalidated it): drop the dead
+    // session before redirecting so it is not reused.
     await auth.removeUser()
     const locale = $i18n.locale.value
     $router.push(`/${locale}/auth/login`)
   })
 
-  // Renewal of an expired session is owned by middleware/auth.global.ts, which
-  // runs on every navigation. The plugin deliberately does NOT renew here: an
-  // awaited signinSilent() at init would block app bootstrap and race the login
-  // callback's signinRedirectCallback(), leaving the first render stuck on a
-  // spinner when the stored refresh token is stale.
+  // Session renewal is handled per-navigation by middleware/auth.global.ts;
+  // intentionally not done here (it would block app bootstrap).
 
   return {
     provide: {

--- a/packages/web/plugins/oidc-client.ts
+++ b/packages/web/plugins/oidc-client.ts
@@ -40,35 +40,23 @@ export default defineNuxtPlugin(async ({ $i18n, $router }) => {
     $router.push(`/${locale}/auth/login`)
   })
 
-  auth.events.addSilentRenewError((error) => {
+  auth.events.addSilentRenewError(async (error) => {
     console.error('Silent renew error:', error)
-    // The refresh token is rejected (typically: Keycloak invalidated it).
-    // Without a working renew path, the SDK starts sending unauthenticated
-    // requests on the next navigation — surfacing as 401s downstream. Send
-    // the user to the login page now so they re-auth in place.
+    // The refresh token is rejected (typically: Keycloak invalidated it, e.g.
+    // after a dev-stack restart). Purge the dead session so the stale token
+    // can't poison the next app init, then send the user to login to re-auth.
+    // Without this, the SDK would keep sending unauthenticated requests on the
+    // next navigation — surfacing as 401s downstream.
+    await auth.removeUser()
     const locale = $i18n.locale.value
     $router.push(`/${locale}/auth/login`)
   })
 
-  // Check for user session on startup
-  try {
-    const user = await auth.getUser()
-    if (user && !user.expired) {
-      console.log('User already logged in')
-    }
-    else if (user?.expired) {
-      console.log('User session expired, attempting renewal')
-      try {
-        await auth.signinSilent()
-      }
-      catch (e) {
-        console.error('Failed to renew session:', e)
-      }
-    }
-  }
-  catch (e) {
-    console.error('Error checking initial user state:', e)
-  }
+  // Renewal of an expired session is owned by middleware/auth.global.ts, which
+  // runs on every navigation. The plugin deliberately does NOT renew here: an
+  // awaited signinSilent() at init would block app bootstrap and race the login
+  // callback's signinRedirectCallback(), leaving the first render stuck on a
+  // spinner when the stored refresh token is stale.
 
   return {
     provide: {


### PR DESCRIPTION
## Summary

On the very first login, the app hung on an endless loading spinner at the home route (`/en`) instead of redirecting into the workspace. The redirect was issued from the `index.vue` page component, which Vue Router silently **drops** while the post-login navigation is still settling — so it only ever reproduced on the first login (a hard refresh "fixed" it because there was no in-flight navigation to race). This moves tenant resolution + redirect into a **route middleware** so it runs inside the navigation-guard pipeline (where a returned redirect can't be dropped), and relocates the loading spinner to the app root since the page no longer mounts during the wait.

## Changes

- **`middleware/home-redirect.ts`** (new): resolves the user's tenants via `getMyTenants()` and redirects from the home route — stored deep-link → single tenant's OpenWebUI → or `/select-tenant`. Attached to the index route via `definePageMeta({ middleware: 'home-redirect' })`, so the redirect is part of the navigation and never dropped. Sets a `home-resolving` flag for the spinner.
- **`pages/index.vue`**: removed the `onMounted` fetch/redirect logic; now only renders the "no tenant" message (it only mounts when the user has no tenants — otherwise the middleware redirects first).
- **`app.vue`**: full-screen `ProgressSpinner` overlay shown while `home-resolving` is set; cleared on `router.afterEach` / `onError`. The spinner can't live in the page because the redirect happens before any page mounts.
- **`plugins/oidc-client.ts`**: removed the redundant startup `signinSilent()` (it blocked app bootstrap and raced the login callback); `addSilentRenewError` now `removeUser()` to purge a rejected/stale refresh token before redirecting to login.
- **`middleware/auth.global.ts`**: `removeUser()` when `signinSilent()` fails, so a dead refresh token isn't retried on subsequent navigations.

## Test plan

Verified live in a browser against the local dev stack (Web + API + Keycloak):

- Real first login (cleared OIDC session + full Keycloak login) now lands directly on `/<tenant>/service/openai` — no spinner, no skeletons.
- Confirmed the dropped-navigation root cause: a manual `router.push` to the same URL always worked, while the page-component redirect was dropped on first login.
- Verified the redirect survives the in-app navigation pipeline used by the auth callback.
- Verified the root-level spinner overlay paints during a slow tenant resolution (simulated 30s delay) and clears on completion, and does not flash on normal page navigations.

No automated tests added — `packages/web` has no frontend test setup (`make test` is a no-op there).

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>`
- [x] Exactly one of `major` / `minor` / `patch` label applied (`patch`)
- [ ] CLA signed — to be handled by the author
- [ ] Tests added or updated where relevant — N/A (no frontend test infra; verified manually in-browser)
