### PR TITLE
doc(deploy): Document Azure app registration IdP setup and prune unused role mappers

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -71,15 +71,15 @@ KEYCLOAK_OAUTH2_PROXY_ATTU_SECRET='oauth2-proxy-attu-secret-dev'
 KEYCLOAK_OAUTH2_PROXY_BACKUP_SECRET='oauth2-proxy-backup-secret-dev'
 LANGFUSE_KEYCLOAK_CLIENT_SECRET='langfuse-keycloak-secret-dev'
 
-# Superuser (interactive Keycloak-seeded admin). Its realm roles grant sysadmin
-# access via the normal OAuth2 flow — AIHubSysAdmin is required for sysadmin
-# routes, so keep it in SUPERUSER_ROLES_JSON.
+# Superuser (interactive Keycloak-seeded admin). Its realm roles grant access via the
+# normal OAuth2 flow — AIHubAccess is the base role required to use the platform (incl.
+# OpenWebUI) and AIHubSysAdmin grants sysadmin. Keep both in SUPERUSER_ROLES_JSON.
 SUPERUSER_USERNAME='admin'
 SUPERUSER_PASSWORD='admin'
 SUPERUSER_EMAIL='admin@your-company.com'
 SUPERUSER_FIRSTNAME='Admin'
 SUPERUSER_LASTNAME='User'
-SUPERUSER_ROLES_JSON='["AIHubAdmin", "AIHubSysAdmin"]'
+SUPERUSER_ROLES_JSON='["AIHubAccess", "AIHubSysAdmin"]'
 # Superuser static bearer token. Seeded into the bearer_tokens collection at
 # API startup, bound to the Keycloak user found by SUPERUSER_EMAIL. Internal
 # services use this as their API key and authenticate via TokenAuthHandler.

--- a/.env.prod
+++ b/.env.prod
@@ -61,15 +61,15 @@ KEYCLOAK_OAUTH2_PROXY_ATTU_SECRET='REPLACE_WITH_RANDOM_STRING'
 KEYCLOAK_OAUTH2_PROXY_BACKUP_SECRET='REPLACE_WITH_RANDOM_STRING'
 LANGFUSE_KEYCLOAK_CLIENT_SECRET='REPLACE_WITH_RANDOM_STRING'
 
-# Superuser (interactive Keycloak-seeded admin). Its realm roles grant sysadmin
-# access via the normal OAuth2 flow — AIHubSysAdmin is required for sysadmin
-# routes, so keep it in SUPERUSER_ROLES_JSON.
+# Superuser (interactive Keycloak-seeded admin). Its realm roles grant access via the
+# normal OAuth2 flow — AIHubAccess is the base role required to use the platform (incl.
+# OpenWebUI) and AIHubSysAdmin grants sysadmin. Keep both in SUPERUSER_ROLES_JSON.
 SUPERUSER_USERNAME='admin'
 SUPERUSER_PASSWORD='REPLACE_WITH_RANDOM_STRING'
 SUPERUSER_EMAIL='admin@your-company.com'
 SUPERUSER_FIRSTNAME='Admin'
 SUPERUSER_LASTNAME='User'
-SUPERUSER_ROLES_JSON='["AIHubAdmin", "AIHubSysAdmin"]'
+SUPERUSER_ROLES_JSON='["AIHubAccess", "AIHubSysAdmin"]'
 # Superuser static bearer token. Seeded into the bearer_tokens collection at
 # API startup, bound to the Keycloak user found by SUPERUSER_EMAIL. Internal
 # services use this as their API key and authenticate via TokenAuthHandler.

--- a/docs/docs/1_vision_and_positioning/2_why_swiss_ai_hub/3_the_ecosystem_model/index.de.md
+++ b/docs/docs/1_vision_and_positioning/2_why_swiss_ai_hub/3_the_ecosystem_model/index.de.md
@@ -1,17 +1,26 @@
 ---
 title: Das Ökosystem-Modell
-source_sha: "706ece8d3491f90543ea15bc96d04d42f10ba8201f2bf141e9781c7b56b063d7"
+source_sha: 706ece8d3491f90543ea15bc96d04d42f10ba8201f2bf141e9781c7b56b063d7
 ---
 
 # Das Ökosystem-Modell: Wie alle davon profitieren
 
-Der Swiss AI Hub existiert, weil KI-Infrastruktur kein Wettbewerbsvorteil sein sollte. Grundlegende Fähigkeiten wie LLM-Zugriff, Dokumentenverarbeitung und RAG sollten Güter sein, die allen zur Verfügung stehen. Schweizer Organisationen sollten auf ihrer Domänenexpertise und Geschäftsinnovation konkurrieren, nicht darauf, wer bessere Authentifizierungssysteme oder Vektordatenbanken aufbauen kann.
+Der Swiss AI Hub existiert, weil KI-Infrastruktur kein Wettbewerbsvorteil sein sollte. Grundlegende Fähigkeiten wie
+LLM-Zugriff, Dokumentenverarbeitung und RAG sollten Güter sein, die allen zur Verfügung stehen. Schweizer Organisationen
+sollten auf ihrer Domänenexpertise und Geschäftsinnovation konkurrieren, nicht darauf, wer bessere
+Authentifizierungssysteme oder Vektordatenbanken aufbauen kann.
 
 ## Die Schweizer Chance
 
-Die Schweiz ist ein kleines Land, das in einer globalen Wirtschaft konkurriert, die von Tech-Giganten dominiert wird. Während Google, Microsoft und Amazon Milliarden in KI-Infrastruktur stecken, fehlt es Schweizer Unternehmen individuell an den Ressourcen, um diese Investition zu erreichen. Die typische Reaktion wäre, die Abhängigkeit von ausländischen Plattformen zu akzeptieren, aber die Schweiz hat eine andere Option: die Zusammenarbeit.
+Die Schweiz ist ein kleines Land, das in einer globalen Wirtschaft konkurriert, die von Tech-Giganten dominiert wird.
+Während Google, Microsoft und Amazon Milliarden in KI-Infrastruktur stecken, fehlt es Schweizer Unternehmen individuell
+an den Ressourcen, um diese Investition zu erreichen. Die typische Reaktion wäre, die Abhängigkeit von ausländischen
+Plattformen zu akzeptieren, aber die Schweiz hat eine andere Option: die Zusammenarbeit.
 
-Dieselben demokratischen Prinzipien, die die Schweiz als Nation erfolgreich machen, können unseren Ansatz zur KI transformieren. Anstatt dass jede Organisation redundante Infrastruktur aufbaut, können wir unsere Anstrengungen auf die Grundlage konzentrieren und gleichzeitig auf der Anwendungsschicht konkurrieren. Hier geht es nicht darum, den Wettbewerb zu eliminieren; es geht darum, den Wettbewerb dorthin zu verlagern, wo er Wert schafft.
+Dieselben demokratischen Prinzipien, die die Schweiz als Nation erfolgreich machen, können unseren Ansatz zur KI
+transformieren. Anstatt dass jede Organisation redundante Infrastruktur aufbaut, können wir unsere Anstrengungen auf die
+Grundlage konzentrieren und gleichzeitig auf der Anwendungsschicht konkurrieren. Hier geht es nicht darum, den
+Wettbewerb zu eliminieren; es geht darum, den Wettbewerb dorthin zu verlagern, wo er Wert schafft.
 
 ## Infrastruktur als Gut
 
@@ -23,116 +32,194 @@ Betrachten Sie, was jede Organisation, die KI aufbaut, benötigt:
 - Monitoring und Observability
 - Deployment- und Skalierungsmuster
 
-Diese Anforderungen sind universell. Die Authentifizierungsbedürfnisse einer Bank unterscheiden sich nicht grundlegend von denen einer Versicherungsgesellschaft. Die Herausforderungen eines Pharmaunternehmens bei der Dokumentenverarbeitung spiegeln die eines Fertigungsunternehmens wider. Doch heute baut jede Organisation diese Fähigkeiten entweder separat auf oder gibt sich einer ausländischen Plattform hin.
+Diese Anforderungen sind universell. Die Authentifizierungsbedürfnisse einer Bank unterscheiden sich nicht grundlegend
+von denen einer Versicherungsgesellschaft. Die Herausforderungen eines Pharmaunternehmens bei der Dokumentenverarbeitung
+spiegeln die eines Fertigungsunternehmens wider. Doch heute baut jede Organisation diese Fähigkeiten entweder separat
+auf oder gibt sich einer ausländischen Plattform hin.
 
-Der Swiss AI Hub macht diese Infrastruktur zu einem Gut. Deployen Sie die Plattform einmal, und diese Probleme sind gelöst. Jede Verbesserung der Kernplattform kommt jeder Organisation zugute, die sie nutzt. Wenn jemand eine bessere Dokumentenanalyse beisteuert, verbessert sich die Dokumentenverarbeitung aller. Wenn jemand eine neue Sicherheitsfunktion hinzufügt, werden alle sicherer.
+Der Swiss AI Hub macht diese Infrastruktur zu einem Gut. Deployen Sie die Plattform einmal, und diese Probleme sind
+gelöst. Jede Verbesserung der Kernplattform kommt jeder Organisation zugute, die sie nutzt. Wenn jemand eine bessere
+Dokumentenanalyse beisteuert, verbessert sich die Dokumentenverarbeitung aller. Wenn jemand eine neue
+Sicherheitsfunktion hinzufügt, werden alle sicherer.
 
 ## Die Beitragsdynamik
 
