### PR TITLE
fix(swiss-ai-hub): Persist login sessions and restore active tenant after login

### DIFF
--- a/docs/arc42/decisions/2026_06_11_keycloak_sso_session_lifespans.md
+++ b/docs/arc42/decisions/2026_06_11_keycloak_sso_session_lifespans.md
@@ -1,0 +1,81 @@
+# Keycloak SSO Session Lifespans
+
+## Context
+
+The Keycloak realm import never set any session or token lifetime values, so every deployment ran on Keycloak's
+defaults: 30 minutes SSO session idle timeout and 10 hours SSO session max lifespan. The admin UI is a pure SPA OIDC
+client (`oidc-client-ts`) whose refresh token is an *online* token bound to the SSO session — `offline_access` is not
+requested. Any overnight pause therefore exceeded the 30-minute idle window, invalidated the refresh token stored in
+localStorage, and forced users through a full credential login every morning.
+
+Two timers govern an SSO session, whichever fires first ends it:
+
+- **`ssoSessionIdleTimeout`** — sliding window; resets on every session activity (most importantly each refresh-token
+  grant). Expires sessions that go unused.
+- **`ssoSessionMaxLifespan`** — hard ceiling counted from login, regardless of activity. Bounds the total lifetime of
+  any session.
+
+A complicating operational constraint: the realm JSON is imported on **first container start only**
+(`keycloak-entrypoint.sh` deliberately avoids `OVERWRITE_EXISTING`, see import strategy comments there). Realm-level
+settings added to the template never reach already-provisioned deployments.
+
+## Decision Drivers
+
+- **Daily forced re-login is unacceptable UX**:\
+  An enterprise platform used as a daily co-worker must survive an overnight pause and a normal weekend (Friday evening
+  → Monday morning, ~2.5 days idle) without re-authentication.
+- **Sessions must still expire**:\
+  Unbounded sessions extend the window in which a stolen refresh token or an offboarded user's live session remains
+  usable. Periodic re-authentication re-verifies credentials against the identity provider (e.g. picks up disabled Entra
+  ID accounts).
+- **Existing deployments must converge without manual intervention**:\
+  Auto-deployed customer environments (ansible-pull every 15 minutes) cannot rely on a first-start-only realm import to
+  pick up lifespan changes, and operators should not have to run `kcadm` by hand.
+- **Single source of truth**:\
+  The values must not drift between the realm template (fresh installs) and any runtime enforcement mechanism.
+
+## Decision
+
+**SSO session lifespans are set explicitly to 5 days idle (`ssoSessionIdleTimeout: 432000`) and 30 days max
+(`ssoSessionMaxLifespan: 2592000`), defined once in `infra/deployment/compose-config.yml` under the `keycloak:`
+section.**
+
+The chosen values balance the drivers: 5 days idle comfortably covers overnight pauses and weekends while expiring
+sessions abandoned for a full vacation week; 30 days max caps the total lifetime of even continuously used sessions,
+forcing a credential re-verification at least monthly.
+
+### Implementation
+
+- **`compose-config.yml`** holds the values; both Jinja2 templates below render from it, so there is exactly one place
+  to change them.
+- **`keycloak-realm.json.j2`** includes the lifespans in the realm import — fresh installs are correct from first start.
+- **`keycloak-entrypoint.sh.j2`** applies the lifespans via `kcadm.sh update realms/aihub` in the post-startup block on
+  **every container start** — existing deployments converge on their next Keycloak container recreation, without realm
+  re-import and without touching users, clients, or sessions.
+
+## Consequences
+
+### Positive
+
+- Users stay logged in across nights and weekends; silent token renewal succeeds instead of redirecting to the login
+  page.
+- The persisted active-tenant restore (see related decision) is reached through silent renew rather than a fresh login,
+  so users land directly in their last tenant.
+- Lifespan changes are a one-line config edit followed by `make generate-compose`; rollout to all deployments is
+  automatic on the next Keycloak container start.
+
+### Trade-offs
+
+- A leaked refresh token remains usable for up to 5 days of inactivity (previously 30 minutes). Mitigations: tokens are
+  bound to the Keycloak session and revoked server-side on logout (`useAuth.logout()` calls the backchannel logout), and
+  the 30-day ceiling bounds the worst case.
+- The lifespans are enforced on every start, so ad-hoc changes made through the Keycloak admin console are overwritten
+  on the next container restart — intended, since config-as-code is the source of truth, but admins must know the
+  console is not authoritative for these two settings.
+- Sessions already expired before the rollout cannot be revived; users see one final forced login after the change is
+  deployed.
+
+### Related Decisions
+
+- `2026_04_07_active_tenant_as_keycloak_user_attribute.md` — active tenant persisted in Keycloak, restored after login
+- `2025_12_28_keycloak_as_identity_broker.md` — Keycloak as sole OIDC provider

