### PR TITLE
fix(ui): Make the agent configuration form behave correctly

### DIFF
--- a/docs/arc42/decisions/2026_06_15_correct_dynamic_config_form_behaviour.md
+++ b/docs/arc42/decisions/2026_06_15_correct_dynamic_config_form_behaviour.md
@@ -1,0 +1,137 @@
+# Correct End-to-End Behaviour of the Dynamic Agent/Process Configuration Form
+
+## Context
+
+The Form Duality system in `packages/core/swiss_ai_hub/core/form/` lets a single Pydantic class double as a form schema
+and a typed data model. It powers the dynamic agent and process configuration forms in `packages/web`
+(`useFormKitTransform.ts`, `Agent/CreateModal.vue`, `DynamicConfiguration.vue`). Two earlier ADRs established this area:
+`2026_01_07_enable_dynamic_agent_configuration_ui.md` (render backend-defined schemas as forms) and
+`2026_05_07_nullable_form_fields_over_enabled_toggle.md` (treat `T | None` as the source of truth for an optional
+sub-form and synthesize a `__<field>__enabled` toggle in the frontend).
+
+An end-to-end audit of the configuration form (five parallel reviews over backend generation, frontend transform,
+create/edit data-flow, round-trip integrity, and custom inputs) surfaced a cluster of correctness defects that all
+shared one root: the form's create path and edit path were **two separate implementations** of "schema → hydrated model
+→ submitted payload", and several invariants held in one but not the other. Concretely, against a real `RAGAgent`:
+
+- A nullable field with a **non-null default** (`system_prompt`, `context_prompt`, and `org_memory`, which defaults to a
+  populated `OrgMemoryReadConfig()`) loaded **enabled** on edit but came up **disabled** on a fresh create, so its
+  default was silently dropped at submit. `2026_05_07`'s `seedNullableToggles()` only handled the saved-data case
+  (`field !== null`); the fresh-create case was never specified.
+- The edit submit never stripped the repeater `__validate__<name>__<index>` mirror keys (only create did), so the two
+  endpoints validating the same config sanitized it asymmetrically.
+- Repeater rows were keyed by array index (both as the Vue `:key` and inside the per-item FormKit group id), so deleting
+  a non-last row reindexed survivors and rebound FormKit groups to the wrong row's data (`[5, 5, 22]` → delete middle →
+  `[5, 5]`).
+- A `useChangeCase` (VueUse) composable used in selector option resolvers returns a `ComputedRef`;
+  `display_name || useChangeCase(name, 'capitalCase')` leaked a `Ref` into PrimeVue/FormKit labels and, because it ran
+  inside render computeds, spawned throwaway reactive effects every render — the instability behind intermittently
+  blank/broken forms.
+- PrimeVue `InputNumber` is integer-only unless fraction digits are configured, so fractional fields (LLM `temperature`,
+  step `0.1`) rejected the decimal point.
+- `buildFormKitSchema` wrapped the whole element list in one `try/catch` returning `[]`, so a single throwing element
+  wiped an entire section (most visibly the Basic Info step, leaving an unsubmittable form).
+
+These are not abstract: each was reproduced live, and each is the kind of regression that the absence of a frontend test
+harness (`make test` is a no-op in `packages/web`) lets through silently.
+
+## Decision Drivers
+
+- **One behaviour, not two**\
+  The create and edit forms must hydrate and serialize identically. Divergent pipelines are the structural cause of
+  "works on edit, broken on create" (and vice-versa); every such pair of code paths is a latent inconsistency.
+- **The schema must carry enough to render a fresh form correctly**\
+  `2026_05_07` made `T | None` the toggle's source of truth, but the *initial* toggle state on a brand-new form depends
+  on whether the field's **data default** is null — information the serialized schema did not preserve. The duality
+  pattern requires `as_form()` to always emit a fully-populated `Group` (so children can render when re-enabled), and a
+  `Group` extends `FormkitElement`, which has **no `value` field**. So a `None`-default nullable group
+  (`reranking_config = None`) and an object-default one (`org_memory = OrgMemoryReadConfig()`) serialize
+  **identically**. The frontend cannot infer the difference; the backend — the only place the Pydantic default is
+  visible at schema-generation time — must transmit it.
+- **Defaults are a contract, not decoration**\
+  A field that declares a default must present that default in the form and persist it unless the user changes it.
+  Dropping `system_prompt`'s default because a toggle defaulted off is a silent contract violation.
+- **Stable identity for list rows**\
+  A repeater row's UI identity must track the logical row, not its current array index, or editing one row after
+  deleting another corrupts data.
+- **Pure functions in render paths**\
+  Option/label resolvers run inside Vue render computeds; they must be pure (no reactive-effect allocation, no `Ref`
+  leakage into props) to keep rendering stable.
+- **Graceful degradation over all-or-nothing**\
+  One malformed schema element should drop itself, not the whole form. A config form that can't be submitted because of
+  one bad field is worse than one missing field.
+- **Symmetric server-side sanitisation**\
+  Create and update must normalize submitted config through the same path so neither endpoint is one frontend bug away
+  from persisting FormKit artifacts.
+
+## Decision
+
+Make the configuration form correct end-to-end by unifying its pipelines and closing the create-path gap left by
+`2026_05_07`, plus targeted fixes for the independent defects found in the same audit.
+
+**1. `default_enabled` signal (backend → frontend).** `FormkitElement` gains `default_enabled: bool | None` (alias
+`defaultEnabled`). `Form.to_formkit_form()` sets it on nullable leaves and groups from
+`_default_is_non_null(field_info)` (`default is not None and not PydanticUndefined`). The frontend's
+`seedNullableToggles()` now falls back to `default_enabled` when a field is **absent** from the source data (a fresh
+form), while still using the value's null-ness when it is present (edit/clone). This is the create-path completion of
+`2026_05_07`: that ADR specified the saved-data case only. BaseModel defaults (e.g. a `LocaleString` prompt) are
+`model_dump()`-ed into the primitive `value` so they no longer trip the Pydantic serializer.
+
+**2. Unify create and edit behind two shared functions** in `useFormKitTransform.ts`:
+
+- `hydrateFormData = seedFormDefaults ∘ seedNullableToggles` — raw saved/template/empty data → hydrated model.
+- `serializeFormData = cleanFormData ∘ normalizeFormLocaleStrings ∘ coerceNullableToggles` — model → submission payload.
+
+`useCreateInstanceForm` drops its bespoke `initializeGroupData` / `stripNullsForGroups` / `cleanFormData`;
+`DynamicConfiguration` and both create modals call the shared helpers. This removes the create-path default discard and
+the edit-path `__validate__` leak in one move.
+
+**3. Stable repeater row keys.** `Repeater.vue` assigns each row a `crypto.randomUUID()` on add/load and keys both the
+`v-for` and the per-item FormKit group (`__validate__<name>__<uuid>`) by it. add/remove keep the key array aligned; a
+watch reconciles external model replacement. The mirror keys keep the `__validate__` prefix and are still stripped at
+submit by `serializeFormData`.
+
+**4. Auto-derive `InputNumber` fraction digits.** `InputNumber` derives `max_fraction_digits` from the field's own
+precision (step/min/max/value) when unset, so fractional fields accept decimals while integer fields stay integer-only.
+
+**5. Pure `capitalCase` in resolvers.** Replace `useChangeCase(x, 'capitalCase')` with the synchronous `capitalCase(x)`
+from `change-case` across all selector option resolvers and related pages, eliminating the `Ref`-in- label class and
+per-render reactive-effect churn.
+
+**6. Per-element error isolation.** `buildFormKitSchema` and the group/repeater extractors wrap each element
+individually, so a malformed element is skipped and logged while siblings render.
+
+**7. Symmetric server-side normalisation.** Agent and process **create** endpoints route through
+`InstanceConfigHelper.normalize_form_configuration` (which strips FormKit `_`-prefixed keys), matching update.
+
+Deferred, latent/structural items were filed rather than bundled: transform hardening (#1475: `combineConditions` string
+surgery, `isLocaleStringObject` heuristic, schema churn, merge-arrays, nested repeaters), backend persistence
+canonicalisation (#1476: storing `model_dump()` and de-duplicating identity fields), and a Vitest harness for the
+transform layer (#1477).
+
+## Consequences
+
+### Positive
+
+- Create and edit forms hydrate and serialize through one code path, so behaviour is provably consistent and the "works
+  in one, broken in the other" class is closed.
+- Fresh forms present nullable fields enabled exactly when their data default is non-null; declared defaults are no
+  longer silently discarded.
+- A disabled nullable group still round-trips as `null` (verified: DB keeps `reranking_config`/`org_memory` null on
+  save) with no `__validate__`/`slots` leakage from either endpoint.
+- Deleting a repeater row no longer corrupts the surviving rows.
+- Fractional numeric inputs accept decimals; one bad element can't blank the form.
+
+### Trade-offs
+
+- `default_enabled` adds a field to `FormkitElement` that is meaningful only for nullable elements. It duplicates, on
+  the wire, information the backend already holds — a deliberate cost, because the serialized group schema cannot
+  otherwise convey it (see the second Decision Driver). An alternative — inferring from `element.value` for leaves and
+  leaving groups unhandled — was rejected as two code paths for one concept.
+- The repeater still relies on the `__validate__<field>__<key>` mirror group for per-item FormKit validation; the keys
+  are now stable and stripped at submit, but the mirror itself remains (full removal is follow-up).
+- The frontend transform layer carries shared `hydrateFormData`/`serializeFormData` conventions and synthetic
+  `__<field>__enabled` keys, visible to anyone reading raw `formData` mid-edit. With no Vitest harness yet (#1477) these
+  invariants are guarded only by the `packages/core` form tests and manual verification.
+- This branch corrected behaviour but did not address the structural persistence smells (dual-stored identity fields,
+  raw-vs-`model_dump()` storage) deferred to #1476.

--- a/packages/api/swiss_ai_hub/api/routes/agent/agent_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/agent/agent_service.py
@@ -18,7 +18,6 @@ from swiss_ai_hub.core.events.agent import (
     StartEvent,
     StopEvent,
 )
-from swiss_ai_hub.core.form import normalize_empty_locale_strings, normalize_empty_objects_to_none
 from swiss_ai_hub.core.i18n import LocaleHandler
 from swiss_ai_hub.core.infrastructure import trace_fn
 from swiss_ai_hub.core.persistence.agents import AgentClassEntity
@@ -430,8 +429,9 @@ class AgentService:
                 status_code=409, detail=f"Agent instance '{agent_class}/{request.agent_id}' already exists."
             )
 
-        config = normalize_empty_objects_to_none(request.configuration)
-        config = normalize_empty_locale_strings(config) or {}
+        # Same normalization as update: strip FormKit internal `_`-keys and empty values, so a
+        # stray repeater/toggle artifact can never be persisted into config_data.
+        config = InstanceConfigHelper.normalize_form_configuration(request.configuration)
 
         config_model = ModelCreationService.create_agent_config_model(
             AgentConfigSpecs(

--- a/packages/api/swiss_ai_hub/api/routes/agent/agent_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/agent/agent_service.py
@@ -429,8 +429,6 @@ class AgentService:
                 status_code=409, detail=f"Agent instance '{agent_class}/{request.agent_id}' already exists."
             )
 
-        # Same normalization as update: strip FormKit internal `_`-keys and empty values, so a
-        # stray repeater/toggle artifact can never be persisted into config_data.
         config = InstanceConfigHelper.normalize_form_configuration(request.configuration)
 
         config_model = ModelCreationService.create_agent_config_model(

--- a/packages/api/swiss_ai_hub/api/routes/process/process_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/process/process_service.py
@@ -7,7 +7,6 @@ from swiss_ai_hub.core.auth.access.access_checker import AccessChecker
 from swiss_ai_hub.core.auth.identity.user_identity import UserIdentity
 from swiss_ai_hub.core.distributor import ExternalProcessEvent, ExternalProcessEventDistributor
 from swiss_ai_hub.core.events.process import ProcessConfigSpecs, ProcessStartEvent, WorkEvent
-from swiss_ai_hub.core.form import normalize_empty_locale_strings, normalize_empty_objects_to_none
 from swiss_ai_hub.core.i18n import LocaleHandler
 from swiss_ai_hub.core.infrastructure import trace_fn
 from swiss_ai_hub.core.persistence.messaging.entities.persisted_process_event_entity import PersistedProcessEventEntity
@@ -333,8 +332,8 @@ class ProcessService:
                 status_code=409, detail=f"Process instance '{process_class}/{request.process_id}' already exists."
             )
 
-        config = normalize_empty_objects_to_none(request.configuration)
-        config = normalize_empty_locale_strings(config) or {}
+        # Same normalization as update: strip FormKit internal `_`-keys and empty values.
+        config = InstanceConfigHelper.normalize_form_configuration(request.configuration)
 
         config_model = ModelCreationService.create_process_config_model(
             ProcessConfigSpecs(

--- a/packages/api/swiss_ai_hub/api/routes/process/process_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/process/process_service.py
@@ -332,7 +332,6 @@ class ProcessService:
                 status_code=409, detail=f"Process instance '{process_class}/{request.process_id}' already exists."
             )
 
-        # Same normalization as update: strip FormKit internal `_`-keys and empty values.
         config = InstanceConfigHelper.normalize_form_configuration(request.configuration)
 
         config_model = ModelCreationService.create_process_config_model(

--- a/packages/core/swiss_ai_hub/core/form/base/formkit_element.py
+++ b/packages/core/swiss_ai_hub/core/form/base/formkit_element.py
@@ -29,6 +29,14 @@ class FormkitElement(BaseModel, abc.ABC):
         bool,
         Field(description="Render with a sibling toggle that sets this field to null when off"),
     ] = False
+    default_enabled: Annotated[
+        bool | None,
+        Field(
+            description="For a nullable element, whether its toggle should start enabled on a fresh "
+            "form (i.e. the field's data default is non-null). Ignored for non-nullable elements.",
+            alias="defaultEnabled",
+        ),
+    ] = None
 
     @abc.abstractmethod
     def in_locale(self, t: LocaleHandler) -> Self: ...

--- a/packages/core/swiss_ai_hub/core/form/elements/input_number.py
+++ b/packages/core/swiss_ai_hub/core/form/elements/input_number.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 from typing import Annotated, Literal, Self
 
-from pydantic import Field, computed_field
+from pydantic import Field, computed_field, model_validator
 
 from swiss_ai_hub.core.form.base.prime_vue_element import PrimeVueElement
 from swiss_ai_hub.core.i18n.locale_handler import LocaleHandler
@@ -39,6 +39,25 @@ class InputNumber(PrimeVueElement):
         Literal["stacked", "horizontal"] | None,
         Field(description="Layout of increment/decrement buttons", alias="buttonLayout"),
     ] = None
+
+    @model_validator(mode="after")
+    def _allow_fractional_input(self) -> Self:
+        # PrimeVue InputNumber is integer-only unless fraction digits are configured, so a
+        # fractional field (e.g. temperature with step 0.1) would reject the decimal point.
+        # When unset, allow as many fraction digits as the field's own precision implies.
+        if self.max_fraction_digits is None:
+            numeric = [value for value in (self.step, self.min, self.max, self.value) if isinstance(value, float)]
+            decimals = max((self._decimal_places(value) for value in numeric), default=0)
+            if decimals:
+                self.max_fraction_digits = decimals
+                if self.min_fraction_digits is None:
+                    self.min_fraction_digits = 0
+        return self
+
+    @staticmethod
+    def _decimal_places(value: float) -> int:
+        exponent = Decimal(repr(value)).normalize().as_tuple().exponent
+        return -exponent if isinstance(exponent, int) and exponent < 0 else 0
 
     @computed_field
     @property

--- a/packages/core/swiss_ai_hub/core/form/elements/input_number.py
+++ b/packages/core/swiss_ai_hub/core/form/elements/input_number.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 from typing import Annotated, Literal, Self
 
-from pydantic import Field, computed_field, model_validator
+from pydantic import Field, computed_field
 
 from swiss_ai_hub.core.form.base.prime_vue_element import PrimeVueElement
 from swiss_ai_hub.core.i18n.locale_handler import LocaleHandler
@@ -21,12 +21,15 @@ class InputNumber(PrimeVueElement):
     max: Annotated[float | None, Field(description="Maximum value")] = None
     step: Annotated[float | None, Field(description="Step factor for increment/decrement")] = None
     use_grouping: Annotated[bool, Field(description="Whether to use grouping separators", alias="useGrouping")] = True
+    # PrimeVue InputNumber is integer-only unless fraction digits are configured. Default to
+    # accepting up to 6 decimals so fractional fields (e.g. temperature) take a decimal point;
+    # integer-typed fields are still validated as ints by the config model on submit.
     min_fraction_digits: Annotated[
-        int | None, Field(description="Minimum number of fraction digits", alias="minFractionDigits")
-    ] = None
+        int, Field(description="Minimum number of fraction digits", alias="minFractionDigits")
+    ] = 0
     max_fraction_digits: Annotated[
-        int | None, Field(description="Maximum number of fraction digits", alias="maxFractionDigits")
-    ] = None
+        int, Field(description="Maximum number of fraction digits", alias="maxFractionDigits")
+    ] = 6
     locale: Annotated[str | None, Field(description="Locale to use for number formatting")] = None
     mode: Annotated[Literal["decimal", "currency"] | None, Field(description="Input mode")] = None
     currency: Annotated[str | None, Field(description="Currency code for currency mode")] = None
@@ -39,25 +42,6 @@ class InputNumber(PrimeVueElement):
         Literal["stacked", "horizontal"] | None,
         Field(description="Layout of increment/decrement buttons", alias="buttonLayout"),
     ] = None