-Die Runtime, das SDK, die Agents, Pipelines und Prozesse der Swiss AI Hub Plattform sind unter Apache 2.0 lizenziert. (Die Web-UI und die Backup-Orchestrierung sind AGPL-3.0; die Multi-Tenant-Management-Ebene ist proprietär. Eine detaillierte Aufschlüsselung pro Paket finden Sie unter [LICENSES.md](https://github.com/bbvch-ai/aihub-core/blob/main/LICENSES.md).) Die permissive Lizenz für die Runtime + SDK schafft natürliche Anreize zur Zusammenarbeit, ohne sie zu erzwingen.
+Die Runtime, das SDK, die Agents, Pipelines und Prozesse der Swiss AI Hub Plattform sind unter Apache 2.0 lizenziert.
+(Die Web-UI und die Backup-Orchestrierung sind AGPL-3.0; die Multi-Tenant-Management-Ebene ist proprietär. Eine
+detaillierte Aufschlüsselung pro Paket finden Sie unter
+[LICENSES.md](https://github.com/bbvch-ai/aihub-core/blob/main/LICENSES.md).) Die permissive Lizenz für die Runtime +
+SDK schafft natürliche Anreize zur Zusammenarbeit, ohne sie zu erzwingen.
 
-**Gemeinsam genutzte Infrastruktur kommt allen zugute:** Wenn Organisationen die Kerninfrastruktur verbessern, ist das Teilen sinnvoll, weil alle davon profitieren. Eine Bank, die eine bessere Compliance-Protokollierung hinzufügt, hilft jeder regulierten Branche. Ein Gesundheitsdienstleister, der den Umgang mit PII verbessert, hilft allen mit Datenschutzbedenken. Diese Beiträge fließen natürlich zurück, weil eine bessere gemeinsame Infrastruktur die Kosten aller senkt.
+**Gemeinsam genutzte Infrastruktur kommt allen zugute:** Wenn Organisationen die Kerninfrastruktur verbessern, ist das
+Teilen sinnvoll, weil alle davon profitieren. Eine Bank, die eine bessere Compliance-Protokollierung hinzufügt, hilft
+jeder regulierten Branche. Ein Gesundheitsdienstleister, der den Umgang mit PII verbessert, hilft allen mit
+Datenschutzbedenken. Diese Beiträge fließen natürlich zurück, weil eine bessere gemeinsame Infrastruktur die Kosten
+aller senkt.
 
-**Strategische Differenzierung bleibt privat:** Organisationen behalten ihre Wettbewerbsvorteile proprietär. Der kundenorientierte Agent, der Ihre einzigartigen Geschäftsprozesse, Ihre spezialisierte Datenverarbeitung, Ihre Domänenexpertise verkörpert – diese bleiben Ihre. Die Apache 2.0 Runtime erfordert kein Zurückgeben von Beiträgen, sodass Sie strategische Innovationen privat halten können, während Sie von der gemeinsamen Infrastruktur profitieren und dazu beitragen.
+**Strategische Differenzierung bleibt privat:** Organisationen behalten ihre Wettbewerbsvorteile proprietär. Der
+kundenorientierte Agent, der Ihre einzigartigen Geschäftsprozesse, Ihre spezialisierte Datenverarbeitung, Ihre
+Domänenexpertise verkörpert – diese bleiben Ihre. Die Apache 2.0 Runtime erfordert kein Zurückgeben von Beiträgen,
+sodass Sie strategische Innovationen privat halten können, während Sie von der gemeinsamen Infrastruktur profitieren und
+dazu beitragen.
 
 ## Warum Lizenzen für KI-Infrastruktur wichtig sind
 
-Das Verständnis von Softwarelizenzen ist beim Aufbau von KI-Infrastruktur entscheidend. Viele Organisationen machen kostspielige Fehler, indem sie davon ausgehen, dass Code auf GitHub automatisch kostenlos nutzbar ist – das ist er nicht.
+Das Verständnis von Softwarelizenzen ist beim Aufbau von KI-Infrastruktur entscheidend. Viele Organisationen machen
+kostspielige Fehler, indem sie davon ausgehen, dass Code auf GitHub automatisch kostenlos nutzbar ist – das ist er
+nicht.
 
 ### Das GitHub-Missverständnis
 
-**Quellcode sehen ≠ Open Source ≠ kostenlose Nutzung.** GitHub hostet sowohl Open-Source-Projekte als auch proprietäre Software mit restriktiven Lizenzen. Die Möglichkeit, Code zu *sehen* oder herunterzuladen, bedeutet nicht, dass Sie ihn legal *nutzen* dürfen, insbesondere nicht in Produktions- oder kommerziellen Kontexten.
+**Quellcode sehen ≠ Open Source ≠ kostenlose Nutzung.** GitHub hostet sowohl Open-Source-Projekte als auch proprietäre
+Software mit restriktiven Lizenzen. Die Möglichkeit, Code zu *sehen* oder herunterzuladen, bedeutet nicht, dass Sie ihn
+legal *nutzen* dürfen, insbesondere nicht in Produktions- oder kommerziellen Kontexten.
 
-Beispiel: **n8n**, eines der beliebtesten Workflow-Automatisierungstools auf GitHub, verwendet die „Sustainable Use License“ (keine Open-Source-Lizenz). Obwohl Sie es herunterladen und ausführen können, verbietet die Lizenz die kommerzielle Nutzung ohne den Kauf einer Enterprise-Lizenz – selbst wenn Sie es selbst hosten. Viele Organisationen entdecken dies zu spät, nachdem sie Abhängigkeiten von diesen Tools aufgebaut haben.
+Beispiel: **n8n**, eines der beliebtesten Workflow-Automatisierungstools auf GitHub, verwendet die „Sustainable Use
+License“ (keine Open-Source-Lizenz). Obwohl Sie es herunterladen und ausführen können, verbietet die Lizenz die
+kommerzielle Nutzung ohne den Kauf einer Enterprise-Lizenz – selbst wenn Sie es selbst hosten. Viele Organisationen
+entdecken dies zu spät, nachdem sie Abhängigkeiten von diesen Tools aufgebaut haben.
 
 ### Lizenzkategorien erklärt
 
-**Permissive Lizenzen** (MIT, Apache 2.0, BSD): Gewähren weitreichende Freiheiten – Nutzung, Änderung, kommerzielle Verbreitung, private Haltung von Modifikationen. Keine Bedingungen. Diese sind ideal für den Aufbau von Geschäftsinfrastruktur.
+**Permissive Lizenzen** (MIT, Apache 2.0, BSD): Gewähren weitreichende Freiheiten – Nutzung, Änderung, kommerzielle
+Verbreitung, private Haltung von Modifikationen. Keine Bedingungen. Diese sind ideal für den Aufbau von
+Geschäftsinfrastruktur.
 
-**Copyleft-Lizenzen** (GPL, AGPL): Erfordern, dass alle Modifikationen oder abgeleiteten Werke unter derselben Lizenz veröffentlicht werden. Wenn Sie auf GPL-Software aufbauen und diese vertreiben, müssen Sie Ihre gesamte Anwendung quelloffen machen. **AGPL erweitert dies auf die Netzwerknutzung** – selbst das Anbieten der Software als Service löst diese Anforderung aus. Dies macht Copyleft zu einer schlechten Wahl für die Bausteine, die Sie mit proprietärer Logik erweitern – genau aus diesem Grund sind die Swiss AI Hub Runtime und das SDK permissiv, nicht Copyleft. (Copyleft ist die richtige Wahl für Endbenutzeranwendungen wie die UI; siehe unten.)
+**Copyleft-Lizenzen** (GPL, AGPL): Erfordern, dass alle Modifikationen oder abgeleiteten Werke unter derselben Lizenz
+veröffentlicht werden. Wenn Sie auf GPL-Software aufbauen und diese vertreiben, müssen Sie Ihre gesamte Anwendung
+quelloffen machen. **AGPL erweitert dies auf die Netzwerknutzung** – selbst das Anbieten der Software als Service löst
+diese Anforderung aus. Dies macht Copyleft zu einer schlechten Wahl für die Bausteine, die Sie mit proprietärer Logik
+erweitern – genau aus diesem Grund sind die Swiss AI Hub Runtime und das SDK permissiv, nicht Copyleft. (Copyleft ist
+die richtige Wahl für Endbenutzeranwendungen wie die UI; siehe unten.)
 
-**Source-available-Lizenzen** (Elastic License, BSL, SSPL, „Sustainable Use“): Ermöglichen Ihnen das Anzeigen und manchmal auch die Nutzung des Codes, erlegen jedoch strenge Beschränkungen auf – oft ist die kommerzielle Nutzung, Managed Services oder konkurrierende Produkte verboten. Nicht quelloffen, obwohl sie auf GitHub erscheinen.
+**Source-available-Lizenzen** (Elastic License, BSL, SSPL, „Sustainable Use“): Ermöglichen Ihnen das Anzeigen und
+manchmal auch die Nutzung des Codes, erlegen jedoch strenge Beschränkungen auf – oft ist die kommerzielle Nutzung,
+Managed Services oder konkurrierende Produkte verboten. Nicht quelloffen, obwohl sie auf GitHub erscheinen.
 
-**Proprietäre/Kundenspezifische Lizenzen**: Variieren stark. Erfordern eine sorgfältige rechtliche Prüfung. Verbieten oft die Nutzung in der Produktion ohne Bezahlung.
+**Proprietäre/Kundenspezifische Lizenzen**: Variieren stark. Erfordern eine sorgfältige rechtliche Prüfung. Verbieten
+oft die Nutzung in der Produktion ohne Bezahlung.
 
 ### Lizenzen, die in KI-Infrastruktur vermieden werden sollten
 
 Für KI-Produktionssysteme sollten Sie extrem vorsichtig sein mit:
 
--   **AGPL/GPL**: Zwingen Ihr gesamtes System zur Offenlegung des Quellcodes, wenn Sie die Software modifizieren und vertreiben
--   **SSPL (Server Side Public License)**: MongoDBs Versuch, Cloud-Anbieter daran zu hindern, Managed Services anzubieten; löst Open-Source-Anforderungen für die Infrastruktur aus
--   **Elastic License v2**: Verbietet das Anbieten der Software als konkurrierenden Service
--   **Business Source License (BSL)**: Zeitverzögertes Open Source; restriktiv bis zum Ablaufdatum
--   **Benutzerdefinierte „Source-available“-Lizenzen**: Verbieten in der Regel die kommerzielle Nutzung oder haben unklare Bedingungen
+- **AGPL/GPL**: Zwingen Ihr gesamtes System zur Offenlegung des Quellcodes, wenn Sie die Software modifizieren und
+  vertreiben
+- **SSPL (Server Side Public License)**: MongoDBs Versuch, Cloud-Anbieter daran zu hindern, Managed Services anzubieten;
+  löst Open-Source-Anforderungen für die Infrastruktur aus
+- **Elastic License v2**: Verbietet das Anbieten der Software als konkurrierenden Service
+- **Business Source License (BSL)**: Zeitverzögertes Open Source; restriktiv bis zum Ablaufdatum
+- **Benutzerdefinierte „Source-available“-Lizenzen**: Verbieten in der Regel die kommerzielle Nutzung oder haben unklare
+  Bedingungen
 
-Diese Lizenzen mögen anfangs akzeptabel erscheinen, schaffen aber rechtliche Fallstricke, wenn Sie skalieren, Services anbieten oder in Kundensysteme integrieren – **wenn sie sich unter dem Code befinden, auf dem Sie aufbauen**. Genau aus diesem Grund hält der Swiss AI Hub die Runtime und das SDK permissiv. Die Web-UI und die Backup-Orchestrierung sind eine bewusste Ausnahme: Sie sind AGPL-3.0, *weil* sie Endbenutzeranwendungen und keine Bausteine sind, sodass Copyleft Community-Verbesserungen schützt, ohne jemals Ihre Agents oder Geschäftslogik zur Offenlegung zu zwingen.
+Diese Lizenzen mögen anfangs akzeptabel erscheinen, schaffen aber rechtliche Fallstricke, wenn Sie skalieren, Services
+anbieten oder in Kundensysteme integrieren – **wenn sie sich unter dem Code befinden, auf dem Sie aufbauen**. Genau aus
+diesem Grund hält der Swiss AI Hub die Runtime und das SDK permissiv. Die Web-UI und die Backup-Orchestrierung sind eine
+bewusste Ausnahme: Sie sind AGPL-3.0, *weil* sie Endbenutzeranwendungen und keine Bausteine sind, sodass Copyleft
+Community-Verbesserungen schützt, ohne jemals Ihre Agents oder Geschäftslogik zur Offenlegung zu zwingen.
 
 ### Unser Lizenzierungs-Engagement
 
-Der Swiss AI Hub bewertet jede Abhängigkeit rigoros – alle 232 Python-Pakete, 197 Node.js-Pakete und 28 externe Docker-Images. Wir verifizieren, dass jede Komponente permissive Lizenzen (MIT, Apache 2.0, BSD) verwendet oder explizit überprüft und genehmigt wurde.
+Der Swiss AI Hub bewertet jede Abhängigkeit rigoros – alle 232 Python-Pakete, 197 Node.js-Pakete und 28 externe
+Docker-Images. Wir verifizieren, dass jede Komponente permissive Lizenzen (MIT, Apache 2.0, BSD) verwendet oder explizit
+überprüft und genehmigt wurde.
 
-**Sie erhalten die Freiheit, die die Lizenz jedes Pakets gewährt – siehe [LICENSES.md](https://github.com/bbvch-ai/aihub-core/blob/main/LICENSES.md) für die genauen Bedingungen pro Paket.** Kurz gesagt: Die Runtime + SDK (Apache 2.0) legen keine Beschränkungen für die kommerzielle Nutzung oder die Integration mit proprietären Systemen fest; die Web-UI und die Backup-Orchestrierung (AGPL-3.0) erfordern die Offenlegung des Quellcodes Ihrer Modifikationen, wenn Sie diese als Netzwerkservice anbieten; die Multi-Tenant-Administrationsplattform ist proprietär und erfordert eine kommerzielle Lizenz.
+**Sie erhalten die Freiheit, die die Lizenz jedes Pakets gewährt – siehe
+[LICENSES.md](https://github.com/bbvch-ai/aihub-core/blob/main/LICENSES.md) für die genauen Bedingungen pro Paket.**
+Kurz gesagt: Die Runtime + SDK (Apache 2.0) legen keine Beschränkungen für die kommerzielle Nutzung oder die Integration
+mit proprietären Systemen fest; die Web-UI und die Backup-Orchestrierung (AGPL-3.0) erfordern die Offenlegung des
+Quellcodes Ihrer Modifikationen, wenn Sie diese als Netzwerkservice anbieten; die Multi-Tenant-Administrationsplattform
+ist proprietär und erfordert eine kommerzielle Lizenz.
 
-**Warum Apache 2.0 speziell für die Runtime und das SDK:** Apache 2.0 ist nicht nur permissiv, sondern enthält auch explizite Patenterteilungen, die Sie vor Patentansprüchen von Mitwirkenden schützen. Es wird von Unternehmen geschätzt, von Rechtsteams gut verstanden und ist mit praktisch allen anderen Lizenzen kompatibel. Es ist der Goldstandard für kollaborative Infrastruktur – was genau die Rolle der Runtime und des SDK ist.
+**Warum Apache 2.0 speziell für die Runtime und das SDK:** Apache 2.0 ist nicht nur permissiv, sondern enthält auch
+explizite Patenterteilungen, die Sie vor Patentansprüchen von Mitwirkenden schützen. Es wird von Unternehmen geschätzt,
+von Rechtsteams gut verstanden und ist mit praktisch allen anderen Lizenzen kompatibel. Es ist der Goldstandard für
+kollaborative Infrastruktur – was genau die Rolle der Runtime und des SDK ist.
 
-Dies ist nicht nur Idealismus – es ist Pragmatismus. Eine permissive Runtime + SDK beseitigt Adoptionsbarrieren und verhindert einen Vendor Lock-in für die Bausteine, die Sie erweitern; die AGPL-Komponenten schützen vor feindseligen SaaS-Rehosts der UI, ohne die Bausteine zu belasten; die proprietäre Ebene finanziert die fortgesetzte Entwicklung.
+Dies ist nicht nur Idealismus – es ist Pragmatismus. Eine permissive Runtime + SDK beseitigt Adoptionsbarrieren und
+verhindert einen Vendor Lock-in für die Bausteine, die Sie erweitern; die AGPL-Komponenten schützen vor feindseligen
+SaaS-Rehosts der UI, ohne die Bausteine zu belasten; die proprietäre Ebene finanziert die fortgesetzte Entwicklung.
 
 ## Echte Kollaborationsmuster
 
 Das Ökosystem zeigt bereits, wie dies funktioniert:
 
-**Gemeinsam genutzte Komponenten:** Gängige Agents für Dokumentenzusammenfassung, Frage-Antwort-Systeme und Datenextraktion werden zu Community-Assets. Jede Organisation benötigt diese Grundlagen, daher ist das Teilen sinnvoll.
+**Gemeinsam genutzte Komponenten:** Gängige Agents für Dokumentenzusammenfassung, Frage-Antwort-Systeme und
+Datenextraktion werden zu Community-Assets. Jede Organisation benötigt diese Grundlagen, daher ist das Teilen sinnvoll.
 
-**Branchenlösungen:** Gesundheitsorganisationen arbeiten an der Verarbeitung medizinischer Dokumente zusammen. Finanzdienstleister teilen Compliance-fokussierte Agents. Diese branchenspezifischen Lösungen entstehen natürlich, wenn Organisationen erkennen, dass ihre Konkurrenten im Ausland, nicht im Inland, die eigentliche Bedrohung darstellen.
+**Branchenlösungen:** Gesundheitsorganisationen arbeiten an der Verarbeitung medizinischer Dokumente zusammen.
+Finanzdienstleister teilen Compliance-fokussierte Agents. Diese branchenspezifischen Lösungen entstehen natürlich, wenn
+Organisationen erkennen, dass ihre Konkurrenten im Ausland, nicht im Inland, die eigentliche Bedrohung darstellen.
 
-**Infrastrukturverbesserungen:** Performance-Optimierungen, Sicherheitsverbesserungen und operative Tools fließen in die Plattform zurück. Alle profitieren von einer schnelleren, sichereren, zuverlässigeren Grundlage.
+**Infrastrukturverbesserungen:** Performance-Optimierungen, Sicherheitsverbesserungen und operative Tools fließen in die
+Plattform zurück. Alle profitieren von einer schnelleren, sichereren, zuverlässigeren Grundlage.
 
-**Wissensaustausch:** Organisationen teilen Deployment-Muster, Best Practices und gewonnene Erkenntnisse. Die gleiche Plattform bedeutet, dass Lösungen übertragbar sind.
+**Wissensaustausch:** Organisationen teilen Deployment-Muster, Best Practices und gewonnene Erkenntnisse. Die gleiche
+Plattform bedeutet, dass Lösungen übertragbar sind.
 
 ## Wo Wettbewerb hingehört
 
 Das Ökosystem-Modell eliminiert den Wettbewerb nicht; es konzentriert ihn dort, wo er wichtig ist:
 
-**Ihre Domänenexpertise** bleibt Ihre. Die Plattform kennt Ihre Geschäftsregeln, Ihre Kundenbeziehungen oder Ihre Markteinblicke nicht. Diese schaffen Wettbewerbsvorteile.
+**Ihre Domänenexpertise** bleibt Ihre. Die Plattform kennt Ihre Geschäftsregeln, Ihre Kundenbeziehungen oder Ihre
+Markteinblicke nicht. Diese schaffen Wettbewerbsvorteile.
 
-**Ihre spezialisierten Agents** spiegeln Ihre einzigartigen Prozesse und Ihr Wissen wider. Während Sie möglicherweise generische Dokumentenverarbeitung teilen, verkörpert Ihr Kundenservice-Agent Ihren spezifischen Ansatz.
+**Ihre spezialisierten Agents** spiegeln Ihre einzigartigen Prozesse und Ihr Wissen wider. Während Sie möglicherweise
+generische Dokumentenverarbeitung teilen, verkörpert Ihr Kundenservice-Agent Ihren spezifischen Ansatz.
 
-**Ihre Daten und Trainings** bleiben proprietär. Die Plattform bietet Tools zur Verarbeitung und Abfrage Ihrer Daten, aber die Daten selbst und die daraus abgeleiteten Erkenntnisse sind Ihr Wettbewerbsvorteil.
+**Ihre Daten und Trainings** bleiben proprietär. Die Plattform bietet Tools zur Verarbeitung und Abfrage Ihrer Daten,
+aber die Daten selbst und die daraus abgeleiteten Erkenntnisse sind Ihr Wettbewerbsvorteil.
 
-**Ihre Geschäftsinnovation** ist der Ort, an dem Wettbewerb stattfinden sollte. Anstatt darum zu konkurrieren, wer bessere Vektordatenbanken hat, konkurrieren Sie darum, wer KI kreativer einsetzt, um Kunden zu bedienen.
+**Ihre Geschäftsinnovation** ist der Ort, an dem Wettbewerb stattfinden sollte. Anstatt darum zu konkurrieren, wer
+bessere Vektordatenbanken hat, konkurrieren Sie darum, wer KI kreativer einsetzt, um Kunden zu bedienen.
 
 ## Der Netzwerkeffekt
 
 Je mehr Organisationen den Swiss AI Hub adoptieren, desto stärker wird das Ökosystem:
 
-**Die Entwicklung beschleunigt sich**, weil gemeinsame Muster entstehen und in das SDK kodiert werden. Was Wochen zum Bauen dauerte, wird zu einer Konfigurationsoption.
+**Die Entwicklung beschleunigt sich**, weil gemeinsame Muster entstehen und in das SDK kodiert werden. Was Wochen zum
+Bauen dauerte, wird zu einer Konfigurationsoption.
 
-**Die Qualität verbessert sich** durch kollektives Debugging und Testen. Da viele Organisationen dieselbe Plattform betreiben, werden Randfälle schnell entdeckt und behoben.
+**Die Qualität verbessert sich** durch kollektives Debugging und Testen. Da viele Organisationen dieselbe Plattform
+betreiben, werden Randfälle schnell entdeckt und behoben.
 
-**Die Kosten sinken** durch gemeinsame Investitionen. Anstatt dass jede Organisation für die vollständige Entwicklung bezahlt, werden die Kosten auf das gesamte Ökosystem verteilt.
+**Die Kosten sinken** durch gemeinsame Investitionen. Anstatt dass jede Organisation für die vollständige Entwicklung
+bezahlt, werden die Kosten auf das gesamte Ökosystem verteilt.
 
-**Die Innovation nimmt zu**, weil Entwickler auf einer höheren Grundlage aufbauen können. Anstatt Grundlagen neu zu implementieren, können sie neue Fähigkeiten erkunden.
+**Die Innovation nimmt zu**, weil Entwickler auf einer höheren Grundlage aufbauen können. Anstatt Grundlagen neu zu
+implementieren, können sie neue Fähigkeiten erkunden.
 
 ## Der Schweizer KI-Vorteil
 
 Dieser kollaborative Ansatz verschafft Schweizer Organisationen kollektive Vorteile:
 
-**Geschwindigkeit:** Neue Organisationen können Produktions-KI in Tagen statt in Monaten deployen, indem sie bestehende Arbeiten nutzen.
+**Geschwindigkeit:** Neue Organisationen können Produktions-KI in Tagen statt in Monaten deployen, indem sie bestehende
+Arbeiten nutzen.
 
-**Souveränität:** Schweizer Daten bleiben in der Schweiz, werden von Schweizer kontrollierter Infrastruktur verarbeitet und unterliegen Schweizer Recht.
+**Souveränität:** Schweizer Daten bleiben in der Schweiz, werden von Schweizer kontrollierter Infrastruktur verarbeitet
+und unterliegen Schweizer Recht.
 
-**Unabhängigkeit:** Kein einzelner Anbieter kontrolliert die Plattform. Kein ausländisches Unternehmen kann Bedingungen ändern oder den Zugang sperren.
+**Unabhängigkeit:** Kein einzelner Anbieter kontrolliert die Plattform. Kein ausländisches Unternehmen kann Bedingungen
+ändern oder den Zugang sperren.
 
-**Qualität:** Kollektive Investitionen führen zu einer besseren Infrastruktur, als jede einzelne Organisation aufbauen könnte.
+**Qualität:** Kollektive Investitionen führen zu einer besseren Infrastruktur, als jede einzelne Organisation aufbauen
+könnte.
 
-**Innovation:** Befreit von Infrastrukturfragen konzentrieren sich Organisationen auf Geschäftsinnovationen, wo der wahre Wert liegt.
+**Innovation:** Befreit von Infrastrukturfragen konzentrieren sich Organisationen auf Geschäftsinnovationen, wo der
+wahre Wert liegt.
 
 ## Kollaboration erfolgreich gestalten
 
 Das Ökosystem ist erfolgreich, weil es Anreize korrekt ausrichtet:
 
-Organisationen tragen zur Infrastruktur bei, weil sie direkt von Verbesserungen profitieren. Sie teilen nicht-differenzierende Fähigkeiten, weil Zusammenarbeit wertvoller ist als Geheimhaltung. Sie halten strategische Innovationen privat, weil Apache 2.0 beide Ansätze erlaubt – die Wahl liegt immer bei Ihnen.
+Organisationen tragen zur Infrastruktur bei, weil sie direkt von Verbesserungen profitieren. Sie teilen
+nicht-differenzierende Fähigkeiten, weil Zusammenarbeit wertvoller ist als Geheimhaltung. Sie halten strategische
+Innovationen privat, weil Apache 2.0 beide Ansätze erlaubt – die Wahl liegt immer bei Ihnen.
 
-Der Swiss AI Hub bietet die technische Grundlage für diese Zusammenarbeit, aber das Ökosystem wird von seinen Mitgliedern aufgebaut. Jede Organisation, die die Plattform deployt, Verbesserungen beisteuert oder Wissen teilt, stärkt die Schweizer KI-Fähigkeiten kollektiv.
+Der Swiss AI Hub bietet die technische Grundlage für diese Zusammenarbeit, aber das Ökosystem wird von seinen
+Mitgliedern aufgebaut. Jede Organisation, die die Plattform deployt, Verbesserungen beisteuert oder Wissen teilt, stärkt
+die Schweizer KI-Fähigkeiten kollektiv.
 
-So konkurriert die Schweiz global: nicht durch einzelne Organisationen, die versuchen, die Ressourcen von Big Tech zu erreichen, sondern durch kollaborative Infrastruktur, die es jeder Organisation ermöglicht, sich auf das zu konzentrieren, was sie einzigartig macht. Die Plattform ist die Rohstoffschicht, die Innovation ermöglicht.
+So konkurriert die Schweiz global: nicht durch einzelne Organisationen, die versuchen, die Ressourcen von Big Tech zu
+erreichen, sondern durch kollaborative Infrastruktur, die es jeder Organisation ermöglicht, sich auf das zu
+konzentrieren, was sie einzigartig macht. Die Plattform ist die Rohstoffschicht, die Innovation ermöglicht.

--- a/docs/docs/2_platform/18_api/5_api_tokens/index.de.md
+++ b/docs/docs/2_platform/18_api/5_api_tokens/index.de.md
@@ -1,27 +1,36 @@
 ---
 title: API-Token
 description: Generieren Sie ein persönliches API-Token, um REST API-Anfragen zu authentifizieren.
-source_sha: "f44da54f76b2cf3ec15a7674ea25cd29f509177754b46e69f9cbbc11032885ad"
+source_sha: f44da54f76b2cf3ec15a7674ea25cd29f509177754b46e69f9cbbc11032885ad
 ---
 
 # API-Token
 
-Der Aufruf der REST API von einem Skript, einer Integration oder der Kommandozeile erfordert ein Bearer-Token. Anstatt das kurzlebige JWT aus Ihrer Browser-Session wiederzuverwenden, erstellen Sie ein langlebiges persönliches Token (präfixiert mit `sk-`), das sich als Ihr eigener Benutzer authentifiziert. Diese Seite beschreibt die Generierung eines solchen Tokens direkt im Browser mithilfe der integrierten Swagger UI.
+Der Aufruf der REST API von einem Skript, einer Integration oder der Kommandozeile erfordert ein Bearer-Token. Anstatt
+das kurzlebige JWT aus Ihrer Browser-Session wiederzuverwenden, erstellen Sie ein langlebiges persönliches Token
+(präfixiert mit `sk-`), das sich als Ihr eigener Benutzer authentifiziert. Diese Seite beschreibt die Generierung eines
+solchen Tokens direkt im Browser mithilfe der integrierten Swagger UI.
 
-Es gibt noch keine dedizierte Oberfläche hierfür in der Admin-Oberfläche. Daher ist die Swagger UI unter `/api/v1/docs` der unterstützte Weg, ein Token interaktiv zu erstellen.
+Es gibt noch keine dedizierte Oberfläche hierfür in der Admin-Oberfläche. Daher ist die Swagger UI unter `/api/v1/docs`
+der unterstützte Weg, ein Token interaktiv zu erstellen.
 
 ## Ein Session-Token abrufen
 
-Die Token-Endpunkte sind selbst geschützt, daher müssen Sie zuerst die Anfrage authentifizieren, die Ihr `sk-`-Token erstellt. Die einfachste Anmeldeinformation ist das Zugriffstoken, das Ihr Browser bereits nach dem Einloggen besitzt.
+Die Token-Endpunkte sind selbst geschützt, daher müssen Sie zuerst die Anfrage authentifizieren, die Ihr `sk-`-Token
+erstellt. Die einfachste Anmeldeinformation ist das Zugriffstoken, das Ihr Browser bereits nach dem Einloggen besitzt.
 
-1.  Melden Sie sich in Ihrem Browser bei der Plattform an.
-2.  Öffnen Sie die Entwicklertools des Browsers, wechseln Sie zum Netzwerk-Tab und klicken Sie auf eine beliebige Anfrage an die API.
-3.  Suchen Sie unter den Anfrage-Headern nach `Authorization: Bearer eyJ...` und kopieren Sie den Wert nach `Bearer `.
+1. Melden Sie sich in Ihrem Browser bei der Plattform an.
+2. Öffnen Sie die Entwicklertools des Browsers, wechseln Sie zum Netzwerk-Tab und klicken Sie auf eine beliebige Anfrage
+   an die API.
+3. Suchen Sie unter den Anfrage-Headern nach `Authorization: Bearer eyJ...` und kopieren Sie den Wert nach `Bearer `.
 
 ::: warning Kopieren Sie das Zugriffstoken, nicht das ID-Token
-Die API validiert die `account`-Audience, die nur das Zugriffstoken enthält. Wenn Sie das ID-Token kopieren (zum Beispiel aus dem Eintrag `oidc.user:...` im lokalen Speicher), schlägt die Anfrage mit `401 ... Invalid token` fehl. Der Netzwerk-Tab zeigt immer das Zugriffstoken an, daher ist er die zuverlässigste Quelle.
+Die API validiert die `account`-Audience, die nur das Zugriffstoken enthält. Wenn Sie das ID-Token kopieren (zum
+Beispiel aus dem Eintrag `oidc.user:...` im lokalen Speicher), schlägt die Anfrage mit `401 ... Invalid token` fehl. Der
+Netzwerk-Tab zeigt immer das Zugriffstoken an, daher ist er die zuverlässigste Quelle.
 
-Um ein Token zu überprüfen, dekodieren Sie dessen Payload und bestätigen Sie `"typ": "Bearer"` und eine `"aud"`, die `"account"` enthält.
+Um ein Token zu überprüfen, dekodieren Sie dessen Payload und bestätigen Sie `"typ": "Bearer"` und eine `"aud"`, die
+`"account"` enthält.
 :::
 
 ## Das Token in Swagger erstellen
@@ -32,21 +41,27 @@ Um ein Token zu überprüfen, dekodieren Sie dessen Payload und bestätigen Sie 
 https://<your-deployment>/api/v1/docs
 ```
 
-1.  Klicken Sie auf Authorize (oben rechts).
-2.  Fügen Sie das Zugriffstoken in das HTTPBearer-Feld ein. Geben Sie nur das Token ein, ohne das Präfix `Bearer `.
-3.  Klicken Sie auf Authorize, dann auf Close.
-4.  Suchen Sie `POST /api/v1/{tenant_id}/tokens/` (Create API Token) und klicken Sie auf Try it out.
-5.  Setzen Sie `tenant_id` auf `active`, was sich zu Ihrem aktiven Mandanten auflöst.
-6.  Geben Sie einen Anfragekörper an. Der Name muss 1 bis 100 Zeichen lang sein und das Ablaufdatum muss ein zukünftiges ISO-8601 Datums-/Zeitformat sein:
+1. Klicken Sie auf Authorize (oben rechts).
 
-    ```json
-    {
-      "name": "my-api-token",
-      "expiry_date": "2026-12-31T23:59:59Z"
-    }
-    ```
+2. Fügen Sie das Zugriffstoken in das HTTPBearer-Feld ein. Geben Sie nur das Token ein, ohne das Präfix `Bearer `.
 
-7.  Klicken Sie auf Execute.
+3. Klicken Sie auf Authorize, dann auf Close.
+
+4. Suchen Sie `POST /api/v1/{tenant_id}/tokens/` (Create API Token) und klicken Sie auf Try it out.
+
+5. Setzen Sie `tenant_id` auf `active`, was sich zu Ihrem aktiven Mandanten auflöst.
+
+6. Geben Sie einen Anfragekörper an. Der Name muss 1 bis 100 Zeichen lang sein und das Ablaufdatum muss ein zukünftiges
+   ISO-8601 Datums-/Zeitformat sein:
+
+   ```json
+   {
+     "name": "my-api-token",
+     "expiry_date": "2026-12-31T23:59:59Z"
+   }
+   ```
+
+7. Klicken Sie auf Execute.
 
 Eine `201`-Antwort enthält das Token:
 
@@ -60,7 +75,8 @@ Eine `201`-Antwort enthält das Token:
 ```
 
 ::: danger Kopieren Sie das Token sofort
-Der `token`-Wert wird nur einmal bei der Erstellung zurückgegeben. Er wird danach nie wieder angezeigt. Wenn Sie ihn verlieren, widerrufen Sie das Token und erstellen Sie ein neues.
+Der `token`-Wert wird nur einmal bei der Erstellung zurückgegeben. Er wird danach nie wieder angezeigt. Wenn Sie ihn
+verlieren, widerrufen Sie das Token und erstellen Sie ein neues.
 :::
 
 ## Das Token verwenden
@@ -72,7 +88,8 @@ curl https://<your-deployment>/api/v1/active/agents/ \
   -H "Authorization: Bearer sk-..."
 ```
 
-Im Gegensatz zum Browser-Session-Token bleibt das `sk-`-Token bis zu seinem Ablaufdatum gültig und eignet sich daher für Skripte und langlebige Integrationen.
+Im Gegensatz zum Browser-Session-Token bleibt das `sk-`-Token bis zu seinem Ablaufdatum gültig und eignet sich daher für
+Skripte und langlebige Integrationen.
 
 ## Token auflisten und widerrufen
 
@@ -84,4 +101,5 @@ Derselbe Controller bietet den Rest des Token-Lebenszyklus an, ebenfalls aufrufb
 | List      | `GET /api/v1/{tenant_id}/tokens/`              |
 | Revoke    | `DELETE /api/v1/{tenant_id}/tokens/{token_id}` |
 
-Der List-Endpunkt gibt die ID, den Namen und das Ablaufdatum jedes Tokens zurück, aber niemals den Token-Wert. Das Widerrufen eines Tokens löscht es dauerhaft und invalidiert sofort jeden Client, der es noch verwendet.
+Der List-Endpunkt gibt die ID, den Namen und das Ablaufdatum jedes Tokens zurück, aber niemals den Token-Wert. Das
+Widerrufen eines Tokens löscht es dauerhaft und invalidiert sofort jeden Client, der es noch verwendet.

--- a/docs/docs/2_platform/20_security/1_authentication/index.de.md
+++ b/docs/docs/2_platform/20_security/1_authentication/index.de.md
@@ -1,118 +1,117 @@
 ---
 title: Authentifizierung und Autorisierung
-source_sha: 9ff7afdd202ecf971428eddf61971e7c96f8e8cba061975c033ddbf4e31735e9
+source_sha: 50b10d4f1012632658dacf0ba16809b2a98a6aa4f1ce7d53beb127960b67de89
 ---
 
 # Authentifizierung und Autorisierung
 
 Der Swiss AI Hub implementiert Authentifizierung und Autorisierung basierend auf den branchenüblichen OpenID Connect
-(OIDC)- und OAuth 2.0-Protokollen. Dieser standardbasierte Ansatz gewährleistet die Kompatibilität mit
-Unternehmens-Identitätsanbietern, während der sichere Zugriff auf alle Plattformressourcen aufrechterhalten wird.
+(OIDC)- und OAuth 2.0-Protokollen. Dieser standardbasierte Ansatz gewährleistet die Kompatibilität mit Identity
+Providern von Unternehmen und ermöglicht gleichzeitig eine sichere Zugriffskontrolle über alle Plattformressourcen.
 
 ## Authentifizierung: OpenID Connect (OIDC)
 
-Die Plattform authentifiziert Benutzer durch OpenID Connect, eine Identitätsebene, die auf OAuth 2.0 aufbaut. Dies
-ermöglicht eine sichere Benutzerauthentifizierung durch Unternehmens-Identitätsanbieter wie Microsoft Entra ID (Azure
-Active Directory), während der OAuth 2.0 Authorization Code Flow unterstützt wird.
+Die Plattform authentifiziert Benutzer mittels OpenID Connect, einer Identitätsschicht, die auf OAuth 2.0 aufbaut. Dies
+ermöglicht eine sichere Benutzerauthentifizierung über Identity Provider von Unternehmen wie Microsoft Entra ID (Azure
+Active Directory) und unterstützt gleichzeitig den OAuth 2.0 Authorization Code Flow.
 
-### So funktioniert Authentifizierung
+### Wie die Authentifizierung funktioniert
 
-**Token-basierte Authentifizierung:** Benutzer authentifizieren sich über den Identitätsanbieter ihrer Organisation, der
-einen JSON Web Token (JWT) ausstellt, der kryptographisch signierte Claims über die Identität des Benutzers enthält. Die
-Plattform validiert diese Tokens bei jeder Anfrage, um Authentizität und Aktualität zu gewährleisten.
+**Token-basierte Authentifizierung:** Benutzer authentifizieren sich über den Identity Provider ihrer Organisation, der
+ein JSON Web Token (JWT) ausgibt, das kryptographisch signierte Claims über die Identität des Benutzers enthält. Die
+Plattform validiert diese Tokens bei jeder Anfrage, um Authentizität und Aktualität sicherzustellen.
 
-**JWT Token-Validierung:** Die Plattform ruft öffentliche Schlüssel vom JWKS-Endpunkt (JSON Web Key Set) des
-Identitätsanbieters ab und verwendet diese, um die kryptographische Signatur jedes JWT-Tokens zu verifizieren. Diese
-Validierung umfasst die Prüfung des Ausstellers, der Zielgruppe, der Ablaufzeit und der Signaturintegrität des Tokens
-gemäß dem JWT-Standard (RFC 7519).
+**JWT-Token-Validierung:** Die Plattform ruft öffentliche Schlüssel vom JWKS (JSON Web Key Set)-Endpunkt des Identity
+Providers ab und verwendet diese, um die kryptographische Signatur jedes JWT-Tokens zu verifizieren. Diese Validierung
+umfasst die Überprüfung des Ausstellers, der Zielgruppe, der Ablaufzeit und der Signaturintegrität des Tokens gemäß dem
+JWT-Standard (RFC 7519).
 
-**Auflösung der Benutzeridentität:** Nach erfolgreicher Token-Validierung extrahiert die Plattform den eindeutigen
-Bezeichner des Benutzers (OID) und grundlegende Profilinformationen (Name, E-Mail) aus den JWT-Token-Claims.
-Rollenzuweisungen werden lokal innerhalb der Plattform durch Mandanten-bezogene Rollenentitäten verwaltet und nicht vom
-Identitätsanbieter abgerufen.
+**Auflösung der Benutzeridentität:** Nach erfolgreicher Token-Validierung extrahiert die Plattform die eindeutige
+Benutzerkennung (OID) und grundlegende Profilinformationen (Name, E-Mail) aus den JWT-Token-Claims. Rollenzuweisungen
+werden lokal innerhalb der Plattform über Mandanten-spezifische Rollenentitäten verwaltet und nicht vom Identity
+Provider abgerufen.
 
 ### Unterstützte Authentifizierungsmethoden
 
 **OAuth 2.0 Authorization Code Flow:** Die primäre Authentifizierungsmethode für interaktive Benutzer folgt dem OAuth
 2.0 Authorization Code Flow mit PKCE (Proof Key for Code Exchange). Benutzer werden zur Authentifizierung an den
-Identitätsanbieter ihrer Organisation umgeleitet und erhalten nach erfolgreicher Anmeldung einen sicheren
-Autorisierungscode, der gegen Zugriffs-Tokens ausgetauscht wird.
+Identity Provider ihrer Organisation weitergeleitet und erhalten nach erfolgreichem Login einen sicheren
+Autorisierungscode, der gegen Access Tokens ausgetauscht wird.
 
-**Bearer Token-Authentifizierung:** Für den API-Zugriff und programmatische Integrationen unterstützt die Plattform die
-Standard-OAuth 2.0 Bearer Token-Authentifizierung. API-Clients präsentieren gültige JWT-Tokens im
-HTTP-Autorisierungs-Header, die mit demselben JWKS-basierten Verifizierungsprozess validiert werden.
+**Bearer-Token-Authentifizierung:** Für den API-Zugriff und programmatische Integrationen unterstützt die Plattform die
+standardmäßige OAuth 2.0 Bearer-Token-Authentifizierung. API-Clients präsentieren gültige JWT-Tokens im HTTP
+Authorization-Header, die mithilfe desselben JWKS-basierten Verifizierungsprozesses validiert werden.
 
 ## Autorisierung: Berechtigungsbasierte Zugriffskontrolle
 
 Die Autorisierung wird unabhängig von der Authentifizierung implementiert, wodurch eine konsistente Zugriffskontrolle
-ermöglicht wird, unabhängig davon, wie sich Benutzer authentifizieren. Die Plattform evaluiert Berechtigungen für jede
-API-Anfrage basierend auf den zugewiesenen Rollen des Benutzers und dem hierarchischen Berechtigungsmodell, das in den
-[Berechtigungen](../../11_access_management/2_permissions/) beschrieben ist.
+gewährleistet wird, unabhängig davon, wie sich Benutzer authentifizieren. Die Plattform evaluiert Berechtigungen für
+jede API-Anfrage basierend auf den zugewiesenen Rollen des Benutzers und dem hierarchischen Berechtigungsmodell, das
+unter [Berechtigungen](/de/docs/11_access_management/2_permissions/) beschrieben ist.
 
-### Integration von Unternehmens-Identitätsanbietern
+### Integration von Enterprise Identity Providern
 
-Die Plattform integriert sich mit Unternehmens-Identitätsanbietern über standardmäßige OIDC-/OAuth 2.0-Protokolle. Jeder
-OIDC-konforme Anbieter (Microsoft Entra ID, Google Workspace, Okta, Auth0, Keycloak) kann zur Authentifizierung
+Die Plattform integriert sich mit Enterprise Identity Providern über standardmäßige OIDC-/OAuth 2.0-Protokolle. Jeder
+OIDC-konforme Provider (Microsoft Entra ID, Google Workspace, Okta, Auth0, Keycloak) kann zur Authentifizierung
 verwendet werden.
 
-**Generische OIDC-Integration:** Die Plattform verbindet sich mit dem konfigurierten OIDC-Anbieter als OAuth 2.0
-Autorisierungsserver und Identitätsanbieter. Die Benutzerauthentifizierung wird an den Anbieter delegiert, der die
-Überprüfung der Anmeldeinformationen, die Multi-Faktor-Authentifizierung und das Session-Management gemäß den
+**Generische OIDC-Integration:** Die Plattform verbindet sich mit dem konfigurierten OIDC-Provider als OAuth
+2.0-Autorisierungsserver und Identity Provider. Die Benutzerauthentifizierung wird an den Provider delegiert, der die
+Überprüfung der Anmeldeinformationen, die Multi-Faktor-Authentifizierung und die Sitzungsverwaltung gemäß den
 Sicherheitsrichtlinien der Organisation handhabt.
 
-**Lokales Rollenmanagement:** Benutzerprofile werden aus JWT-Token-Claims (Name, E-Mail, OID) extrahiert. Rollen werden
-lokal innerhalb der Plattform durch Mandanten-bezogene Rollenzuweisungen verwaltet und nicht vom Identitätsanbieter
-synchronisiert. Dies entkoppelt die Plattformautorisierung von der Gruppen- oder Rollenmodellierung eines spezifischen
-Identitätsanbieters.
+**Lokale Rollenverwaltung:** Benutzerprofile werden aus JWT-Token-Claims (Name, E-Mail, OID) extrahiert. Rollen werden
+lokal innerhalb der Plattform über Mandanten-spezifische Rollenzuweisungen verwaltet und nicht vom Identity Provider
+synchronisiert. Dies entkoppelt die Plattform-Autorisierung von einem spezifischen Gruppen- oder Rollenmodell eines
+Identity Providers.
 
-### So funktioniert Autorisierung
+### Wie die Autorisierung funktioniert
 
 Autorisierungsentscheidungen werden unabhängig von der Authentifizierung getroffen. Nachdem die Identität eines
-Benutzers durch OIDC-Authentifizierung festgestellt wurde, bestimmt die Plattform, auf welche Ressourcen und Operationen
-der Benutzer zugreifen kann, basierend auf seinen zugewiesenen Rollen.
+Benutzers durch die OIDC-Authentifizierung festgestellt wurde, bestimmt die Plattform, auf welche Ressourcen und
+Operationen der Benutzer basierend auf seinen zugewiesenen Rollen zugreifen kann.
 
 **Berechtigungsevaluierungsprozess:**
 
-1. Die Plattform löst die Rollenzuweisungen des Benutzers aus der lokalen, mandantenbezogenen Rollendatenbank auf.
+1. Die Plattform löst die Rollenzuweisungen des Benutzers aus der lokalen, Mandanten-spezifischen Rollendatenbank auf.
 2. Jede Rolle ist mit einem Satz von Zugriffsregeln verknüpft, die in der Plattformdatenbank gespeichert sind.
 3. Für jede API-Anfrage evaluiert die Plattform die erforderliche Berechtigung anhand der Zugriffsregeln des Benutzers.
-4. Zugriffsregeln unterstützen hierarchisches Matching mit Wildcard-Mustern für flexibles Berechtigungsmanagement.
-5. Die Autorisierungsentscheidung (Gewähren oder Verweigern) wird getroffen und zu Audit-Zwecken protokolliert.
+4. Zugriffsregeln unterstützen hierarchisches Matching mit Wildcard-Mustern für eine flexible Berechtigungsverwaltung.
+5. Die Autorisierungsentscheidung (Gewährung oder Verweigerung) wird getroffen und zu Prüfzwecken protokolliert.
 
 **API-Level-Berechtigungsdurchsetzung:** Jeder API-Endpunkt deklariert seine erforderlichen Berechtigungen. Diese
-Berechtigungen werden automatisch überprüft, bevor die Endpunktlogik ausgeführt wird, wodurch sichergestellt wird, dass
-kein Ressourcenzugriff die Autorisierung umgeht. Die Berechtigungsevaluierung verwendet das hierarchische
-Berechtigungsmodell, das in den [Berechtigungen](../../11_access_management/2_permissions/) beschrieben ist.
+Berechtigungen werden automatisch überprüft, bevor die Endpunkt-Logik ausgeführt wird, um sicherzustellen, dass kein
+Ressourcenzugriff die Autorisierung umgeht. Die Berechtigungsevaluierung verwendet das hierarchische
+Berechtigungsmodell, das unter [Berechtigungen](/de/docs/11_access_management/2_permissions/) beschrieben ist.
 
 **Dynamische Autorisierung:** Für Operationen, die Laufzeit-Berechtigungsprüfungen erfordern, bietet die Plattform
 programmatischen Zugriff auf das Berechtigungsevaluierungssystem. Dies ermöglicht das Filtern von Ergebnismengen
 basierend auf Benutzerberechtigungen, die Implementierung unterschiedlicher Verhaltensweisen für verschiedene
 Zugriffsebenen und die Validierung von Berechtigungen vor ressourcenintensiven Operationen.
 
-## Dynamische Identitätsanbieter-Erkennung
+## Dynamische Erkennung von Identity Providern
 
-Die Anmeldeseite entdeckt dynamisch verfügbare Identitätsanbieter von Keycloak zur Laufzeit. Wenn ein Benutzer die
-Anmeldeseite besucht, ruft das Frontend `GET /api/v1/{tenant_id}/auth-providers/` auf – ein nicht authentifizierter
-API-Endpunkt, der die Keycloak Admin API unter Verwendung eines dedizierten Service-Kontos mit den geringsten
-Berechtigungen (`aihub-api-service`) mit nur der `view-identity-providers`-Berechtigung abfragt.
+Die Login-Seite erkennt verfügbare Identity Provider von Keycloak dynamisch zur Laufzeit. Wenn ein Benutzer die
+Login-Seite besucht, ruft das Frontend `GET /api/v1/{tenant_id}/auth-providers/` auf – einen nicht authentifizierten
+API-Endpunkt, der die Keycloak Admin API unter Verwendung eines dedizierten Service-Kontos mit geringsten Rechten
+(`aihub-api-service`) und nur der `view-identity-providers`-Berechtigung abfragt.
 
-Die API filtert die Anbieterliste, um nur aktivierte, sichtbare Anbieter einzuschließen, und gibt deren Alias,
-Anzeigenamen und Icon zurück. Ergebnisse werden für 5 Minuten gecached. Das Frontend rendert einen Marken-Login-Button
-für jeden Anbieter. Das Klicken auf einen Button initiiert den OIDC Authorization Code Flow, wobei `kc_idp_hint` auf den
-Alias des Anbieters gesetzt ist, und leitet den Benutzer direkt zum vorgelagerten Identitätsanbieter weiter, ohne
-Keycloaks Login-Theme anzuzeigen.
+Die API filtert die Provider-Liste, um nur aktivierte, sichtbare Provider einzuschließen und gibt deren Alias,
+Anzeigenamen und Icon zurück. Die Ergebnisse werden für 5 Minuten zwischengespeichert. Das Frontend rendert einen
+gebrandeten Login-Button für jeden Provider. Durch Klicken auf einen Button wird der OIDC Authorization Code Flow mit
+`kc_idp_hint`, der auf den Alias des Providers gesetzt ist, initiiert und der Benutzer direkt zum vorgelagerten Identity
+Provider weitergeleitet, ohne Keycloaks Login-Theme anzuzeigen.
 
-Dieser Ansatz eliminiert jegliche Frontend-Konfiguration für Identitätsanbieter – das Hinzufügen oder Entfernen eines
-IdP ist eine reine Keycloak-Änderung.
+Dieser Ansatz eliminiert jede Frontend-Konfiguration für Identity Provider – das Hinzufügen oder Entfernen eines IdP ist
+eine reine Keycloak-Änderung.
 
-### Konfigurieren von Anbieter-Icons
+### Konfiguration von Provider-Icons
 
-Jeder Identitätsanbieter kann ein benutzerdefiniertes Icon haben, das auf seinem Login-Button angezeigt wird. Icons
-werden direkt in der `config`-Map des Keycloak-Identitätsanbieters als `icon`-Feld unter Verwendung von PrimeIcon
-CSS-Klassen (z. B. `pi-microsoft`, `pi-google`) konfiguriert. Anbieter ohne konfiguriertes Icon fallen auf `pi-sign-in`
-zurück.
+Jeder Identity Provider kann ein benutzerdefiniertes Icon auf seinem Login-Button anzeigen. Icons werden direkt in der
+`config`-Map des Keycloak Identity Providers als `icon`-Feld unter Verwendung von PrimeIcon CSS-Klassen (z.B.
+`pi-microsoft`, `pi-google`) konfiguriert. Provider ohne konfiguriertes Icon greifen auf `pi-sign-in` zurück.
 
-Um ein Icon festzulegen, fügen Sie das `icon`-Feld zur Konfiguration des Identitätsanbieters in
+Um ein Icon festzulegen, fügen Sie das `icon`-Feld zur Konfiguration des Identity Providers in
 `keycloak-identity-providers.json.j2` hinzu:
 
 ```json
@@ -124,36 +123,36 @@ Um ein Icon festzulegen, fügen Sie das `icon`-Feld zur Konfiguration des Identi
 
 ### Direkter Keycloak-Login
 
-Wenn `KEYCLOAK_SHOW_KEYCLOAK_LOGIN=true` (API-Umgebungsvariable, Standard: `true`) ist, erscheint ein zusätzlicher
-"Login with Keycloak"-Button neben den Buttons der föderierten Anbieter. Dies ermöglicht die Anmeldung mit
-Benutzername/Passwort über Keycloaks eigenen Benutzer-Store – nützlich für Entwicklungsumgebungen oder Deployments, in
-denen sich einige Benutzer direkt mit Keycloak authentifizieren, anstatt über einen externen IdP.
+Wenn `KEYCLOAK_SHOW_KEYCLOAK_LOGIN=true` (API-Umgebungsvariable, Standard: `true`), erscheint ein zusätzlicher „Login
+mit Keycloak“-Button neben den Buttons der föderierten Provider. Dies ermöglicht die Benutzername/Passwort-Anmeldung
+über den eigenen Benutzer-Store von Keycloak – nützlich für Entwicklungsumgebungen oder Deployments, bei denen einige
+Benutzer sich direkt bei Keycloak anstatt über einen externen IdP authentifizieren.
 
-## Admin Service Authentifizierung via OAuth2 Proxy
+## Authentifizierung von Admin-Services über OAuth2 Proxy
 
 Interne Admin-Services (Dagster, Attu, SeaweedFS) werden durch [OAuth2 Proxy](https://oauth2-proxy.github.io/)-Instanzen
-geschützt, die vor jedem Service sitzen. OAuth2 Proxy handhabt den vollständigen OIDC-Login-Flow gegen Keycloak, bevor
-authentifizierte Anfragen an den vorgelagerten Service weitergeleitet werden. Nur Benutzer mit der Rolle `AIHubSysAdmin`
-können auf diese Services zugreifen.
+geschützt, die vor jedem Service sitzen. OAuth2 Proxy handhabt den vollständigen OIDC-Login-Flow gegenüber Keycloak,
+bevor authentifizierte Anfragen an den vorgelagerten Service weitergeleitet werden. Nur Benutzer mit der Rolle
+`AIHubSysAdmin` können auf diese Services zugreifen.
 
 Aufgrund des Split-Horizon-Netzwerks in Docker-Deployments (Container verwenden interne Hostnamen, Browser externe URLs)
 wird die OIDC-Erkennung übersprungen und Endpunkte werden explizit konfiguriert.
 
-## Hardening: Keycloak Admin-Konsolenzugriff
+## Härtung: Zugriff auf die Keycloak Admin Console
 
-Die Keycloak Admin-Konsole (`https://auth.<domain>/admin/`) ist durch Benutzername und Passwort geschützt, aber
+Die Keycloak Admin Console (`https://auth.<domain>/admin/`) ist durch Benutzername und Passwort geschützt, aber
 standardmäßig von jeder IP-Adresse aus zugänglich. Für Produktions-Deployments wird dringend empfohlen, den Zugriff auf
-die Admin-Konsole und den Metrik-Endpunkt auf bekannte Administrator-IP-Adressen zu beschränken.
+die Admin Console und den Metrik-Endpunkt auf bekannte Administrator-IP-Adressen zu beschränken.
 
-### Empfohlen: IP Allowlisting via Traefik
+### Empfohlen: IP-Allowlisting via Traefik
 
-Die Plattform verwendet Traefik v3 als Reverse-Proxy. Traefiks
+Die Plattform verwendet Traefik v3 als Reverse Proxy. Traefiks
 [`ipAllowList`](https://doc.traefik.io/traefik/middlewares/http/ipallowlist/)-Middleware kann den Zugriff auf die
 Keycloak Admin-Pfade einschränken, während die OIDC-Login-Endpunkte für alle Benutzer öffentlich zugänglich bleiben.
 
 **Implementierungsschritte:**
 
-1. Fügen Sie eine Umgebungsvariable zu `.env` mit Ihren erlaubten IP-Bereichen hinzu:
+1. Fügen Sie eine Umgebungsvariable zu `.env` mit Ihren zulässigen IP-Bereichen hinzu:
 
    ```bash
    KEYCLOAK_ADMIN_ALLOWED_IPS="203.0.113.0/24,198.51.100.10/32"
@@ -174,67 +173,76 @@ Keycloak Admin-Pfade einschränken, während die OIDC-Login-Endpunkte für alle 
    - "traefik.http.middlewares.keycloak-admin-ipallowlist.ipallowlist.sourcerange=${KEYCLOAK_ADMIN_ALLOWED_IPS}"
    ```
 
-Der öffentliche Router (Priorität 7000) bedient weiterhin OIDC-Endpunkte (`/realms/...`) ohne Einschränkung, während der
-Admin-Router (Priorität 7500) `/admin`- und `/metrics`-Anfragen abfängt und Verbindungen von nicht zugelassenen IPs mit
-einer `403 Forbidden`-Antwort abweist.
+Der öffentliche Router (Priorität 7000) dient weiterhin OIDC-Endpunkten (`/realms/...`) ohne Einschränkung, während der
+Admin-Router (Priorität 7500) Anfragen an `/admin` und `/metrics` abfängt und Verbindungen von nicht-allowgelisteten IPs
+mit einer `403 Forbidden`-Antwort ablehnt.
 
 ::: tip
-Dasselbe Muster kann auf jeden über Traefik exponierten Service angewendet werden. Erwägen Sie auch, den Zugriff auf das
-Traefik-Dashboard selbst einzuschränken, wenn es in Produktion aktiviert ist.
+Das gleiche Muster kann auf jeden über Traefik exponierten Service angewendet werden. Erwägen Sie auch, den Zugriff auf
+das Traefik-Dashboard selbst zu beschränken, wenn es in der Produktion aktiviert ist.
 :::
 
-## Keycloak Realm-Rollen und Automatische Zuweisung
+## Keycloak Realm-Rollen und automatische Zuweisung
 
 Keycloak verwaltet Realm-Level-Rollen, die bestimmen, ob ein Benutzer auf die Plattform zugreifen darf. Diese Rollen
-sind grobe Zugangstore – fein granulare Berechtigungen werden lokal von der Plattform verwaltet (siehe
-[Berechtigungen](../../11_access_management/2_permissions/)).
+sind grobe Zugangstore – fein abgestufte Berechtigungen werden lokal von der Plattform über Mandanten-spezifische Rollen
+verwaltet (siehe [Berechtigungen](/de/docs/11_access_management/2_permissions/)).
 
-| Rolle            | Zweck                                                                                                                |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `AIHubAccess`    | Erforderlich für den Plattform-Login. Benutzern ohne diese Rolle wird der Zugriff im Keycloak Login-Flow verweigert. |
-| `AIHubAdmin`     | Voller administrativer Zugriff                                                                                       |
-| `AIHubUser`      | Standard-Benutzerzugriff                                                                                             |
-| `AIHubDeveloper` | Zugriff auf Entwickler-Tools (Dagster, Attu, etc.)                                                                   |
-| `AIHubSysAdmin`  | Systemadministrator-Zugriff auf Infrastruktur-Tools                                                                  |
+Zwei Realm-Rollen treten in der Plattform in Kraft:
+
+| Rolle           | Effekt                                                                                                                                                         |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AIHubAccess`   | Für den Plattform-Login erforderlich. Benutzer ohne diese Rolle werden im Keycloak Login Flow abgelehnt.                                                       |
+| `AIHubSysAdmin` | Plattform-Administrator. Wird vom Token gelesen, um Admin-Zugriff zu gewähren und die OAuth2-Proxy Admin-Tools (Dagster, Attu, SeaweedFS, Backup) zu schützen. |
+
+::: info Realm-Rollen vs. Plattform-Rollen
+Das `aihub`-Realm definiert nur diese beiden Rollen. Fein abgestufte, alltägliche Berechtigungen werden separat von
+**Mandanten-spezifischen Rollen** gehandhabt, die innerhalb der Plattform verwaltet werden – diese können Namen wie
+`AIHubUser` oder `AIHubAdmin` tragen, sind aber unabhängig von Keycloak Realm-Rollen und werden nicht vom IdP
+abgeleitet. Weisen Sie in Ihrem Identity Provider nur `AIHubAccess` und `AIHubSysAdmin` zu.
+
+Für die Operator-Einrichtung der Azure App-Registrierung und Rollenzuweisung siehe
+[Identity Provider Einrichtung](/de/docs/3_deployment_guide/10_identity_provider_setup/).
+:::
 
 Standardmäßig werden neuen Benutzern keine Rollen automatisch zugewiesen. Dies stellt sicher, dass Benutzer, die von
-einem externen Identitätsanbieter föderiert werden, nur die Rollen erhalten, die explizit aus ihren IdP-Claims
-abgebildet wurden, dem Prinzip der geringsten Rechte folgend.
+einem externen Identity Provider föderiert werden, nur die Rollen erhalten, die explizit aus ihren IdP-Claims abgebildet
+wurden, gemäß dem Prinzip der geringsten Rechte.
 
-### Konfigurieren der Automatischen Rollenzuweisung
+### Konfiguration der automatischen Rollenzuweisung
 
-Wenn Ihr Deployment erfordert, dass alle neuen Benutzer eine Standardrolle (z. B. `AIHubUser`) erhalten, kann dies in
+Wenn Ihr Deployment erfordert, dass alle neuen Benutzer eine Standardrolle (z.B. `AIHubUser`) erhalten, kann dies in
 Keycloak konfiguriert werden:
 
 **Option 1: Realm-Standardrollen (gilt für alle neuen Benutzer)**
 
-Navigieren Sie in der Keycloak Admin-Konsole zu **Realm Settings > User Registration > Default Roles** und fügen Sie die
-gewünschten Rollen hinzu. Alternativ legen Sie das `defaultRoles`-Array in der Realm-Konfigurationsvorlage
-(`keycloak-realm.json.j2`) fest:
+Navigieren Sie in der Keycloak Admin Console zu **Realm Settings > User Registration > Default Roles** und fügen Sie die
+gewünschten Rollen hinzu. Alternativ können Sie das `defaultRoles`-Array in der Realm-Konfigurationsvorlage
+(`keycloak-realm.json.j2`) festlegen:
 
 ```json
 "defaultRoles": ["AIHubUser"]
 ```
 
-**Option 2: Identitätsanbieter-Mapper (gilt pro IdP)**
+**Option 2: Identity Provider Mapper (gilt pro IdP)**
 
-Für eine granularere Kontrolle konfigurieren Sie Rollen-Mapper für individuelle Identitätsanbieter. Dies ermöglicht
-unterschiedliche Rollen für Benutzer aus verschiedenen Organisationen. Navigieren Sie in der Keycloak Admin-Konsole zu
-**Identity Providers > [Ihr IdP] > Mappers** und fügen Sie einen **Hardcoded Role**-Mapper hinzu:
+Für eine granularere Kontrolle konfigurieren Sie Rollen-Mapper auf einzelnen Identity Providern. Dies ermöglicht
+unterschiedliche Rollen für Benutzer aus verschiedenen Organisationen. Navigieren Sie in der Keycloak Admin Console zu
+**Identity Providers > [Ihr IdP] > Mappers** und fügen Sie einen **Hardcoded Role** Mapper hinzu:
 
-| Feld       | Wert                |
-| ---------- | ------------------- |
-| Name       | `default-user-role` |
-| Mapper-Typ | Hardcoded Role      |
-| Rolle      | `AIHubUser`         |
+| Feld        | Wert                |
+| ----------- | ------------------- |
+| Name        | `default-user-role` |
+| Mapper Type | Hardcoded Role      |
+| Role        | `AIHubUser`         |
 
-Dies weist die Rolle nur Benutzern zu, die sich über diesen spezifischen Identitätsanbieter authentifizieren.
+Dies weist die Rolle nur Benutzern zu, die sich über diesen spezifischen Identity Provider authentifizieren.
 
-**Option 3: Claim-basierte Rollen-Mapping (bedingte Zuweisung)**
+**Option 3: Claim-basierte Rollenzuweisung (bedingte Zuweisung)**
 
-Für die bedingte Rollenzuweisung basierend auf IdP-Claims (z. B. Azure AD App-Rollen) verwenden Sie das bestehende
+Für die bedingte Rollenzuweisung basierend auf IdP-Claims (z.B. Azure AD App-Rollen) verwenden Sie das bestehende
 `oidc-role-idp-mapper`-Muster, das bereits in `keycloak-identity-providers.json.j2` konfiguriert ist. Jede Azure AD
-App-Rolle wird auf eine entsprechende Keycloak-Realm-Rolle abgebildet. Um eine neue Zuordnung hinzuzufügen, fügen Sie
+App-Rolle wird einer entsprechenden Keycloak Realm-Rolle zugeordnet. Um eine neue Zuordnung hinzuzufügen, fügen Sie
 einen Eintrag zum `identityProviderMappers`-Array hinzu:
 
 ```json
@@ -252,36 +260,36 @@ einen Eintrag zum `identityProviderMappers`-Array hinzu:
 ```
 
 ::: warning
-Die Rolle `AIHubAccess` wird auf der Ebene des Keycloak Login-Flows über den Authentifizierungs-Flow "Post Broker Login
-\- AIHubAccess Check" durchgesetzt. Benutzern ohne diese Rolle wird der Zugriff unabhängig von anderen Rollenzuweisungen
-verweigert. Stellen Sie sicher, dass Ihre Rollen-Mapping-Strategie `AIHubAccess` für Benutzer einschließt, die sich
-anmelden können sollen.
+Die Rolle `AIHubAccess` wird auf Ebene des Keycloak Login Flows über den Authentifizierungsfluss „Post Broker Login -
+AIHubAccess Check“ erzwungen. Benutzer ohne diese Rolle wird der Zugriff verweigert, unabhängig von anderen
+Rollenzuweisungen. Stellen Sie sicher, dass Ihre Rollenzuweisungsstrategie `AIHubAccess` für Benutzer einschließt, die
+sich anmelden können sollen.
 :::
 
-## Sicherheitsstandards und Operationale Fähigkeiten
+## Sicherheitsstandards und operative Fähigkeiten
 
-### Standards-Konformität
+### Standardkonformität
 
-Die Authentifizierungs- und Autorisierungsimplementierung hält sich an branchenübliche Protokolle und Spezifikationen:
+Die Implementierung von Authentifizierung und Autorisierung entspricht branchenüblichen Protokollen und Spezifikationen:
 
 **OIDC- und OAuth 2.0-Standards:**
 
-- OpenID Connect Core 1.0 für Authentifizierung
-- OAuth 2.0 Autorisierungs-Framework (RFC 6749)
+- OpenID Connect Core 1.0 zur Authentifizierung
+- OAuth 2.0 Authorization Framework (RFC 6749)
 - OAuth 2.0 Authorization Code Flow mit PKCE
 - JSON Web Token (JWT) - RFC 7519
 - JSON Web Key Set (JWKS) - RFC 7517
-- OAuth 2.0 Bearer Token Nutzung (RFC 6750)
+- OAuth 2.0 Bearer Token Usage (RFC 6750)
 
-**Kryptographische Sicherheit:** Alle JWT-Tokens werden mittels kryptographischer RSA-256-Signaturen validiert.
-Öffentliche Schlüssel werden vom JWKS-Endpunkt des Identitätsanbieters abgerufen und für die Performance gecached. Die
-Token-Validierung umfasst die Signaturprüfung, Ausstellerprüfung, Zielgruppenprüfung und Ablaufprüfung bei jeder
-Anfrage.
+**Kryptographische Sicherheit:** Alle JWT-Tokens werden mithilfe von RSA-256 kryptographischen Signaturen validiert.
+Öffentliche Schlüssel werden vom JWKS-Endpunkt des Identity Providers abgerufen und zur Leistungsoptimierung
+zwischengespeichert. Die Token-Validierung umfasst die Signaturprüfung, Aussteller-Validierung, Zielgruppen-Validierung
+und die Überprüfung der Ablaufzeit bei jeder Anfrage.
 
 ### Audit und Monitoring
 
-Alle Authentifizierungs- und Autorisierungsereignisse werden umfassend mit strukturierten Metadaten zu Audit- und
-Sicherheitsüberwachungszwecken protokolliert. Dies umfasst Benutzeridentität, angeforderte Ressourcen,
+Alle Authentifizierungs- und Autorisierungsereignisse werden umfassend mit strukturierten Metadaten für Audit- und
+Sicherheitsüberwachungszwecke protokolliert. Dies umfasst Benutzeridentität, angeforderte Ressourcen,
 Berechtigungsevaluierungen, Zugriffsentscheidungen und den vollständigen Anforderungskontext.
 
 **Sicherheitsereignisprotokollierung:** Die Plattform integriert sich mit OpenTelemetry-Standards, um strukturierte,
@@ -289,38 +297,38 @@ nachvollziehbare Sicherheitsereignisse bereitzustellen. Dies ermöglicht die Kor
 verteilte Systemkomponenten hinweg und unterstützt Compliance-Anforderungen für Audit-Trails.
 
 **Echtzeit-Sicherheitsüberwachung:** Sicherheitsteams können Authentifizierungsmuster, Autorisierungsfehler,
-Token-Validierungsereignisse und Zugriffsmuster in Echtzeit überwachen. Diese Transparenz ermöglicht eine schnelle
+Token-Validierungsereignisse und Zugriffsmuster in Echtzeit überwachen. Diese Transparenz ermöglicht die schnelle
 Erkennung und Reaktion auf potenzielle Sicherheitsvorfälle.
 
-### Regulatorische und Unternehmens-Compliance
+### Regulatorische und Unternehmenskonformität
 
 Die Authentifizierungs- und Autorisierungsarchitektur unterstützt die Einhaltung regulatorischer Anforderungen und
-Unternehmens-Sicherheitsstandards:
+Unternehmenssicherheitsstandards:
 
-**Datenschutz-Compliance:**
+**Datenschutzkonformität:**
 
-- DSGVO-konforme Benutzerauthentifizierung und Datenverarbeitung
+- GDPR-konforme Benutzerauthentifizierung und Datenverarbeitung
 - Einhaltung des Schweizer Datenschutzgesetzes durch selbst gehostete Deployment-Optionen
-- Umfassende Audit-Trails, die regulatorische Anforderungen für die Zugriffsprotokollierung erfüllen
-- Datenhoheit durch On-Premises- oder Schweizer Cloud-Deployment gewahrt
+- Umfassende Audit-Trails, die die regulatorischen Anforderungen an die Zugriffsprotokollierung erfüllen
+- Datensouveränität durch On-Premises- oder Schweizer Cloud-Deployment gewahrt
 
-**Unternehmens-Sicherheitsanforderungen:**
+**Anforderungen an die Unternehmenssicherheit:**
 
-- Multi-Faktor-Authentifizierungsunterstützung durch Unternehmens-Identitätsanbieter
-- Integration in bestehende Unternehmens-Identitätsinfrastruktur
-- Schutz vor gängigen Authentifizierungsangriffen (Token-Replay, Session-Hijacking, CSRF)
+- Multi-Faktor-Authentifizierungsunterstützung durch Enterprise Identity Provider
+- Integration in bestehende Unternehmens-Identity-Infrastruktur
+- Schutz vor gängigen Authentifizierungsangriffen (Token Replay, Session Hijacking, CSRF)
 - Sicheres Token-Lifecycle-Management mit Ablauf und Widerruf
-- HTTPS-only-Kommunikation für alle Authentifizierungs-Flows
+- Nur HTTPS-Kommunikation für alle Authentifizierungsflüsse
 
-**Security Best Practices:**
+**Best Practices für Sicherheit:**
 
 - Zero-Trust-Sicherheitsmodell mit Authentifizierung, die für jeden API-Zugriff erforderlich ist
-- Trennung von Authentifizierungs- und Autorisierungsbelangen
-- Prinzip der geringsten Rechte durch granuläres Berechtigungssystem
-- Defense in Depth mit mehreren Schichten von Sicherheitskontrollen
-- Regelmäßige Token-Validierungs- und Refresh-Mechanismen
+- Trennung von Authentifizierungs- und Autorisierungsanliegen
+- Prinzip der geringsten Rechte durch granular abgestuftes Berechtigungssystem
+- Defense-in-Depth mit mehreren Schichten von Sicherheitskontrollen
+- Regelmäßige Token-Validierungs- und Aktualisierungsmechanismen
 
-Dieser standardbasierte Ansatz zur Authentifizierung und Autorisierung stellt sicher, dass die Plattform die
-Sicherheitsanforderungen von Unternehmen erfüllt, während sie mit Standard-Identitätsanbietern und
-Sicherheitsinfrastruktur interoperabel bleibt. Die Verwendung von OIDC und OAuth 2.0 bietet bewährte
-Sicherheitsmechanismen, die in Unternehmensumgebungen weit verbreitet verstanden, auditiert und vertraut sind.
+Dieser standardbasierte Ansatz für Authentifizierung und Autorisierung stellt sicher, dass die Plattform die
+Sicherheitsanforderungen von Unternehmen erfüllt und gleichzeitig mit Standard-Identity-Providern und
+Sicherheitsinfrastrukturen interoperabel bleibt. Die Verwendung von OIDC und OAuth 2.0 bietet bewährte
+Sicherheitsmechanismen, die in Unternehmensumgebungen weithin verstanden, geprüft und vertraut sind.

--- a/docs/docs/2_platform/20_security/1_authentication/index.en.md
+++ b/docs/docs/2_platform/20_security/1_authentication/index.en.md
@@ -184,10 +184,11 @@ Two realm roles take effect in the platform:
 | `AIHubAccess`   | Required for platform login. Users without this role are denied at the Keycloak login flow.                                                 |
 | `AIHubSysAdmin` | Platform administrator. Read from the token to grant admin access and gate the OAuth2-Proxy admin tools (Dagster, Attu, SeaweedFS, Backup). |
 
-::: info Roles that are mapped but currently inert
-The realm also defines `AIHubAdmin`, `AIHubUser`, and `AIHubDeveloper`, and the Azure IdP maps them — but the platform
-does not read them for authorization. Day-to-day permissions come from tenant-scoped roles managed inside the platform,
-not from these realm roles. Assign only `AIHubAccess` and `AIHubSysAdmin` to users.
+::: info Realm roles vs. platform roles
+The `aihub` realm defines only these two roles. Fine-grained, day-to-day permissions are handled separately by
+**tenant-scoped roles** managed inside the platform — these may share names such as `AIHubUser` or `AIHubAdmin` but are
+unrelated to Keycloak realm roles and are not derived from the IdP. Assign only `AIHubAccess` and `AIHubSysAdmin` in
+your identity provider.
 
 For the operator setup of the Azure app registration and role assignment, see
 [Identity Provider Setup](../../3_deployment_guide/10_identity_provider_setup/).

--- a/docs/docs/2_platform/20_security/1_authentication/index.en.md
+++ b/docs/docs/2_platform/20_security/1_authentication/index.en.md
@@ -174,16 +174,24 @@ dashboard itself if it is enabled in production.
 ## Keycloak Realm Roles and Automatic Assignment
 
 Keycloak manages realm-level roles that determine whether a user may access the platform. These roles are coarse access
-gates — fine-grained permissions are managed locally by the platform (see
+gates — fine-grained permissions are managed locally by the platform through tenant-scoped roles (see
 [Permissions](../../11_access_management/2_permissions/)).
 
-| Role             | Purpose                                                                                     |
-| ---------------- | ------------------------------------------------------------------------------------------- |
-| `AIHubAccess`    | Required for platform login. Users without this role are denied at the Keycloak login flow. |
-| `AIHubAdmin`     | Full administrative access                                                                  |
-| `AIHubUser`      | Standard user access                                                                        |
-| `AIHubDeveloper` | Developer tools access (Dagster, Attu, etc.)                                                |
-| `AIHubSysAdmin`  | System administrator access to infrastructure tools                                         |
+Two realm roles take effect in the platform:
+
+| Role            | Effect                                                                                                                                      |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AIHubAccess`   | Required for platform login. Users without this role are denied at the Keycloak login flow.                                                 |
+| `AIHubSysAdmin` | Platform administrator. Read from the token to grant admin access and gate the OAuth2-Proxy admin tools (Dagster, Attu, SeaweedFS, Backup). |
+
+::: info Roles that are mapped but currently inert
+The realm also defines `AIHubAdmin`, `AIHubUser`, and `AIHubDeveloper`, and the Azure IdP maps them — but the platform
+does not read them for authorization. Day-to-day permissions come from tenant-scoped roles managed inside the platform,
+not from these realm roles. Assign only `AIHubAccess` and `AIHubSysAdmin` to users.
+
+For the operator setup of the Azure app registration and role assignment, see
+[Identity Provider Setup](../../3_deployment_guide/10_identity_provider_setup/).
+:::
 
 By default, no roles are automatically assigned to new users. This ensures that users federated from an external
 identity provider only receive the roles explicitly mapped from their IdP claims, following the principle of least

--- a/docs/docs/2_platform/3_deployment_guide/10_identity_provider_setup/1_azure_entra_id/1_azure_app_registration/index.de.md
+++ b/docs/docs/2_platform/3_deployment_guide/10_identity_provider_setup/1_azure_entra_id/1_azure_app_registration/index.de.md
@@ -1,0 +1,87 @@
+---
+title: Azure App-Registrierung
+description: Konfigurieren Sie eine Entra ID App-Registrierung, damit Keycloak sie als Identitätsanbieter akzeptiert
+source_sha: 7658b23b473fe0f88018be7d4e2a72d7ecf3b677670bcc4d081a0b73ae9e9240
+---
+
+# Azure App-Registrierung
+
+Keycloaks `aihub`-Realm wird mit einem bereits definierten Microsoft Entra ID-Anbieter (Alias `azure-ad`) ausgeliefert.
+Um ihn zu aktivieren, erstellen Sie eine **App-Registrierung** in Ihrem Entra-Mandanten, die wie unten beschrieben
+konfiguriert ist, und übergeben Sie dann drei Werte an die Plattform.
+
+::: info Voraussetzungen
+Ein Entra ID-Mandant und die Berechtigung, App-Registrierungen zu erstellen und Unternehmensanwendungsrollen zuzuweisen.
+Das Erstellen einer App-Registrierung selbst ist eine Standard-Entra-Administration – siehe
+[Microsofts Dokumentation](https://learn.microsoft.com/entra/identity-platform/quickstart-register-app). Diese Seite
+dokumentiert nur die AI-Hub-spezifische Konfiguration.
+:::
+
+## Was die Plattform von Azure benötigt
+
+Nach der Konfiguration der App-Registrierung legen Sie diese drei Variablen in Ihrer `.env`-Datei fest. Keycloak liest
+sie beim Start und injiziert sie in den `azure-ad`-Anbieter:
+
+| Variable                       | Quelle in Azure                                |
+| :----------------------------- | :--------------------------------------------- |
+| `KEYCLOAK_AZURE_CLIENT_ID`     | Anwendungs-(Client-)ID der App-Registrierung   |
+| `KEYCLOAK_AZURE_TENANT_ID`     | Verzeichnis-(Mandanten-)ID                     |
+| `KEYCLOAK_AZURE_CLIENT_SECRET` | Wert eines von Ihnen erstellten Client-Secrets |
+
+## Erforderliche Konfiguration
+
+### Umleitungs-URI
+
+Registrieren Sie diese exakte **Web**-Umleitungs-URI (es ist Keycloaks Broker-Endpunkt für den `azure-ad`-Alias im
+`aihub`-Realm):
+
+```text
+https://auth.<DOMAIN>/realms/aihub/broker/azure-ad/endpoint
+```
+
+Ersetzen Sie `<DOMAIN>` durch Ihre Deployment-Domain. Für die lokale Entwicklung fügen Sie zusätzlich hinzu:
+
+```text
+http://localhost:8180/realms/aihub/broker/azure-ad/endpoint
+```
+
+### API-Berechtigungen
+
+Keycloak fordert die Standard-OpenID Connect-Scopes an – keine Microsoft Graph-Berechtigungen sind erforderlich:
+
+```text
+openid email profile
+```
+
+Diese liefern die Claims, die Keycloak dem Benutzer zuordnet: `email`, `given_name`, `family_name` und
+`preferred_username`.
+
+### Client-Secret
+
+Erstellen Sie ein Client-Secret und kopieren Sie dessen **Wert** (nicht die Secret-ID) in
+`KEYCLOAK_AZURE_CLIENT_SECRET`. Keycloak authentifiziert sich gegenüber Azure mit diesem Secret (`client_secret_post`)
+und fügt zusätzlich PKCE (`S256`) hinzu.
+
+::: warning
+Client-Secrets verfallen. Erstellen Sie eine Kalendererinnerung vor dem Ablaufdatum und rotieren Sie das Secret, indem
+Sie `KEYCLOAK_AZURE_CLIENT_SECRET` aktualisieren – ein abgelaufenes Secret unterbricht alle Anmeldungen über diesen
+Anbieter.
+:::
+
+## Nächster Schritt
+
+Die App-Registrierung ist erst nutzbar, wenn Sie deren **App-Rollen** definieren und zuweisen – siehe
+[Benutzer- und Rollenverwaltung](../2_user_and_role_management/). Mindestens benötigen Benutzer die Rolle `AIHubAccess`,
+um sich anzumelden.
+
+::: tip Betreiber bearbeiten den Anbieter nicht
+Der `azure-ad`-Anbieter und seine Claim-Mapper sind in
+`infra/deployment/templates/configs/keycloak-identity-providers.json.j2` definiert. Normalerweise setzen Sie nur die
+drei `.env`-Variablen – es ist keine Keycloak-Konfiguration erforderlich.
+:::
+
+::: tip Multi-Tenant-Deployments
+Ein einzelnes Deployment kann mehrere Organisationen föderieren, jede mit ihrer eigenen App-Registrierung, die einer
+separaten Mandantengruppe in Keycloak zugeordnet ist. Dies ist eine erweiterte, nicht standardmäßige Einrichtung; siehe
+die Kommentare in `keycloak-identity-providers.json.j2` für das hardcoded-group-Mapper-Muster.
+:::

--- a/docs/docs/2_platform/3_deployment_guide/10_identity_provider_setup/1_azure_entra_id/1_azure_app_registration/index.en.md
+++ b/docs/docs/2_platform/3_deployment_guide/10_identity_provider_setup/1_azure_entra_id/1_azure_app_registration/index.en.md
@@ -1,0 +1,82 @@
+---
+title: Azure App Registration
+description: Configure an Entra ID app registration so Keycloak accepts it as an identity provider
+---
+
+# Azure App Registration
+
+Keycloak's `aihub` realm ships with a Microsoft Entra ID provider (alias `azure-ad`) already defined. To activate it,
+create an **App Registration** in your Entra tenant configured as described below, then hand three values to the
+platform.
+
+::: info Prerequisites
+An Entra ID tenant and permission to create app registrations and assign enterprise application roles. Creating an app
+registration itself is standard Entra administration — see
+[Microsoft's documentation](https://learn.microsoft.com/entra/identity-platform/quickstart-register-app). This page
+documents only the AI-Hub-specific configuration.
+:::
+
+## What the platform needs from Azure
+
+After configuring the app registration, set these three variables in your `.env` file. Keycloak reads them at startup
+and injects them into the `azure-ad` provider:
+
+| Variable                       | Source in Azure                         |
+| ------------------------------ | --------------------------------------- |
+| `KEYCLOAK_AZURE_CLIENT_ID`     | Application (client) ID of the app reg. |
+| `KEYCLOAK_AZURE_TENANT_ID`     | Directory (tenant) ID                   |
+| `KEYCLOAK_AZURE_CLIENT_SECRET` | Value of a client secret you create     |
+
+## Required configuration
+
+### Redirect URI
+
+Register this exact **Web** redirect URI (it is Keycloak's broker endpoint for the `azure-ad` alias on the `aihub`
+realm):
+
+```text
+https://auth.<DOMAIN>/realms/aihub/broker/azure-ad/endpoint
+```
+
+Replace `<DOMAIN>` with your deployment domain. For local development, also add:
+
+```text
+http://localhost:8180/realms/aihub/broker/azure-ad/endpoint
+```
+
+### API permissions
+
+Keycloak requests the standard OpenID Connect scopes — no Microsoft Graph permissions are required:
+
+```text
+openid email profile
+```
+
+These provide the claims Keycloak maps to the user: `email`, `given_name`, `family_name`, and `preferred_username`.
+
+### Client secret
+
+Create a client secret and copy its **value** (not the secret ID) into `KEYCLOAK_AZURE_CLIENT_SECRET`. Keycloak
+authenticates to Azure with this secret (`client_secret_post`) and adds PKCE (`S256`) on top.
+
+::: warning
+Client secrets expire. Set a calendar reminder before the expiry date and rotate the secret by updating
+`KEYCLOAK_AZURE_CLIENT_SECRET` — an expired secret breaks all logins through this provider.
+:::
+
+## Next step
+
+The app registration is not usable until you define and assign its **app roles** — see
+[User and Role Management](../2_user_and_role_management/). At minimum, users need the `AIHubAccess` role to log in.
+
+::: tip Operators don't edit the provider
+The `azure-ad` provider and its claim mappers are defined in
+`infra/deployment/templates/configs/keycloak-identity-providers.json.j2`. You normally only set the three `.env`
+variables — no Keycloak configuration is needed.
+:::
+
+::: tip Multi-tenant deployments
+A single deployment can federate multiple organizations, each with its own app registration mapped to a separate tenant
+group in Keycloak. This is an advanced, non-default setup; see the comments in `keycloak-identity-providers.json.j2` for
+the hardcoded-group mapper pattern.
+:::

--- a/docs/docs/2_platform/3_deployment_guide/10_identity_provider_setup/1_azure_entra_id/2_user_and_role_management/index.de.md
+++ b/docs/docs/2_platform/3_deployment_guide/10_identity_provider_setup/1_azure_entra_id/2_user_and_role_management/index.de.md
@@ -1,0 +1,69 @@
+---
+title: Benutzer- und Rollenverwaltung
+description: Definieren und weisen Sie die App-Rollen zu, die den Zugriff auf den Swiss AI Hub gewähren
+source_sha: 87c815508b4dc3f54c9207c16f6b953bbd1c0dea65215fcde6ed90915fce1e13
+---
+
+# Benutzer- und Rollenverwaltung
+
+Der Zugriff auf den Swiss AI Hub wird über **App-Rollen** in der Azure App-Registrierung gewährt. Wenn sich ein Benutzer
+anmeldet, nimmt Entra ID die zugewiesenen App-Rollen in den `roles`-Claim auf; Keycloak bildet jede dieser Rollen auf
+eine Realm-Rolle desselben Namens ab.
+
+Zwei Rollen wirken sich in der Plattform aus — definieren Sie beide in der App-Registrierung und weisen Sie sie den
+Benutzern zu.
+
+## App-Rollen definieren
+
+Fügen Sie in der App-Registrierung diese App-Rollen hinzu (App-Rollen-Blade oder das Manifest). Der **Wert** muss exakt
+übereinstimmen — er wird von Keycloak abgebildet:
+
+| Anzeigename     | Wert            | Gewährt                                                                                  |
+| --------------- | --------------- | ---------------------------------------------------------------------------------------- |
+| AI-Hub Access   | `AIHubAccess`   | Berechtigung zur Anmeldung. **Erforderlich** — ohne diese wird die Anmeldung verweigert. |
+| AI-Hub Sysadmin | `AIHubSysAdmin` | Plattformadministrator + Zugriff auf Admin-Tools (Dagster, Attu, …).                     |
+
+Entsprechende `appRoles`-Manifesteinträge:
+
+```json
+"appRoles": [
+  {
+    "displayName": "AI-Hub Access",
+    "value": "AIHubAccess",
+    "description": "Allows login to the Swiss AI Hub",
+    "allowedMemberTypes": ["User"],
+    "isEnabled": true
+  },
+  {
+    "displayName": "AI-Hub Sysadmin",
+    "value": "AIHubSysAdmin",
+    "description": "Platform administrator and admin tool access",
+    "allowedMemberTypes": ["User"],
+    "isEnabled": true
+  }
+]
+```
+
+::: warning
+`AIHubAccess` ist obligatorisch. Keycloaks Login-Flow verweigert jedem Benutzer den Zugriff, der diese Rolle nicht
+besitzt, unabhängig von anderen Rollen. Jeder Benutzer, der die Plattform erreichen soll, muss `AIHubAccess` zugewiesen
+bekommen.
+:::
+
+## Rollen Benutzern zuweisen
+
+Weisen Sie die App-Rollen Benutzern oder Gruppen in der zugehörigen **Enterprise Application** zu — siehe Microsofts
+[Benutzer und Gruppen einer Anwendung zuweisen](https://learn.microsoft.com/entra/identity/enterprise-apps/assign-user-or-group-access-portal).
+Zugewiesene App-Rollen erscheinen automatisch im `roles`-Claim des Tokens; es ist keine Konfiguration optionaler Claims
+erforderlich.
+
+Eine typische Zuweisung:
+
+- **Alle Plattformbenutzer** → `AIHubAccess`
+- **Plattformadministratoren** → `AIHubAccess` **und** `AIHubSysAdmin`
+
+::: tip
+Die Zuweisung einer Rolle zu einer **Gruppe** (anstatt zu einzelnen Benutzern) erfordert eine Microsoft Entra ID P1-
+oder P2-Lizenz und `"Group"` in den `allowedMemberTypes` der Rolle. Die Zuweisung pro Benutzer funktioniert auf jeder
+Stufe.
+:::

--- a/docs/docs/2_platform/3_deployment_guide/10_identity_provider_setup/1_azure_entra_id/2_user_and_role_management/index.en.md
+++ b/docs/docs/2_platform/3_deployment_guide/10_identity_provider_setup/1_azure_entra_id/2_user_and_role_management/index.en.md
@@ -1,0 +1,63 @@
+---
+title: User and Role Management
+description: Define and assign the app roles that grant access to the Swiss AI Hub
+---
+
+# User and Role Management
+
+Access to the Swiss AI Hub is granted through **app roles** on the Azure app registration. When a user logs in, Entra ID
+includes their assigned app roles in the `roles` claim; Keycloak maps each one to a realm role of the same name.
+
+Two roles take effect in the platform — define both on the app registration and assign them to users.
+
+## Define the app roles
+
+In the app registration, add these app roles (App roles blade, or the manifest). The **value** must match exactly — it
+is what Keycloak maps:
+
+| Display name    | Value           | Grants                                                             |
+| --------------- | --------------- | ------------------------------------------------------------------ |
+| AI-Hub Access   | `AIHubAccess`   | Permission to log in. **Required** — without it, login is denied.  |
+| AI-Hub Sysadmin | `AIHubSysAdmin` | Platform administrator + access to admin tools (Dagster, Attu, …). |
+
+Equivalent `appRoles` manifest entries:
+
+```json
+"appRoles": [
+  {
+    "displayName": "AI-Hub Access",
+    "value": "AIHubAccess",
+    "description": "Allows login to the Swiss AI Hub",
+    "allowedMemberTypes": ["User"],
+    "isEnabled": true
+  },
+  {
+    "displayName": "AI-Hub Sysadmin",
+    "value": "AIHubSysAdmin",
+    "description": "Platform administrator and admin tool access",
+    "allowedMemberTypes": ["User"],
+    "isEnabled": true
+  }
+]
+```
+
+::: warning
+`AIHubAccess` is mandatory. Keycloak's login flow denies any user who does not have it, regardless of other roles. Every
+user who should reach the platform must be assigned `AIHubAccess`.
+:::
+
+## Assign roles to users
+
+Assign the app roles to users or groups on the backing **Enterprise Application** — see Microsoft's
+[Assign users and groups to an application](https://learn.microsoft.com/entra/identity/enterprise-apps/assign-user-or-group-access-portal).
+Assigned app roles appear automatically in the token's `roles` claim; no optional-claims configuration is needed.
+
+A typical assignment:
+
+- **All platform users** → `AIHubAccess`
+- **Platform administrators** → `AIHubAccess` **and** `AIHubSysAdmin`
+
+::: tip
+Assigning a role to a **group** (rather than individual users) requires a Microsoft Entra ID P1 or P2 license and
+`"Group"` in the role's `allowedMemberTypes`. Per-user assignment works on any tier.
+:::

--- a/docs/docs/2_platform/3_deployment_guide/10_identity_provider_setup/1_azure_entra_id/index.de.md
+++ b/docs/docs/2_platform/3_deployment_guide/10_identity_provider_setup/1_azure_entra_id/index.de.md
@@ -1,0 +1,23 @@
+---
+title: Microsoft Entra ID
+description: Föderieren Sie den Swiss AI Hub über Keycloak mit Microsoft Entra ID (Azure AD)
+source_sha: fd65cc5495094842db53461762023478e1cf5f11600a8652f18042b683c8bbe4
+---
+
+# Microsoft Entra ID
+
+Das `aihub`-Realm von Keycloak wird mit einem bereits definierten Microsoft Entra ID-Provider (Alias `azure-ad`)
+ausgeliefert. Um ihn zu aktivieren, erstellen Sie eine **App-Registrierung** in Ihrem Entra-Tenant, konfiguriert, wie
+das Realm es erwartet, definieren Sie dessen App-Rollen und weisen Sie Benutzern diese zu.
+
+Entra ID ist als ein
+[OpenID Connect v1.0 Identitätsprovider](https://www.keycloak.org/docs/latest/server_admin/index.html#_identity_broker_oidc)
+integriert. Keycloak validiert das ID-Token anhand des JWKS-Endpoints von Entra und authentifiziert sich mit einem
+Client-Geheimnis plus PKCE (`S256`) — hier gibt es nichts zu wählen, das Realm ist für OIDC vorkonfiguriert.
+
+## Seiten
+
+- **[Azure App-Registrierung](./1_azure_app_registration/)** — erstellen Sie die App-Registrierung und konfigurieren Sie
+  diese genau so, wie Keycloak es erwartet (Redirect-URI, Scopes, Client-Geheimnis).
+- **[Benutzer- und Rollenverwaltung](./2_user_and_role_management/)** — definieren Sie die AI-Hub App-Rollen und weisen
+  Sie diese Benutzern zu, damit diese sich anmelden und den richtigen Zugang erhalten können.

--- a/docs/docs/2_platform/3_deployment_guide/10_identity_provider_setup/1_azure_entra_id/index.en.md
+++ b/docs/docs/2_platform/3_deployment_guide/10_identity_provider_setup/1_azure_entra_id/index.en.md
@@ -1,0 +1,22 @@
+---
+title: Microsoft Entra ID
+description: Federate the Swiss AI Hub to Microsoft Entra ID (Azure AD) via Keycloak
+---
+
+# Microsoft Entra ID
+
+Keycloak's `aihub` realm ships with a Microsoft Entra ID provider (alias `azure-ad`) already defined. To activate it,
+create an **App Registration** in your Entra tenant configured as the realm expects, define its app roles, and assign
+users.
+
+Entra ID is integrated as an
+[OpenID Connect v1.0 identity provider](https://www.keycloak.org/docs/latest/server_admin/index.html#_identity_broker_oidc).
+Keycloak validates the ID token against Entra's JWKS endpoint and authenticates with a client secret plus PKCE (`S256`)
+— there is nothing to choose here, the realm is preconfigured for OIDC.
+
+## Pages
+
+- **[Azure App Registration](./1_azure_app_registration/)** — create the app registration and configure it exactly as
+  Keycloak expects (redirect URI, scopes, client secret).
+- **[User and Role Management](./2_user_and_role_management/)** — define the AI-Hub app roles and assign them to users
+  so they can log in and gain the right access.

--- a/docs/docs/2_platform/3_deployment_guide/10_identity_provider_setup/index.de.md
+++ b/docs/docs/2_platform/3_deployment_guide/10_identity_provider_setup/index.de.md
@@ -1,0 +1,37 @@
+---
+title: Einrichtung des Identitätsanbieters
+description: Verbindung eines externen Identitätsanbieters mit dem Swiss AI Hub über Keycloak
+source_sha: d02098df6b97875deee207127cc2631e44b7bff868c429899a2b3be7cb2af3bc
+---
+
+# Einrichtung des Identitätsanbieters
+
+Der Swiss AI Hub verwaltet Benutzeranmeldeinformationen nicht selbst. Er verwendet **Keycloak als Identitätsbroker**,
+der an den Identitätsanbieter (IdP) Ihrer Organisation föderiert. Benutzer melden sich mit ihrem bestehenden
+Unternehmenskonto an; Keycloak validiert die Anmeldung und stellt der Plattform einen Token aus.
+
+Keycloak kann Anbieter über drei Protokolle sowie eine Reihe von integrierten sozialen Anbietern vermitteln – eine
+vollständige Liste finden Sie in der
+[Keycloak-Dokumentation zum Identitätsbrokering](https://www.keycloak.org/docs/latest/server_admin/index.html#_identity_broker):
+
+- [OpenID Connect v1.0](https://www.keycloak.org/docs/latest/server_admin/index.html#_identity_broker_oidc)
+- [OAuth v2](https://www.keycloak.org/docs/latest/server_admin/index.html#_identity_broker_oauth)
+- [SAML v2.0](https://www.keycloak.org/docs/latest/server_admin/index.html#saml-v2-0-identity-providers)
+
+Die Plattform schränkt das Protokoll nicht ein – jeder aktivierte, sichtbare Anbieter, der im `aihub`-Realm konfiguriert
+ist, erscheint auf der Anmeldeseite. Die einzige praktische Anforderung für den **rollenbasierten Zugriff** ist, dass
+der Anbieter die AI-Hub-Rollenwerte in einem Claim ausgibt, den Keycloak Realm-Rollen zuordnet (siehe
+[Benutzer- und Rollenverwaltung](./1_azure_entra_id/2_user_and_role_management/)).
+
+Die folgenden Seiten führen Sie durch die IdPs, die wir vorkonfigurieren und unterstützen. Jede Seite erklärt, wie Sie
+den Anbieter so einrichten, dass er den Erwartungen des Keycloak `aihub`-Realms entspricht.
+
+## Unterstützte Anbieter
+
+- **[Microsoft Entra ID (Azure AD)](./1_azure_entra_id/)** – Erstellung der App-Registrierung und Verwaltung ihrer
+  Benutzer und Rollen.
+
+::: tip
+Dieser Abschnitt ist operativ. Für das konzeptionelle Modell – wie Keycloak Tokens validiert, Claims zuordnet und Rollen
+durchsetzt – siehe [Authentifizierung und Autorisierung](../../20_security/1_authentication/).
+:::

--- a/docs/docs/2_platform/3_deployment_guide/10_identity_provider_setup/index.en.md
+++ b/docs/docs/2_platform/3_deployment_guide/10_identity_provider_setup/index.en.md
@@ -1,0 +1,35 @@
+---
+title: Identity Provider Setup
+description: Connect an external identity provider to the Swiss AI Hub through Keycloak
+---
+
+# Identity Provider Setup
+
+The Swiss AI Hub does not manage user credentials itself. It uses **Keycloak as an identity broker** that federates to
+your organization's identity provider (IdP). Users sign in with their existing corporate account; Keycloak validates the
+login and issues the platform a token.
+
+Keycloak can broker providers over three protocols, plus a range of built-in social providers — see the
+[Keycloak identity brokering documentation](https://www.keycloak.org/docs/latest/server_admin/index.html#_identity_broker)
+for the full list:
+
+- [OpenID Connect v1.0](https://www.keycloak.org/docs/latest/server_admin/index.html#_identity_broker_oidc)
+- [OAuth v2](https://www.keycloak.org/docs/latest/server_admin/index.html#_identity_broker_oauth)
+- [SAML v2.0](https://www.keycloak.org/docs/latest/server_admin/index.html#saml-v2-0-identity-providers)
+
+The platform places no restriction on the protocol — any enabled, visible provider configured in the `aihub` realm
+appears on the login page. The one practical requirement for **role-based access** is that the provider emits the AI-Hub
+role values in a claim that Keycloak maps to realm roles (see
+[User and Role Management](./1_azure_entra_id/2_user_and_role_management/)).
+
+The pages below walk through the IdPs we configure and support out of the box. Each one explains how to set up the
+provider so it matches what the Keycloak `aihub` realm expects.
+
+## Supported providers
+
+- **[Microsoft Entra ID (Azure AD)](./1_azure_entra_id/)** — create the app registration and manage its users and roles.
+
+::: tip
+This section is operational. For the conceptual model — how Keycloak validates tokens, maps claims, and enforces roles —
+see [Authentication and Authorization](../../20_security/1_authentication/).
+:::

--- a/docs/docs/2_platform/5_agents/10_company_knowledge_agent/index.de.md
+++ b/docs/docs/2_platform/5_agents/10_company_knowledge_agent/index.de.md
@@ -1,34 +1,34 @@
 ---
 title: Agent für Unternehmenswissen
 description: Ein Dokumenten-Antwort-Assistent, der bei fehlender Antwort in den Dokumenten auf einen menschlichen Experten zurückgreift (mit Ihrer Erlaubnis).
-source_sha: "ae3d76e2f6ad35aeea01fa4401cb8b4e99886796950b64a094af84fcd580cf2d"
+source_sha: ae3d76e2f6ad35aeea01fa4401cb8b4e99886796950b64a094af84fcd580cf2d
 ---
 
 # Agent für Unternehmenswissen
 
 Der **Agent für Unternehmenswissen** (der Experten-RAG-Agent) ist der
-[Assistent für Dokumentenintelligenz](../5_document_intelligence_assistant/) mit einem menschlichen Sicherheitsnetz. Er beantwortet Fragen
-aus Ihren Dokumenten genau wie der Assistent für Dokumentenintelligenz – und wenn er keine ausreichend gute Antwort findet,
-gibt er nicht auf, sondern bietet an, **einen menschlichen Experten zu fragen**. Mit der Erlaubnis des Benutzers
-übergibt er die Frage an einen
-[Expertenkoordinator-Agenten](../9_expert_coordinator_agent/), der eine Person auf Slack oder Teams kontaktiert und dem Benutzer
-dann mit der Antwort des Experten antwortet.
+[Assistent für Dokumentenintelligenz](../5_document_intelligence_assistant/) mit einem menschlichen Sicherheitsnetz. Er
+beantwortet Fragen aus Ihren Dokumenten genau wie der Assistent für Dokumentenintelligenz – und wenn er keine
+ausreichend gute Antwort findet, gibt er nicht auf, sondern bietet an, **einen menschlichen Experten zu fragen**. Mit
+der Erlaubnis des Benutzers übergibt er die Frage an einen
+[Expertenkoordinator-Agenten](../9_expert_coordinator_agent/), der eine Person auf Slack oder Teams kontaktiert und dem
+Benutzer dann mit der Antwort des Experten antwortet.
 
-Er kombiniert zwei Stärken: die Geschwindigkeit und Skalierbarkeit dokumentenbasierter Antworten sowie die Zuverlässigkeit
-eines Menschen für Fragen, die Ihre Dokumente noch nicht abdecken. Und da Expertenantworten im Organisationsgedächtnis
-erfasst werden, benötigt der Agent den Menschen allmählich seltener.
+Er kombiniert zwei Stärken: die Geschwindigkeit und Skalierbarkeit dokumentenbasierter Antworten sowie die
+Zuverlässigkeit eines Menschen für Fragen, die Ihre Dokumente noch nicht abdecken. Und da Expertenantworten im
+Organisationsgedächtnis erfasst werden, benötigt der Agent den Menschen allmählich seltener.
 
 ::: tip Wann dieser Agent nützlich ist
-Nutzen Sie ihn, wenn die Dokumentenabdeckung unvollständig ist und eine falsche oder fehlende Antwort wichtig ist – Sie würden
-lieber einen Menschen einbeziehen, als dass der Agent rät oder sagt „Ich weiss es nicht“. Wenn Ihre Dokumente das Thema
-vollständig abdecken, ist der einfache
+Nutzen Sie ihn, wenn die Dokumentenabdeckung unvollständig ist und eine falsche oder fehlende Antwort wichtig ist – Sie
+würden lieber einen Menschen einbeziehen, als dass der Agent rät oder sagt „Ich weiss es nicht“. Wenn Ihre Dokumente das
+Thema vollständig abdecken, ist der einfache
 [Assistent für Dokumentenintelligenz](../5_document_intelligence_assistant/) einfacher und ausreichend.
 :::
 
 ## Was er tut
 
-Er führt zuerst den vollständigen RAG-Workflow aus; der Expertenpfad öffnet sich nur, wenn der abgerufene Kontext
-nicht ausreicht, um die Frage zu beantworten.
+Er führt zuerst den vollständigen RAG-Workflow aus; der Expertenpfad öffnet sich nur, wenn der abgerufene Kontext nicht
+ausreicht, um die Frage zu beantworten.
 
 ```mermaid
 flowchart LR
@@ -40,35 +40,37 @@ flowchart LR
     F --> G[Answer using<br/>the expert's reply]
 ```
 
-1. **Versuch, aus Dokumenten zu antworten.** Er führt denselben Workflow aus (retrieve → rerank → check-sufficiency) wie der
-   [Assistent für Dokumentenintelligenz](../5_document_intelligence_assistant/). Wenn die Dokumente ausreichen, antwortet er
-   mit Zitaten und stoppt – identisch mit einer normalen RAG-Antwort.
+1. **Versuch, aus Dokumenten zu antworten.** Er führt denselben Workflow aus (retrieve → rerank → check-sufficiency) wie
+   der [Assistent für Dokumentenintelligenz](../5_document_intelligence_assistant/). Wenn die Dokumente ausreichen,
+   antwortet er mit Zitaten und stoppt – identisch mit einer normalen RAG-Antwort.
 2. **Eine Lücke erkennen.** Wenn die Prüfung der Kontext-Ausreichendheit entscheidet, dass das abgerufene Material nicht
    ausreicht, beginnt der Expertenpfad.
 3. **Die Erlaubnis des Benutzers einholen.** Der Agent teilt dem Benutzer mit, dass er die Antwort nicht hat, und fragt,
-   ob er einen Experten konsultieren darf. Ohne Zustimmung wird nichts weitergeleitet. Lehnt der Benutzer ab,
-   antwortet der Agent einfach mit dem, was er hat.
+   ob er einen Experten konsultieren darf. Ohne Zustimmung wird nichts weitergeleitet. Lehnt der Benutzer ab, antwortet
+   der Agent einfach mit dem, was er hat.
 4. **Einen Experten konsultieren.** Bei Zustimmung delegiert er die Frage an den konfigurierten
-   [Expertenkoordinator-Agenten](../9_expert_coordinator_agent/), der sie einem Menschen auf Slack oder Teams übermittelt. Dem Benutzer wird
-   mitgeteilt, dass seine Frage weitergeleitet wurde.
+   [Expertenkoordinator-Agenten](../9_expert_coordinator_agent/), der sie einem Menschen auf Slack oder Teams
+   übermittelt. Dem Benutzer wird mitgeteilt, dass seine Frage weitergeleitet wurde.
 5. **Mit der Antwort des Experten antworten.** Wenn der Experte antwortet, wird diese Antwort als Kontext wieder
    aufgenommen und der Agent erstellt die endgültige Antwort. (Der Expertenkoordinator speichert die Antwort auch im
    Organisationsgedächtnis, sodass der Agent sie beim nächsten Mal direkt beantworten kann.)
 
 ::: tip Zwei Arten menschlicher Beteiligung
 Der Agent für Unternehmenswissen nutzt **Human-in-the-Loop** für die *Zustimmung* des Benutzers („Darf ich einen
-Experten fragen?“) und der Expertenkoordinator, an den er delegiert, nutzt **Bot-in-the-Loop**, um den *Experten*
-über einen Chat-Kanal zu erreichen. Zusammen halten sie die Eskalation transparent: Der Benutzer stimmt immer zu, bevor
-ein Kollege kontaktiert wird.
+Experten fragen?“) und der Expertenkoordinator, an den er delegiert, nutzt **Bot-in-the-Loop**, um den *Experten* über
+einen Chat-Kanal zu erreichen. Zusammen halten sie die Eskalation transparent: Der Benutzer stimmt immer zu, bevor ein
+Kollege kontaktiert wird.
 :::
 
 ## Was er *nicht* tut
 
 - **Er kontaktiert Experten nicht direkt.** Jeglicher menschlicher Kontakt erfolgt über den
-  [Expertenkoordinator-Agenten](../9_expert_coordinator_agent/), an den er delegiert – dieser muss separat konfiguriert werden.
+  [Expertenkoordinator-Agenten](../9_expert_coordinator_agent/), an den er delegiert – dieser muss separat konfiguriert
+  werden.
 - **Er eskaliert nicht ohne Zustimmung.** Der Benutzer wird immer zuerst gefragt; eine Ablehnung hält die Konversation
   rein dokumentenbasiert.
-- **Er ingestiert keine Dokumente.** Wie alle RAG-Agenten liest er das, was eine [Pipeline](../../6_pipelines/) indiziert hat.
+- **Er ingestiert keine Dokumente.** Wie alle RAG-Agenten liest er das, was eine [Pipeline](../../6_pipelines/)
+  indiziert hat.
 
 ## Bevor Sie beginnen: Voraussetzungen
 
@@ -78,10 +80,10 @@ Dieser Agent baut auf zwei anderen auf, daher müssen beide Konfigurationen zuer
    Embedding-Modell und ein Chat-Modell – siehe die
    [Voraussetzungen](../5_document_intelligence_assistant/#before-you-start-prerequisites) dieses Agenten. Der Agent für
    Unternehmenswissen teilt sich dieselbe Retrieval-Konfiguration.
-2. **Ein konfiguriertes Expertenkoordinator-Agentenprofil.** Das Eskalationsziel muss bereits existieren und funktionieren,
-   einschliesslich des verbundenen Teams-/Slack-Bots. Richten Sie zuerst den
-   [Expertenkoordinator-Agenten](../9_expert_coordinator_agent/) ein und testen Sie ihn – der
-   Agent für Unternehmenswissen ist ohne einen zur Delegation nutzlos.
+2. **Ein konfiguriertes Expertenkoordinator-Agentenprofil.** Das Eskalationsziel muss bereits existieren und
+   funktionieren, einschliesslich des verbundenen Teams-/Slack-Bots. Richten Sie zuerst den
+   [Expertenkoordinator-Agenten](../9_expert_coordinator_agent/) ein und testen Sie ihn – der Agent für
+   Unternehmenswissen ist ohne einen zur Delegation nutzlos.
 
 ## Einrichtung
 
@@ -95,10 +97,12 @@ Der Agent wird als **Blueprint** geliefert, aus dem Sie konfigurierte **Profile*
 3. **Aktivieren Sie den Kontext-Ausreichendheits-Guard.** Die Experteneskalation wird durch die Ausreichendheitsprüfung
    ausgelöst, die entscheidet, dass der Kontext nicht ausreicht – daher sollte dieser Guard aktiviert sein, sonst wird
    der Agent nicht eskalieren.
-4. **Wählen Sie den Experten-Agenten.** Wählen Sie das [Expertenkoordinator-Agentenprofil](../9_expert_coordinator_agent/)
-   aus, an das eskaliert werden soll. Dies ist die einzige Einstellung, die für diesen Agenten einzigartig ist.
+4. **Wählen Sie den Experten-Agenten.** Wählen Sie das
+   [Expertenkoordinator-Agentenprofil](../9_expert_coordinator_agent/) aus, an das eskaliert werden soll. Dies ist die
+   einzige Einstellung, die für diesen Agenten einzigartig ist.
 5. **Speichern und testen Sie** mit einer Frage, die Ihre Dokumente *beantworten können* (erwarten Sie eine normale
-   zitierte Antwort) und einer, die sie *nicht beantworten können* (erwarten Sie die Zustimmungsaufforderung und Eskalation).
+   zitierte Antwort) und einer, die sie *nicht beantworten können* (erwarten Sie die Zustimmungsaufforderung und
+   Eskalation).
 
 ## Konfigurationsreferenz
 
@@ -112,8 +116,8 @@ Darüber hinaus fügt er eine einzige neue Einstellung für die Eskalation hinzu
 
 ### Experteneskalation
 
-| Feld              | Typ             | Erforderlich | Beschreibung                                                                                                                                                                             |
-| ----------------- | --------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Feld               | Typ             | Erforderlich | Beschreibung                                                                                                                                                                                                                                |
+| ------------------ | --------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Experten-Agent** | Agenten-Auswahl | Ja           | Das Profil des [Expertenkoordinator-Agenten](../9_expert_coordinator_agent/), das konsultiert werden soll, wenn die Dokumente keine ausreichende Antwort liefern. Die Auswahl listet Agenten auf, die Expertenfragen entgegennehmen können. |
 
 ::: warning Kontext-Ausreichendheits-Guard aktivieren
@@ -126,12 +130,12 @@ antworten und den Expertenpfad nie erreichen – was den Zweck dieses Blueprints
 ## Bewährte Praktiken
 
 **Stellen Sie sicher, dass beide zugrunde liegenden Agenten zuerst funktionieren.** Dies ist eine Komposition aus einem
-RAG-Agenten und einem Experten-Agenten. Vergewissern Sie sich, dass Ihr Document Intelligence Setup gut antwortet und Ihr
-Expertenkoordinator einen echten Menschen erreicht, bevor Sie sie hier kombinieren.
+RAG-Agenten und einem Experten-Agenten. Vergewissern Sie sich, dass Ihr Document Intelligence Setup gut antwortet und
+Ihr Expertenkoordinator einen echten Menschen erreicht, bevor Sie sie hier kombinieren.
 
 **Aktivieren und optimieren Sie den Ausreichendheits-Guard.** Er ist der Auslöser für die Eskalation. Zu nachsichtig,
-und der Agent rät, anstatt zu fragen; zu streng, und er eskaliert triviale Fragen. Testen Sie mit echten Fragen und passen
-Sie ihn an.
+und der Agent rät, anstatt zu fragen; zu streng, und er eskaliert triviale Fragen. Testen Sie mit echten Fragen und
+passen Sie ihn an.
 
 **Richten Sie Eskalation und Memory auf denselben Namespace aus.** Damit erfasste Expertenantworten später als
 dokumentenfreie Antworten zurückkommen, muss der Expertenkoordinator in einen Namespace schreiben, aus dem das

--- a/docs/docs/2_platform/5_agents/9_expert_coordinator_agent/index.de.md
+++ b/docs/docs/2_platform/5_agents/9_expert_coordinator_agent/index.de.md
@@ -139,10 +139,10 @@ Wählen Sie die Plattform aus und füllen Sie dann die Felder dieser Plattform a
 
 ### Sprachmodell
 
-| Feld                                                                                      | Typ           | Standard | Beschreibung                                                                                                                              |
-| :---------------------------------------------------------------------------------------- | :------------ | :------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
-| **Modell**                                                                                | Modellauswahl | —        | Das Chat-Modell, das verwendet wird, um die Vollständigkeit der Antwort zu beurteilen und Nachfragen zu verfassen. Erforderlich.          |
-| **Temperatur**                                                                            | Zahl          | `0.0`    | Niedrig halten — dies ist eine Beurteilungs-/Extraktionsaufgabe, keine kreative. Bereich 0.0–2.0.                                         |
+| Feld                                                                                      | Typ           | Standard | Beschreibung                                                                                                                            |
+| :---------------------------------------------------------------------------------------- | :------------ | :------- | :-------------------------------------------------------------------------------------------------------------------------------------- |
+| **Modell**                                                                                | Modellauswahl | —        | Das Chat-Modell, das verwendet wird, um die Vollständigkeit der Antwort zu beurteilen und Nachfragen zu verfassen. Erforderlich.        |
+| **Temperatur**                                                                            | Zahl          | `0.0`    | Niedrig halten — dies ist eine Beurteilungs-/Extraktionsaufgabe, keine kreative. Bereich 0.0–2.0.                                       |
 | **Log-Wahrscheinlichkeiten zurückgeben** / **Top Log-Wahrscheinlichkeiten** / **Timeout** | —             | —        | Standard-Sprachmodelloptionen, wie auf der Seite [Document Intelligence Assistant](../5_document_intelligence_assistant/#sprachmodell). |
 
 ### Organisationsgedächtnis

--- a/docs/docs/3_sdk/5_advanced_topics/5_extending_the_ui/index.de.md
+++ b/docs/docs/3_sdk/5_advanced_topics/5_extending_the_ui/index.de.md
@@ -5,122 +5,235 @@ source_sha: eb206c9118f83ca12d29616aa160088adec48f59c055247c5a189b039390633d
 
 # Erweiterbarkeit und Anpassung
 
-Die Benutzeroberfläche der Swiss AI Hub Suite ist auf Erweiterbarkeit ausgelegt. Dies ermöglicht Unternehmen, massgeschneiderte KI-Funktionen hinzuzufügen, proprietäre Systeme zu integrieren und die Plattform an spezifische Geschäftsanforderungen anzupassen – und das alles, ohne das einheitliche Suite-Erlebnis zu beeinträchtigen oder den Kerncode der Plattform zu modifizieren.
+Die Benutzeroberfläche der Swiss AI Hub Suite ist auf Erweiterbarkeit ausgelegt. Dies ermöglicht Unternehmen,
+massgeschneiderte KI-Funktionen hinzuzufügen, proprietäre Systeme zu integrieren und die Plattform an spezifische
+Geschäftsanforderungen anzupassen – und das alles, ohne das einheitliche Suite-Erlebnis zu beeinträchtigen oder den
+Kerncode der Plattform zu modifizieren.
 
 ::: tip Hinweis zur Lizenzierung
-Das hier beschriebene Erweiterungsmodell – benutzerdefinierte Services und Ihre eigenen Komponenten, die *auf* der Plattform aufgebaut sind – lässt Ihren Service-Code unter der Lizenz Ihrer Wahl; Sie modifizieren die Plattform selbst nicht. Die gebündelte UI (`packages/web`) ist jedoch unter der Lizenz **AGPL-3.0** lizenziert. Wenn Sie diese UI selbst modifizieren und als Netzwerkdienst anbieten, verlangt AGPL-3.0 von Ihnen, diese UI-Modifikationen unter derselben Lizenz zu veröffentlichen. Weitere Details finden Sie unter [Warum Backend und UI unterschiedliche Lizenzen verwenden](../../../4_ecosystem/3_certification/2_sdk_licensing/) und [LICENSES.md](https://github.com/bbvch-ai/aihub-core/blob/main/LICENSES.md).
+Das hier beschriebene Erweiterungsmodell – benutzerdefinierte Services und Ihre eigenen Komponenten, die *auf* der
+Plattform aufgebaut sind – lässt Ihren Service-Code unter der Lizenz Ihrer Wahl; Sie modifizieren die Plattform selbst
+nicht. Die gebündelte UI (`packages/web`) ist jedoch unter der Lizenz **AGPL-3.0** lizenziert. Wenn Sie diese UI selbst
+modifizieren und als Netzwerkdienst anbieten, verlangt AGPL-3.0 von Ihnen, diese UI-Modifikationen unter derselben
+Lizenz zu veröffentlichen. Weitere Details finden Sie unter
+[Warum Backend und UI unterschiedliche Lizenzen verwenden](../../../4_ecosystem/3_certification/2_sdk_licensing/) und
+[LICENSES.md](https://github.com/bbvch-ai/aihub-core/blob/main/LICENSES.md).
 :::
 
 ## Architektonische Grundlagen für die Erweiterbarkeit
 
-Die Erweiterbarkeit der Suite resultiert aus bewussten Architektur-Entscheidungen, die Erweiterungspunkte von der Kerninfrastruktur trennen. Dies ermöglicht Unternehmen, Funktionen hinzuzufügen, ohne die Codebasis zu forken oder benutzerdefinierte Plattformversionen zu erstellen.
+Die Erweiterbarkeit der Suite resultiert aus bewussten Architektur-Entscheidungen, die Erweiterungspunkte von der
+Kerninfrastruktur trennen. Dies ermöglicht Unternehmen, Funktionen hinzuzufügen, ohne die Codebasis zu forken oder
+benutzerdefinierte Plattformversionen zu erstellen.
 
-**Plugin-Architektur**: Services integrieren sich in die Suite über ein klar definiertes Controller-Muster statt durch direkte Code-Integration. Unternehmen, die benutzerdefinierte Services implementieren, folgen denselben Mustern wie native Services, wodurch sichergestellt wird, dass ihre Erweiterungen automatisch in die Infrastruktur für Authentifizierung, Berechtigungen, Internationalisierung und Observability integriert werden.
+**Plugin-Architektur**: Services integrieren sich in die Suite über ein klar definiertes Controller-Muster statt durch
+direkte Code-Integration. Unternehmen, die benutzerdefinierte Services implementieren, folgen denselben Mustern wie
+native Services, wodurch sichergestellt wird, dass ihre Erweiterungen automatisch in die Infrastruktur für
+Authentifizierung, Berechtigungen, Internationalisierung und Observability integriert werden.
 
-**Standard-Integrationsverträge**: Das Controller-Muster definiert klare Verträge für die Service-Integration. Benutzerdefinierte Services implementieren diese Verträge, deklarieren ihre Metadaten (Name, Beschreibung, Icon, Berechtigungen) und binden ihre API-Endpunkte ein. Die Suite erkennt und integriert konforme Controller automatisch, ohne dass Modifikationen an der Kernplattform erforderlich sind.
+**Standard-Integrationsverträge**: Das Controller-Muster definiert klare Verträge für die Service-Integration.
+Benutzerdefinierte Services implementieren diese Verträge, deklarieren ihre Metadaten (Name, Beschreibung, Icon,
+Berechtigungen) und binden ihre API-Endpunkte ein. Die Suite erkennt und integriert konforme Controller automatisch,
+ohne dass Modifikationen an der Kernplattform erforderlich sind.
 
-**Trennung von Kern und Erweiterung**: Die Plattform trennt explizit die Kerninfrastruktur (Authentifizierung, Autorisierung, Messaging, Persistenz) von den Service-Implementierungen. Erweiterungen nutzen die Kerninfrastruktur, ohne sie zu modifizieren, wodurch sichergestellt wird, dass Plattform-Updates benutzerdefinierte Services nicht beeinträchtigen und benutzerdefinierte Services die Stabilität der Kernplattform nicht gefährden.
+**Trennung von Kern und Erweiterung**: Die Plattform trennt explizit die Kerninfrastruktur (Authentifizierung,
+Autorisierung, Messaging, Persistenz) von den Service-Implementierungen. Erweiterungen nutzen die Kerninfrastruktur,
+ohne sie zu modifizieren, wodurch sichergestellt wird, dass Plattform-Updates benutzerdefinierte Services nicht
+beeinträchtigen und benutzerdefinierte Services die Stabilität der Kernplattform nicht gefährden.
 
-**Versionskompatibilität**: Der Controller-Integrationsvertrag gewährleistet Abwärtskompatibilität über verschiedene Plattformversionen hinweg. Services, die für eine Plattformversion implementiert wurden, funktionieren weiterhin, wenn die Plattform aktualisiert wird, was die Investition des Unternehmens in benutzerdefinierte Funktionen schützt.
+**Versionskompatibilität**: Der Controller-Integrationsvertrag gewährleistet Abwärtskompatibilität über verschiedene
+Plattformversionen hinweg. Services, die für eine Plattformversion implementiert wurden, funktionieren weiterhin, wenn
+die Plattform aktualisiert wird, was die Investition des Unternehmens in benutzerdefinierte Funktionen schützt.
 
 ## Implementierung benutzerdefinierter Services
 
-Unternehmen können benutzerdefinierte Services implementieren, die als First-Class-Citizens in der Suite-Oberfläche erscheinen und von nativen Funktionen nicht zu unterscheiden sind.
+Unternehmen können benutzerdefinierte Services implementieren, die als First-Class-Citizens in der Suite-Oberfläche
+erscheinen und von nativen Funktionen nicht zu unterscheiden sind.
 
-**Controller-Implementierung**: Benutzerdefinierte Services implementieren eine Controller-Klasse, die vom Basis-Controller der Plattform erbt. Dieser Controller definiert die API-Endpunkte des Services, Berechtigungsanforderungen und Metadaten. Die Implementierung folgt Standard-FastAPI-Mustern, die Python-Entwicklern vertraut sind.
+**Controller-Implementierung**: Benutzerdefinierte Services implementieren eine Controller-Klasse, die vom
+Basis-Controller der Plattform erbt. Dieser Controller definiert die API-Endpunkte des Services,
+Berechtigungsanforderungen und Metadaten. Die Implementierung folgt Standard-FastAPI-Mustern, die Python-Entwicklern
+vertraut sind.
 
-**Frontend-Komponentenentwicklung**: Services, die benutzerdefinierte Benutzeroberflächen benötigen, implementieren Frontend-Komponenten unter Verwendung desselben Technologie-Stacks wie die native Schnittstelle – Nuxt 3, Vue 3 und PrimeVue. Diese Komponenten greifen über automatisch generierte TypeScript-Clients auf die API-Endpunkte des benutzerdefinierten Controllers zu, wodurch Typsicherheit über die Frontend-Backend-Grenze hinweg gewährleistet wird.
+**Frontend-Komponentenentwicklung**: Services, die benutzerdefinierte Benutzeroberflächen benötigen, implementieren
+Frontend-Komponenten unter Verwendung desselben Technologie-Stacks wie die native Schnittstelle – Nuxt 3, Vue 3 und
+PrimeVue. Diese Komponenten greifen über automatisch generierte TypeScript-Clients auf die API-Endpunkte des
+benutzerdefinierten Controllers zu, wodurch Typsicherheit über die Frontend-Backend-Grenze hinweg gewährleistet wird.
 
-**Automatische Suite-Integration**: Wenn ein benutzerdefinierter Controller bei der Plattform registriert wird, erscheint er automatisch in der dynamischen Service-Erkennung der Suite. Benutzer mit den entsprechenden Berechtigungen sehen den benutzerdefinierten Service in ihrer Seitenleisten-Navigation neben den nativen Services. Das Icon, der Name und die Beschreibung des benutzerdefinierten Services integrieren sich nahtlos in die einheitliche Benutzeroberfläche.
+**Automatische Suite-Integration**: Wenn ein benutzerdefinierter Controller bei der Plattform registriert wird,
+erscheint er automatisch in der dynamischen Service-Erkennung der Suite. Benutzer mit den entsprechenden Berechtigungen
+sehen den benutzerdefinierten Service in ihrer Seitenleisten-Navigation neben den nativen Services. Das Icon, der Name
+und die Beschreibung des benutzerdefinierten Services integrieren sich nahtlos in die einheitliche Benutzeroberfläche.
 
-**Zugriff auf gemeinsame Infrastruktur**: Benutzerdefinierte Services erhalten automatisch Zugriff auf die Plattform-Infrastruktur – NATS Messaging für ereignisgesteuerte Kommunikation, MongoDB Persistenz für die Datenspeicherung, Authentifizierung/Autorisierung für Sicherheit, Internationalisierung für mehrsprachige Unterstützung und Observability-Tools für Monitoring und Tracing.
+**Zugriff auf gemeinsame Infrastruktur**: Benutzerdefinierte Services erhalten automatisch Zugriff auf die
+Plattform-Infrastruktur – NATS Messaging für ereignisgesteuerte Kommunikation, MongoDB Persistenz für die
+Datenspeicherung, Authentifizierung/Autorisierung für Sicherheit, Internationalisierung für mehrsprachige Unterstützung
+und Observability-Tools für Monitoring und Tracing.
 
 ## Anwendungsfälle für Erweiterungen
 
-Unternehmen implementieren verschiedene Arten von benutzerdefinierten Services, um spezifische Geschäftsanforderungen zu erfüllen.
+Unternehmen implementieren verschiedene Arten von benutzerdefinierten Services, um spezifische Geschäftsanforderungen zu
+erfüllen.
 
-**Branchenspezifische Agents**: Ein Finanzdienstleistungsunternehmen könnte benutzerdefinierte Agents für die Analyse der Einhaltung gesetzlicher Vorschriften, Finanzmodellierung oder Risikobewertung implementieren. Diese Agents integrieren sich in den Agent-Service der Suite und erscheinen neben nativen Agents mit branchenspezifischen Workflows und Wissensintegration.
+**Branchenspezifische Agents**: Ein Finanzdienstleistungsunternehmen könnte benutzerdefinierte Agents für die Analyse
+der Einhaltung gesetzlicher Vorschriften, Finanzmodellierung oder Risikobewertung implementieren. Diese Agents
+integrieren sich in den Agent-Service der Suite und erscheinen neben nativen Agents mit branchenspezifischen Workflows
+und Wissensintegration.
 
-**Proprietäre Systemintegration**: Unternehmen können Services implementieren, die den Swiss AI Hub mit proprietären Unternehmenssystemen – ERP-Systemen, kundenspezifischen Datenbanken, Legacy-Anwendungen – verbinden. Diese Integrations-Services könnten spezialisierte Agents bereitstellen, die mit proprietären Systemen interagieren, oder Monitoring-Schnittstellen für KI-gesteuerte Automatisierung innerhalb dieser Systeme anbieten.
+**Proprietäre Systemintegration**: Unternehmen können Services implementieren, die den Swiss AI Hub mit proprietären
+Unternehmenssystemen – ERP-Systemen, kundenspezifischen Datenbanken, Legacy-Anwendungen – verbinden. Diese
+Integrations-Services könnten spezialisierte Agents bereitstellen, die mit proprietären Systemen interagieren, oder
+Monitoring-Schnittstellen für KI-gesteuerte Automatisierung innerhalb dieser Systeme anbieten.
 
-**Benutzerdefinierte Analyse-Dashboards**: Unternehmen mit spezifischen Berichts- oder Analyseanforderungen können benutzerdefinierte Dashboard-Services implementieren, die Daten von Agents, Prozessen und Wissenssystemen aggregieren und unternehmensspezifische Metriken und Visualisierungen präsentieren.
+**Benutzerdefinierte Analyse-Dashboards**: Unternehmen mit spezifischen Berichts- oder Analyseanforderungen können
+benutzerdefinierte Dashboard-Services implementieren, die Daten von Agents, Prozessen und Wissenssystemen aggregieren
+und unternehmensspezifische Metriken und Visualisierungen präsentieren.
 
-**Spezialisierte Workflows**: Prozessintensive Unternehmen könnten benutzerdefinierte Prozessmanagement-Schnittstellen implementieren, die auf spezifische Workflow-Typen zugeschnitten sind – Dokumenten-Genehmigungs-Workflows, Compliance-Verifizierungsprozesse, mehrstufige Überprüfungsverfahren. Diese benutzerdefinierten Schnittstellen nutzen die Prozessautomatisierungs-Infrastruktur der Plattform, während sie domänenspezifische Ansichten präsentieren.
+**Spezialisierte Workflows**: Prozessintensive Unternehmen könnten benutzerdefinierte Prozessmanagement-Schnittstellen
+implementieren, die auf spezifische Workflow-Typen zugeschnitten sind – Dokumenten-Genehmigungs-Workflows,
+Compliance-Verifizierungsprozesse, mehrstufige Überprüfungsverfahren. Diese benutzerdefinierten Schnittstellen nutzen
+die Prozessautomatisierungs-Infrastruktur der Plattform, während sie domänenspezifische Ansichten präsentieren.
 
-**Integration externer KI-Modelle**: Unternehmen, die proprietäre oder spezialisierte KI-Modelle verwenden, können benutzerdefinierte Modellintegrations-Services implementieren, die diese Modelle über die Suite zugänglich machen, wodurch Agents unternehmensspezifische KI-Funktionen neben Standardmodellen nutzen können.
+**Integration externer KI-Modelle**: Unternehmen, die proprietäre oder spezialisierte KI-Modelle verwenden, können
+benutzerdefinierte Modellintegrations-Services implementieren, die diese Modelle über die Suite zugänglich machen,
+wodurch Agents unternehmensspezifische KI-Funktionen neben Standardmodellen nutzen können.
 
 ## Workflow für die Erweiterungsentwicklung
 
-Die Plattform bietet umfassende Tools und Dokumentationen zur Unterstützung der Entwicklung benutzerdefinierter Services.
+Die Plattform bietet umfassende Tools und Dokumentationen zur Unterstützung der Entwicklung benutzerdefinierter
+Services.
 
-**Entwicklungsumgebung**: Unternehmen richten lokale Entwicklungsumgebungen ein, die Produktions-Deployments widerspiegeln. Dies ermöglicht die Entwicklung und das Testen benutzerdefinierter Services, ohne Produktionssysteme zu beeinträchtigen. Docker Compose-Konfigurationen stellen die gesamte erforderliche Infrastruktur (Datenbanken, Message Buses, Observability-Tools) für die lokale Entwicklung bereit.
+**Entwicklungsumgebung**: Unternehmen richten lokale Entwicklungsumgebungen ein, die Produktions-Deployments
+widerspiegeln. Dies ermöglicht die Entwicklung und das Testen benutzerdefinierter Services, ohne Produktionssysteme zu
+beeinträchtigen. Docker Compose-Konfigurationen stellen die gesamte erforderliche Infrastruktur (Datenbanken, Message
+Buses, Observability-Tools) für die lokale Entwicklung bereit.
 
-**Code-Generierung**: Die Plattform bietet Code-Generatoren, die neue Services mit der korrekten Struktur, Boilerplate-Code und Integrationsmustern gerüsten. Entwickler beginnen mit funktionierenden Service-Vorlagen, anstatt von Grund auf neu zu entwickeln, was die Entwicklung beschleunigt und die Einhaltung von Plattform-Konventionen sicherstellt.
+**Code-Generierung**: Die Plattform bietet Code-Generatoren, die neue Services mit der korrekten Struktur,
+Boilerplate-Code und Integrationsmustern gerüsten. Entwickler beginnen mit funktionierenden Service-Vorlagen, anstatt
+von Grund auf neu zu entwickeln, was die Entwicklung beschleunigt und die Einhaltung von Plattform-Konventionen
+sicherstellt.
 
-**Testinfrastruktur**: Benutzerdefinierte Services nutzen dieselben Test-Frameworks wie native Services. Die Plattform stellt Test-Runner bereit, die die Suite-Umgebung simulieren und so ein umfassendes Testen benutzerdefinierter Services vor dem Deployment ermöglichen.
+**Testinfrastruktur**: Benutzerdefinierte Services nutzen dieselben Test-Frameworks wie native Services. Die Plattform
+stellt Test-Runner bereit, die die Suite-Umgebung simulieren und so ein umfassendes Testen benutzerdefinierter Services
+vor dem Deployment ermöglichen.
 
-**Dokumentationsvorlagen**: Die Plattform enthält Dokumentationsvorlagen und Beispiele, die die Implementierung benutzerdefinierter Services, die Frontend-Komponentenentwicklung, das API-Design und die Suite-Integration demonstrieren. Diese Ressourcen beschleunigen die Entwicklung, indem sie funktionierende Beispiele gängiger Muster bereitstellen.
+**Dokumentationsvorlagen**: Die Plattform enthält Dokumentationsvorlagen und Beispiele, die die Implementierung
+benutzerdefinierter Services, die Frontend-Komponentenentwicklung, das API-Design und die Suite-Integration
+demonstrieren. Diese Ressourcen beschleunigen die Entwicklung, indem sie funktionierende Beispiele gängiger Muster
+bereitstellen.
 
 ## Deployment und Distribution
 
-Benutzerdefinierte Services werden zusammen mit der nativen Plattform deployed und werden so zu integralen Bestandteilen der Swiss AI Hub-Installationen von Unternehmen.
+Benutzerdefinierte Services werden zusammen mit der nativen Plattform deployed und werden so zu integralen Bestandteilen
+der Swiss AI Hub-Installationen von Unternehmen.
 
-**Container-Verpackung**: Benutzerdefinierte Services werden als Docker-Container nach den Plattformkonventionen verpackt. Diese Container werden zusammen mit nativen Plattformkomponenten deployed, was eine unabhängige Skalierung und Versionsverwaltung ermöglicht.
+**Container-Verpackung**: Benutzerdefinierte Services werden als Docker-Container nach den Plattformkonventionen
+verpackt. Diese Container werden zusammen mit nativen Plattformkomponenten deployed, was eine unabhängige Skalierung und
+Versionsverwaltung ermöglicht.
 
-**Konfigurationsmanagement**: Benutzerdefinierte Services nutzen das Konfigurationsmanagement-System der Plattform und lesen Einstellungen aus Umgebungsvariablen und Konfigurationsdateien. Diese Integration ermöglicht konsistente Konfigurationspraktiken über native und benutzerdefinierte Services hinweg.
+**Konfigurationsmanagement**: Benutzerdefinierte Services nutzen das Konfigurationsmanagement-System der Plattform und
+lesen Einstellungen aus Umgebungsvariablen und Konfigurationsdateien. Diese Integration ermöglicht konsistente
+Konfigurationspraktiken über native und benutzerdefinierte Services hinweg.
 
-**Deployment-Orchestrierung**: Unternehmen erweitern die Plattform-Deployment-Konfigurationen (Docker Compose-Dateien, Kubernetes-Manifeste), um benutzerdefinierte Services einzuschliessen. Deployment-Tools behandeln benutzerdefinierte Services identisch mit nativen Services und wenden dieselben Health Checks, Monitoring- und Lifecycle-Management-Verfahren an.
+**Deployment-Orchestrierung**: Unternehmen erweitern die Plattform-Deployment-Konfigurationen (Docker Compose-Dateien,
+Kubernetes-Manifeste), um benutzerdefinierte Services einzuschliessen. Deployment-Tools behandeln benutzerdefinierte
+Services identisch mit nativen Services und wenden dieselben Health Checks, Monitoring- und
+Lifecycle-Management-Verfahren an.
 
-**Update-Unabhängigkeit**: Benutzerdefinierte Services können unabhängig von der nativen Plattform aktualisiert werden (innerhalb der Garantien für Versionskompatibilität). Unternehmen können neue benutzerdefinierte Service-Versionen deployen, ohne vollständige Plattform-Updates zu benötigen, was eine agile Entwicklung benutzerdefinierter Funktionen ermöglicht.
+**Update-Unabhängigkeit**: Benutzerdefinierte Services können unabhängig von der nativen Plattform aktualisiert werden
+(innerhalb der Garantien für Versionskompatibilität). Unternehmen können neue benutzerdefinierte Service-Versionen
+deployen, ohne vollständige Plattform-Updates zu benötigen, was eine agile Entwicklung benutzerdefinierter Funktionen
+ermöglicht.
 
 ## Governance und Qualität
 
-Während die Plattform Erweiterbarkeit ermöglicht, behalten Unternehmen die Kontrolle darüber, welche benutzerdefinierten Services deployed werden und wie sie integriert werden.
+Während die Plattform Erweiterbarkeit ermöglicht, behalten Unternehmen die Kontrolle darüber, welche benutzerdefinierten
+Services deployed werden und wie sie integriert werden.
 
-**Berechtigungssteuerung**: Benutzerdefinierte Services deklarieren Berechtigungsanforderungen wie native Services. Administratoren steuern den Zugriff von Benutzern auf benutzerdefinierte Services über dieselben Rollen- und Berechtigungsmanagement-Schnittstellen, die für native Funktionen verwendet werden.
+**Berechtigungssteuerung**: Benutzerdefinierte Services deklarieren Berechtigungsanforderungen wie native Services.
+Administratoren steuern den Zugriff von Benutzern auf benutzerdefinierte Services über dieselben Rollen- und
+Berechtigungsmanagement-Schnittstellen, die für native Funktionen verwendet werden.
 
-**Qualitätsstandards**: Unternehmen können Qualitätstore für das Deployment benutzerdefinierter Services etablieren – Anforderungen an Code-Reviews, Teststandards, Sicherheitsaudits, Performance-Benchmarks. Die Erweiterbarkeit der Plattform schreibt keine niedrigeren Standards für benutzerdefinierte Services vor.
+**Qualitätsstandards**: Unternehmen können Qualitätstore für das Deployment benutzerdefinierter Services etablieren –
+Anforderungen an Code-Reviews, Teststandards, Sicherheitsaudits, Performance-Benchmarks. Die Erweiterbarkeit der
+Plattform schreibt keine niedrigeren Standards für benutzerdefinierte Services vor.
 
-**Service-Registry**: Unternehmen behalten über dieselben Monitoring- und Management-Schnittstellen, die für native Services verwendet werden, den Überblick über deployed benutzerdefinierte Services. Benutzerdefinierte Services melden den Zustand, stellen Metriken bereit und generieren Audit-Logs identisch mit nativen Funktionen.
+**Service-Registry**: Unternehmen behalten über dieselben Monitoring- und Management-Schnittstellen, die für native
+Services verwendet werden, den Überblick über deployed benutzerdefinierte Services. Benutzerdefinierte Services melden
+den Zustand, stellen Metriken bereit und generieren Audit-Logs identisch mit nativen Funktionen.
 
-**Namespace-Isolation**: Unternehmen können Namespace-Isolation implementieren, bei der benutzerdefinierte Services für verschiedene Organisationseinheiten sich nicht gegenseitig stören. Das Berechtigungssystem stellt angemessene Zugriffsbarrieren sicher.
+**Namespace-Isolation**: Unternehmen können Namespace-Isolation implementieren, bei der benutzerdefinierte Services für
+verschiedene Organisationseinheiten sich nicht gegenseitig stören. Das Berechtigungssystem stellt angemessene
+Zugriffsbarrieren sicher.
 
 ## Community- und Ökosystem-Potenzial
 
-Die Erweiterbarkeitsarchitektur ermöglicht die potenzielle Entwicklung eines Ökosystems rund um die Swiss AI Hub Plattform.
+Die Erweiterbarkeitsarchitektur ermöglicht die potenzielle Entwicklung eines Ökosystems rund um die Swiss AI Hub
+Plattform.
 
-**Geteilte Erweiterungen**: Unternehmen könnten benutzerdefinierte Services mit Branchenkollegen teilen, die ähnliche Anforderungen haben. Ein benutzerdefinierter Service für die Einhaltung gesetzlicher Vorschriften im Schweizer Bankwesen könnte mehreren Finanzinstituten zugutekommen und die kollaborative Entwicklung fördern.
+**Geteilte Erweiterungen**: Unternehmen könnten benutzerdefinierte Services mit Branchenkollegen teilen, die ähnliche
+Anforderungen haben. Ein benutzerdefinierter Service für die Einhaltung gesetzlicher Vorschriften im Schweizer Bankwesen
+könnte mehreren Finanzinstituten zugutekommen und die kollaborative Entwicklung fördern.
 
-**Partner-Ökosystem**: Technologiepartner könnten benutzerdefinierte Services entwickeln, die ihre Lösungen mit dem Swiss AI Hub integrieren. Dadurch entsteht ein Marktplatz komplementärer Funktionen, die Unternehmen je nach ihren Bedürfnissen bereitstellen können.
+**Partner-Ökosystem**: Technologiepartner könnten benutzerdefinierte Services entwickeln, die ihre Lösungen mit dem
+Swiss AI Hub integrieren. Dadurch entsteht ein Marktplatz komplementärer Funktionen, die Unternehmen je nach ihren
+Bedürfnissen bereitstellen können.
 
-**Innovationsbeschleunigung**: Durch die Ermöglichung der Entwicklung benutzerdefinierter Services erlaubt die Plattform Unternehmen, schnell auf neue Anforderungen zu reagieren, ohne auf native Plattformfunktionen warten zu müssen. Erfolgreiche benutzerdefinierte Services könnten die zukünftige Entwicklung der nativen Plattform beeinflussen.
+**Innovationsbeschleunigung**: Durch die Ermöglichung der Entwicklung benutzerdefinierter Services erlaubt die Plattform
+Unternehmen, schnell auf neue Anforderungen zu reagieren, ohne auf native Plattformfunktionen warten zu müssen.
+Erfolgreiche benutzerdefinierte Services könnten die zukünftige Entwicklung der nativen Plattform beeinflussen.
 
-**Wissensaustausch**: Die Community der Swiss AI Hub-Benutzer kann Implementierungsmuster, Best Practices und Referenzarchitekturen für gängige benutzerdefinierte Service-Typen austauschen, was die Fähigkeitsentwicklung des gesamten Ökosystems beschleunigt.
+**Wissensaustausch**: Die Community der Swiss AI Hub-Benutzer kann Implementierungsmuster, Best Practices und
+Referenzarchitekturen für gängige benutzerdefinierte Service-Typen austauschen, was die Fähigkeitsentwicklung des
+gesamten Ökosystems beschleunigt.
 
 ## Strategischer Wert für Unternehmen
 
 Die Erweiterbarkeit der Suite bietet Unternehmen, die in KI-Funktionen investieren, erhebliche strategische Vorteile.
 
-**Zukunftssichere Investition**: Während sich die KI-Technologie weiterentwickelt und neue Funktionen entstehen, können Unternehmen diese über benutzerdefinierte Services in ihr Swiss AI Hub Deployment integrieren. Die heutige Plattforminvestition bleibt relevant, während die Technologie fortschreitet.
+**Zukunftssichere Investition**: Während sich die KI-Technologie weiterentwickelt und neue Funktionen entstehen, können
+Unternehmen diese über benutzerdefinierte Services in ihr Swiss AI Hub Deployment integrieren. Die heutige
+Plattforminvestition bleibt relevant, während die Technologie fortschreitet.
 
-**Vermeidung von Vendor Lock-in**: Unternehmen können proprietäre KI-Funktionen, benutzerdefinierte Modelle oder Drittanbieter-Services neben nativen Funktionen integrieren. Diese Flexibilität verhindert die Abhängigkeit von der Feature-Roadmap oder den Technologieentscheidungen eines einzelnen Anbieters.
+**Vermeidung von Vendor Lock-in**: Unternehmen können proprietäre KI-Funktionen, benutzerdefinierte Modelle oder
+Drittanbieter-Services neben nativen Funktionen integrieren. Diese Flexibilität verhindert die Abhängigkeit von der
+Feature-Roadmap oder den Technologieentscheidungen eines einzelnen Anbieters.
 
-**Wettbewerbsdifferenzierung**: Unternehmen können KI-Funktionen implementieren, die ihre einzigartigen Geschäftsprozesse, Branchenanforderungen oder Wettbewerbsstrategien widerspiegeln. Die Suite bietet die Infrastruktur, während Unternehmen die Differenzierung steuern.
+**Wettbewerbsdifferenzierung**: Unternehmen können KI-Funktionen implementieren, die ihre einzigartigen
+Geschäftsprozesse, Branchenanforderungen oder Wettbewerbsstrategien widerspiegeln. Die Suite bietet die Infrastruktur,
+während Unternehmen die Differenzierung steuern.
 
-**Inkrementelle Investition**: Anstatt massiver kundenspezifischer Entwicklungsprojekte können Unternehmen zielgerichtete benutzerdefinierte Services implementieren, die spezifische Bedürfnisse adressieren, während sie native Funktionen für Standardanforderungen nutzen. Dies ermöglicht inkrementelle Investitionen, die auf die Wertschöpfung abgestimmt sind.
+**Inkrementelle Investition**: Anstatt massiver kundenspezifischer Entwicklungsprojekte können Unternehmen
+zielgerichtete benutzerdefinierte Services implementieren, die spezifische Bedürfnisse adressieren, während sie native
+Funktionen für Standardanforderungen nutzen. Dies ermöglicht inkrementelle Investitionen, die auf die Wertschöpfung
+abgestimmt sind.
 
-**Kontrolle über die Roadmap**: Unternehmen bestimmen, welche benutzerdefinierten Funktionen wann entwickelt werden sollen, anstatt auf Feature-Releases von Anbietern zu warten. Kritische Geschäftsanforderungen können durch kundenspezifische Entwicklung sofort adressiert werden.
+**Kontrolle über die Roadmap**: Unternehmen bestimmen, welche benutzerdefinierten Funktionen wann entwickelt werden
+sollen, anstatt auf Feature-Releases von Anbietern zu warten. Kritische Geschäftsanforderungen können durch
+kundenspezifische Entwicklung sofort adressiert werden.
 
 ## Technische Überlegungen
 
-Unternehmen, die die Entwicklung benutzerdefinierter Services planen, sollten mehrere technische Faktoren berücksichtigen.
+Unternehmen, die die Entwicklung benutzerdefinierter Services planen, sollten mehrere technische Faktoren
+berücksichtigen.
 
-**Entwicklungskompetenzen**: Die Entwicklung benutzerdefinierter Services erfordert Python-Expertise für die Backend-Implementierung und TypeScript-/Vue.js-Kenntnisse für die Frontend-Entwicklung. Unternehmen sollten den Zugang zu Entwicklern mit diesen Fähigkeiten sicherstellen oder in Schulungen investieren.
+**Entwicklungskompetenzen**: Die Entwicklung benutzerdefinierter Services erfordert Python-Expertise für die
+Backend-Implementierung und TypeScript-/Vue.js-Kenntnisse für die Frontend-Entwicklung. Unternehmen sollten den Zugang
+zu Entwicklern mit diesen Fähigkeiten sicherstellen oder in Schulungen investieren.
 
-**Wartungsaufwand**: Benutzerdefinierte Services erfordern fortlaufende Wartung – Bugfixes, Sicherheitsupdates, Kompatibilität mit der Plattformentwicklung. Unternehmen sollten langfristige Wartung planen, anstatt benutzerdefinierte Services als einmalige Entwicklungsprojekte zu behandeln.
+**Wartungsaufwand**: Benutzerdefinierte Services erfordern fortlaufende Wartung – Bugfixes, Sicherheitsupdates,
+Kompatibilität mit der Plattformentwicklung. Unternehmen sollten langfristige Wartung planen, anstatt benutzerdefinierte
+Services als einmalige Entwicklungsprojekte zu behandeln.
 
-**Testanforderungen**: Umfassende Tests sind für benutzerdefinierte Services unerlässlich, um sicherzustellen, dass sie die Plattformstabilität oder -sicherheit nicht beeinträchtigen. Unternehmen sollten in Testinfrastruktur und -praktiken investieren, die für ihr Portfolio an benutzerdefinierten Services angemessen sind.
+**Testanforderungen**: Umfassende Tests sind für benutzerdefinierte Services unerlässlich, um sicherzustellen, dass sie
+die Plattformstabilität oder -sicherheit nicht beeinträchtigen. Unternehmen sollten in Testinfrastruktur und -praktiken
+investieren, die für ihr Portfolio an benutzerdefinierten Services angemessen sind.
 
-**Dokumentation**: Benutzerdefinierte Services sollten nach denselben Standards wie native Funktionen dokumentiert werden, um sicherzustellen, dass Benutzer deren Zweck, Funktionen und Nutzungsmuster verstehen. Dieser Dokumentationsaufwand sollte in die Entwicklungsplanung einfliessen.
+**Dokumentation**: Benutzerdefinierte Services sollten nach denselben Standards wie native Funktionen dokumentiert
+werden, um sicherzustellen, dass Benutzer deren Zweck, Funktionen und Nutzungsmuster verstehen. Dieser
+Dokumentationsaufwand sollte in die Entwicklungsplanung einfliessen.
 
-Diese Erweiterbarkeitsarchitektur stellt sicher, dass die Swiss AI Hub Suite eine Grundlage für die langfristige Entwicklung von KI-Funktionen bietet. Sie ermöglicht Unternehmen, vertrauensvoll in die Plattform zu investieren, da sie wissen, dass sie diese an neue Anforderungen anpassen können, ohne das einheitliche Suite-Erlebnis zu beeinträchtigen oder Plattformmodifikationen vornehmen zu müssen, die Updates erschweren.
+Diese Erweiterbarkeitsarchitektur stellt sicher, dass die Swiss AI Hub Suite eine Grundlage für die langfristige
+Entwicklung von KI-Funktionen bietet. Sie ermöglicht Unternehmen, vertrauensvoll in die Plattform zu investieren, da sie
+wissen, dass sie diese an neue Anforderungen anpassen können, ohne das einheitliche Suite-Erlebnis zu beeinträchtigen
+oder Plattformmodifikationen vornehmen zu müssen, die Updates erschweren.

--- a/infra/configs/keycloak/aihub-realm.build.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.build.gpu.json
@@ -40,18 +40,6 @@
         "description": "Required role to access AI-Hub. Users without this role are denied at login."
       },
       {
-        "name": "AIHubAdmin",
-        "description": "Full administrative access to AI-Hub"
-      },
-      {
-        "name": "AIHubUser",
-        "description": "Standard user access to AI-Hub"
-      },
-      {
-        "name": "AIHubDeveloper",
-        "description": "Developer access to AI-Hub tools (Dagster, Attu, etc.)"
-      },
-      {
         "name": "AIHubSysAdmin",
         "description": "System administrator access to infrastructure tools (Dagster, SeaweedFS, Attu, etc.)"
       }

--- a/infra/configs/keycloak/aihub-realm.build.json
+++ b/infra/configs/keycloak/aihub-realm.build.json
@@ -40,18 +40,6 @@
         "description": "Required role to access AI-Hub. Users without this role are denied at login."
       },
       {
-        "name": "AIHubAdmin",
-        "description": "Full administrative access to AI-Hub"
-      },
-      {
-        "name": "AIHubUser",
-        "description": "Standard user access to AI-Hub"
-      },
-      {
-        "name": "AIHubDeveloper",
-        "description": "Developer access to AI-Hub tools (Dagster, Attu, etc.)"
-      },
-      {
         "name": "AIHubSysAdmin",
         "description": "System administrator access to infrastructure tools (Dagster, SeaweedFS, Attu, etc.)"
       }

--- a/infra/configs/keycloak/aihub-realm.dev.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.dev.gpu.json
@@ -40,18 +40,6 @@
         "description": "Required role to access AI-Hub. Users without this role are denied at login."
       },
       {
-        "name": "AIHubAdmin",
-        "description": "Full administrative access to AI-Hub"
-      },
-      {
-        "name": "AIHubUser",
-        "description": "Standard user access to AI-Hub"
-      },
-      {
-        "name": "AIHubDeveloper",
-        "description": "Developer access to AI-Hub tools (Dagster, Attu, etc.)"
-      },
-      {
         "name": "AIHubSysAdmin",
         "description": "System administrator access to infrastructure tools (Dagster, SeaweedFS, Attu, etc.)"
       }

--- a/infra/configs/keycloak/aihub-realm.dev.json
+++ b/infra/configs/keycloak/aihub-realm.dev.json
@@ -40,18 +40,6 @@
         "description": "Required role to access AI-Hub. Users without this role are denied at login."
       },
       {
-        "name": "AIHubAdmin",
-        "description": "Full administrative access to AI-Hub"
-      },
-      {
-        "name": "AIHubUser",
-        "description": "Standard user access to AI-Hub"
-      },
-      {
-        "name": "AIHubDeveloper",
-        "description": "Developer access to AI-Hub tools (Dagster, Attu, etc.)"
-      },
-      {
         "name": "AIHubSysAdmin",
         "description": "System administrator access to infrastructure tools (Dagster, SeaweedFS, Attu, etc.)"
       }

--- a/infra/configs/keycloak/aihub-realm.latest.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.latest.gpu.json
@@ -40,18 +40,6 @@
         "description": "Required role to access AI-Hub. Users without this role are denied at login."
       },
       {
-        "name": "AIHubAdmin",
-        "description": "Full administrative access to AI-Hub"
-      },
-      {
-        "name": "AIHubUser",
-        "description": "Standard user access to AI-Hub"
-      },
-      {
-        "name": "AIHubDeveloper",
-        "description": "Developer access to AI-Hub tools (Dagster, Attu, etc.)"
-      },
-      {
         "name": "AIHubSysAdmin",
         "description": "System administrator access to infrastructure tools (Dagster, SeaweedFS, Attu, etc.)"
       }

--- a/infra/configs/keycloak/aihub-realm.latest.json
+++ b/infra/configs/keycloak/aihub-realm.latest.json
@@ -40,18 +40,6 @@
         "description": "Required role to access AI-Hub. Users without this role are denied at login."
       },
       {
-        "name": "AIHubAdmin",
-        "description": "Full administrative access to AI-Hub"
-      },
-      {
-        "name": "AIHubUser",
-        "description": "Standard user access to AI-Hub"
-      },
-      {
-        "name": "AIHubDeveloper",
-        "description": "Developer access to AI-Hub tools (Dagster, Attu, etc.)"
-      },
-      {
         "name": "AIHubSysAdmin",
         "description": "System administrator access to infrastructure tools (Dagster, SeaweedFS, Attu, etc.)"
       }

--- a/infra/configs/keycloak/aihub-realm.local.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.local.gpu.json
@@ -40,18 +40,6 @@
         "description": "Required role to access AI-Hub. Users without this role are denied at login."
       },
       {
-        "name": "AIHubAdmin",
-        "description": "Full administrative access to AI-Hub"
-      },
-      {
-        "name": "AIHubUser",
-        "description": "Standard user access to AI-Hub"
-      },
-      {
-        "name": "AIHubDeveloper",
-        "description": "Developer access to AI-Hub tools (Dagster, Attu, etc.)"
-      },
-      {
         "name": "AIHubSysAdmin",
         "description": "System administrator access to infrastructure tools (Dagster, SeaweedFS, Attu, etc.)"
       }

--- a/infra/configs/keycloak/aihub-realm.local.json
+++ b/infra/configs/keycloak/aihub-realm.local.json
@@ -40,18 +40,6 @@
         "description": "Required role to access AI-Hub. Users without this role are denied at login."
       },
       {
-        "name": "AIHubAdmin",
-        "description": "Full administrative access to AI-Hub"
-      },
-      {
-        "name": "AIHubUser",
-        "description": "Standard user access to AI-Hub"
-      },
-      {
-        "name": "AIHubDeveloper",
-        "description": "Developer access to AI-Hub tools (Dagster, Attu, etc.)"
-      },
-      {
         "name": "AIHubSysAdmin",
         "description": "System administrator access to infrastructure tools (Dagster, SeaweedFS, Attu, etc.)"
       }

--- a/infra/configs/keycloak/aihub-realm.nightly.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.nightly.gpu.json
@@ -40,18 +40,6 @@
         "description": "Required role to access AI-Hub. Users without this role are denied at login."
       },
       {
-        "name": "AIHubAdmin",
-        "description": "Full administrative access to AI-Hub"
-      },
-      {
-        "name": "AIHubUser",
-        "description": "Standard user access to AI-Hub"
-      },
-      {
-        "name": "AIHubDeveloper",
-        "description": "Developer access to AI-Hub tools (Dagster, Attu, etc.)"
-      },
-      {
         "name": "AIHubSysAdmin",
         "description": "System administrator access to infrastructure tools (Dagster, SeaweedFS, Attu, etc.)"
       }

--- a/infra/configs/keycloak/aihub-realm.nightly.json
+++ b/infra/configs/keycloak/aihub-realm.nightly.json
@@ -40,18 +40,6 @@
         "description": "Required role to access AI-Hub. Users without this role are denied at login."
       },
       {
-        "name": "AIHubAdmin",
-        "description": "Full administrative access to AI-Hub"
-      },
-      {
-        "name": "AIHubUser",
-        "description": "Standard user access to AI-Hub"
-      },
-      {
-        "name": "AIHubDeveloper",
-        "description": "Developer access to AI-Hub tools (Dagster, Attu, etc.)"
-      },
-      {
         "name": "AIHubSysAdmin",
         "description": "System administrator access to infrastructure tools (Dagster, SeaweedFS, Attu, etc.)"
       }

--- a/infra/configs/keycloak/identity-providers.build.gpu.json
+++ b/infra/configs/keycloak/identity-providers.build.gpu.json
@@ -74,39 +74,6 @@
       }
     },
     {
-      "name": "role-mapper-admin",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubAdmin",
-        "role": "AIHubAdmin"
-      }
-    },
-    {
-      "name": "role-mapper-user",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubUser",
-        "role": "AIHubUser"
-      }
-    },
-    {
-      "name": "role-mapper-developer",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubDeveloper",
-        "role": "AIHubDeveloper"
-      }
-    },
-    {
       "name": "role-mapper-access",
       "identityProviderAlias": "azure-ad",
       "identityProviderMapper": "oidc-role-idp-mapper",

--- a/infra/configs/keycloak/identity-providers.build.json
+++ b/infra/configs/keycloak/identity-providers.build.json
@@ -74,39 +74,6 @@
       }
     },
     {
-      "name": "role-mapper-admin",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubAdmin",
-        "role": "AIHubAdmin"
-      }
-    },
-    {
-      "name": "role-mapper-user",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubUser",
-        "role": "AIHubUser"
-      }
-    },
-    {
-      "name": "role-mapper-developer",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubDeveloper",
-        "role": "AIHubDeveloper"
-      }
-    },
-    {
       "name": "role-mapper-access",
       "identityProviderAlias": "azure-ad",
       "identityProviderMapper": "oidc-role-idp-mapper",

--- a/infra/configs/keycloak/identity-providers.dev.gpu.json
+++ b/infra/configs/keycloak/identity-providers.dev.gpu.json
@@ -74,39 +74,6 @@
       }
     },
     {
-      "name": "role-mapper-admin",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubAdmin",
-        "role": "AIHubAdmin"
-      }
-    },
-    {
-      "name": "role-mapper-user",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubUser",
-        "role": "AIHubUser"
-      }
-    },
-    {
-      "name": "role-mapper-developer",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubDeveloper",
-        "role": "AIHubDeveloper"
-      }
-    },
-    {
       "name": "role-mapper-access",
       "identityProviderAlias": "azure-ad",
       "identityProviderMapper": "oidc-role-idp-mapper",

--- a/infra/configs/keycloak/identity-providers.dev.json
+++ b/infra/configs/keycloak/identity-providers.dev.json
@@ -74,39 +74,6 @@
       }
     },
     {
-      "name": "role-mapper-admin",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubAdmin",
-        "role": "AIHubAdmin"
-      }
-    },
-    {
-      "name": "role-mapper-user",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubUser",
-        "role": "AIHubUser"
-      }
-    },
-    {
-      "name": "role-mapper-developer",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubDeveloper",
-        "role": "AIHubDeveloper"
-      }
-    },
-    {
       "name": "role-mapper-access",
       "identityProviderAlias": "azure-ad",
       "identityProviderMapper": "oidc-role-idp-mapper",

--- a/infra/configs/keycloak/identity-providers.latest.gpu.json
+++ b/infra/configs/keycloak/identity-providers.latest.gpu.json
@@ -74,39 +74,6 @@
       }
     },
     {
-      "name": "role-mapper-admin",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubAdmin",
-        "role": "AIHubAdmin"
-      }
-    },
-    {
-      "name": "role-mapper-user",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubUser",
-        "role": "AIHubUser"
-      }
-    },
-    {
-      "name": "role-mapper-developer",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubDeveloper",
-        "role": "AIHubDeveloper"
-      }
-    },
-    {
       "name": "role-mapper-access",
       "identityProviderAlias": "azure-ad",
       "identityProviderMapper": "oidc-role-idp-mapper",

--- a/infra/configs/keycloak/identity-providers.latest.json
+++ b/infra/configs/keycloak/identity-providers.latest.json
@@ -74,39 +74,6 @@
       }
     },
     {
-      "name": "role-mapper-admin",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubAdmin",
-        "role": "AIHubAdmin"
-      }
-    },
-    {
-      "name": "role-mapper-user",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubUser",
-        "role": "AIHubUser"
-      }
-    },
-    {
-      "name": "role-mapper-developer",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubDeveloper",
-        "role": "AIHubDeveloper"
-      }
-    },
-    {
       "name": "role-mapper-access",
       "identityProviderAlias": "azure-ad",
       "identityProviderMapper": "oidc-role-idp-mapper",

--- a/infra/configs/keycloak/identity-providers.local.gpu.json
+++ b/infra/configs/keycloak/identity-providers.local.gpu.json
@@ -74,39 +74,6 @@
       }
     },
     {
-      "name": "role-mapper-admin",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubAdmin",
-        "role": "AIHubAdmin"
-      }
-    },
-    {
-      "name": "role-mapper-user",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubUser",
-        "role": "AIHubUser"
-      }
-    },
-    {
-      "name": "role-mapper-developer",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubDeveloper",
-        "role": "AIHubDeveloper"
-      }
-    },
-    {
       "name": "role-mapper-access",
       "identityProviderAlias": "azure-ad",
       "identityProviderMapper": "oidc-role-idp-mapper",

--- a/infra/configs/keycloak/identity-providers.local.json
+++ b/infra/configs/keycloak/identity-providers.local.json
@@ -74,39 +74,6 @@
       }
     },
     {
-      "name": "role-mapper-admin",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubAdmin",
-        "role": "AIHubAdmin"
-      }
-    },
-    {
-      "name": "role-mapper-user",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubUser",
-        "role": "AIHubUser"
-      }
-    },
-    {
-      "name": "role-mapper-developer",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubDeveloper",
-        "role": "AIHubDeveloper"
-      }
-    },
-    {
       "name": "role-mapper-access",
       "identityProviderAlias": "azure-ad",
       "identityProviderMapper": "oidc-role-idp-mapper",

--- a/infra/configs/keycloak/identity-providers.nightly.gpu.json
+++ b/infra/configs/keycloak/identity-providers.nightly.gpu.json
@@ -74,39 +74,6 @@
       }
     },
     {
-      "name": "role-mapper-admin",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubAdmin",
-        "role": "AIHubAdmin"
-      }
-    },
-    {
-      "name": "role-mapper-user",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubUser",
-        "role": "AIHubUser"
-      }
-    },
-    {
-      "name": "role-mapper-developer",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubDeveloper",
-        "role": "AIHubDeveloper"
-      }
-    },
-    {
       "name": "role-mapper-access",
       "identityProviderAlias": "azure-ad",
       "identityProviderMapper": "oidc-role-idp-mapper",

--- a/infra/configs/keycloak/identity-providers.nightly.json
+++ b/infra/configs/keycloak/identity-providers.nightly.json
@@ -74,39 +74,6 @@
       }
     },
     {
-      "name": "role-mapper-admin",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubAdmin",
-        "role": "AIHubAdmin"
-      }
-    },
-    {
-      "name": "role-mapper-user",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubUser",
-        "role": "AIHubUser"
-      }
-    },
-    {
-      "name": "role-mapper-developer",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubDeveloper",
-        "role": "AIHubDeveloper"
-      }
-    },
-    {
       "name": "role-mapper-access",
       "identityProviderAlias": "azure-ad",
       "identityProviderMapper": "oidc-role-idp-mapper",

--- a/infra/deployment/templates/configs/keycloak-identity-providers.json.j2
+++ b/infra/deployment/templates/configs/keycloak-identity-providers.json.j2
@@ -20,15 +20,13 @@
    2. Set redirect URI: https://auth.YOUR_DOMAIN/realms/aihub/broker/azure-ad/endpoint
    3. Create client secret and copy value
    4. Grant API permissions: openid, email, profile
-   5. Define App Roles in manifest (AIHubAccess, AIHubAdmin, AIHubUser, AIHubDeveloper, AIHubSysAdmin)
+   5. Define App Roles in manifest (AIHubAccess, AIHubSysAdmin)
    6. Assign users/groups to roles in Enterprise Applications
 
    Role Mapping:
-   Azure AD App Roles are automatically mapped to Keycloak realm roles:
+   Azure AD App Roles are automatically mapped to Keycloak realm roles. Only these two
+   roles have an effect in AI-Hub; the platform reads no other realm roles for authorization:
    - Azure "AIHubAccess" → Keycloak "AIHubAccess" (REQUIRED for login)
-   - Azure "AIHubAdmin" → Keycloak "AIHubAdmin"
-   - Azure "AIHubUser" → Keycloak "AIHubUser"
-   - Azure "AIHubDeveloper" → Keycloak "AIHubDeveloper"
    - Azure "AIHubSysAdmin" → Keycloak "AIHubSysAdmin"
 
    Multi-Tenant IDP-to-Tenant Mapping (Optional, Not Default):
@@ -129,39 +127,6 @@
       "config": {
         "syncMode": "INHERIT",
         "template": "${CLAIM.preferred_username}"
-      }
-    },
-    {
-      "name": "role-mapper-admin",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubAdmin",
-        "role": "AIHubAdmin"
-      }
-    },
-    {
-      "name": "role-mapper-user",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubUser",
-        "role": "AIHubUser"
-      }
-    },
-    {
-      "name": "role-mapper-developer",
-      "identityProviderAlias": "azure-ad",
-      "identityProviderMapper": "oidc-role-idp-mapper",
-      "config": {
-        "syncMode": "INHERIT",
-        "claim": "roles",
-        "claim.value": "AIHubDeveloper",
-        "role": "AIHubDeveloper"
       }
     },
     {

--- a/infra/deployment/templates/configs/keycloak-realm.json.j2
+++ b/infra/deployment/templates/configs/keycloak-realm.json.j2
@@ -44,18 +44,6 @@
         "description": "Required role to access AI-Hub. Users without this role are denied at login."
       },
       {
-        "name": "AIHubAdmin",
-        "description": "Full administrative access to AI-Hub"
-      },
-      {
-        "name": "AIHubUser",
-        "description": "Standard user access to AI-Hub"
-      },
-      {
-        "name": "AIHubDeveloper",
-        "description": "Developer access to AI-Hub tools (Dagster, Attu, etc.)"
-      },
-      {
         "name": "AIHubSysAdmin",
         "description": "System administrator access to infrastructure tools (Dagster, SeaweedFS, Attu, etc.)"
       }


