### PR TITLE
fix(deploy): Add traefik.docker.network label to langfuse-web

### DIFF
--- a/infra/deployment/templates/docker-compose.yml.j2
+++ b/infra/deployment/templates/docker-compose.yml.j2
@@ -1000,6 +1000,7 @@ services:
     {%- if stage != 'dev' %}
     labels:
       - "traefik.enable=true"
+      - "traefik.docker.network=proxy"
       - "traefik.http.routers.langfuse.rule=Host(`langfuse.${DOMAIN}`)"
       - "traefik.http.routers.langfuse.priority=4000"
       - "traefik.http.routers.langfuse.entrypoints=websecure"

--- a/infra/docker-compose.build.gpu.yml
+++ b/infra/docker-compose.build.gpu.yml
@@ -871,6 +871,7 @@ services:
         max-file: 2
     labels:
       - traefik.enable=true
+      - traefik.docker.network=proxy
       - traefik.http.routers.langfuse.rule=Host(`langfuse.${DOMAIN}`)
       - traefik.http.routers.langfuse.priority=4000
       - traefik.http.routers.langfuse.entrypoints=websecure

--- a/infra/docker-compose.build.yml
+++ b/infra/docker-compose.build.yml
@@ -871,6 +871,7 @@ services:
         max-file: 2
     labels:
       - traefik.enable=true
+      - traefik.docker.network=proxy
       - traefik.http.routers.langfuse.rule=Host(`langfuse.${DOMAIN}`)
       - traefik.http.routers.langfuse.priority=4000
       - traefik.http.routers.langfuse.entrypoints=websecure

--- a/infra/docker-compose.latest.gpu.yml
+++ b/infra/docker-compose.latest.gpu.yml
@@ -857,6 +857,7 @@ services:
         max-file: 2
     labels:
       - traefik.enable=true
+      - traefik.docker.network=proxy
       - traefik.http.routers.langfuse.rule=Host(`langfuse.${DOMAIN}`)
       - traefik.http.routers.langfuse.priority=4000
       - traefik.http.routers.langfuse.entrypoints=websecure

--- a/infra/docker-compose.latest.yml
+++ b/infra/docker-compose.latest.yml
@@ -857,6 +857,7 @@ services:
         max-file: 2
     labels:
       - traefik.enable=true
+      - traefik.docker.network=proxy
       - traefik.http.routers.langfuse.rule=Host(`langfuse.${DOMAIN}`)
       - traefik.http.routers.langfuse.priority=4000
       - traefik.http.routers.langfuse.entrypoints=websecure

--- a/infra/docker-compose.local.gpu.yml
+++ b/infra/docker-compose.local.gpu.yml
@@ -870,6 +870,7 @@ services:
         max-file: 2
     labels:
       - traefik.enable=true
+      - traefik.docker.network=proxy
       - traefik.http.routers.langfuse.rule=Host(`langfuse.${DOMAIN}`)
       - traefik.http.routers.langfuse.priority=4000
       - traefik.http.routers.langfuse.entrypoints=websecure

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -870,6 +870,7 @@ services:
         max-file: 2
     labels:
       - traefik.enable=true
+      - traefik.docker.network=proxy
       - traefik.http.routers.langfuse.rule=Host(`langfuse.${DOMAIN}`)
       - traefik.http.routers.langfuse.priority=4000
       - traefik.http.routers.langfuse.entrypoints=websecure

--- a/infra/docker-compose.nightly.gpu.yml
+++ b/infra/docker-compose.nightly.gpu.yml
@@ -857,6 +857,7 @@ services:
         max-file: 2
     labels:
       - traefik.enable=true
+      - traefik.docker.network=proxy
       - traefik.http.routers.langfuse.rule=Host(`langfuse.${DOMAIN}`)
       - traefik.http.routers.langfuse.priority=4000
       - traefik.http.routers.langfuse.entrypoints=websecure

--- a/infra/docker-compose.nightly.yml
+++ b/infra/docker-compose.nightly.yml
@@ -857,6 +857,7 @@ services:
         max-file: 2
     labels:
       - traefik.enable=true
+      - traefik.docker.network=proxy
       - traefik.http.routers.langfuse.rule=Host(`langfuse.${DOMAIN}`)
       - traefik.http.routers.langfuse.priority=4000
       - traefik.http.routers.langfuse.entrypoints=websecure


### PR DESCRIPTION
## Summary

`langfuse-web` is attached to four Docker networks (`backend`, `data`, `storage`, `proxy`) but did not declare a `traefik.docker.network` label. Without it, Traefik can select a network it is not attached to when resolving the container's address, causing intermittent or total routing failures to the Langfuse UI. Every other Traefik-enabled service already sets this label — `langfuse-web` was the only one missing it.

## Changes

- Add `- "traefik.docker.network=proxy"` to the `langfuse-web` labels block in `infra/deployment/templates/docker-compose.yml.j2`.
- Regenerate all affected compose files via `make generate-compose` (8 non-dev variants: build/latest/local/nightly × gpu/non-gpu). Dev stages are unaffected — they run no Traefik.

## Test plan

- Audited the template: all 15 services with `traefik.enable=true` now carry a `traefik.docker.network` label (counts match 15/15; was 15/14 before the fix).
- Verified the label propagated correctly into each generated non-dev compose file.
- Change is YAML-only; no application code affected.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>`
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [ ] CLA signed
- [x] Tests added or updated where relevant (N/A — infra YAML only)