--- a/docs/arc42/decisions/2026_06_11_keycloak_sso_session_lifespans.md
+++ b/docs/arc42/decisions/2026_06_11_keycloak_sso_session_lifespans.md
@@ -29,8 +29,8 @@ settings added to the template never reach already-provisioned deployments.
   usable. Periodic re-authentication re-verifies credentials against the identity provider (e.g. picks up disabled Entra
   ID accounts).
 - **Existing deployments must converge without manual intervention**:\
-  Auto-deployed customer environments (ansible-pull every 15 minutes) cannot rely on a first-start-only realm import to
-  pick up lifespan changes, and operators should not have to run `kcadm` by hand.
+  Automatically updated customer environments cannot rely on a first-start-only realm import to pick up lifespan
+  changes, and operators should not have to run `kcadm` by hand.
 - **Single source of truth**:\
   The values must not drift between the realm template (fresh installs) and any runtime enforcement mechanism.
 

--- a/docs/arc42/decisions/2026_06_11_keycloak_sso_session_lifespans.md
+++ b/docs/arc42/decisions/2026_06_11_keycloak_sso_session_lifespans.md
@@ -50,8 +50,10 @@ forcing a credential re-verification at least monthly.
   to change them.
 - **`keycloak-realm.json.j2`** includes the lifespans in the realm import — fresh installs are correct from first start.
 - **`keycloak-entrypoint.sh.j2`** applies the lifespans via `kcadm.sh update realms/aihub` in the post-startup block on
-  **every container start** — existing deployments converge on their next Keycloak container recreation, without realm
-  re-import and without touching users, clients, or sessions.
+  container start, but **only for fields still holding the Keycloak default** (30 min idle / 10 h max). Existing
+  deployments converge on their next Keycloak container recreation, without realm re-import and without touching users,
+  clients, or sessions — while values an operator customized in the admin console are left untouched. Each of the two
+  fields is checked independently.
 
 ## Consequences
 
@@ -69,9 +71,12 @@ forcing a credential re-verification at least monthly.
 - A leaked refresh token remains usable for up to 5 days of inactivity (previously 30 minutes). Mitigations: tokens are
   bound to the Keycloak session and revoked server-side on logout (`useAuth.logout()` calls the backchannel logout), and
   the 30-day ceiling bounds the worst case.
-- The lifespans are enforced on every start, so ad-hoc changes made through the Keycloak admin console are overwritten
-  on the next container restart — intended, since config-as-code is the source of truth, but admins must know the
-  console is not authoritative for these two settings.
+- The entrypoint only migrates away from Keycloak defaults; it does not enforce the configured values. A deployment
+  whose lifespans were already migrated (or customized) will not pick up future changes to the platform defaults in
+  `compose-config.yml` — rolling out new values to such deployments requires a manual `kcadm`/admin-console change.
+- An operator who deliberately sets a lifespan back to the exact Keycloak default (1800 or 36000 seconds) will see it
+  migrated to the platform value on the next container start, since it is indistinguishable from a never-configured
+  realm.
 - Sessions already expired before the rollout cannot be revived; users see one final forced login after the change is
   deployed.
 

--- a/infra/configs/keycloak/aihub-realm.build.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.build.gpu.json
@@ -11,7 +11,7 @@
   "registrationAllowed": false,
   "registrationEmailAsUsername": true,
   "rememberMe": true,
-  "ssoSessionIdleTimeout": 1209600,
+  "ssoSessionIdleTimeout": 432000,
   "ssoSessionMaxLifespan": 2592000,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,

--- a/infra/configs/keycloak/aihub-realm.build.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.build.gpu.json
@@ -11,6 +11,8 @@
   "registrationAllowed": false,
   "registrationEmailAsUsername": true,
   "rememberMe": true,
+  "ssoSessionIdleTimeout": 1209600,
+  "ssoSessionMaxLifespan": 2592000,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,

--- a/infra/configs/keycloak/aihub-realm.build.json
+++ b/infra/configs/keycloak/aihub-realm.build.json
@@ -11,7 +11,7 @@
   "registrationAllowed": false,
   "registrationEmailAsUsername": true,
   "rememberMe": true,
