### PR TITLE
fix(iac): Attach otel-collector to egress network for SigNoz export

### DIFF
--- a/infra/deployment/templates/docker-compose.yml.j2
+++ b/infra/deployment/templates/docker-compose.yml.j2
@@ -2014,6 +2014,7 @@ services:
         max-file: 2
     networks:
       - backend
+      - egress
 
   # ===================================================================
   # Open WebUI Stack (Primary User Interface)

--- a/infra/docker-compose.build.gpu.yml
+++ b/infra/docker-compose.build.gpu.yml
@@ -1794,6 +1794,7 @@ services:
         max-file: 2
     networks:
       - backend
+      - egress
 
   # ===================================================================
   # Open WebUI Stack (Primary User Interface)

--- a/infra/docker-compose.build.yml
+++ b/infra/docker-compose.build.yml
@@ -1574,6 +1574,7 @@ services:
         max-file: 2
     networks:
       - backend
+      - egress
 
   # ===================================================================
   # Open WebUI Stack (Primary User Interface)

--- a/infra/docker-compose.dev.gpu.yml
+++ b/infra/docker-compose.dev.gpu.yml
@@ -1493,6 +1493,7 @@ services:
         max-file: 2
     networks:
       - backend
+      - egress
 
   # ===================================================================
   # Open WebUI Stack (Primary User Interface)

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -1273,6 +1273,7 @@ services:
         max-file: 2
     networks:
       - backend
+      - egress
 
   # ===================================================================
   # Open WebUI Stack (Primary User Interface)

--- a/infra/docker-compose.latest.gpu.yml
+++ b/infra/docker-compose.latest.gpu.yml
@@ -1760,6 +1760,7 @@ services:
         max-file: 2
     networks:
       - backend
+      - egress
 
   # ===================================================================
   # Open WebUI Stack (Primary User Interface)

--- a/infra/docker-compose.latest.yml
+++ b/infra/docker-compose.latest.yml
@@ -1546,6 +1546,7 @@ services:
         max-file: 2
     networks:
       - backend
+      - egress
 
   # ===================================================================
   # Open WebUI Stack (Primary User Interface)

--- a/infra/docker-compose.local.gpu.yml
+++ b/infra/docker-compose.local.gpu.yml
@@ -1787,6 +1787,7 @@ services:
         max-file: 2
     networks:
       - backend
+      - egress
 
   # ===================================================================
   # Open WebUI Stack (Primary User Interface)

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -1567,6 +1567,7 @@ services:
         max-file: 2
     networks:
       - backend
+      - egress
 
   # ===================================================================
   # Open WebUI Stack (Primary User Interface)

--- a/infra/docker-compose.nightly.gpu.yml
+++ b/infra/docker-compose.nightly.gpu.yml
@@ -1761,6 +1761,7 @@ services:
         max-file: 2
     networks:
       - backend
+      - egress
 
   # ===================================================================
   # Open WebUI Stack (Primary User Interface)

--- a/infra/docker-compose.nightly.yml
+++ b/infra/docker-compose.nightly.yml
@@ -1546,6 +1546,7 @@ services:
         max-file: 2
     networks:
       - backend
+      - egress
 
   # ===================================================================
   # Open WebUI Stack (Primary User Interface)


### PR DESCRIPTION
## Problem

In online deployments (`nightly`/`latest`), the otel-collector cannot reach SigNoz Cloud. Logs show a continuous failure cascade:

```
dns: A record lookup error: lookup ingest.eu.signoz.cloud on 127.0.0.11:53: server misbehaving
...
exporter otlp/cloud: no more retries left ... dropped_items: 2818
batch processor: sending queue is full
```

## Root cause

The `otel-collector` service was attached to **only the `backend` network**, which is declared `internal: true` in every non-dev stage:

```yaml
backend:
  driver: bridge
  {%- if stage != 'dev' %}
  internal: true   # no gateway to the outside world
  {%- endif %}
```

An `internal` Docker network has no NAT route to the internet. The collector's exporter targets the **external** SigNoz Cloud endpoint (`ingest.eu.signoz.cloud`), so it cannot even DNS-resolve the host via Docker's embedded resolver (`127.0.0.11`) — surfacing as `server misbehaving` (SERVFAIL). The "sending queue is full" / "dropping data" errors are the downstream symptom of every export failing.

This only manifests online: in `dev` the networks are non-internal, so it works there.

## Fix

Add the `egress` network (the only zone with outbound internet) to the otel-collector, keeping `backend` so app services still push OTLP to it on `:4317`.

```yaml
networks:
  - backend
  - egress
```

`egress` has inter-container communication disabled (`enable_icc: "false"`), which only blocks container-to-container traffic — outbound-to-internet (what the collector needs) is unaffected.

## Changes

- `infra/deployment/templates/docker-compose.yml.j2` — the source-of-truth template
- 10 regenerated `infra/docker-compose.{stage}{.gpu}.yml` files (via `make generate-compose`)

Each compose file is a single `+ - egress` line under the otel-collector `networks:` block.

## Test plan

- [ ] Deploy to nightly and confirm otel-collector exports succeed (no `server misbehaving` / `sending queue is full` in collector logs)
- [ ] Confirm traces/metrics/logs land in SigNoz Cloud