-
-    @model_validator(mode="after")
-    def _allow_fractional_input(self) -> Self:
-        # PrimeVue InputNumber is integer-only unless fraction digits are configured, so a
-        # fractional field (e.g. temperature with step 0.1) would reject the decimal point.
-        # When unset, allow as many fraction digits as the field's own precision implies.
-        if self.max_fraction_digits is None:
-            numeric = [value for value in (self.step, self.min, self.max, self.value) if isinstance(value, float)]
-            decimals = max((self._decimal_places(value) for value in numeric), default=0)
-            if decimals:
-                self.max_fraction_digits = decimals
-                if self.min_fraction_digits is None:
-                    self.min_fraction_digits = 0
-        return self
-
-    @staticmethod
-    def _decimal_places(value: float) -> int:
-        exponent = Decimal(repr(value)).normalize().as_tuple().exponent
-        return -exponent if isinstance(exponent, int) and exponent < 0 else 0
 
     @computed_field
     @property

--- a/packages/core/swiss_ai_hub/core/form/form.py
+++ b/packages/core/swiss_ai_hub/core/form/form.py
@@ -175,6 +175,7 @@ class Form(BaseModel):
                                 children=nested_elements,
                                 ref=group_ref,
                                 nullable=True,
+                                default_enabled=self._default_is_non_null(field_info),
                             )
                         )
                 continue
