### PR TITLE
fix(swiss-ai-hub): Avoid  partition name collision in default_rclone_to_datalake_definition

### DIFF
--- a/packages/pipeline/CLAUDE.md
+++ b/packages/pipeline/CLAUDE.md
@@ -248,6 +248,14 @@ def observe_source(context, client: ResourceParam[SourceResource]) -> DataVersio
 `replace_partition_keys(context, partition_name, keys, max_partitions)` in `util/partition_utils.py`. Default max: 1000
 partitions added/deleted per tick.
 
+**Partition definition naming convention**: `DynamicPartitionsDefinition` names are global within a single Dagster
+instance — two factories using the same name will collide and share partition state. All
+`default_*_to_datalake_definitions` builders therefore derive the name from both the data lake container and the source,
+in the form `{datalake_container_name}_{source_name}_rclone_partitions` (and the analogous shape for sharepoint,
+local_fs, etc.). Never hard-code a partition definition name in a factory: when multiple pipelines (e.g. two
+rclone-backed sources for different tenants) are registered in the same Dagster code location, the name must be unique
+per pipeline.
+
 ## Automation & Triggering
 
 Four triggering mechanisms work together:

--- a/packages/pipeline/swiss_ai_hub/pipeline/util/definitions_util.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/util/definitions_util.py
@@ -453,8 +453,6 @@ def default_rclone_to_datalake_definitions(
     """
     encode = resolve_encode_partition_keys(encode_partition_keys)
 
-    rclone_partitions = DynamicPartitionsDefinition(name="rclone_partitions")
-
     # Extract source name from config or from source_remote (e.g., "onedrive:Documents" -> "onedrive")
     # Ensure we always derive a non-empty, stable source_name for asset keys
     if rclone_config and rclone_config.name:
@@ -467,6 +465,8 @@ def default_rclone_to_datalake_definitions(
             source_name = candidate if candidate else "local_fs"
         else:
             source_name = "local_fs"
+
+    rclone_partitions = DynamicPartitionsDefinition(name=f"{datalake_container_name}_{source_name}_rclone_partitions")
 
     pipeline_group = f"{source_name}_to_datalake"
 

--- a/packages/pipeline/swiss_ai_hub/pipeline/util/tests/test_definitions_util.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/util/tests/test_definitions_util.py
@@ -1,6 +1,10 @@
 import warnings
+from unittest.mock import patch
 
-from swiss_ai_hub.pipeline.util.definitions_util import resolve_encode_partition_keys
+from swiss_ai_hub.pipeline.util.definitions_util import (
+    default_rclone_to_datalake_definitions,
+    resolve_encode_partition_keys,
+)
 
 
 class TestResolveEncodePartitionKeys:
@@ -18,3 +22,26 @@ class TestResolveEncodePartitionKeys:
             assert len(w) == 1
             assert issubclass(w[0].category, DeprecationWarning)
             assert "encode_partition_keys" in str(w[0].message)
+
+
+class TestRclonePipelinePartitionNaming:
+    """Regression test for issue #1236: two rclone pipelines registered in the same
+    Dagster instance must produce distinct ``DynamicPartitionsDefinition`` names so
+    that their partition state does not collide."""
+
+    @patch("swiss_ai_hub.pipeline.util.definitions_util.get_db_name_from_bucket_name")
+    def test_two_rclone_pipelines_have_distinct_partition_names(self, mock_get_db_name) -> None:
+        mock_get_db_name.side_effect = lambda bucket_name, **_: bucket_name
+
+        defs_a = default_rclone_to_datalake_definitions(
+            datalake_container_name="bucket_a",
+            source_remote="onedrive:Docs",
+            encode_partition_keys=False,
+        )
+        defs_b = default_rclone_to_datalake_definitions(
+            datalake_container_name="bucket_a",
+            source_remote="gdrive:Shared",
+            encode_partition_keys=False,
+        )
+
+        assert defs_a.assets[0].partitions_def.name != defs_b.assets[0].partitions_def.name


### PR DESCRIPTION
## Summary
Fixes https://github.com/bbvch-ai/aihub-core/issues/1236

## Considerations
For consistency with sibling factories, the name is built as:
"{datalake_container_name}_{source_name}_rclone_partitions"

...in contrast to:
"rclone_{source_name}_partitions" as suggested in the issue.

Examples:

- f"{datalake_container_name}_document_partitions" # default_definitions
- f"{datalake_container_name}_sharepoint_partitions" # default_sharepoint_to_datalake_definitions
- f"{datalake_container_name}_local_fs_partitions" # default_local_filesystem_to_datalake_definitions