### PR TITLE
fix(swiss-ai-hub): Fix 500 in /model/info on nested LiteLLM search-context cost

### DIFF
--- a/packages/api/swiss_ai_hub/api/routes/model/dto/model_dto.py
+++ b/packages/api/swiss_ai_hub/api/routes/model/dto/model_dto.py
@@ -1,6 +1,9 @@
+import logging
 from typing import Annotated
 
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError, computed_field, model_validator
+
+logger = logging.getLogger(__name__)
 
 
 class SearchContextCostPerQueryDTO(BaseModel):
@@ -18,7 +21,9 @@ class SearchContextCostPerQueryDTO(BaseModel):
 
 
 class ModelInfoDTO(BaseModel):
-    mode: Annotated[str, Field(description="The mode of the model (e.g., 'chat', 'completion', 'embedding')")]
+    mode: Annotated[
+        str | None, Field(None, description="The mode of the model (e.g., 'chat', 'completion', 'embedding')")
+    ]
     max_input_tokens: Annotated[
         int | None, Field(None, description="Maximum number of input tokens the model can handle")
     ]
@@ -106,6 +111,27 @@ class ModelInfoDTO(BaseModel):
     supported_openai_params: Annotated[
         list[str] | None, Field(None, description="List of supported OpenAI API parameters")
     ]
+
+    @model_validator(mode="before")
+    @classmethod
+    def _keep_only_parseable_fields(cls, data: object) -> object:
+        """LiteLLM's model metadata is an external, versioned feed. Drop any field whose shape drifts so the model
+        still renders with everything else — only the drifted datapoint is lost until the DTO is updated."""
+        if not isinstance(data, dict):
+            return data
+
+        cleaned: dict[str, object] = {}
+        for name, field in cls.model_fields.items():
+            key = field.alias or name
+            if key not in data:
+                continue
+            try:
+                TypeAdapter(field.annotation).validate_python(data[key])
+            except ValidationError:
+                logger.warning("Dropping unexpected shape for model_info.%s", key)
+                continue
+            cleaned[key] = data[key]
+        return cleaned
 
 
 class ModelDTO(BaseModel):

--- a/packages/api/swiss_ai_hub/api/routes/model/dto/model_dto.py
+++ b/packages/api/swiss_ai_hub/api/routes/model/dto/model_dto.py
@@ -3,6 +3,20 @@ from typing import Annotated
 from pydantic import BaseModel, Field, computed_field
 
 
+class SearchContextCostPerQueryDTO(BaseModel):
+    """LiteLLM reports search context cost per query broken down by context size, not as a single value."""
+
+    search_context_size_low: Annotated[
+        float | None, Field(None, description="Cost per query with low search context size")
+    ]
+    search_context_size_medium: Annotated[
+        float | None, Field(None, description="Cost per query with medium search context size")
+    ]
+    search_context_size_high: Annotated[
+        float | None, Field(None, description="Cost per query with high search context size")
+    ]
+
+
 class ModelInfoDTO(BaseModel):
     mode: Annotated[str, Field(description="The mode of the model (e.g., 'chat', 'completion', 'embedding')")]
     max_input_tokens: Annotated[
@@ -43,7 +57,9 @@ class ModelInfoDTO(BaseModel):
         float | None, Field(None, description="Cost per output token for contexts above 200k tokens")
     ]
     output_cost_per_image: Annotated[float | None, Field(None, description="Cost per image output")]
-    search_context_cost_per_query: Annotated[float | None, Field(None, description="Cost per search context query")]
+    search_context_cost_per_query: Annotated[
+        SearchContextCostPerQueryDTO | None, Field(None, description="Cost per search context query by context size")
+    ]
     output_vector_size: Annotated[int | None, Field(None, description="Size of output vectors for embedding models")]
     supports_system_messages: Annotated[
         bool | None, Field(None, description="Whether the model supports system messages")
@@ -128,7 +144,6 @@ class ModelDTO(BaseModel):
             "output_cost_per_token_above_128k_tokens",
             "output_cost_per_token_above_200k_tokens",
             "output_cost_per_image",
-            "search_context_cost_per_query",
         ]
 
         updates: dict[str, float] = {}

--- a/packages/web/components/Models/ModelDetailsPanel.vue
+++ b/packages/web/components/Models/ModelDetailsPanel.vue
@@ -221,9 +221,19 @@ const advancedPricingItems = computed<Array<{ key: string, label: string, value:
     },
     { key: 'output_cost_per_image', label: t('models.modelDetails.imageCost'), value: info.output_cost_per_image },
     {
-      key: 'search_context_cost_per_query',
-      label: t('models.modelDetails.searchContextCost'),
-      value: info.search_context_cost_per_query,
+      key: 'search_context_cost_per_query_low',
+      label: t('models.modelDetails.searchContextCostLow'),
+      value: info.search_context_cost_per_query?.search_context_size_low,
+    },
+    {
+      key: 'search_context_cost_per_query_medium',
+      label: t('models.modelDetails.searchContextCostMedium'),
+      value: info.search_context_cost_per_query?.search_context_size_medium,
+    },
+    {
+      key: 'search_context_cost_per_query_high',
+      label: t('models.modelDetails.searchContextCostHigh'),
+      value: info.search_context_cost_per_query?.search_context_size_high,
     },
   ]
 

