### PR TITLE
fix(swiss-ai-hub): Drain display-event streams before consumer teardown

### DIFF
--- a/docs/arc42/decisions/2026_06_09_drain_display_event_streams_before_consumer_teardown.md
+++ b/docs/arc42/decisions/2026_06_09_drain_display_event_streams_before_consumer_teardown.md
@@ -1,0 +1,77 @@
+# Drain Display-Event Streams Before Consumer Teardown
+
+## Context
+
+The API streams an agent's output to chat clients as `DisplayEvent`s (`ChunkEvent`, `ThoughtEvent`, …) over NATS,
+terminated by a `StopEvent`. Four consumption sites subscribe to a thread's display events and finish on the stop: the
+OpenAI-compatible SSE generator, the OpenAI JSON aggregate, the agent `_send_event` aggregate, and the native "yield all
+events raw" stream used by the OpenWebUI aihub pipe.
+
+`NCSubscriber` dispatches one `asyncio` task per message. Messages are delivered to the handler in order, but their
+handler tasks run concurrently, so the stop event's task can set the stop signal before a preceding chunk's task has
+enqueued it. Each consumer ended the instant the stop signal was set and the queue looked empty, dropping the in-flight
+chunk(s). Short answers therefore rendered blank intermittently, and the empty assistant turn poisoned follow-up
+requests (some providers reject an empty assistant message with a 400). This is a task-scheduling race in the consumer,
+not NATS message reordering.
+
+## Decision Drivers
+
+- The fix must cover every consumer. The OpenWebUI pipe uses the native stream, not the OpenAI endpoint.
+- The fix must cover all display events, not only the answer. The native stream forwards thoughts and intermediate
+  events.
+- No new infrastructure and no per-agent workarounds.
+- A hard guarantee for the answer (whose loss blanks the turn and breaks the next request), best-effort for the rest.
+
+## Alternatives Considered
+
+1. **Reconcile the answer from the stop event only.** Recovers the answer text on the OpenAI endpoint, but not on the
+   native stream (which has no single "answer" payload) nor for non-answer display events.
+
+2. **Unify the producer transport.** Chunks are published to JetStream (`JSPublisher` in the displayer); the dispatcher
+   publishes the terminal event's display copy over NATS core (`NCPublisher`). Display events are already
+   stream-persisted (the per-class stream subject wildcards `event_type`), and the race is consumer-side task
+   scheduling, so changing the publish transport does not address it.
+
+3. **Durable-consume.** Read the run's events from the JetStream stream in sequence order up to the stop — ordered and
+   lossless for a single stream. Streams are per-agent-class and JetStream forbids overlapping stream subjects, so a
+   thread spanning classes via AITL delegation has events across several streams with no global order, and one consumer
+   cannot span them. A per-thread stream would replace the per-class streams the dispatcher uses for load-balanced
+   execution.
+
+## Decision
+
+Drain before teardown, with a durable backstop for the answer.
+
+1. Shared helpers on `ChatService` (`packages/core/.../routes/chat/chat_service.py`), used by all four sites:
+
+   - `iter_streamed_display_events()` — yields queued display events until the run has stopped and no event has surfaced
+     for a grace window, so trailing handler tasks complete before the consumer ends.
+   - `wait_for_stop_then_drain()` — for the collect-then-build paths: wait for the stop, drain the grace, then tear the
+     subscription down.
+
+2. `DISPLAY_STREAM_DRAIN_GRACE_SECONDS = 0.25`.
+
+3. Backstop: the answer is recovered from the stop event's durable `output_messages` via delta reconciliation (emit only
+   the un-streamed remainder) in `_resolve_final_content` (SSE) and `build_json_response_content` (JSON).
+
+Display events are best-effort observability that must never drive workflow, so a bounded drain is acceptable for them;
+the answer is the one payload that must not be lost and is guaranteed by the durable stop event.
+
+## Consequences
+
+### Positive
+
+- All streaming consumers are fixed in one place, covering all display-event types and all agents, including delegated
+  sub-agents whose events arrive on a different per-class stream.
+- The answer cannot blank: the backstop is independent of the drain.
+- No new infrastructure and no stream re-topology. The self-awareness `stop_after_meta_answer_step` /
+  `MetaAnswerReadyEvent` indirection, which worked around this race, can be removed.
+
+### Trade-offs
+
+- Up to the grace window (0.25s) of added latency after the last token before the terminal frame.
+- The drain is heuristic: a straggler slower than the grace can still drop. Acceptable for best-effort display events;
+  anything that must not be lost should be a control event, not a display event.
+- The producer transport inconsistency (chunks → JetStream, terminal display copy → NATS core) and the inaccurate
+  "display events are ephemeral" framing in scope docs are left as a separate follow-up; display events are
+  stream-persisted.

