### PR TITLE
fix(deploy): Persist OpenWebUI agent responses by returning pipe content

### DIFF
--- a/infra/configs/openwebui/functions/aihub_pipeline.py
+++ b/infra/configs/openwebui/functions/aihub_pipeline.py
@@ -1710,6 +1710,7 @@ class Pipe:
                 "user.email": __user__["email"],
             },
         ) as span:
+            state_manager = StreamingStateManager()
             try:
                 logger.debug(f"Processing request for {agent_class}.{agent_id}")
                 logger.debug(f"Thread ID: {thread_id}, Display ID: {display_id}")
@@ -1766,8 +1767,6 @@ class Pipe:
                     }
                 )
 
-                state_manager = StreamingStateManager()
-
                 async def stream_start_callback():
                     await self._set_ui_context(thread_id, hitl_display_id, __event_emitter__)
 
@@ -1816,4 +1815,5 @@ class Pipe:
                 )
                 span.record_exception(e)
                 span.set_status(trace.Status(trace.StatusCode.ERROR, str(e)))
-                return f"Error: {str(e)}"
+                partial = state_manager.serialize_to_html()
+                return f"{partial}\n\n> Error: {e}" if partial else f"Error: {e}"

--- a/infra/configs/openwebui/functions/aihub_pipeline.py
+++ b/infra/configs/openwebui/functions/aihub_pipeline.py
@@ -1799,7 +1799,7 @@ class Pipe:
                 )
 
                 logger.debug("Request processing completed")
-                return ""
+                return state_manager.serialize_to_html()
 
             except Exception as e:
                 logger.exception(f"Error in pipe: {e}")

--- a/infra/deployment/templates/openwebui_functions/aihub_pipeline.py
+++ b/infra/deployment/templates/openwebui_functions/aihub_pipeline.py
@@ -1710,6 +1710,7 @@ class Pipe:
                 "user.email": __user__["email"],
             },
         ) as span:
+            state_manager = StreamingStateManager()
             try:
                 logger.debug(f"Processing request for {agent_class}.{agent_id}")
                 logger.debug(f"Thread ID: {thread_id}, Display ID: {display_id}")
@@ -1766,8 +1767,6 @@ class Pipe:
                     }
                 )
 
-                state_manager = StreamingStateManager()
-
                 async def stream_start_callback():
                     await self._set_ui_context(thread_id, hitl_display_id, __event_emitter__)
 
@@ -1816,4 +1815,5 @@ class Pipe:
                 )
                 span.record_exception(e)
                 span.set_status(trace.Status(trace.StatusCode.ERROR, str(e)))
-                return f"Error: {str(e)}"
+                partial = state_manager.serialize_to_html()
+                return f"{partial}\n\n> Error: {e}" if partial else f"Error: {e}"

--- a/infra/deployment/templates/openwebui_functions/aihub_pipeline.py
+++ b/infra/deployment/templates/openwebui_functions/aihub_pipeline.py
@@ -1799,7 +1799,7 @@ class Pipe:
                 )
 
                 logger.debug("Request processing completed")
-                return ""
+                return state_manager.serialize_to_html()
 
             except Exception as e:
                 logger.exception(f"Error in pipe: {e}")


### PR DESCRIPTION
## Summary

Agent answers streamed through the `aihub-pipeline` OpenWebUI function vanished after a second message, leaving only a "Response completed" status. Reproduces and fixes the bug reported in bbvch-ai/aihub-core-test#26.

## Changes

- `pipe()` now returns `state_manager.serialize_to_html()` instead of `""`. OpenWebUI turns the pipe's return value into the stream's final chunk and persists THAT as the message content; returning `""` overwrote the live `replace`-emitted answer with empty, so every assistant message rendered blank on chat reload (triggered by title/tag/follow-up generation or sending the next message).
- Applied to both the live config (`infra/configs/openwebui/functions/aihub_pipeline.py`) and the deployment template (`infra/deployment/templates/openwebui_functions/aihub_pipeline.py`).

## Test plan

Reproduced and verified locally against the dev stack via the embedded OpenWebUI (`/<tenant>/service/openai`) with a live `LLMWrappingAgent` instance:

- **Before:** ask Q1 (answer shows) → ask Q2 → both answers collapse to "Response completed". OpenWebUI DB persisted assistant `content` length `0 / 0`.
- **After:** ask Q1 → ask Q2 → both answers persist, including after a full chat reload from the DB. OpenWebUI DB persisted assistant `content` length `199 / 286`.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>`
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [ ] CLA signed
- [ ] Tests added or updated where relevant (n/a — OpenWebUI function file has no automated test harness; verified empirically via live UI + DB)