@@ -199,6 +200,7 @@ class Form(BaseModel):
                     condition_if=group_condition,
                     ref=group_ref,
                     nullable=allows_none,
+                    default_enabled=self._default_is_non_null(field_info) if allows_none else None,
                 )
                 formkit_elements.append(group)
 
@@ -256,13 +258,16 @@ class Form(BaseModel):
             element_copy.required = is_required
             if allows_none and not is_skip_required:
                 element_copy.nullable = True
+                element_copy.default_enabled = self._default_is_non_null(field_info)
 
             # If element has no explicit value, use Pydantic field default
             if element_copy.value is None and field_info.default is not PydanticUndefined:
-                # Only use primitive defaults (not FormkitElements or Forms)
+                # A BaseModel default (e.g. a LocaleString prompt) is dumped to its dict so it fits
+                # the primitive `value` type and doesn't trip the Pydantic serializer; FormkitElement
+                # and Form defaults are not values (they describe structure) so they are skipped.
                 default = field_info.default
-                if not isinstance(default, FormkitElement | Form) and default is not None:
-                    element_copy.value = default
+                if default is not None and not isinstance(default, FormkitElement | Form):
+                    element_copy.value = default.model_dump() if isinstance(default, BaseModel) else default
 
             return element_copy
 
@@ -282,6 +287,12 @@ class Form(BaseModel):
             return type(None) in union_args
 
         return False
+
+    @staticmethod
+    def _default_is_non_null(field_info: FieldInfo) -> bool:
+        """Whether the field's data default is a concrete non-null value. Drives a nullable
+        element's initial toggle state on a fresh form (toggle on ⇔ default is non-null)."""
+        return field_info.default is not PydanticUndefined and field_info.default is not None
 
     @staticmethod
     def _extract_form_type(annotation: Any) -> type[Form] | None:

--- a/packages/core/swiss_ai_hub/core/form/tests/unit/test_form.py
+++ b/packages/core/swiss_ai_hub/core/form/tests/unit/test_form.py
@@ -881,6 +881,20 @@ class FormWithNullableLeaf(Form):
     count: Annotated[int | InputNumber | None, Field(description="Count")] = None
 
 
+class FormWithDefaultedNullableLeaf(Form):
+    """Optional scalar leaf whose data default is a concrete non-null value."""
+
+    name: Annotated[str | InputText, Field(description="Name")]
+    count: Annotated[int | InputNumber | None, Field(description="Count")] = 5
+
+
+class FormWithDefaultedNullableSubForm(Form):
+    """Optional nested form whose data default is a concrete (non-null) instance."""
+
+    name: Annotated[str | InputText, Field(description="Name")]
+    inner: Annotated[NullableInnerForm | None, Field(description="Inner", title="Inner")] = NullableInnerForm(value=5)
+
+
 class TestNullableFlag:
     """Tests for the nullable flag on sub-forms and leaf elements."""
 
@@ -925,6 +939,35 @@ class TestNullableFlag:
         )
         for element in form.to_formkit_form():
             assert element.nullable is False
+            assert element.default_enabled is None
+
+    def test_nullable_leaf_default_enabled_reflects_default(self) -> None:
+        # default is None -> toggle should start off
+        none_default = FormWithNullableLeaf(
+            name=InputText(label=LocaleString(en="Name")),
+            count=InputNumber(label=LocaleString(en="Count")),
+        ).to_formkit_form()
+        assert next(e for e in none_default if e.name == "count").default_enabled is False
+
+        # default is a concrete value -> toggle should start on
+        value_default = FormWithDefaultedNullableLeaf(
+            name=InputText(label=LocaleString(en="Name")),
+            count=InputNumber(label=LocaleString(en="Count")),
+        ).to_formkit_form()
+        assert next(e for e in value_default if e.name == "count").default_enabled is True
+
+    def test_nullable_subform_default_enabled_reflects_default(self) -> None:
+        none_default = FormWithNullableSubForm(
+            name=InputText(label=LocaleString(en="Name")),
+            inner=NullableInnerForm.as_form(),
+        ).to_formkit_form()
+        assert next(e for e in none_default if e.name == "inner").default_enabled is False
+
+        value_default = FormWithDefaultedNullableSubForm(
+            name=InputText(label=LocaleString(en="Name")),
+            inner=NullableInnerForm.as_form(),
+        ).to_formkit_form()
+        assert next(e for e in value_default if e.name == "inner").default_enabled is True
 
     def test_nullable_subform_submission_accepts_null(self) -> None:
         Model = FormWithNullableSubForm.to_form_submission_model()

--- a/packages/core/swiss_ai_hub/core/form/tests/unit/test_input_number.py
+++ b/packages/core/swiss_ai_hub/core/form/tests/unit/test_input_number.py
@@ -40,23 +40,15 @@ class TestInputNumberValidation:
 
 
 class TestInputNumberFractionDigits:
-    """PrimeVue InputNumber is integer-only unless fraction digits are configured, so a
-    fractional field must auto-enable decimals (otherwise the decimal point is rejected)."""
+    """PrimeVue InputNumber is integer-only unless fraction digits are configured, so the
+    element defaults to accepting decimals (0..6) and a fractional field takes a decimal point."""
 
-    def test_fractional_step_enables_decimals(self) -> None:
+    def test_defaults_accept_decimals(self) -> None:
         element = InputNumber(label=LocaleString(en="Temperature"), min=0.0, max=2.0, step=0.1, value=0.1)
-        assert element.max_fraction_digits == 1
         assert element.min_fraction_digits == 0
-
-    def test_finer_step_allows_more_decimals(self) -> None:
-        element = InputNumber(label=LocaleString(en="Score"), step=0.05)
-        assert element.max_fraction_digits == 2
-
-    def test_integer_field_stays_integer(self) -> None:
-        element = InputNumber(label=LocaleString(en="Tokens"), min=0, max=128_000, step=1024, value=128_000)
-        assert element.max_fraction_digits is None
-        assert element.min_fraction_digits is None
+        assert element.max_fraction_digits == 6
 
     def test_explicit_fraction_digits_are_respected(self) -> None:
-        element = InputNumber(label=LocaleString(en="Custom"), step=0.1, max_fraction_digits=4)
+        element = InputNumber(label=LocaleString(en="Custom"), step=0.1, max_fraction_digits=4, min_fraction_digits=2)
         assert element.max_fraction_digits == 4
+        assert element.min_fraction_digits == 2

--- a/packages/core/swiss_ai_hub/core/form/tests/unit/test_input_number.py
+++ b/packages/core/swiss_ai_hub/core/form/tests/unit/test_input_number.py
@@ -37,3 +37,26 @@ class TestInputNumberValidation:
         assert "max:0|" not in element.validation + "|"
         assert "e-" not in element.validation
         assert "E-" not in element.validation