### PR DESCRIPTION
## Summary

Adds operator documentation for federating the Swiss AI Hub to **Microsoft Entra ID (Azure AD)** through Keycloak, and prunes Keycloak identity-provider role mappers that had no effect in the platform. The new docs describe only the AI-Hub-specific configuration contract (and link out to Microsoft/Keycloak docs rather than reproducing them).

## Changes

- **New deployment-guide section** `2_platform/3_deployment_guide/10_identity_provider_setup/`:
  - IdP-agnostic landing page — explains Keycloak-as-broker, links to Keycloak's OIDC / OAuth v2 / SAML v2.0 brokering docs, and notes the platform places no protocol restriction beyond the role-claim requirement.
  - `1_azure_entra_id/` parent grouping, documenting that Entra ID is integrated as an **OpenID Connect v1.0** provider (alias `azure-ad`).
  - `1_azure_app_registration/` — the config contract Keycloak expects: redirect URI, scopes (`openid email profile`), client secret, and the `KEYCLOAK_AZURE_*` env vars.
  - `2_user_and_role_management/` — defining the two effective app roles (`AIHubAccess`, `AIHubSysAdmin`) and assigning them, linking to Microsoft's docs for the portal steps.
- **Corrected** `2_platform/20_security/1_authentication/` role table — only `AIHubAccess` and `AIHubSysAdmin` take effect; `AIHubAdmin`/`AIHubUser`/`AIHubDeveloper` are noted as mapped-but-inert. Added cross-link to the new section.
- **Removed unused IdP role mappers** (`AIHubAdmin`, `AIHubUser`, `AIHubDeveloper`) from `keycloak-identity-providers.json.j2` and regenerated all `infra/configs/keycloak/identity-providers.*.json` variants. The realm-role definitions are intentionally kept; only the no-op auto-assignment mappers were dropped.