--- a/packages/api/playground/testing/tests/agent/test_agent_service_unit_tests.py
+++ b/packages/api/playground/testing/tests/agent/test_agent_service_unit_tests.py
@@ -255,13 +255,10 @@ class TestAgentServiceUnit:
 
             with patch("swiss_ai_hub.api.routes.agent.agent_service.ChatService") as mock_chat_service:
                 mock_resources = Mock()
-                mock_resources.stop_signal = Mock()
-                mock_resources.stop_signal.wait = AsyncMock()
-                mock_resources.subscriber = Mock()
-                mock_resources.subscriber.stop = AsyncMock()
                 mock_resources.stop_event = mock_stop_event
 
                 mock_chat_service.start_json_event_interaction = AsyncMock(return_value=mock_resources)
+                mock_chat_service.wait_for_stop_then_drain = AsyncMock()
 
                 thread_id = ObjectId()
                 result = await AgentService._send_event(
@@ -276,8 +273,7 @@ class TestAgentServiceUnit:
 
                 mock_get_thread.assert_called_once_with(str(thread_id))
                 mock_chat_service.start_json_event_interaction.assert_called_once()
-                mock_resources.stop_signal.wait.assert_called_once()
-                mock_resources.subscriber.stop.assert_called_once()
+                mock_chat_service.wait_for_stop_then_drain.assert_called_once_with(mock_resources)
 
                 assert result == mock_stop_event
 
@@ -295,13 +291,10 @@ class TestAgentServiceUnit:
 
             with patch("swiss_ai_hub.api.routes.agent.agent_service.ChatService") as mock_chat_service:
                 mock_resources = Mock()
-                mock_resources.stop_signal = Mock()
-                mock_resources.stop_signal.wait = AsyncMock()
-                mock_resources.subscriber = Mock()
-                mock_resources.subscriber.stop = AsyncMock()
                 mock_resources.stop_event = mock_stop_event
 
                 mock_chat_service.start_json_event_interaction = AsyncMock(return_value=mock_resources)
+                mock_chat_service.wait_for_stop_then_drain = AsyncMock()
 
                 result = await AgentService._send_event(
                     nc=mock_nats,

--- a/packages/api/playground/testing/tests/openai/test_resolve_final_content.py
+++ b/packages/api/playground/testing/tests/openai/test_resolve_final_content.py
@@ -1,0 +1,44 @@
+from types import SimpleNamespace
+
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+
+from swiss_ai_hub.api.routes.openai.openai_service import OpenaiService
+
+
+def _assistant_stop_event(content: str | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        is_hitl_request_event=False,
+        is_exception_event=False,
+        output_messages=[ChatMessage(role=MessageRole.ASSISTANT, content=content)],
+    )
+
+
+def test_resolve_final_content_emits_full_answer_when_nothing_streamed():
+    stop_event = _assistant_stop_event("the whole answer")
+
+    assert OpenaiService._resolve_final_content(stop_event, streamed="") == "the whole answer"
+
+
+def test_resolve_final_content_emits_only_remainder_on_partial_stream():
+    stop_event = _assistant_stop_event("the whole answer")
+
+    assert OpenaiService._resolve_final_content(stop_event, streamed="the whole ") == "answer"
+
+
+def test_resolve_final_content_emits_nothing_when_fully_streamed():
+    stop_event = _assistant_stop_event("the whole answer")
+
+    assert OpenaiService._resolve_final_content(stop_event, streamed="the whole answer") == ""
+
+
+def test_resolve_final_content_keeps_streamed_when_value_diverges():
+    """When what streamed is not a prefix of the answer, stay conservative and emit nothing extra."""
+    stop_event = _assistant_stop_event("the whole answer")
+
+    assert OpenaiService._resolve_final_content(stop_event, streamed="something else") == ""
+
+
+def test_resolve_final_content_handles_none_message_content():
+    stop_event = _assistant_stop_event(None)
+
+    assert OpenaiService._resolve_final_content(stop_event, streamed="") == ""

--- a/packages/api/swiss_ai_hub/api/routes/agent/agent_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/agent/agent_service.py
@@ -145,8 +145,7 @@ class AgentService:
             external_agent_event_distributor=external_agent_event_distributor,
         )
 
-        await resources.stop_signal.wait()
-        await resources.subscriber.stop()
+        await ChatService.wait_for_stop_then_drain(resources)
 
         return resources.stop_event
 

--- a/packages/api/swiss_ai_hub/api/routes/openai/openai_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/openai/openai_service.py
@@ -320,9 +320,8 @@ class OpenaiService:
             locale=locale,
             aihub_headers=aihub_headers,
         )