-  "ssoSessionIdleTimeout": 1209600,
+  "ssoSessionIdleTimeout": 432000,
   "ssoSessionMaxLifespan": 2592000,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,

--- a/infra/configs/keycloak/aihub-realm.build.json
+++ b/infra/configs/keycloak/aihub-realm.build.json
@@ -11,6 +11,8 @@
   "registrationAllowed": false,
   "registrationEmailAsUsername": true,
   "rememberMe": true,
+  "ssoSessionIdleTimeout": 1209600,
+  "ssoSessionMaxLifespan": 2592000,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,

--- a/infra/configs/keycloak/aihub-realm.dev.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.dev.gpu.json
@@ -11,7 +11,7 @@
   "registrationAllowed": false,
   "registrationEmailAsUsername": true,
   "rememberMe": true,
-  "ssoSessionIdleTimeout": 1209600,
+  "ssoSessionIdleTimeout": 432000,
   "ssoSessionMaxLifespan": 2592000,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,

--- a/infra/configs/keycloak/aihub-realm.dev.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.dev.gpu.json
@@ -11,6 +11,8 @@
   "registrationAllowed": false,
   "registrationEmailAsUsername": true,
   "rememberMe": true,
+  "ssoSessionIdleTimeout": 1209600,
+  "ssoSessionMaxLifespan": 2592000,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,

--- a/infra/configs/keycloak/aihub-realm.dev.json
+++ b/infra/configs/keycloak/aihub-realm.dev.json
@@ -11,7 +11,7 @@
   "registrationAllowed": false,
   "registrationEmailAsUsername": true,
   "rememberMe": true,
-  "ssoSessionIdleTimeout": 1209600,
+  "ssoSessionIdleTimeout": 432000,
   "ssoSessionMaxLifespan": 2592000,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,

--- a/infra/configs/keycloak/aihub-realm.dev.json
+++ b/infra/configs/keycloak/aihub-realm.dev.json
@@ -11,6 +11,8 @@
   "registrationAllowed": false,
   "registrationEmailAsUsername": true,
   "rememberMe": true,
+  "ssoSessionIdleTimeout": 1209600,
+  "ssoSessionMaxLifespan": 2592000,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,

--- a/infra/configs/keycloak/aihub-realm.latest.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.latest.gpu.json
@@ -11,7 +11,7 @@
   "registrationAllowed": false,
   "registrationEmailAsUsername": true,
   "rememberMe": true,
-  "ssoSessionIdleTimeout": 1209600,
+  "ssoSessionIdleTimeout": 432000,
   "ssoSessionMaxLifespan": 2592000,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,

--- a/infra/configs/keycloak/aihub-realm.latest.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.latest.gpu.json
@@ -11,6 +11,8 @@
   "registrationAllowed": false,
   "registrationEmailAsUsername": true,
   "rememberMe": true,
+  "ssoSessionIdleTimeout": 1209600,
+  "ssoSessionMaxLifespan": 2592000,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,

--- a/infra/configs/keycloak/aihub-realm.latest.json
+++ b/infra/configs/keycloak/aihub-realm.latest.json
@@ -11,7 +11,7 @@
   "registrationAllowed": false,
   "registrationEmailAsUsername": true,
   "rememberMe": true,
-  "ssoSessionIdleTimeout": 1209600,
+  "ssoSessionIdleTimeout": 432000,
   "ssoSessionMaxLifespan": 2592000,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,

--- a/infra/configs/keycloak/aihub-realm.latest.json
+++ b/infra/configs/keycloak/aihub-realm.latest.json
@@ -11,6 +11,8 @@
   "registrationAllowed": false,
   "registrationEmailAsUsername": true,
   "rememberMe": true,
+  "ssoSessionIdleTimeout": 1209600,
+  "ssoSessionMaxLifespan": 2592000,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,

--- a/infra/configs/keycloak/aihub-realm.local.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.local.gpu.json
@@ -11,7 +11,7 @@
   "registrationAllowed": false,
   "registrationEmailAsUsername": true,
   "rememberMe": true,
-  "ssoSessionIdleTimeout": 1209600,
+  "ssoSessionIdleTimeout": 432000,
   "ssoSessionMaxLifespan": 2592000,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,

--- a/infra/configs/keycloak/aihub-realm.local.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.local.gpu.json
@@ -11,6 +11,8 @@
   "registrationAllowed": false,
   "registrationEmailAsUsername": true,
   "rememberMe": true,