--- a/packages/web/i18n/locales/de.yaml
+++ b/packages/web/i18n/locales/de.yaml
@@ -39,7 +39,9 @@ models:
     outputCostAbove128k: Output-Kosten (über 128K)
     outputCostAbove200k: Output-Kosten (über 200K)
     imageCost: Bild-Kosten
-    searchContextCost: Suchkontext-Kosten
+    searchContextCostLow: Suchkontext-Kosten (Niedrig)
+    searchContextCostMedium: Suchkontext-Kosten (Mittel)
+    searchContextCostHigh: Suchkontext-Kosten (Hoch)
     rateLimits: Rate Limits
     tokensPerMinute: Token pro Minute
     requestsPerMinute: Anfragen pro Minute

--- a/packages/web/i18n/locales/en.yaml
+++ b/packages/web/i18n/locales/en.yaml
@@ -39,7 +39,9 @@ models:
     outputCostAbove128k: Output Cost (Above 128K)
     outputCostAbove200k: Output Cost (Above 200K)
     imageCost: Image Cost
-    searchContextCost: Search Context Cost
+    searchContextCostLow: Search Context Cost (Low)
+    searchContextCostMedium: Search Context Cost (Medium)
+    searchContextCostHigh: Search Context Cost (High)
     rateLimits: Rate Limits
     tokensPerMinute: Tokens per Minute
     requestsPerMinute: Requests per Minute

--- a/packages/web/i18n/locales/fr.yaml
+++ b/packages/web/i18n/locales/fr.yaml
@@ -39,7 +39,9 @@ models:
     outputCostAbove128k: Coût de sortie (au-dessus de 128K)
     outputCostAbove200k: Coût de sortie (au-dessus de 200K)
     imageCost: Coût d'image
-    searchContextCost: Coût du contexte de recherche
+    searchContextCostLow: Coût du contexte de recherche (Faible)
+    searchContextCostMedium: Coût du contexte de recherche (Moyen)
+    searchContextCostHigh: Coût du contexte de recherche (Élevé)
     rateLimits: Limites de taux
     tokensPerMinute: Jetons par minute
     requestsPerMinute: Requêtes par minute

--- a/packages/web/i18n/locales/it.yaml
+++ b/packages/web/i18n/locales/it.yaml
@@ -39,7 +39,9 @@ models:
     outputCostAbove128k: Costo output (sopra 128K)
     outputCostAbove200k: Costo output (sopra 200K)
     imageCost: Costo immagine
-    searchContextCost: Costo contesto ricerca
+    searchContextCostLow: Costo contesto ricerca (Basso)
+    searchContextCostMedium: Costo contesto ricerca (Medio)
+    searchContextCostHigh: Costo contesto ricerca (Alto)
     rateLimits: Limiti di velocità
     tokensPerMinute: Token per minuto
     requestsPerMinute: Richieste per minuto