-        # Wait until all events are processed
-        await resources.stop_signal.wait()
-        await resources.subscriber.stop()
+        # Wait until all events are processed, draining trailing events before teardown
+        await ChatService.wait_for_stop_then_drain(resources)
 
         if resources.stop_event.is_exception_event:
             raise HTTPException(resources.stop_event.http_status_code, resources.stop_event.message)
@@ -401,32 +400,33 @@ class OpenaiService:
 
     @staticmethod
     async def _sse_event_generator(resources: StreamingResources) -> AsyncGenerator[str]:
-        while True:
-            if resources.stop_signal.is_set() and resources.chunk_queue.empty():
-                logger.debug("Stop streaming due to stop_event and empty queue")
-                break
-            try:
-                chunk_event = await asyncio.wait_for(resources.chunk_queue.get(), timeout=0.5)
-                yield OpenaiService._build_chunk_sse(content=chunk_event.content, model=chunk_event.model_name)
-                resources.chunk_queue.task_done()
-            except TimeoutError:
-                continue
-            except asyncio.CancelledError:
-                break
+        streamed = ""
+        async for chunk_event in ChatService.iter_streamed_display_events(resources):
+            streamed += chunk_event.content
+            yield OpenaiService._build_chunk_sse(content=chunk_event.content, model=chunk_event.model_name)
 
         yield OpenaiService._build_chunk_sse(
-            content=OpenaiService._resolve_final_content(resources.stop_event),
+            content=OpenaiService._resolve_final_content(resources.stop_event, streamed=streamed),
             model="",
             finish_reason="stop",
         )
 
     @staticmethod
-    def _resolve_final_content(stop_event: StopEvent | HumanInTheLoopRequestEvent | ExceptionEvent | None) -> str:
+    def _resolve_final_content(
+        stop_event: StopEvent | HumanInTheLoopRequestEvent | ExceptionEvent | None,
+        streamed: str = "",
+    ) -> str:
         if stop_event.is_hitl_request_event:
             return stop_event.question
         if stop_event.is_exception_event:
             return f"\n\n>[!CAUTION]\n>**Error:** {stop_event.message}\n"
-        return ""
+        # Backstop: emit only the portion of the authoritative answer the client never received, in case
+        # chunks were lost to the stop-vs-chunk dispatch race. Empty once everything has already streamed.
+        output_messages = getattr(stop_event, "output_messages", None) or []
+        full_answer = output_messages[-1].content if output_messages else ""
+        if full_answer and full_answer.startswith(streamed):
+            return full_answer[len(streamed) :]
+        return "" if streamed else full_answer
 
     @staticmethod
     def _build_chunk_sse(*, content: str, model: str, finish_reason: str | None = None) -> str:

--- a/packages/api/swiss_ai_hub/api/routes/openai/openai_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/openai/openai_service.py
@@ -400,13 +400,13 @@ class OpenaiService:
 
     @staticmethod
     async def _sse_event_generator(resources: StreamingResources) -> AsyncGenerator[str]:
-        streamed = ""
+        streamed_parts: list[str] = []
         async for chunk_event in ChatService.iter_streamed_display_events(resources):
-            streamed += chunk_event.content
+            streamed_parts.append(chunk_event.content)
             yield OpenaiService._build_chunk_sse(content=chunk_event.content, model=chunk_event.model_name)
 
         yield OpenaiService._build_chunk_sse(
-            content=OpenaiService._resolve_final_content(resources.stop_event, streamed=streamed),
+            content=OpenaiService._resolve_final_content(resources.stop_event, streamed="".join(streamed_parts)),
             model="",
             finish_reason="stop",
         )