+  "ssoSessionIdleTimeout": 1209600,
+  "ssoSessionMaxLifespan": 2592000,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,

--- a/infra/configs/keycloak/aihub-realm.local.json
+++ b/infra/configs/keycloak/aihub-realm.local.json
@@ -11,7 +11,7 @@
   "registrationAllowed": false,
   "registrationEmailAsUsername": true,
   "rememberMe": true,
-  "ssoSessionIdleTimeout": 1209600,
+  "ssoSessionIdleTimeout": 432000,
   "ssoSessionMaxLifespan": 2592000,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,

--- a/infra/configs/keycloak/aihub-realm.local.json
+++ b/infra/configs/keycloak/aihub-realm.local.json
@@ -11,6 +11,8 @@
   "registrationAllowed": false,
   "registrationEmailAsUsername": true,
   "rememberMe": true,
+  "ssoSessionIdleTimeout": 1209600,
+  "ssoSessionMaxLifespan": 2592000,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,

--- a/infra/configs/keycloak/aihub-realm.nightly.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.nightly.gpu.json
@@ -11,7 +11,7 @@
   "registrationAllowed": false,
   "registrationEmailAsUsername": true,
   "rememberMe": true,
-  "ssoSessionIdleTimeout": 1209600,
+  "ssoSessionIdleTimeout": 432000,
   "ssoSessionMaxLifespan": 2592000,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,

--- a/infra/configs/keycloak/aihub-realm.nightly.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.nightly.gpu.json
@@ -11,6 +11,8 @@
   "registrationAllowed": false,
   "registrationEmailAsUsername": true,
   "rememberMe": true,
+  "ssoSessionIdleTimeout": 1209600,
+  "ssoSessionMaxLifespan": 2592000,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,

--- a/infra/configs/keycloak/aihub-realm.nightly.json
+++ b/infra/configs/keycloak/aihub-realm.nightly.json
@@ -11,7 +11,7 @@
   "registrationAllowed": false,
   "registrationEmailAsUsername": true,
   "rememberMe": true,
-  "ssoSessionIdleTimeout": 1209600,
+  "ssoSessionIdleTimeout": 432000,
   "ssoSessionMaxLifespan": 2592000,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,

--- a/infra/configs/keycloak/aihub-realm.nightly.json
+++ b/infra/configs/keycloak/aihub-realm.nightly.json
@@ -11,6 +11,8 @@
   "registrationAllowed": false,
   "registrationEmailAsUsername": true,
   "rememberMe": true,
+  "ssoSessionIdleTimeout": 1209600,
+  "ssoSessionMaxLifespan": 2592000,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,

--- a/infra/configs/keycloak/keycloak-entrypoint.sh
+++ b/infra/configs/keycloak/keycloak-entrypoint.sh
@@ -63,7 +63,7 @@ cp /tmp/aihub-realm.json /opt/keycloak/data/import/
       || echo "ERROR: Failed to apply identity providers."
   fi
   /opt/keycloak/bin/kcadm.sh update realms/aihub \
-    -s ssoSessionIdleTimeout=1209600 \
+    -s ssoSessionIdleTimeout=432000 \
     -s ssoSessionMaxLifespan=2592000 \
     && echo "Realm session lifespans applied successfully." \
     || echo "ERROR: Failed to apply realm session lifespans."

--- a/infra/configs/keycloak/keycloak-entrypoint.sh
+++ b/infra/configs/keycloak/keycloak-entrypoint.sh
@@ -16,9 +16,10 @@
 # - identity-providers.json: Applied via partialImport API after startup (every start,
 #   with OVERWRITE so config changes are picked up). This keeps the files separate
 #   and avoids --import-realm's OVERWRITE_EXISTING destroying the realm.
-# - Realm session lifespans: Applied via kcadm update after startup (every start),
-#   because the first-start-only realm import never propagates them to
-#   existing deployments.
+# - Realm session lifespans: Applied via kcadm update after startup, but only
+#   while a lifespan still holds the Keycloak default (30 min idle / 10 h max) —
+#   the first-start-only realm import never propagates them to existing
+#   deployments, while operator overrides made in the admin console must survive.
 
 set -euo pipefail
 
@@ -45,7 +46,9 @@ cp /tmp/aihub-realm.json /opt/keycloak/data/import/
 # Post-startup configuration applied on every start: identity providers via
 # partialImport, and realm session lifespans via kcadm (the realm import only
 # runs on first start, so existing deployments would otherwise never pick up