--- a/packages/web/sdk/client/index.ts
+++ b/packages/web/sdk/client/index.ts
@@ -835,6 +835,7 @@ export {
   type RouterEventWritable,
   type RunStatistics,
   type RunStatisticsWritable,
+  type SearchContextCostPerQueryDto,
   type SearchOrganizationMemoriesData,
   type SearchOrganizationMemoriesError,
   type SearchOrganizationMemoriesErrors,

--- a/packages/web/sdk/client/schemas.gen.ts
+++ b/packages/web/sdk/client/schemas.gen.ts
@@ -13893,7 +13893,14 @@ export const ModelDetailsSchema = {
 export const ModelInfoDTOSchema = {
   properties: {
     mode: {
-      type: "string",
+      anyOf: [
+        {
+          type: "string",
+        },
+        {
+          type: "null",
+        },
+      ],
       title: "Mode",
       description:
         "The mode of the model (e.g., 'chat', 'completion', 'embedding')",
@@ -14347,7 +14354,6 @@ export const ModelInfoDTOSchema = {
     },
   },
   type: "object",
-  required: ["mode"],
   title: "ModelInfoDTO",
 } as const;
 

--- a/packages/web/sdk/client/schemas.gen.ts
+++ b/packages/web/sdk/client/schemas.gen.ts
@@ -14094,14 +14094,13 @@ export const ModelInfoDTOSchema = {
     search_context_cost_per_query: {
       anyOf: [
         {
-          type: "number",
+          $ref: "#/components/schemas/SearchContextCostPerQueryDTO",
         },
         {
           type: "null",
         },
       ],
-      title: "Search Context Cost Per Query",
-      description: "Cost per search context query",
+      description: "Cost per search context query by context size",
     },
     output_vector_size: {
       anyOf: [
@@ -18398,6 +18397,51 @@ export const RunStatisticsSchema = {
   required: ["run_id", "agent"],
   title: "RunStatistics",
   description: "Statistics for a single run, intended for API response.",
+} as const;
+
+export const SearchContextCostPerQueryDTOSchema = {
+  properties: {
+    search_context_size_low: {
+      anyOf: [
+        {
+          type: "number",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Search Context Size Low",
+      description: "Cost per query with low search context size",
+    },
+    search_context_size_medium: {
+      anyOf: [
+        {
+          type: "number",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Search Context Size Medium",
+      description: "Cost per query with medium search context size",
+    },
+    search_context_size_high: {
+      anyOf: [
+        {
+          type: "number",
+        },
+        {
+          type: "null",
+        },
+      ],
+      title: "Search Context Size High",
+      description: "Cost per query with high search context size",
+    },
+  },
+  type: "object",
+  title: "SearchContextCostPerQueryDTO",
+  description:
+    "LiteLLM reports search context cost per query broken down by context size, not as a single value.",
 } as const;
 
 export const SelectSchema = {

--- a/packages/web/sdk/client/types.gen.ts
+++ b/packages/web/sdk/client/types.gen.ts
@@ -9359,7 +9359,7 @@ export type ModelInfoDto = {
    *
    * The mode of the model (e.g., 'chat', 'completion', 'embedding')
    */
-  mode: string;
+  mode?: string | null;
   /**
    * Max Input Tokens
    *

--- a/packages/web/sdk/client/types.gen.ts
+++ b/packages/web/sdk/client/types.gen.ts
@@ -9457,11 +9457,9 @@ export type ModelInfoDto = {
    */
   output_cost_per_image?: number | null;
   /**
-   * Search Context Cost Per Query
-   *
-   * Cost per search context query
+   * Cost per search context query by context size
    */
-  search_context_cost_per_query?: number | null;
+  search_context_cost_per_query?: SearchContextCostPerQueryDto | null;
   /**
    * Output Vector Size
    *
@@ -12406,6 +12404,32 @@ export type RunStatistics = {
    * The agent that ran the run
    */
   agent: MinimalAgentInstanceDto;
+};
+
+/**
+ * SearchContextCostPerQueryDTO
+ *
+ * LiteLLM reports search context cost per query broken down by context size, not as a single value.
+ */
+export type SearchContextCostPerQueryDto = {
+  /**
+   * Search Context Size Low
+   *
+   * Cost per query with low search context size
+   */
+  search_context_size_low?: number | null;
+  /**
+   * Search Context Size Medium
+   *
+   * Cost per query with medium search context size
+   */
+  search_context_size_medium?: number | null;
+  /**
+   * Search Context Size High
+   *
+   * Cost per query with high search context size
+   */
+  search_context_size_high?: number | null;
 };
 
 /**


### PR DESCRIPTION
## Summary

`GET /api/v1/{tenant}/models` returned a **500 for the entire model list** whenever LiteLLM reported a web-search-capable model. `ModelInfoDTO.search_context_cost_per_query` was typed `float | None`, but LiteLLM returns it as a nested object keyed by context size (`low`/`medium`/`high`). One unparseable model failed the whole `/model/info` parse, so the UI model dropdown went completely empty.

## What changed

**1. Model the real shape** (`80a7805`)
- Added `SearchContextCostPerQueryDTO` (the three size tiers) and retyped the field accordingly.
- Removed it from the per-million-token microunit conversion — it's a per-query dollar cost, not a per-token cost, so multiplying by 1M was both type-incorrect now and semantically wrong before.
- Regenerated the SDK; expanded the single search-context row into low/medium/high in `ModelDetailsPanel.vue` + locale keys (de/en/fr/it).

**2. Prevent the whole class of bug** (`d15edf4`)
- Added a `model_validator(mode="before")` on `ModelInfoDTO` that keeps only fields whose value matches the declared type and drops (with a `logger.warning`) any that drifted. **Any** future LiteLLM metadata shape change now degrades that single field instead of hiding every model.
- Made `mode` nullable (`str | None = None`) so a missing/renamed mode represents honest absence — grouping still buckets it under "other" and the UI shows "Not specified" — rather than dropping the model or fabricating a category.
- Identity (`model_name`) stays strict; all enrichment is best-effort.

## Why this matters

This is exactly what unblocks adding Claude (Sonnet 4.x) and the GPT search models — they're the models that carry the tiered `search_context_cost_per_query` and would otherwise have blanked the dropdown.

## Test plan

- [x] DTO validates a payload with the nested search-context object
- [x] Microunit conversion leaves the search-context object untouched
- [x] A field with a drifted shape is dropped (warned), model still renders
- [x] Missing `mode` → `None`, model still renders (robot icon, "Not specified")
- [x] Well-formed data stays fully typed
- [x] SDK regenerated (`mode?: string | null`, `SearchContextCostPerQueryDto`); frontend `mode` usage null-guarded
- [ ] Manual: model dropdown loads with a web-search model configured in LiteLLM
