### PR TITLE
fix(swiss-ai-hub): Render changelog with v-pre to fix docs build

### DIFF
--- a/docs/sync-docs.sh
+++ b/docs/sync-docs.sh
@@ -24,9 +24,19 @@ mkdir -p "changelog"
 # Copy LICENSE_REPORT.md as both .en.md and .de.md (no translation needed)
 cp "../LICENSE_REPORT.md" "./licenses/index.en.md"
 cp "../LICENSE_REPORT.md" "./licenses/index.de.md"
-# Copy CHANGELOG.md as both .en.md and .de.md (no translation needed)
-cp "../CHANGELOG.md" "./changelog/index.en.md"
-cp "../CHANGELOG.md" "./changelog/index.de.md"
+# Copy CHANGELOG.md as both .en.md and .de.md (no translation needed).
+# The body is wrapped in a VitePress `v-pre` container so literal release-note
+# text — e.g. a GitHub Actions `${{ ... }}` expression — is rendered verbatim
+# instead of being parsed as a Vue interpolation, which would break the build.
+# The top-level H1 is kept OUTSIDE the container: the copy/download buttons are
+# injected right after the first <h1>, and `v-pre` would stop them from rendering.
+{
+    head -n 1 "../CHANGELOG.md"
+    printf '\n::: v-pre\n'
+    tail -n +2 "../CHANGELOG.md"
+    printf '\n:::\n'
+} > "./changelog/index.en.md"
+cp "./changelog/index.en.md" "./changelog/index.de.md"
 
 # == Root README -> Introduction page ==
 root_intro="./docs/6_code_deep_dive/1_introduction/index.en.md"


### PR DESCRIPTION
## Summary

The **Deploy Documentation to GitHub Pages** workflow fails in the *Build documentation* job. The synced changelog page contains a literal GitHub Actions expression in inline code, which VitePress compiles as a Vue SFC and tries to evaluate as a Vue interpolation — failing with `Error parsing JavaScript expression: Unexpected token`. This wraps the changelog body in a VitePress `v-pre` container so its contents render verbatim.

## Changes

- `docs/sync-docs.sh`: wrap the synced `CHANGELOG.md` body in a `::: v-pre` container so any release-note text (e.g. a GitHub Actions expression block) renders literally instead of being parsed as a Vue interpolation.
- Keep the top-level `# Changelog` H1 **outside** the container — the `vitepress-plugin-llms` copy/download buttons are injected right after the first `<h1>`, and `v-pre` would otherwise stop them from rendering.

## Test plan

- Ran `pnpm run docs:build:ci` locally → `build complete` (previously failed in ~4.5s on `changelog/index.en.md`).
- Confirmed in the compiled output that the changelog renders the literal expression as code, and that the `CopyOrDownloadAsMarkdownButtons` copy/download buttons are present on the page.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>` (see
  [CONTRIBUTING.md](https://github.com/bbvch-ai/aihub-core/blob/main/CONTRIBUTING.md))
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [x] CLA signed — post this exact comment on the PR if the bot hasn't prompted you yet:
  `I have read the CONTRIBUTOR_AGREEMENT and I hereby sign the CLA`
  ([read the agreement](https://github.com/bbvch-ai/aihub-core/blob/main/CONTRIBUTOR_AGREEMENT.md))
- [x] Tests added or updated where relevant (n/a — docs build script; verified via `docs:build:ci`)