@@ -422,8 +422,10 @@ class OpenaiService:
             return f"\n\n>[!CAUTION]\n>**Error:** {stop_event.message}\n"
         # Backstop: emit only the portion of the authoritative answer the client never received, in case
         # chunks were lost to the stop-vs-chunk dispatch race. Empty once everything has already streamed.
+        # Best-effort: the prefix match can miss if the stream parser normalized whitespace differently
+        # from output_messages, in which case we keep what streamed rather than risk duplicating it.
         output_messages = getattr(stop_event, "output_messages", None) or []
-        full_answer = output_messages[-1].content if output_messages else ""
+        full_answer = (output_messages[-1].content or "") if output_messages else ""
         if full_answer and full_answer.startswith(streamed):
             return full_answer[len(streamed) :]
         return "" if streamed else full_answer

--- a/packages/api/swiss_ai_hub/api/services/agent_endpoints_discovery_service.py
+++ b/packages/api/swiss_ai_hub/api/services/agent_endpoints_discovery_service.py
@@ -1,4 +1,3 @@
-import asyncio
 import hashlib
 import logging
 from asyncio import sleep
@@ -40,6 +39,7 @@ from swiss_ai_hub.core.persistence import (
     User,
 )
 from swiss_ai_hub.core.publishers import NCPublisher
+from swiss_ai_hub.core.routes import ChatService
 from swiss_ai_hub.core.subscribers import AgentNCSubscriber
 from swiss_ai_hub.core.topic_managers import AgentTopicManager
 
@@ -517,23 +517,8 @@ class AgentEndpointsDiscoveryService(EndpointsDiscoveryService):
 
             async def sse_event_generator():
                 """Generator that yields raw events as SSE without conversion"""
-                while True:
-                    if resources.stop_signal.is_set() and resources.chunk_queue.empty():
-                        logger.debug("Stop streaming due to stop_event and empty queue")
-                        break
-                    try:
-                        event = await asyncio.wait_for(resources.chunk_queue.get(), timeout=0.5)
-
-                        # Dump the raw event as JSON for SSE
-                        event_data = event.model_dump_json()
-                        yield f"data: {event_data}\n\n"
-
-                        resources.chunk_queue.task_done()
-                    except TimeoutError:
-                        # No new event yet; keep waiting
-                        continue
-                    except asyncio.CancelledError:
-                        break
+                async for event in ChatService.iter_streamed_display_events(resources):
+                    yield f"data: {event.model_dump_json()}\n\n"
 
                 # Final event to signal stream end
                 yield "data: [DONE]\n\n"