+
+
+class TestInputNumberFractionDigits:
+    """PrimeVue InputNumber is integer-only unless fraction digits are configured, so a
+    fractional field must auto-enable decimals (otherwise the decimal point is rejected)."""
+
+    def test_fractional_step_enables_decimals(self) -> None:
+        element = InputNumber(label=LocaleString(en="Temperature"), min=0.0, max=2.0, step=0.1, value=0.1)
+        assert element.max_fraction_digits == 1
+        assert element.min_fraction_digits == 0
+
+    def test_finer_step_allows_more_decimals(self) -> None:
+        element = InputNumber(label=LocaleString(en="Score"), step=0.05)
+        assert element.max_fraction_digits == 2
+
+    def test_integer_field_stays_integer(self) -> None:
+        element = InputNumber(label=LocaleString(en="Tokens"), min=0, max=128_000, step=1024, value=128_000)
+        assert element.max_fraction_digits is None
+        assert element.min_fraction_digits is None
+
+    def test_explicit_fraction_digits_are_respected(self) -> None:
+        element = InputNumber(label=LocaleString(en="Custom"), step=0.1, max_fraction_digits=4)
+        assert element.max_fraction_digits == 4

--- a/packages/web/components/Agent/CreateModal.vue
+++ b/packages/web/components/Agent/CreateModal.vue
@@ -136,7 +136,7 @@
 </template>
 
 <script setup lang="ts">
