### PR TITLE
fix(swiss-ai-hub): Allow decimal input for LLM temperature field

### DIFF
--- a/packages/core/swiss_ai_hub/core/generative_ai/resources/models/llm/llm_config.py
+++ b/packages/core/swiss_ai_hub/core/generative_ai/resources/models/llm/llm_config.py
@@ -63,6 +63,8 @@ class LLMParameter(Form):
                 max=2.0,
                 step=0.1,
                 value=0.1,
+                min_fraction_digits=0,
+                max_fraction_digits=1,
             ),
             logprobs=Checkbox(
                 label=LocaleString.from_i18n_path("lib.llm.config.logprobs.label"),


### PR DESCRIPTION
## What

The LLM **temperature** config field rejected the decimal-separator (`.`) keypress — users could not change e.g. `0.1` to `0.2`; input collapsed to `0` or `2`.

## Root cause

The `temperature` `InputNumber` in `LLMParameter.as_form()` omitted fraction-digit hints. PrimeVue's `InputNumber.insert()` only inserts a *new* decimal point when `maxFractionDigits` is truthy (`decimalCharIndex === -1 && this.maxFractionDigits`). With it unset, the `.` keypress was silently dropped. Loading an existing value worked because that path only *formats* a number; the block is specific to typing.

This is a backend issue: the form schema (form-duality pattern) owns the field's precision, and it failed to declare that temperature accepts decimals. The frontend faithfully rendered what it was told.

## Fix

Set `min_fraction_digits=0` / `max_fraction_digits=1` on the temperature field — matching its `step=0.1` granularity, while keeping whole numbers (`1`, `2`) typable.

## Scope

The fix lives in `LLMConfig.as_form()`, so it applies to **every** agent that uses an LLM config (RAGAgent, LLMWrappingAgent, etc.). The form is regenerated and re-cached automatically when agents re-register on the next discovery cycle — no data migration needed (existing saved temperature values are unaffected).

## Testing

- `packages/core` `make test`: 772 passed.
- Manually verified in the UI: temperature now accepts `0.2` on RAGAgent and LLMWrappingAgent config forms after agent restart.

Closes bbvch-ai/aihub-core-test#18