## Test plan

- Verified every documented value (redirect URI, scopes, env var names, role values) matches the source-of-truth `keycloak-identity-providers.json.j2`.
- Validated against platform code that only `AIHubSysAdmin` (read from JWT) and `AIHubAccess` (Keycloak login flow + OpenWebUI/OAuth2-proxy gates) have authorization effect; the removed roles are not consumed anywhere (no composites, `defaultRoles: []`, no scope mappings).
- Ran `make generate-compose`; confirmed the 9 regenerated identity-provider configs contain only the `AIHubAccess` and `AIHubSysAdmin` mappers.
- **Known follow-up:** German `index.de.md` files are not yet generated (`pnpm run docs:translate` requires the `llm` CLI, unavailable in the authoring environment). They should be generated before/after merge per the docs translation pipeline.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>` (see
  [CONTRIBUTING.md](https://github.com/bbvch-ai/aihub-core/blob/main/CONTRIBUTING.md))
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [ ] CLA signed — post this exact comment on the PR if the bot hasn't prompted you yet:
  `I have read the CONTRIBUTOR_AGREEMENT and I hereby sign the CLA`
  ([read the agreement](https://github.com/bbvch-ai/aihub-core/blob/main/CONTRIBUTOR_AGREEMENT.md))
- [ ] Tests added or updated where relevant — N/A (documentation + generated Keycloak config only)