-import { type FormElement, normalizeFormLocaleStrings } from '@core/composables/form/useFormKitTransform'
+import { type FormElement, serializeFormData } from '@core/composables/form/useFormKitTransform'
 import { getNode } from '@formkit/core'
 
 const props = defineProps<{
@@ -169,8 +169,6 @@ const {
   getRepeaterStepIndex,
   getRepeaterData,
   setRepeaterData,
-  cleanFormData,
-  coerceNullableToggles,
   applyInitialData,
   resetForm,
 } = useCreateInstanceForm({
@@ -220,9 +218,7 @@ function triggerFormSubmit() {
 
 async function handleFormSubmit() {
   try {
-    const cleanedData = cleanFormData(formData.value)
-    const coerced = coerceNullableToggles(cleanedData, configForm.value as FormElement[])
-    const normalizedConfig = normalizeFormLocaleStrings(coerced)
+    const normalizedConfig = serializeFormData(formData.value, configForm.value as FormElement[])
     const agentId = normalizedConfig.agent_id as string
     await createAgentInstance({
       agentClass: selectedClass.value,

--- a/packages/web/components/Agent/CreateModal.vue
+++ b/packages/web/components/Agent/CreateModal.vue
@@ -105,6 +105,7 @@
                       :label="rep.label"
                       :add-label="rep.addLabel"
                       :children-schema="rep.childrenSchema"
+                      :default-item="rep.defaultItem"
                       :min="rep.min"
                       :max="rep.max"
                       @update:model-value="setRepeaterData(rep.path, $event)"

--- a/packages/web/components/Event/Display/ToolEvent.vue
+++ b/packages/web/components/Event/Display/ToolEvent.vue
@@ -16,7 +16,7 @@
         v-for="(val, key) in event.event.parameters"
         :key="key"
       >
-        <Button :label="useChangeCase(key, 'capitalCase')" />
+        <Button :label="capitalCase(key)" />
         <InputText
           :placeholder="val"
           readonly
@@ -27,7 +27,7 @@
 </template>
 
 <script setup lang="ts">
-import { useChangeCase } from '@vueuse/integrations/useChangeCase'
+import { capitalCase } from 'change-case'
 
 import type { ThreadDto, ToolEvent, ContextualizedAgentEvent } from '@core/sdk/client'
 

--- a/packages/web/components/FormKit/AgentSelector.vue
+++ b/packages/web/components/FormKit/AgentSelector.vue
@@ -93,7 +93,7 @@
 
 <script setup lang="ts">
 import { getAgentClasses, getAgentClassInstances } from '@core/sdk/client'
-import { useChangeCase } from '@vueuse/integrations/useChangeCase'
+import { capitalCase } from 'change-case'
 
 import type { AgentClassDto, FullAgentInstanceDto, LocaleString } from '@core/sdk/client'
 
@@ -200,7 +200,7 @@ function emitValue(agentClass: string, agentId: string) {
 const classOptions = computed<ClassOption[]>(() =>
   agentClasses.value.map(cls => ({
     name: cls.agent_class,
-    displayName: getLocalizedValue(cls.name, locale.value) || useChangeCase(cls.agent_class, 'capitalCase'),
+    displayName: getLocalizedValue(cls.name, locale.value) || capitalCase(cls.agent_class),
     icon: cls.icon || 'mage:robot',
   })),
 )

--- a/packages/web/components/FormKit/DynamicConfiguration.vue
+++ b/packages/web/components/FormKit/DynamicConfiguration.vue
@@ -39,12 +39,10 @@
 <script setup lang="ts">
 import {
   buildFormKitSchema,
-  coerceNullableToggles,
   extractRepeaterConfigs,
   getNestedValue,
-  normalizeFormLocaleStrings,
-  seedFormDefaults,
-  seedNullableToggles,
+  hydrateFormData,
+  serializeFormData,
   setNestedValue,
   type FormElement,
   type RepeaterConfig,
@@ -62,8 +60,7 @@ const props = defineProps<{
 }>()
 
 function hydrate(raw: Record<string, unknown>): Record<string, unknown> {
-  const seeded = seedNullableToggles(raw, props.form as FormElement[])
-  return seedFormDefaults(seeded, props.form as FormElement[])
+  return hydrateFormData(raw, props.form as FormElement[])
 }
 
 const data = ref<Record<string, unknown>>(hydrate(props.initialData || {}))
@@ -111,9 +108,7 @@ function setRepeaterData(path: string, value: Record<string, unknown>[]): void {
 }
 
 async function submitHandler() {
-  const coerced = coerceNullableToggles(data.value, props.form as FormElement[])
-  const normalizedData = normalizeFormLocaleStrings(coerced)
-  emit('submit', normalizedData)
+  emit('submit', serializeFormData(data.value, props.form as FormElement[]))
 }
 </script>
 

--- a/packages/web/components/FormKit/DynamicConfiguration.vue
+++ b/packages/web/components/FormKit/DynamicConfiguration.vue
@@ -27,6 +27,7 @@
         :label="rep.label"
         :add-label="rep.addLabel"
         :children-schema="rep.childrenSchema"
+        :default-item="rep.defaultItem"
         :min="rep.min"
         :max="rep.max"
         @update:model-value="setRepeaterData(rep.path, $event)"

--- a/packages/web/components/FormKit/KnowledgeDatabaseSelector.vue
+++ b/packages/web/components/FormKit/KnowledgeDatabaseSelector.vue
@@ -26,7 +26,7 @@
 
 <script setup lang="ts">
 import { getDatabases } from '@core/sdk/client'
-import { useChangeCase } from '@vueuse/integrations/useChangeCase'
+import { capitalCase } from 'change-case'
 
 import type { DatabaseDto } from '@core/sdk/client'
 
@@ -64,7 +64,7 @@ const selectedDatabases = computed({
 const databaseOptions = computed<DatabaseOption[]>(() =>
   databases.value.map(db => ({
     name: db.name,
-    displayName: db.display_name || useChangeCase(db.name, 'capitalCase').value,
+    displayName: db.display_name || capitalCase(db.name),
   })),
 )
 

--- a/packages/web/components/FormKit/Repeater.vue
+++ b/packages/web/components/FormKit/Repeater.vue
@@ -7,7 +7,7 @@
     <div class="flex flex-col gap-3">
       <div
         v-for="(item, index) in items"
-        :key="index"
+        :key="rowKeys[index]"
         class="relative rounded-lg border border-surface-200 p-4 dark:border-surface-700"
       >
         <div class="mb-3 flex items-center justify-between">
@@ -27,9 +27,9 @@
 
         <FormKit
           v-if="modelValue"
-          :id="`__validate__${name}__${index}`"
+          :id="`__validate__${name}__${rowKeys[index]}`"
           v-model="modelValue[index]"
-          :name="`__validate__${name}__${index}`"
+          :name="`__validate__${name}__${rowKeys[index]}`"
           type="group"
         >
           <FormKitSchema
@@ -71,6 +71,22 @@ const modelValue = defineModel<Record<string, unknown>[]>({ default: () => [] })
 
 const items = computed(() => modelValue.value || [])
 
+function makeRowKey(): string {
+  return crypto.randomUUID()
+}
+
+// One stable key per row, used both as the Vue `:key` and inside the FormKit group id/name.
+// Index-based keys reindex survivors when a non-last row is removed, rebinding each FormKit
+// group to a different row's data and corrupting the form; stable keys avoid that. add/remove
+// keep the array aligned to the rows; the watch only reconciles external model replacement
+// (e.g. form load), preserving existing keys positionally.
+const rowKeys = ref<string[]>(items.value.map(makeRowKey))
+
+watch(() => items.value.length, (length) => {
+  if (length === rowKeys.value.length) return
+  rowKeys.value = Array.from({ length }, (_, index) => rowKeys.value[index] ?? makeRowKey())
+})
+
 const isAddDisabled = computed(() => {
   if (typeof props.max !== 'number') return false
   return items.value.length >= props.max
@@ -86,11 +102,13 @@ function addItem() {
   if (!modelValue.value) {
     modelValue.value = []
   }
+  rowKeys.value.push(makeRowKey())
   modelValue.value.push(props.defaultItem ? cloneDeep(props.defaultItem) : {})
 }
 
 function removeItem(index: number) {
   if (!modelValue.value || isRemoveDisabled.value) return
+  rowKeys.value.splice(index, 1)
   modelValue.value = modelValue.value.filter((_, i) => i !== index)
 }
 </script>

--- a/packages/web/components/FormKit/Repeater.vue
+++ b/packages/web/components/FormKit/Repeater.vue
@@ -53,6 +53,8 @@
 </template>
 
 <script setup lang="ts">
+import { cloneDeep } from 'lodash-es'
+
 import type { FormKitSchemaNode } from '@formkit/core'
 
 const props = defineProps<{
@@ -60,6 +62,7 @@ const props = defineProps<{
   label?: string
   addLabel?: string
   childrenSchema: FormKitSchemaNode[]
+  defaultItem?: Record<string, unknown>
   min?: number
   max?: number
 }>()
@@ -83,7 +86,7 @@ function addItem() {
   if (!modelValue.value) {
     modelValue.value = []
   }
-  modelValue.value.push({})
+  modelValue.value.push(props.defaultItem ? cloneDeep(props.defaultItem) : {})
 }
 
 function removeItem(index: number) {

--- a/packages/web/components/FormKit/VectorStoreInput.vue
+++ b/packages/web/components/FormKit/VectorStoreInput.vue
@@ -96,7 +96,7 @@
 <script setup lang="ts">
 import ChipsInput from '@core/components/FormKit/ChipsInput.vue'
 import { getDatabases } from '@core/sdk/client'
-import { useChangeCase } from '@vueuse/integrations/useChangeCase'
+import { capitalCase } from 'change-case'
 
 import type { DatabaseDto } from '@core/sdk/client'
 
@@ -200,7 +200,7 @@ function emitValue(collectionName: string, namespaces: string[], allowedFilterFi
 const databaseOptions = computed<DatabaseOption[]>(() =>
   databases.value.map(db => ({
     name: db.name,
-    displayName: db.display_name || useChangeCase(db.name, 'capitalCase'),
+    displayName: db.display_name || capitalCase(db.name),
   })),
 )
 
@@ -213,7 +213,7 @@ const namespaceOptions = computed<NamespaceOption[]>(() => {
     return []
   return db.namespaces.map(ns => ({
     name: ns.name,
-    displayName: ns.display_name || useChangeCase(ns.name, 'capitalCase'),
+    displayName: ns.display_name || capitalCase(ns.name),
   }))
 })
 

--- a/packages/web/components/Knowledge/Document/UploadModal.vue
+++ b/packages/web/components/Knowledge/Document/UploadModal.vue
@@ -129,7 +129,7 @@
 </template>
 
 <script setup lang="ts">
-import { useChangeCase } from '@vueuse/integrations/useChangeCase'
+import { capitalCase } from 'change-case'
 
 interface Props {
   visible: boolean
@@ -146,11 +146,11 @@ const props = withDefaults(defineProps<Props>(), {
 const { t } = useI18n()
 
 const databaseDisplayName = computed(() => {
-  return props.databaseDisplayName || useChangeCase(props.database, 'capitalCase').value
+  return props.databaseDisplayName || capitalCase(props.database)
 })
 
 const namespaceDisplayName = computed(() => {
-  return props.namespaceDisplayName || useChangeCase(props.namespace, 'capitalCase').value
+  return props.namespaceDisplayName || capitalCase(props.namespace)
 })
 
 const emit = defineEmits<{

--- a/packages/web/components/Knowledge/Namespace/Card.vue
+++ b/packages/web/components/Knowledge/Namespace/Card.vue
@@ -63,7 +63,7 @@
 </template>
 
 <script setup lang="ts">
-import { useChangeCase } from '@vueuse/integrations/useChangeCase'
+import { capitalCase } from 'change-case'
 
 import type { NamespaceDto } from '@core/sdk/client'
 
@@ -82,7 +82,7 @@ const { t } = useI18n()
 
 const displayName = computed(() => {
   // Use display_name if available, otherwise fall back to formatted technical name
-  return props.namespace.display_name || useChangeCase(props.namespace.name, 'capitalCase')
+  return props.namespace.display_name || capitalCase(props.namespace.name)
 })
 
 const createdAt = computed(() => {

--- a/packages/web/components/Knowledge/Namespace/CreateModal.vue
+++ b/packages/web/components/Knowledge/Namespace/CreateModal.vue
@@ -114,7 +114,7 @@
 </template>
 
 <script setup lang="ts">
-import { useChangeCase } from '@vueuse/integrations/useChangeCase'
+import { capitalCase } from 'change-case'
 
 import type { CreateNamespaceRequest, DatabaseDto } from '@core/sdk/client'
 
@@ -146,7 +146,7 @@ const databaseOptions = computed(() =>
     .filter(db => !db.auto_sync)
     .map(db => ({
       name: db.name,
-      displayName: useChangeCase(db.name, 'capitalCase'),
+      displayName: capitalCase(db.name),
     })),
 )
 const nameValidationError = computed(() => {

--- a/packages/web/components/Process/CreateModal.vue
+++ b/packages/web/components/Process/CreateModal.vue
@@ -135,7 +135,7 @@
 </template>
 
 <script setup lang="ts">
-import { type FormElement, normalizeFormLocaleStrings } from '@core/composables/form/useFormKitTransform'
+import { type FormElement, serializeFormData } from '@core/composables/form/useFormKitTransform'
 import { getNode } from '@formkit/core'
 
 const props = defineProps<{
@@ -167,8 +167,6 @@ const {
   getRepeaterStepIndex,
   getRepeaterData,
   setRepeaterData,
-  cleanFormData,
-  coerceNullableToggles,
   applyInitialData,
   resetForm,
 } = useCreateInstanceForm({
@@ -213,9 +211,7 @@ function triggerFormSubmit() {
 
 async function handleFormSubmit() {
   try {
-    const cleanedData = cleanFormData(formData.value)
-    const coerced = coerceNullableToggles(cleanedData, configForm.value as FormElement[])
-    const normalizedConfig = normalizeFormLocaleStrings(coerced)
+    const normalizedConfig = serializeFormData(formData.value, configForm.value as FormElement[])
     const processId = normalizedConfig.process_id as string
     await createProcessInstance({
       processClass: selectedClass.value,

--- a/packages/web/components/Process/CreateModal.vue
+++ b/packages/web/components/Process/CreateModal.vue
@@ -104,6 +104,7 @@
                       :label="rep.label"
                       :add-label="rep.addLabel"
                       :children-schema="rep.childrenSchema"
+                      :default-item="rep.defaultItem"
                       :min="rep.min"
                       :max="rep.max"
                       @update:model-value="setRepeaterData(rep.path, $event)"

--- a/packages/web/composables/form/useCreateInstanceForm.ts
+++ b/packages/web/composables/form/useCreateInstanceForm.ts
@@ -1,18 +1,13 @@
-import { merge } from 'lodash-es'
-
 import {
   type FormElement,
   type GroupConfig,
   type RepeaterConfig,
   buildFormKitSchema,
   categorizeFormElements,
-  coerceNullableToggles,
   extractGroupConfigs,
   extractRepeaterConfigs,
-  getFormkitType,
   getNestedValue,
-  seedFormDefaults,
-  seedNullableToggles,
+  hydrateFormData,
   setNestedValue,
 } from './useFormKitTransform'
 
@@ -22,51 +17,6 @@ import type { Ref } from 'vue'
 export interface ClassDataLike {
   form: unknown[]
   templates?: Array<Record<string, unknown>>
-}
-
-/**
- * Drops keys whose matching form-schema node is a group/repeater and whose incoming
- * value is `null`. FormKit rejects `null` for group values (must be an object) and for
- * repeater values (must be an array), so template payloads that serialise optional
- * nested configs as `null` (Pydantic `Form | None = None`) would otherwise throw during
- * hydration.
- */
-export function stripNullsForGroups(
-  data: Record<string, unknown>,
-  elements: FormElement[],
-): Record<string, unknown> {
-  const result: Record<string, unknown> = {}
-
-  for (const [key, value] of Object.entries(data)) {
-    const element = elements.find(el => el.name === key)
-    if (!element) {
-      result[key] = value
-      continue
-    }
-    const formkitType = getFormkitType(element)
-
-    if ((formkitType === 'group' || formkitType === 'repeater') && value === null) {
-      continue
-    }
-
-    const children = (element.children as FormElement[] | undefined) ?? []
-
-    if (formkitType === 'group' && value && typeof value === 'object' && !Array.isArray(value)) {
-      result[key] = stripNullsForGroups(value as Record<string, unknown>, children)
-    }
-    else if (formkitType === 'repeater' && Array.isArray(value)) {
-      result[key] = value.map(item =>
-        item && typeof item === 'object' && !Array.isArray(item)
-          ? stripNullsForGroups(item as Record<string, unknown>, children)
-          : item,
-      )
-    }
-    else {
-      result[key] = value
-    }
-  }
-
-  return result
 }
 
 export interface CreateInstanceFormOptions<T extends ClassDataLike> {
@@ -85,9 +35,10 @@ export interface CreateInstanceFormOptions<T extends ClassDataLike> {
 /**
  * Shared form logic for creating agent/process instances from class definitions.
  *
- * Handles class selection, FormKit schema generation, stepper navigation,
- * and form data lifecycle. Template/clone pre-filling is done via applyInitialData().
- * Domain-specific submission logic stays in the calling component.
+ * Handles class selection, FormKit schema generation, stepper navigation, and form data
+ * lifecycle. Hydration is shared with the edit form via `hydrateFormData` (and submission via
+ * `serializeFormData`) so create and edit behave identically. Template/clone pre-filling is
+ * done via applyInitialData(); domain-specific submission stays in the calling component.
  */
 export function useCreateInstanceForm<T extends ClassDataLike>(options: CreateInstanceFormOptions<T>) {
   const { classes, classField, initialClass, locale } = options
@@ -144,81 +95,15 @@ export function useCreateInstanceForm<T extends ClassDataLike>(options: CreateIn
   }
 
   watch(selectedClassData, (newClass) => {
-    if (newClass?.form && newClass.form.length > 0) {
-      const base = initializeGroupData(configForm.value as FormElement[], {})
-      formData.value = seedFormDefaults(base, configForm.value as FormElement[])
-    }
-    else {
-      formData.value = {}
-    }
+    formData.value = newClass?.form && newClass.form.length > 0
+      ? hydrateFormData({}, configForm.value as FormElement[])
+      : {}
   }, { immediate: true })
 
-  function initializeElementData(
-    element: FormElement,
-    result: Record<string, unknown>,
-    recursiveFn: (elements: FormElement[], data: Record<string, unknown>) => Record<string, unknown>,
-  ): void {
-    const formkitType = getFormkitType(element)
-    const name = element.name as string
-    const children = element.children as FormElement[] | undefined
-    const hasChildren = children && Array.isArray(children)
-
-    if (formkitType === 'group') {
-      result[name] = result[name] ?? {}
-      if (hasChildren) {
-        result[name] = recursiveFn(children, result[name] as Record<string, unknown>)
-      }
-    }
-    else if (formkitType === 'repeater') {
-      result[name] = result[name] ?? []
-      if (Array.isArray(result[name]) && hasChildren) {
-        result[name] = (result[name] as Record<string, unknown>[]).map(item => recursiveFn(children, item))
-      }
-    }
-  }
-
-  function initializeGroupData(
-    formElements: FormElement[],
-    data: Record<string, unknown>,
-  ): Record<string, unknown> {
-    const result = { ...data }
-    for (const element of formElements) {
-      initializeElementData(element, result, initializeGroupData)
-    }
-    return result
-  }
-
-  function cleanFormData(data: Record<string, unknown>): Record<string, unknown> {
-    const result: Record<string, unknown> = {}
-    // FormKit artifacts that should be stripped from submissions
-    const formkitArtifacts = new Set(['slots'])
-
-    for (const [key, value] of Object.entries(data)) {
-      if (formkitArtifacts.has(key)) continue
-      // Strip the internal repeater validation mirror written by FormKit/Repeater.vue.
-      if (key.startsWith('__validate__')) continue
-
-      if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
-        result[key] = cleanFormData(value as Record<string, unknown>)
-      }
-      else {
-        result[key] = value
-      }
-    }
-
-    return result
-  }
-
   function applyInitialData(data: Record<string, unknown>) {
-    // Seed toggles from the raw data so that `field: null` in a template becomes
-    // `__field__enabled: false`. If we seeded after stripping nulls and merging
-    // against the `{}` placeholder from initializeGroupData, every nullable group
-    // would look truthy and the toggle would come up enabled.
-    const seeded = seedNullableToggles(data, configForm.value as FormElement[])
-    const base = initializeGroupData(configForm.value as FormElement[], {})
-    const withDefaults = seedFormDefaults(base, configForm.value as FormElement[])
-    const sanitized = stripNullsForGroups(seeded, configForm.value as FormElement[])
-    formData.value = merge(withDefaults, sanitized)
+    // Hydrate from the template/clone data: nullable toggles follow the data's null-ness,
+    // missing leaves fall back to their backend defaults — identical to the edit form.
+    formData.value = hydrateFormData(data, configForm.value as FormElement[])
   }
 
   function resetForm() {
@@ -242,9 +127,6 @@ export function useCreateInstanceForm<T extends ClassDataLike>(options: CreateIn
     getRepeaterStepIndex,
     getRepeaterData,
     setRepeaterData,
-    initializeGroupData,
-    cleanFormData,
-    coerceNullableToggles,
     applyInitialData,
     resetForm,
   }

--- a/packages/web/composables/form/useFormKitTransform.ts
+++ b/packages/web/composables/form/useFormKitTransform.ts
@@ -6,6 +6,10 @@ export interface RepeaterConfig {
   label?: string
   addLabel?: string
   childrenSchema: FormKitSchemaNode[]
+  // Seeded default for a freshly added item. `childrenSchema` is transformed and has its
+  // `value` defaults stripped (see EXCLUDED_FIELDS), so a new item must be cloned from this
+  // instead of `{}` — otherwise fields like "documents to retrieve" render empty.
+  defaultItem: Record<string, unknown>
   min?: number
   max?: number
 }
@@ -457,12 +461,14 @@ export function extractRepeaterConfigs(
       // Build full path for nested data access
       const fullPath = parentPath ? `${parentPath}.${elementName}` : elementName
 
+      const itemChildren = (element.children as FormElement[]) || []
       repeaters.push({
         name: elementName,
         path: fullPath,
         label: getLocalizedString(element.label, locale),
         addLabel: getLocalizedString(element.addLabel || element.add_label, locale),
         childrenSchema,
+        defaultItem: seedFormDefaults({}, itemChildren),
         min: element.min as number | undefined,
         max: element.max as number | undefined,
       })

--- a/packages/web/composables/form/useFormKitTransform.ts
+++ b/packages/web/composables/form/useFormKitTransform.ts
@@ -453,35 +453,42 @@ export function extractRepeaterConfigs(
     const formkitType = getFormkitType(element)
     const elementName = element.name as string
 
-    if (formkitType === 'repeater') {
-      const childrenSchema = (element.children as FormElement[] || []).flatMap(
-        child => transformElementForRepeater(child, locale),
-      ) as FormKitSchemaNode[]
+    // Isolate each element so one malformed repeater (or a group containing one) is skipped
+    // rather than throwing out of the computed and breaking every repeater on the form.
+    try {
+      if (formkitType === 'repeater') {
+        const childrenSchema = (element.children as FormElement[] || []).flatMap(
+          child => transformElementForRepeater(child, locale),
+        ) as FormKitSchemaNode[]
 
-      // Build full path for nested data access
-      const fullPath = parentPath ? `${parentPath}.${elementName}` : elementName
+        // Build full path for nested data access
+        const fullPath = parentPath ? `${parentPath}.${elementName}` : elementName
 
-      const itemChildren = (element.children as FormElement[]) || []
-      repeaters.push({
-        name: elementName,
-        path: fullPath,
-        label: getLocalizedString(element.label, locale),
-        addLabel: getLocalizedString(element.addLabel || element.add_label, locale),
-        childrenSchema,
-        defaultItem: seedFormDefaults({}, itemChildren),
-        min: element.min as number | undefined,
-        max: element.max as number | undefined,
-      })
+        const itemChildren = (element.children as FormElement[]) || []
+        repeaters.push({
+          name: elementName,
+          path: fullPath,
+          label: getLocalizedString(element.label, locale),
+          addLabel: getLocalizedString(element.addLabel || element.add_label, locale),
+          childrenSchema,
+          defaultItem: seedFormDefaults({}, itemChildren),
+          min: element.min as number | undefined,
+          max: element.max as number | undefined,
+        })
+      }
+      else if (formkitType === 'group' && element.children) {
+        // Recursively search for repeaters inside groups, passing the current path
+        const groupPath = parentPath ? `${parentPath}.${elementName}` : elementName
+        const nestedRepeaters = extractRepeaterConfigs(
+          element.children as FormElement[],
+          locale,
+          groupPath,
+        )
+        repeaters.push(...nestedRepeaters)
+      }
     }
-    else if (formkitType === 'group' && element.children) {
-      // Recursively search for repeaters inside groups, passing the current path
-      const groupPath = parentPath ? `${parentPath}.${elementName}` : elementName
-      const nestedRepeaters = extractRepeaterConfigs(
-        element.children as FormElement[],
-        locale,
-        groupPath,
-      )
-      repeaters.push(...nestedRepeaters)
+    catch (error) {
+      console.error(`Error extracting repeater "${elementName ?? '<unknown>'}":`, error)
     }
   }
 
@@ -497,13 +504,19 @@ export function buildFormKitSchema(
 ): FormKitSchemaNode[] {
   if (!formElements || formElements.length === 0) return []
 
-  try {
-    return formElements.flatMap(el => transformElementToSchema(el, options)) as FormKitSchemaNode[]
-  }
-  catch (error) {
-    console.error('Error transforming schema:', error)
-    return []
-  }
+  // Isolate each element: a single malformed element is skipped (and logged) instead of
+  // collapsing the whole section to []. A blanket try/catch here meant one throwing input
+  // took every sibling down with it — e.g. a bad config field wiped the entire Basic Info
+  // step (agent_id, name, …), leaving an unusable form.
+  return formElements.flatMap((element) => {
+    try {
+      return transformElementToSchema(element, options)
+    }
+    catch (error) {
+      console.error(`Error transforming form element "${(element?.name as string) ?? '<unknown>'}":`, error)
+      return []
+    }
+  }) as FormKitSchemaNode[]
 }
 
 const LOCALE_KEYS = new Set(['de', 'en', 'fr', 'it'])
@@ -760,9 +773,11 @@ export function extractGroupConfigs(
   const groups: GroupConfig[] = []
 
   for (const element of formElements) {
-    const formkitType = getFormkitType(element)
+    if (getFormkitType(element) !== 'group') continue
 
-    if (formkitType === 'group') {
+    // Isolate each group so a single malformed group is skipped rather than throwing out
+    // of the computed and blanking the whole step list.
+    try {
       const schema = transformElementToSchema(element, { locale })
       const schemaArray = Array.isArray(schema) ? schema : [schema]
 
@@ -771,6 +786,9 @@ export function extractGroupConfigs(
         label: getLocalizedString(element.label, locale),
         schema: schemaArray,
       })
+    }
+    catch (error) {
+      console.error(`Error transforming group "${(element?.name as string) ?? '<unknown>'}":`, error)
     }
   }
 

--- a/packages/web/composables/form/useFormKitTransform.ts
+++ b/packages/web/composables/form/useFormKitTransform.ts
@@ -229,6 +229,8 @@ const EXCLUDED_FIELDS = new Set([
   'placeholder', // Transformed via getLocalizedString
   'children', // Handled separately for recursion
   'nullable', // Wrapper-level signal for the transform; never a FormKit/PrimeVue prop
+  'defaultEnabled', // Wrapper-level signal (initial nullable-toggle state); never a FormKit prop
+  'default_enabled', // snake_case form of the above
   // Backend serialises the Pydantic default into element.value (form duality). FormKit pushes
   // schema `value` up to the parent v-model on input registration, which would clobber the
   // loaded data with the backend default. Defaults belong in data, seeded via seedFormDefaults.
@@ -696,8 +698,11 @@ export function seedFormDefaults(
 }
 
 /**
- * Recursively seeds synthetic toggle values from initial data: toggle is on iff the
- * matching field was non-null/undefined in the source data.
+ * Recursively seeds synthetic toggle values from initial data. When the field is present in
+ * the source data the toggle follows its null-ness (edit/clone). When it is absent — a fresh
+ * form — the toggle falls back to the backend's `default_enabled` (the field's data default is
+ * non-null), so a nullable field that ships a default (e.g. a prompt, or org_memory) comes up
+ * enabled while a `None`-defaulting one (e.g. reranking_config) stays off.
  */
 export function seedNullableToggles(
   data: Record<string, unknown>,
@@ -708,7 +713,9 @@ export function seedNullableToggles(
   for (const element of elements) {
     const name = element.name as string
     if (element.nullable === true) {
-      result[nullableToggleName(name)] = result[name] !== null && result[name] !== undefined
+      result[nullableToggleName(name)] = name in result
+        ? result[name] !== null && result[name] !== undefined
+        : (element.defaultEnabled ?? element.default_enabled) === true
     }
 
     const formkitType = getFormkitType(element)
@@ -728,6 +735,45 @@ export function seedNullableToggles(
   }
 
   return result
+}
+
+/**
+ * Strips FormKit submission artifacts: the `slots` helper key and the repeater validation
+ * mirror keys (`__validate__*`) registered by Repeater.vue. Recurses into nested group objects.
+ */
+export function cleanFormData(data: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(data)) {
+    if (key === 'slots' || key.startsWith('__validate__')) continue
+    result[key] = value !== null && typeof value === 'object' && !Array.isArray(value)
+      ? cleanFormData(value as Record<string, unknown>)
+      : value
+  }
+  return result
+}
+
+/**
+ * Raw saved/template/empty data → a fully hydrated FormKit model: nullable toggles seeded from
+ * the data's null-ness (or `default_enabled` on a fresh form), then groups materialised and
+ * leaf defaults filled. Single entry point so create and edit forms hydrate identically.
+ */
+export function hydrateFormData(
+  raw: Record<string, unknown>,
+  elements: FormElement[],
+): Record<string, unknown> {
+  return seedFormDefaults(seedNullableToggles(raw, elements), elements)
+}
+
+/**
+ * FormKit model → submission payload: disabled nullable subtrees nulled and synthetic toggle
+ * keys dropped (coerceNullableToggles), LocaleStrings normalised, FormKit artifacts stripped.
+ * Single entry point so create and edit forms serialise identically.
+ */
+export function serializeFormData(
+  data: Record<string, unknown>,
+  elements: FormElement[],
+): Record<string, unknown> {
+  return cleanFormData(normalizeFormLocaleStrings(coerceNullableToggles(data, elements)))
 }
 
 /**

--- a/packages/web/composables/form/useFormKitTransform.ts
+++ b/packages/web/composables/form/useFormKitTransform.ts
@@ -618,13 +618,15 @@ export function coerceNullableToggles(
  * process edit forms.
  */
 /**
- * Seed a group field's value: leave a disabled nullable group as `null`; otherwise
- * materialise its children's defaults (starting from the existing object when present).
- * `coerceNullableToggles` re-nullifies disabled subtrees at submit time, so seeding a
- * group whose toggle will end up off is safe.
+ * Seed a group field's value: always materialise its children's defaults (starting from
+ * the existing object when present, `{}` otherwise — including for a saved `null`). A null
+ * nullable group must still hold an object so FormKit can mount and render its children
+ * when the user flips the "Enable" toggle on. Visibility is governed by the synthetic
+ * toggle (seeded earlier from the raw null-ness by `seedNullableToggles`), and
+ * `coerceNullableToggles` re-nullifies disabled subtrees at submit time — so a materialised
+ * but disabled group is never persisted.
  */
-function seedGroupDefault(value: unknown, children: FormElement[]): Record<string, unknown> | null {
-  if (value === null) return null
+function seedGroupDefault(value: unknown, children: FormElement[]): Record<string, unknown> {
   const groupValue = value && typeof value === 'object' && !Array.isArray(value)
     ? value as Record<string, unknown>
     : {}

--- a/packages/web/pages/[tenant]/service/agents/[agent_class]-[agent_id]/configuration.vue
+++ b/packages/web/pages/[tenant]/service/agents/[agent_class]-[agent_id]/configuration.vue
@@ -34,10 +34,6 @@
 </template>
 
 <script setup lang="ts">
-import type { AgentConfigDtoReadable } from '@core/sdk/client'
-
-type FormElement = NonNullable<AgentConfigDtoReadable['form']>[number]
-
 const route = useRoute()
 const { tenantId } = useTenant()
 const { agentInstance, agentInstanceIsLoading } = useAgentInstance()
@@ -47,42 +43,14 @@ const toast = useToast()
 
 const configForm = computed(() => agentInstance.value?.agent_config?.form || [])
 
-/**
- * Recursively initializes nested Group values with empty objects based on form schema.
- * FormKit Groups require object values - they cannot be null or undefined.
- * This ensures all Group elements have at least an empty object as their value.
- */
-const initializeGroupData = (
-  formElements: FormElement[],
-  data: Record<string, unknown>,
-): Record<string, unknown> => {
-  const result = { ...data }
-
-  for (const element of formElements) {
-    const elementRecord = element as Record<string, unknown>
-    const formkitType = elementRecord.formkit || elementRecord.$formkit
-
-    if (formkitType === 'group') {
-      const name = elementRecord.name as string
-      const children = elementRecord.children as FormElement[] | undefined
-
-      if (result[name] === null || result[name] === undefined) {
-        result[name] = {}
-      }
-
-      if (children && Array.isArray(children)) {
-        result[name] = initializeGroupData(children, result[name] as Record<string, unknown>)
-      }
-    }
-  }
-
-  return result
-}
-
-const configurationData = computed(() => {
-  const rawData = (agentInstance.value?.configuration || {}) as Record<string, unknown>
-  return initializeGroupData(configForm.value, rawData)
-})
+// Pass the saved configuration through unchanged. DynamicConfiguration hydrates it
+// (seedNullableToggles then seedFormDefaults): non-nullable groups are materialised to
+// objects, while nullable groups keep their saved `null` so their "Enable" toggle loads
+// off. Pre-filling `null` groups with `{}` here would make every disabled nullable group
+// (e.g. reranking_config, org_memory) load as enabled.
+const configurationData = computed(
+  () => (agentInstance.value?.configuration || {}) as Record<string, unknown>,
+)
 
 const submitConfiguration = async (formData: Record<string, unknown>) => {
   const agentClass = route.params.agent_class as string

--- a/packages/web/pages/[tenant]/service/knowledge.vue
+++ b/packages/web/pages/[tenant]/service/knowledge.vue
@@ -10,7 +10,7 @@
           :key="database.name"
         >
           <div class="flex items-center gap-2 pb-2 pl-2">
-            <span class="text-sm font-medium">{{ database.display_name || useChangeCase(database.name, 'capitalCase') }}</span>
+            <span class="text-sm font-medium">{{ database.display_name || capitalCase(database.name) }}</span>
             <i
               v-if="database.auto_sync"
               class="pi pi-lock text-surface-400 dark:text-surface-500"
@@ -67,7 +67,7 @@
 </template>
 
 <script setup lang="ts">
-import { useChangeCase } from '@vueuse/integrations/useChangeCase'
+import { capitalCase } from 'change-case'
 
 import type { DatabaseDto, NamespaceDto } from '@core/sdk/client'
 
@@ -96,8 +96,8 @@ const toNamespace = (database_name: string, namespace: NamespaceDto) => {
 const openUploadModal = (database: DatabaseDto, namespace: NamespaceDto) => {
   selectedDatabaseForUpload.value = database.name
   selectedNamespaceForUpload.value = namespace.name
-  selectedDatabaseDisplayNameForUpload.value = database.display_name || useChangeCase(database.name, 'capitalCase')
-  selectedNamespaceDisplayNameForUpload.value = namespace.display_name || useChangeCase(namespace.name, 'capitalCase')
+  selectedDatabaseDisplayNameForUpload.value = database.display_name || capitalCase(database.name)
+  selectedNamespaceDisplayNameForUpload.value = namespace.display_name || capitalCase(namespace.name)
   uploadModalVisible.value = true
 }
 

--- a/packages/web/pages/[tenant]/service/knowledge/[db]/[namespace].vue
+++ b/packages/web/pages/[tenant]/service/knowledge/[db]/[namespace].vue
@@ -58,7 +58,7 @@
 
 <script setup lang="ts">
 import { useDebounceFn } from '@vueuse/core'
-import { useChangeCase } from '@vueuse/integrations/useChangeCase'
+import { capitalCase } from 'change-case'
 
 import type { DocumentDto } from '@core/sdk/client'
 
@@ -113,11 +113,11 @@ const currentNamespace = computed(() => {
 })
 
 const databaseDisplayName = computed(() => {
-  return currentDatabase.value?.display_name || useChangeCase(route.params.db as string, 'capitalCase').value
+  return currentDatabase.value?.display_name || capitalCase(route.params.db as string)
 })
 
 const namespaceDisplayName = computed(() => {
-  return currentNamespace.value?.display_name || useChangeCase(route.params.namespace as string, 'capitalCase').value
+  return currentNamespace.value?.display_name || capitalCase(route.params.namespace as string)
 })
 
 const toDocument = (document: DocumentDto) => {

--- a/packages/web/pages/[tenant]/service/models.vue
+++ b/packages/web/pages/[tenant]/service/models.vue
@@ -24,7 +24,7 @@
           <div
             class="pb-2 pl-2 text-sm font-medium"
           >
-            {{ useChangeCase(modelType.name, 'capitalCase') }}
+            {{ capitalCase(modelType.name) }}
           </div>
           <div
             class="grid grid-cols-2 gap-4 2xl:grid-cols-2"
@@ -45,7 +45,7 @@
 </template>
 
 <script setup lang="ts">
-import { useChangeCase } from '@vueuse/integrations/useChangeCase'
+import { capitalCase } from 'change-case'
 
 import type { ModelDTO } from '@core/sdk/client'
 


### PR DESCRIPTION
## Summary

Makes the agent (and process) configuration form actually usable. Investigated the FormKit form machinery end-to-end (backend `Form.to_formkit_form()` + frontend transform/seed/render) and fixed every expected-vs-actual discrepancy found, verified live against a real RAGAgent instance.

[Screencast from 16.06.2026 15:34:44.webm](https://github.com/user-attachments/assets/786aba9d-39d4-48ab-9716-f5c972e8bbff)

## Bugs fixed

1. **Namespace chip passed a `Ref` as a label** (`VectorStoreInput.vue`). `useChangeCase` returns a `ComputedRef`, so `display_name || useChangeCase(name, 'capitalCase')` produced a `Ref` when `display_name` was empty → `Invalid prop "label": Expected String, got Object`. Worse, it ran inside the `databaseOptions`/`namespaceOptions` render computeds, creating fresh reactive effects every render — the unstable reactivity that intermittently blanked the whole form. Use the pure `capitalCase` from `change-case`.

2. **Nullable groups loaded ENABLED when saved `null`** (`reranking_config`, `org_memory`). The edit page pre-filled every `null` group with `{}` before `seedNullableToggles` (which derives the "Enable" toggle from null-ness) could read it → toggle on → saving silently re-enabled features the user never configured. Pass the saved config through unchanged, and always materialise `{}`+defaults in `seedGroupDefault` so a re-enabled null group can still render its children (the toggle governs visibility, `coerceNullableToggles` re-nullifies disabled groups at submit).

3. **Fractional number fields rejected the decimal point** (e.g. LLM temperature). PrimeVue InputNumber is integer-only unless fraction digits are configured. `InputNumber` now auto-derives `maxFractionDigits` from the field's own precision (step/min/max/value); integer fields stay integer-only.

4. **New repeater items had no defaults** (e.g. a retriever's "documents to retrieve", "query mode"). Adding an item pushed a bare `{}`; the transformed `childrenSchema` has its `value` defaults stripped. `extractRepeaterConfigs` now computes a seeded `defaultItem` and the repeater clones it per add.

## Expected vs actual (after fix)

| Scenario | Before | After |
|---|---|---|
| Create RAGAgent — Basic Info + defaults | intermittently blank | renders; icon/tokens/temperature/timeout/prompts defaulted |
| Edit — `reranking_config: null` toggle | **Enabled** (wrong) | **Disabled** (correct) |
| Edit — `org_memory: null` toggle | **Enabled** (wrong) | **Disabled** (correct) |
| Edit — `user_memory` sub-toggles | Enabled | Enabled (correct — non-nullable, default-true) |
| Enable a previously-null group | n/a (was wrongly on) | children render with defaults |
| Save with no changes | would persist `{}` | keeps `null` (DB-verified) |
| Temperature input "0.5" | "." rejected | accepted (maxFractionDigits=1) |
| Add a retriever | empty + required | documents=5, query mode=Default |

## Test plan

- Verified each fix live against `RAGAgent-test_rag_agent_joel` (DOM + DB): toggles load correctly, enabling renders children, save round-trip keeps `reranking_config`/`org_memory` `null`, temperature serialises `maxFractionDigits`, added retrievers carry defaults.
- `packages/core`: **784 passed** (incl. 4 new `InputNumber` fraction-digit tests).
- ESLint clean on all changed web files.
- Note: 6 `test_form.py` cases fail **in isolation** due to a pre-existing `Group.model_rebuild()` import-order artifact (they fail on `main` without this change and pass in the full suite) — out of scope.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject>`
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [ ] CLA signed
- [x] Tests added/updated where a harness exists (InputNumber; packages/web has no Vitest harness)