-# lifespan changes and fall back to Keycloak defaults of 30 min idle / 10 h max).
+# lifespan changes and stay on Keycloak defaults of 30 min idle / 10 h max).
+# Each lifespan is only written while it still holds the Keycloak default —
+# values customized by operators in the admin console are left untouched.
 (
   echo "Waiting for Keycloak to be ready before applying post-startup configuration..."
   until /opt/keycloak/bin/kcadm.sh config credentials \
@@ -62,11 +65,22 @@ cp /tmp/aihub-realm.json /opt/keycloak/data/import/
       && echo "Identity providers applied successfully." \
       || echo "ERROR: Failed to apply identity providers."
   fi
-  /opt/keycloak/bin/kcadm.sh update realms/aihub \
-    -s ssoSessionIdleTimeout=432000 \
-    -s ssoSessionMaxLifespan=2592000 \
-    && echo "Realm session lifespans applied successfully." \
-    || echo "ERROR: Failed to apply realm session lifespans."
+  current_lifespans=$(/opt/keycloak/bin/kcadm.sh get realms/aihub \
+    --fields ssoSessionIdleTimeout,ssoSessionMaxLifespan 2> /dev/null)
+  lifespan_updates=()
+  if [[ "$current_lifespans" =~ \"ssoSessionIdleTimeout\"[[:space:]]*:[[:space:]]*1800([^0-9]|$) ]]; then
+    lifespan_updates+=(-s ssoSessionIdleTimeout=432000)
+  fi
+  if [[ "$current_lifespans" =~ \"ssoSessionMaxLifespan\"[[:space:]]*:[[:space:]]*36000([^0-9]|$) ]]; then
+    lifespan_updates+=(-s ssoSessionMaxLifespan=2592000)
+  fi
+  if [ ${#lifespan_updates[@]} -gt 0 ]; then
+    /opt/keycloak/bin/kcadm.sh update realms/aihub "${lifespan_updates[@]}" \
+      && echo "Realm session lifespans applied successfully." \
+      || echo "ERROR: Failed to apply realm session lifespans."
+  else
+    echo "Realm session lifespans differ from Keycloak defaults; leaving unchanged."
+  fi
 ) &
 
 exec /opt/keycloak/bin/kc.sh "$@" --import-realm

--- a/infra/configs/keycloak/keycloak-entrypoint.sh
+++ b/infra/configs/keycloak/keycloak-entrypoint.sh
@@ -16,6 +16,9 @@
 # - identity-providers.json: Applied via partialImport API after startup (every start,
 #   with OVERWRITE so config changes are picked up). This keeps the files separate
 #   and avoids --import-realm's OVERWRITE_EXISTING destroying the realm.
+# - Realm session lifespans: Applied via kcadm update after startup (every start),
+#   because the first-start-only realm import never propagates them to
+#   existing deployments.
 
 set -euo pipefail
 
@@ -39,23 +42,31 @@ done
 # Only the realm file goes to --import-realm (first-start creation)
 cp /tmp/aihub-realm.json /opt/keycloak/data/import/
 
-# Apply identity providers via partialImport after Keycloak is ready
-if [ -f /tmp/identity-providers.json ]; then
-  (
-    echo "Waiting for Keycloak to be ready before applying identity providers..."
-    until /opt/keycloak/bin/kcadm.sh config credentials \
-      --server http://localhost:8080 \
-      --realm master \
-      --user "$KC_BOOTSTRAP_ADMIN_USERNAME" \
-      --password "$KC_BOOTSTRAP_ADMIN_PASSWORD" > /dev/null 2>&1; do
-      sleep 3
-    done
+# Post-startup configuration applied on every start: identity providers via
+# partialImport, and realm session lifespans via kcadm (the realm import only
+# runs on first start, so existing deployments would otherwise never pick up
+# lifespan changes and fall back to Keycloak defaults of 30 min idle / 10 h max).
+(
+  echo "Waiting for Keycloak to be ready before applying post-startup configuration..."
+  until /opt/keycloak/bin/kcadm.sh config credentials \
+    --server http://localhost:8080 \
+    --realm master \
+    --user "$KC_BOOTSTRAP_ADMIN_USERNAME" \
+    --password "$KC_BOOTSTRAP_ADMIN_PASSWORD" > /dev/null 2>&1; do
+    sleep 3
+  done
+  if [ -f /tmp/identity-providers.json ]; then
     /opt/keycloak/bin/kcadm.sh create partialImport -r aihub \
       -s ifResourceExists=OVERWRITE \
       -f /tmp/identity-providers.json \
       && echo "Identity providers applied successfully." \
       || echo "ERROR: Failed to apply identity providers."
-  ) &
-fi
+  fi
+  /opt/keycloak/bin/kcadm.sh update realms/aihub \
+    -s ssoSessionIdleTimeout=1209600 \
+    -s ssoSessionMaxLifespan=2592000 \
+    && echo "Realm session lifespans applied successfully." \
+    || echo "ERROR: Failed to apply realm session lifespans."
+) &
 
 exec /opt/keycloak/bin/kc.sh "$@" --import-realm

--- a/infra/deployment/compose-config.yml
+++ b/infra/deployment/compose-config.yml
@@ -151,5 +151,5 @@ notifications:
 # Keycloak defaults (30 min idle / 10 h max) force daily re-logins.
 # -------------------------------------------------------------------
 keycloak:
-  sso_session_idle_timeout: 1209600  # 14 days
+  sso_session_idle_timeout: 432000  # 5 days
   sso_session_max_lifespan: 2592000  # 30 days

--- a/infra/deployment/compose-config.yml
+++ b/infra/deployment/compose-config.yml
@@ -143,3 +143,13 @@ image_tags:
 notifications:
   title_prefix: Swiss AI Hub Pipeline
   min_interval_seconds: 30
+# -------------------------------------------------------------------
+# Keycloak realm session lifespans (seconds), shared by
+# keycloak-realm.json.j2 (first-start import) and
+# keycloak-entrypoint.sh.j2 (kcadm update on every start, so existing
+# deployments converge without re-importing the realm).
+# Keycloak defaults (30 min idle / 10 h max) force daily re-logins.
+# -------------------------------------------------------------------
+keycloak:
+  sso_session_idle_timeout: 1209600  # 14 days
+  sso_session_max_lifespan: 2592000  # 30 days

--- a/infra/deployment/templates/configs/keycloak-entrypoint.sh.j2
+++ b/infra/deployment/templates/configs/keycloak-entrypoint.sh.j2
@@ -16,9 +16,10 @@
 # - identity-providers.json: Applied via partialImport API after startup (every start,
 #   with OVERWRITE so config changes are picked up). This keeps the files separate
 #   and avoids --import-realm's OVERWRITE_EXISTING destroying the realm.
-# - Realm session lifespans: Applied via kcadm update after startup (every start),
-#   because the first-start-only realm import never propagates them to
-#   existing deployments.
+# - Realm session lifespans: Applied via kcadm update after startup, but only
+#   while a lifespan still holds the Keycloak default (30 min idle / 10 h max) —
+#   the first-start-only realm import never propagates them to existing
+#   deployments, while operator overrides made in the admin console must survive.
 
 set -euo pipefail
 
@@ -45,7 +46,9 @@ cp /tmp/aihub-realm.json /opt/keycloak/data/import/
 # Post-startup configuration applied on every start: identity providers via
 # partialImport, and realm session lifespans via kcadm (the realm import only
 # runs on first start, so existing deployments would otherwise never pick up
-# lifespan changes and fall back to Keycloak defaults of 30 min idle / 10 h max).
+# lifespan changes and stay on Keycloak defaults of 30 min idle / 10 h max).
+# Each lifespan is only written while it still holds the Keycloak default —
+# values customized by operators in the admin console are left untouched.
 (
   echo "Waiting for Keycloak to be ready before applying post-startup configuration..."
   until /opt/keycloak/bin/kcadm.sh config credentials \
@@ -62,11 +65,22 @@ cp /tmp/aihub-realm.json /opt/keycloak/data/import/
       && echo "Identity providers applied successfully." \
       || echo "ERROR: Failed to apply identity providers."
   fi
-  /opt/keycloak/bin/kcadm.sh update realms/aihub \
-    -s ssoSessionIdleTimeout={{ keycloak.sso_session_idle_timeout }} \
-    -s ssoSessionMaxLifespan={{ keycloak.sso_session_max_lifespan }} \
-    && echo "Realm session lifespans applied successfully." \
-    || echo "ERROR: Failed to apply realm session lifespans."
+  current_lifespans=$(/opt/keycloak/bin/kcadm.sh get realms/aihub \
+    --fields ssoSessionIdleTimeout,ssoSessionMaxLifespan 2> /dev/null)
+  lifespan_updates=()
+  if [[ "$current_lifespans" =~ \"ssoSessionIdleTimeout\"[[:space:]]*:[[:space:]]*1800([^0-9]|$) ]]; then
+    lifespan_updates+=(-s ssoSessionIdleTimeout={{ keycloak.sso_session_idle_timeout }})
+  fi
+  if [[ "$current_lifespans" =~ \"ssoSessionMaxLifespan\"[[:space:]]*:[[:space:]]*36000([^0-9]|$) ]]; then
+    lifespan_updates+=(-s ssoSessionMaxLifespan={{ keycloak.sso_session_max_lifespan }})
+  fi
+  if [ {% raw %}${#lifespan_updates[@]}{% endraw %} -gt 0 ]; then
+    /opt/keycloak/bin/kcadm.sh update realms/aihub "${lifespan_updates[@]}" \
+      && echo "Realm session lifespans applied successfully." \
+      || echo "ERROR: Failed to apply realm session lifespans."
+  else
+    echo "Realm session lifespans differ from Keycloak defaults; leaving unchanged."
+  fi
 ) &
 
 exec /opt/keycloak/bin/kc.sh "$@" --import-realm

--- a/infra/deployment/templates/configs/keycloak-entrypoint.sh.j2
+++ b/infra/deployment/templates/configs/keycloak-entrypoint.sh.j2
@@ -16,6 +16,9 @@
 # - identity-providers.json: Applied via partialImport API after startup (every start,
 #   with OVERWRITE so config changes are picked up). This keeps the files separate
 #   and avoids --import-realm's OVERWRITE_EXISTING destroying the realm.
+# - Realm session lifespans: Applied via kcadm update after startup (every start),
+#   because the first-start-only realm import never propagates them to
+#   existing deployments.
 
 set -euo pipefail
 
@@ -39,23 +42,31 @@ done
 # Only the realm file goes to --import-realm (first-start creation)
 cp /tmp/aihub-realm.json /opt/keycloak/data/import/
 
-# Apply identity providers via partialImport after Keycloak is ready
-if [ -f /tmp/identity-providers.json ]; then
-  (
-    echo "Waiting for Keycloak to be ready before applying identity providers..."
-    until /opt/keycloak/bin/kcadm.sh config credentials \
-      --server http://localhost:8080 \
-      --realm master \
-      --user "$KC_BOOTSTRAP_ADMIN_USERNAME" \
-      --password "$KC_BOOTSTRAP_ADMIN_PASSWORD" > /dev/null 2>&1; do
-      sleep 3
-    done
+# Post-startup configuration applied on every start: identity providers via
+# partialImport, and realm session lifespans via kcadm (the realm import only
+# runs on first start, so existing deployments would otherwise never pick up
+# lifespan changes and fall back to Keycloak defaults of 30 min idle / 10 h max).
+(
+  echo "Waiting for Keycloak to be ready before applying post-startup configuration..."
+  until /opt/keycloak/bin/kcadm.sh config credentials \
+    --server http://localhost:8080 \
+    --realm master \
+    --user "$KC_BOOTSTRAP_ADMIN_USERNAME" \
+    --password "$KC_BOOTSTRAP_ADMIN_PASSWORD" > /dev/null 2>&1; do
+    sleep 3
+  done
+  if [ -f /tmp/identity-providers.json ]; then
     /opt/keycloak/bin/kcadm.sh create partialImport -r aihub \
       -s ifResourceExists=OVERWRITE \
       -f /tmp/identity-providers.json \
       && echo "Identity providers applied successfully." \
       || echo "ERROR: Failed to apply identity providers."
-  ) &
-fi
+  fi
+  /opt/keycloak/bin/kcadm.sh update realms/aihub \
+    -s ssoSessionIdleTimeout={{ keycloak.sso_session_idle_timeout }} \
+    -s ssoSessionMaxLifespan={{ keycloak.sso_session_max_lifespan }} \
+    && echo "Realm session lifespans applied successfully." \
+    || echo "ERROR: Failed to apply realm session lifespans."
+) &
 
 exec /opt/keycloak/bin/kc.sh "$@" --import-realm

--- a/infra/deployment/templates/configs/keycloak-realm.json.j2
+++ b/infra/deployment/templates/configs/keycloak-realm.json.j2
@@ -15,6 +15,8 @@
   "registrationAllowed": false,
   "registrationEmailAsUsername": true,
   "rememberMe": true,
+  "ssoSessionIdleTimeout": {{ keycloak.sso_session_idle_timeout }},
+  "ssoSessionMaxLifespan": {{ keycloak.sso_session_max_lifespan }},
   "verifyEmail": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,

--- a/packages/web/middleware/home-redirect.ts
+++ b/packages/web/middleware/home-redirect.ts
@@ -1,4 +1,4 @@
-import { getMyTenants } from '@core/sdk/client'
+import { getMyActiveTenant, getMyTenants } from '@core/sdk/client'
 
 import { useLocalePath } from '#i18n'
 
@@ -11,8 +11,11 @@ export default defineNuxtRouteMiddleware(async () => {
 
   const localePath = useLocalePath()
 
-  const response = await getMyTenants({ composable: '$fetch' }).catch(() => null)
-  const tenants = response?.tenants ?? []
+  const [tenantsResponse, activeTenant] = await Promise.all([
+    getMyTenants({ composable: '$fetch' }).catch(() => null),
+    getMyActiveTenant({ composable: '$fetch' }).catch(() => null),
+  ])
+  const tenants = tenantsResponse?.tenants ?? []
   if (!tenants.length) {
     return
   }
@@ -25,6 +28,9 @@ export default defineNuxtRouteMiddleware(async () => {
   }
   if (tenants.length === 1) {
     return navigateTo(localePath(`/${tenants[0].id}/service/openai`), { replace: true })
+  }
+  if (activeTenant && tenants.some(tenant => tenant.id === activeTenant.id)) {
+    return navigateTo(localePath(`/${activeTenant.id}/service/openai`), { replace: true })
   }
   return navigateTo(localePath('/select-tenant'), { replace: true })
 })


### PR DESCRIPTION
## Summary

Users in deployed environments were forced to re-login every morning and then landed on the tenant selection screen instead of their previously active tenant. Two independent root causes: the Keycloak realm import defines no session lifespans (so the defaults of 30 min SSO idle / 10 h max apply), and the post-login redirect never read the `active_tenant_id` user attribute that is persisted in Keycloak.

## Changes

- **Keycloak session lifespans**: new `keycloak:` section in `compose-config.yml` as single source of truth — SSO session idle timeout 5 days, SSO session max lifespan 30 days.
  - `keycloak-realm.json.j2`: lifespans included in the first-start realm import (fresh installs).
  - `keycloak-entrypoint.sh.j2`: post-startup block now always runs and applies the lifespans via `kcadm.sh update realms/aihub` on container start — but **only for fields still holding the Keycloak default** (1800/36000), so existing deployments converge once while operator overrides made in the admin console survive restarts. The realm import is first-start-only, so existing deployments would otherwise never converge.
  - All generated compose configs regenerated via `make generate-compose`.
- **Active tenant restore**: `packages/web/middleware/home-redirect.ts` now fetches `getMyActiveTenant` in parallel with `getMyTenants` and redirects multi-tenant users to their persisted active tenant (validated against the membership list) instead of unconditionally showing `/select-tenant`. Deep-link restore and the single-tenant shortcut keep their existing precedence.

## Test plan

Verified end-to-end against the local dev stack:

- **Migration path**: dev Keycloak with an already-imported realm showed `ssoSessionIdleTimeout: 1800 / ssoSessionMaxLifespan: 36000` before; after one container recreation with the new entrypoint, the realm reports `432000 / 2592000`, realm import correctly skipped (`Realm 'aihub' already exists`), all users and realm data intact.
- **Tenant restore (browser E2E)**: as a two-tenant user — logged in, switched active tenant to a second tenant via the selection screen (verified `active_tenant_id` attribute written in Keycloak), then simulated overnight expiry by clearing all browser storage and re-logging in: landed directly on the persisted tenant's service page instead of the tenant selection screen.
- `infra/deployment/generate_compose.py --check` passes; generated entrypoint passes `bash -n`.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>` (see
  [CONTRIBUTING.md](https://github.com/bbvch-ai/aihub-core/blob/main/CONTRIBUTING.md))
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [x] CLA signed — post this exact comment on the PR if the bot hasn't prompted you yet:
  `I have read the CONTRIBUTOR_AGREEMENT and I hereby sign the CLA`
  ([read the agreement](https://github.com/bbvch-ai/aihub-core/blob/main/CONTRIBUTOR_AGREEMENT.md))
- [ ] Tests added or updated where relevant — no automated tests: frontend has no test framework configured, infra change is config-only; verified manually per test plan