--- a/packages/core/swiss_ai_hub/core/routes/__init__.py
+++ b/packages/core/swiss_ai_hub/core/routes/__init__.py
@@ -1,7 +1,12 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from swiss_ai_hub.core.routes.chat.chat_service import ChatService, JsonResources, StreamingResources
+    from swiss_ai_hub.core.routes.chat.chat_service import (
+        DISPLAY_STREAM_DRAIN_GRACE_SECONDS,
+        ChatService,
+        JsonResources,
+        StreamingResources,
+    )
     from swiss_ai_hub.core.routes.controller import Controller
     from swiss_ai_hub.core.routes.health.dto.health_response import ApiHealthChecks, HealthResponse, ProcessHealthChecks
     from swiss_ai_hub.core.routes.health.health_checks import (
@@ -31,6 +36,7 @@ __all__ = [
     "HealthResponse",
     "ApiHealthChecks",
     "ChatService",
+    "DISPLAY_STREAM_DRAIN_GRACE_SECONDS",
     "Controller",
     "HealthCheckProvider",
     "HealthController",
@@ -52,6 +58,7 @@ _LAZY_IMPORTS = {
     "HealthResponse": "swiss_ai_hub.core.routes.health.dto.health_response",
     "ApiHealthChecks": "swiss_ai_hub.core.routes.health.dto.health_response",
     "ChatService": "swiss_ai_hub.core.routes.chat.chat_service",
+    "DISPLAY_STREAM_DRAIN_GRACE_SECONDS": "swiss_ai_hub.core.routes.chat.chat_service",
     "Controller": "swiss_ai_hub.core.routes.controller",
     "HealthCheckProvider": "swiss_ai_hub.core.routes.health.health_server",
     "HealthController": "swiss_ai_hub.core.routes.health.health_controller",

--- a/packages/core/swiss_ai_hub/core/routes/chat/chat_service.py
+++ b/packages/core/swiss_ai_hub/core/routes/chat/chat_service.py
@@ -49,6 +49,12 @@ from swiss_ai_hub.core.topics.agents.agent_instance_topic import AgentInstanceTo
 
 logger = logging.getLogger(__name__)
 
+# After a run's terminal event arrives, give trailing display events this long to surface before the
+# consumer finishes. NCSubscriber dispatches one asyncio task per message, so the stop event's task can
+# set the stop signal before a preceding chunk's task has finished enqueuing it — without this grace the
+# consumer ends on the stop and silently drops those in-flight chunks.
+DISPLAY_STREAM_DRAIN_GRACE_SECONDS = 0.25
+
 
 @dataclass
 class StreamingResources:
@@ -82,6 +88,38 @@ class ChatService:
     """
     Orchestrates chat interactions for both streaming and JSON-based endpoints.
     """
+
+    @staticmethod
+    async def iter_streamed_display_events(
+        resources: StreamingResources,
+        grace: float = DISPLAY_STREAM_DRAIN_GRACE_SECONDS,
+    ):
+        """
+        Yield queued display events until the run has stopped AND no event has surfaced for `grace`
+        seconds. The grace drains trailing events whose handler tasks finish after the terminal stop's
+        task sets the stop signal; ending on the bare stop signal would drop them.
+        """
+        while True:
+            try:
+                event = await asyncio.wait_for(resources.chunk_queue.get(), timeout=grace)
+                resources.chunk_queue.task_done()
+                yield event
+            except TimeoutError:
+                if resources.stop_signal.is_set():
+                    return
+
+    @staticmethod
+    async def wait_for_stop_then_drain(
+        resources: StreamingResources | JsonResources,
+        grace: float = DISPLAY_STREAM_DRAIN_GRACE_SECONDS,
+    ):
+        """
+        Block until the run stops, then wait out the drain grace so trailing display-event handler
+        tasks finish before the caller reads the collected events and tears the subscription down.
+        """
+        await resources.stop_signal.wait()
+        await asyncio.sleep(grace)
+        await resources.subscriber.stop()
 
     @staticmethod
     def _initialize_interaction(
@@ -374,4 +412,11 @@ class ChatService:
         chat_content.reasoning_content = "".join(getattr(chunk, "reasoning_content", "") for chunk in sorted_chunks)
         if stop_event.is_hitl_request_event:
             chat_content.content += stop_event.question
+            return chat_content
+        # Backstop: if every chunk was lost to the stop-vs-chunk dispatch race, recover the full answer
+        # from the stop event's durable payload so the response is never blank.
+        if not chat_content.content:
+            output_messages = getattr(stop_event, "output_messages", None) or []
+            if output_messages:
+                chat_content.content = output_messages[-1].content
         return chat_content

--- a/packages/core/swiss_ai_hub/core/routes/chat/chat_service.py
+++ b/packages/core/swiss_ai_hub/core/routes/chat/chat_service.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from typing import Annotated
 
@@ -92,16 +93,17 @@ class ChatService:
     @staticmethod
     async def iter_streamed_display_events(
         resources: StreamingResources,
-        grace: float = DISPLAY_STREAM_DRAIN_GRACE_SECONDS,
-    ):
+        drain_grace_seconds: float = DISPLAY_STREAM_DRAIN_GRACE_SECONDS,
+    ) -> AsyncGenerator[DisplayEvent]:
         """
-        Yield queued display events until the run has stopped AND no event has surfaced for `grace`
-        seconds. The grace drains trailing events whose handler tasks finish after the terminal stop's
-        task sets the stop signal; ending on the bare stop signal would drop them.
+        Yield queued display events until the run has stopped AND no event has surfaced for the drain
+        grace. The grace drains trailing events whose handler tasks finish after the terminal stop's
+        task sets the stop signal; ending on the bare stop signal would drop them. The subscription is
+        torn down by the aggregator that handles the stop event, not here.
         """
         while True:
             try:
-                event = await asyncio.wait_for(resources.chunk_queue.get(), timeout=grace)
+                event = await asyncio.wait_for(resources.chunk_queue.get(), timeout=drain_grace_seconds)
                 resources.chunk_queue.task_done()
                 yield event
             except TimeoutError:
@@ -111,15 +113,15 @@ class ChatService:
     @staticmethod
     async def wait_for_stop_then_drain(
         resources: StreamingResources | JsonResources,
-        grace: float = DISPLAY_STREAM_DRAIN_GRACE_SECONDS,
-    ):
+        drain_grace_seconds: float = DISPLAY_STREAM_DRAIN_GRACE_SECONDS,
+    ) -> None:
         """
         Block until the run stops, then wait out the drain grace so trailing display-event handler
-        tasks finish before the caller reads the collected events and tears the subscription down.
+        tasks finish before the caller reads the collected events. The subscription is already torn
+        down by the aggregator that handles the stop event.
         """
         await resources.stop_signal.wait()
-        await asyncio.sleep(grace)
-        await resources.subscriber.stop()
+        await asyncio.sleep(drain_grace_seconds)
 
     @staticmethod
     def _initialize_interaction(
@@ -407,16 +409,17 @@ class ChatService:
         Construct a JSON response from collected chunk events.
         """
         sorted_chunks = sorted(chunk_events, key=lambda x: x.created_at)
-        chat_content = ChatContent(content="", reasoning_content="")
-        chat_content.content = "".join(chunk.content for chunk in sorted_chunks)
+        streamed = "".join(chunk.content for chunk in sorted_chunks)
+        chat_content = ChatContent(content=streamed, reasoning_content="")
         chat_content.reasoning_content = "".join(getattr(chunk, "reasoning_content", "") for chunk in sorted_chunks)
         if stop_event.is_hitl_request_event:
             chat_content.content += stop_event.question
             return chat_content
-        # Backstop: if every chunk was lost to the stop-vs-chunk dispatch race, recover the full answer
-        # from the stop event's durable payload so the response is never blank.
-        if not chat_content.content:
-            output_messages = getattr(stop_event, "output_messages", None) or []
-            if output_messages:
-                chat_content.content = output_messages[-1].content
+        # Backstop: if chunks were lost to the stop-vs-chunk dispatch race, recover from the stop event's
+        # durable payload. Use the full answer whenever what streamed is a prefix of it (covers a fully
+        # empty body and a partial loss). Best-effort: a streamed value that diverges keeps what streamed.
+        output_messages = getattr(stop_event, "output_messages", None) or []
+        full_answer = (output_messages[-1].content or "") if output_messages else ""
+        if full_answer and full_answer.startswith(streamed):
+            chat_content.content = full_answer
         return chat_content

--- a/packages/core/swiss_ai_hub/core/routes/chat/test_chat_service_drain.py
+++ b/packages/core/swiss_ai_hub/core/routes/chat/test_chat_service_drain.py
@@ -16,6 +16,13 @@ def _streaming_resources() -> StreamingResources:
     )
 
 
+def _assistant_stop_event(content: str | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        is_hitl_request_event=False,
+        output_messages=[ChatMessage(role=MessageRole.ASSISTANT, content=content)],
+    )
+
+
 def test_drain_yields_chunk_enqueued_after_stop_signal():
     """
     Reproduces the stop-vs-chunk dispatch race: NCSubscriber handles every message in its own task, so a
@@ -27,7 +34,7 @@ def test_drain_yields_chunk_enqueued_after_stop_signal():
         collected: list[str] = []
 
         async def consume() -> None:
-            async for event in ChatService.iter_streamed_display_events(resources, grace=0.1):
+            async for event in ChatService.iter_streamed_display_events(resources, drain_grace_seconds=0.1):
                 collected.append(event.content)
 
         consumer = asyncio.create_task(consume())
@@ -48,31 +55,61 @@ def test_drain_terminates_after_grace_when_idle():
     async def scenario() -> list[ChunkEvent]:
         resources = _streaming_resources()
         resources.stop_signal.set()
-        return [event async for event in ChatService.iter_streamed_display_events(resources, grace=0.02)]
+        return [event async for event in ChatService.iter_streamed_display_events(resources, drain_grace_seconds=0.02)]
 
     assert asyncio.run(scenario()) == []
 
 
+def test_wait_for_stop_then_drain_blocks_until_stop_then_returns():
+    """wait_for_stop_then_drain returns only after the stop signal is set, then waits out the grace."""
+
+    async def scenario() -> bool:
+        resources = _streaming_resources()
+        drain = asyncio.create_task(ChatService.wait_for_stop_then_drain(resources, drain_grace_seconds=0.02))
+
+        await asyncio.sleep(0.01)
+        blocked_before_stop = not drain.done()
+
+        resources.stop_signal.set()
+        await asyncio.wait_for(drain, timeout=1.0)
+        return blocked_before_stop
+
+    assert asyncio.run(scenario()) is True
+
+
 def test_json_backstop_recovers_answer_when_all_chunks_lost():
     """If every chunk was dropped, the JSON answer is recovered from the stop event's durable payload."""
-    stop_event = SimpleNamespace(
-        is_hitl_request_event=False,
-        output_messages=[ChatMessage(role=MessageRole.ASSISTANT, content="recovered answer")],
+    content = ChatService.build_json_response_content(
+        chunk_events=[], stop_event=_assistant_stop_event("recovered answer")
     )
-
-    content = ChatService.build_json_response_content(chunk_events=[], stop_event=stop_event)
 
     assert content.content == "recovered answer"
 
 
-def test_json_keeps_streamed_chunks_when_present():
-    """When chunks streamed normally, the backstop stays dormant and does not duplicate the answer."""
-    stop_event = SimpleNamespace(
-        is_hitl_request_event=False,
-        output_messages=[ChatMessage(role=MessageRole.ASSISTANT, content="full answer")],
-    )
-    chunks = [ChunkEvent(content="full ", model_name="m"), ChunkEvent(content="answer", model_name="m")]
+def test_json_backstop_recovers_full_answer_on_partial_loss():
+    """If only a prefix of the answer streamed, the JSON backstop fills in the rest from the stop event."""
+    chunks = [ChunkEvent(content="full ", model_name="m")]
 
-    content = ChatService.build_json_response_content(chunk_events=chunks, stop_event=stop_event)
+    content = ChatService.build_json_response_content(
+        chunk_events=chunks, stop_event=_assistant_stop_event("full answer")
+    )
 
     assert content.content == "full answer"
+
+
+def test_json_keeps_streamed_chunks_when_present():
+    """When every chunk streamed, the backstop stays dormant and does not duplicate the answer."""
+    chunks = [ChunkEvent(content="full ", model_name="m"), ChunkEvent(content="answer", model_name="m")]
+
+    content = ChatService.build_json_response_content(
+        chunk_events=chunks, stop_event=_assistant_stop_event("full answer")
+    )
+
+    assert content.content == "full answer"
+
+
+def test_json_backstop_handles_none_message_content():
+    """A stop event whose message content is None must not produce a null body."""
+    content = ChatService.build_json_response_content(chunk_events=[], stop_event=_assistant_stop_event(None))
+
+    assert content.content == ""

--- a/packages/core/swiss_ai_hub/core/routes/chat/test_chat_service_drain.py
+++ b/packages/core/swiss_ai_hub/core/routes/chat/test_chat_service_drain.py
@@ -1,0 +1,78 @@
+import asyncio
+from types import SimpleNamespace
+
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+
+from swiss_ai_hub.core.events.agent.display.chunk_event import ChunkEvent
+from swiss_ai_hub.core.routes.chat.chat_service import ChatService, StreamingResources
+
+
+def _streaming_resources() -> StreamingResources:
+    return StreamingResources(
+        stop_signal=asyncio.Event(),
+        subscriber=None,
+        chunk_queue=asyncio.Queue(),
+        stop_event=None,
+    )
+
+
+def test_drain_yields_chunk_enqueued_after_stop_signal():
+    """
+    Reproduces the stop-vs-chunk dispatch race: NCSubscriber handles every message in its own task, so a
+    trailing chunk's task can enqueue just after the stop task sets the signal. The drain must still yield it.
+    """
+
+    async def scenario() -> list[str]:
+        resources = _streaming_resources()
+        collected: list[str] = []
+
+        async def consume() -> None:
+            async for event in ChatService.iter_streamed_display_events(resources, grace=0.1):
+                collected.append(event.content)
+
+        consumer = asyncio.create_task(consume())
+        await asyncio.sleep(0)  # let the consumer block on the queue
+
+        resources.stop_signal.set()  # the stop task wins the race...
+        await resources.chunk_queue.put(ChunkEvent(content="trailing", model_name="m"))  # ...chunk arrives after
+
+        await asyncio.wait_for(consumer, timeout=1.0)
+        return collected
+
+    assert asyncio.run(scenario()) == ["trailing"]
+
+
+def test_drain_terminates_after_grace_when_idle():
+    """With the run stopped and nothing in flight, the drain ends once the grace window elapses."""
+
+    async def scenario() -> list[ChunkEvent]:
+        resources = _streaming_resources()
+        resources.stop_signal.set()
+        return [event async for event in ChatService.iter_streamed_display_events(resources, grace=0.02)]
+
+    assert asyncio.run(scenario()) == []
+
+
+def test_json_backstop_recovers_answer_when_all_chunks_lost():
+    """If every chunk was dropped, the JSON answer is recovered from the stop event's durable payload."""
+    stop_event = SimpleNamespace(
+        is_hitl_request_event=False,
+        output_messages=[ChatMessage(role=MessageRole.ASSISTANT, content="recovered answer")],
+    )
+
+    content = ChatService.build_json_response_content(chunk_events=[], stop_event=stop_event)
+
+    assert content.content == "recovered answer"
+
+
+def test_json_keeps_streamed_chunks_when_present():
+    """When chunks streamed normally, the backstop stays dormant and does not duplicate the answer."""
+    stop_event = SimpleNamespace(
+        is_hitl_request_event=False,
+        output_messages=[ChatMessage(role=MessageRole.ASSISTANT, content="full answer")],
+    )
+    chunks = [ChunkEvent(content="full ", model_name="m"), ChunkEvent(content="answer", model_name="m")]
+
+    content = ChatService.build_json_response_content(chunk_events=chunks, stop_event=stop_event)
+
+    assert content.content == "full answer"


### PR DESCRIPTION
## Problem

Short agent answers (notably self-awareness meta-answers and one-token replies) intermittently render **blank**, and the empty assistant turn poisons follow-up requests (some providers reject an empty assistant message with a 400).

## Root cause

`NCSubscriber` dispatches **one `asyncio` task per message**. Messages are delivered to the handler in order, but their handler tasks run concurrently, so the terminal stop event's task can set the stop signal before a preceding chunk's task has enqueued it. All four streaming consumers ended the instant the stop signal was set and the queue looked empty, dropping the in-flight chunk(s). This is a consumer-side task-scheduling race, not NATS message reordering.

Affected consumers: OpenAI SSE generator, OpenAI JSON aggregate, agent `_send_event` aggregate, and the native raw-event stream used by the OpenWebUI aihub pipe.

## Fix

- Shared helpers on `ChatService` used by all four sites:
  - `iter_streamed_display_events()` — yields display events until the run has stopped **and** the queue has been idle for a grace window, so trailing handler tasks complete before the consumer ends.
  - `wait_for_stop_then_drain()` — for collect-then-build paths.
- `DISPLAY_STREAM_DRAIN_GRACE_SECONDS = 0.25`.
- **Backstop**: the answer is recovered from the stop event's durable `output_messages` via delta reconciliation in `_resolve_final_content` (SSE) and `build_json_response_content` (JSON), so the answer can never blank even if the drain misses a straggler.

Alternatives considered (and why rejected) are recorded in the ADR: answer-only reconciliation (too narrow), producer transport unification (race is consumer-side), and durable-consume (blocked by per-class, non-overlapping JetStream streams across delegating threads).

## Tests

`packages/core/.../routes/chat/test_chat_service_drain.py` — deterministic repro of the stop-vs-chunk race plus backstop cases (4 tests, green). Core routes suite green. API integration tests run in CI (the `swiss_ai_hub.jambo` dep is unavailable locally).

## Docs

ADR `docs/arc42/decisions/2026_06_09_drain_display_event_streams_before_consumer_teardown.md`.

## Follow-ups (noted in the ADR, out of scope here)

- Producer transport inconsistency: chunks publish to JetStream, the terminal event's display copy to NATS core.
- Scope docs call display events "ephemeral"; they are in fact stream-persisted.
- Once merged, the self-awareness `stop_after_meta_answer_step` / `MetaAnswerReadyEvent` indirection (PR #1379) can be removed — the streaming race it worked around is now handled at the consumer.