### PR TITLE
fix(workflows): Require a system prompt for LLM-wrapping and few-shot agents

### DIFF
--- a/packages/agent/swiss_ai_hub/agent/agents/llm_wrapping_agent/llm_wrapping_agent_config.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/llm_wrapping_agent/llm_wrapping_agent_config.py
@@ -19,7 +19,7 @@ class LLMWrappingAgentConfig(AgentConfig):
 
     system_prompt: Annotated[
         LocaleString | LocaleInput,
-        Field(description="System prompt that sets the context for few-shot learning."),
+        Field(description="System prompt that sets the agent's behaviour for the wrapped LLM."),
     ]
     number_of_input_tokens: Annotated[
         int | InputNumber,

--- a/packages/agent/swiss_ai_hub/agent/agents/llm_wrapping_agent/llm_wrapping_agent_config.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/llm_wrapping_agent/llm_wrapping_agent_config.py
@@ -18,9 +18,9 @@ class LLMWrappingAgentConfig(AgentConfig):
     """
 
     system_prompt: Annotated[
-        LocaleString | LocaleInput | None,
+        LocaleString | LocaleInput,
         Field(description="System prompt that sets the context for few-shot learning."),
-    ] = None
+    ]
     number_of_input_tokens: Annotated[
         int | InputNumber,
         Field(description="Maximum tokens allowed in input to manage context size or cost."),

--- a/packages/agent/swiss_ai_hub/agent/steps/prompting/few_shot_step/few_shot_step_config.py
+++ b/packages/agent/swiss_ai_hub/agent/steps/prompting/few_shot_step/few_shot_step_config.py
@@ -17,9 +17,9 @@ class FewShotStepConfig(StepConfig):
         Field(description="List of few-shot examples to guide the agent's responses.", title="Few-Shot Examples"),
     ] = []
     system_prompt: Annotated[
-        LocaleString | LocaleInput | None,
+        LocaleString | LocaleInput,
         Field(description="System prompt that sets the context for few-shot learning."),
-    ] = None
+    ]
 
     @classmethod
     def as_form(cls) -> Self:


### PR DESCRIPTION
## Summary

Creating an `LLMWrappingAgent` instance without enabling the system prompt crashed on the first message with `'NoneType' object has no attribute 'in_locale'`. Follow-up to #1464 (found while reproducing bbvch-ai/aihub-core-test#26).

## Changes

- `LLMWrappingAgentConfig.system_prompt` changed from `LocaleString | LocaleInput | None = None` to a required `LocaleString | LocaleInput`. `limit_chat_history_step` dereferences `system_prompt.in_locale(locale)` unconditionally, so an optional/None value was a guaranteed crash.
- The form framework derives `required`/`nullable` from the type union (`core/form/form.py`), so dropping `| None` also removes the optional "Enable System Prompt" toggle — the field is now always present and validated. An LLM-wrapping agent's whole purpose is its instructions, so no default is provided (unlike rag/retrieval, which carry default prompts).

## Test plan

- `uv run pytest` for `packages/agent` (excluding slow/integration/flaky/self_hosted/experimental): **141 passed**.
- Sanity check: `as_form()` still builds, all three bundled templates (code_explainer/email_drafter/meeting_minutes) construct fine, and constructing a config without `system_prompt` now raises `ValidationError` instead of crashing at runtime.
- Audited the other agents for the same `| None`-dereferenced-unconditionally pattern: `mcp_react` (guarded), `rag` (default + guarded), `retrieval` (guarded in `combine_nodes_in_order`), `expert_asking` (intentional channel selector) — LLMWrappingAgent was the only one affected.

## Note

Breaking change for persisted data: any existing `LLMWrappingAgent` instance stored with `system_prompt: null` will now fail validation on load. Such instances already crash on every message, so this surfaces an already-broken state rather than regressing a working one.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>`
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [ ] CLA signed
- [x] Tests added or updated where relevant (existing agent suite green; no new test harness for this config)