### PR TITLE
fix(ui): Route subpage close button to correct parent on sysadmin pages

### DIFF
--- a/packages/sysadmin-web/components/TenantAdmin/Card.vue
+++ b/packages/sysadmin-web/components/TenantAdmin/Card.vue
@@ -115,7 +115,7 @@ const confirmDelete = () => {
     },
     accept: async () => {
       if (isActive.value) {
-        await router.push(localePath('/sysadmin/tenants'))
+        await router.push(localePath('/tenants'))
       }
       await deleteTenantMetadata({ tenantId: props.tenant.id })
       toast.add({ severity: 'success', summary: t('tenant_admin.tenant_deleted.summary'), detail: t('tenant_admin.tenant_deleted.detail'), life: 3000 })

--- a/packages/web/CLAUDE.md
+++ b/packages/web/CLAUDE.md
@@ -218,14 +218,15 @@ use this. Use `dark:` Tailwind prefix for dark-mode styles.
 
 ## Sysadmin Layout
 
-A separate `sysadmin.vue` layout powers the `/sysadmin/tenants/...` route tree, used exclusively for tenant
-administration by users with the `AIHubSysAdmin` Keycloak realm role. The route shape is independent of the regular
+Tenant administration lives in the `packages/sysadmin-web` layer (its own `sysadmin.vue` layout + pages), used
+exclusively by users with the `AIHubSysAdmin` Keycloak realm role. Because that app IS the sysadmin app, its routes are
+mounted at `/tenants/...` — there is NO `/sysadmin/` URL prefix. The route shape is independent of the regular
 `/[tenant]/service/...` admin pages:
 
-- `/sysadmin/tenants` — tenant list (Active + Orphaned + Unconfigured states)
-- `/sysadmin/tenants/[tenant_id]/overview` — metadata edit
-- `/sysadmin/tenants/[tenant_id]/roles` — role management within the tenant
-- `/sysadmin/tenants/[tenant_id]/users` — user list within the tenant (read-only; user lifecycle managed in Keycloak)
+- `/tenants` — tenant list (Active + Orphaned + Unconfigured states)
+- `/tenants/[tenant_id]/overview` — metadata edit
+- `/tenants/[tenant_id]/roles` — role management within the tenant
+- `/tenants/[tenant_id]/users` — user list within the tenant (read-only; user lifecycle managed in Keycloak)
 
 `useTenant()` reads from either `route.params.tenant` (regular routes) or `route.params.tenant_id` (sysadmin routes), so
 role/user composables work transparently in both contexts.

--- a/packages/web/composables/tenant/useTenant.ts
+++ b/packages/web/composables/tenant/useTenant.ts
@@ -5,7 +5,7 @@ import { setMyActiveTenant } from '@core/sdk/client'
  *
  * - **Read**: ``tenantId`` is a reactive computed derived from the route. Tenant-scoped
  *   routes carry the id as ``route.params.tenant`` (``/[tenant]/...``); sysadmin admin
- *   routes carry it as ``route.params.tenant_id`` (``/sysadmin/tenants/[tenant_id]/...``).
+ *   routes carry it as ``route.params.tenant_id`` (``/tenants/[tenant_id]/...``).
  *   Both shapes resolve to the same tenant context so composables and components that
  *   depend on ``useTenant()`` work transparently in either place.
  * - **Write**: ``setTenant(id)`` navigates to the same route with the new ``tenant``

--- a/packages/web/composables/tenant/useTenantPath.ts
+++ b/packages/web/composables/tenant/useTenantPath.ts
@@ -1,20 +1,27 @@
 /**
- * Wraps ``useLocalePath()`` to auto-inject the current tenant ID from the route.
+ * Wraps ``useLocalePath()`` to auto-inject the tenant segment for the
+ * ``/[tenant]/...`` route tree.
+ *
+ * Only the tenant-scoped ``route.params.tenant`` is injected — sysadmin routes
+ * carry the tenant as ``route.params.tenant_id`` but their URLs are absolute
+ * (e.g. ``/tenants``), so on those routes this falls back to bare ``localePath``.
+ * (This differs from ``useTenant().tenantId``, which intentionally resolves both
+ * shapes for data fetching.)
  *
  * Usage:
  * ```ts
  * const tenantPath = useTenantPath()
  * router.push(tenantPath('/service/agents'))
- * // → /{locale}/{tenantId}/service/agents
+ * // → /{locale}/{tenant}/service/agents
  * ```
  */
 export function useTenantPath() {
   const localePath = useLocalePath()
-  const { tenantId } = useTenant()
+  const route = useRoute()
 
   return (path: string) => {
-    const id = tenantId.value
-    if (!id) return localePath(path)
-    return localePath(`/${id}${path}`)
+    const tenant = route.params.tenant as string | undefined
+    if (!tenant) return localePath(path)
+    return localePath(`/${tenant}${path}`)
   }
 }


### PR DESCRIPTION
closes #1246

## Summary

The subpage close (×) button routed to a mangled URL on sysadmin pages — e.g. on `/tenants/{tenant_id}/overview`, clicking × produced `/{tenant_id}/tenants` instead of the tenant list. The shared close mechanism (`StructuralColumn`) builds its target via `useTenantPath()`, which prepended the tenant segment using `useTenant().tenantId` — an id that resolves **both** route shapes (`route.params.tenant` and `route.params.tenant_id`). That dual-resolution is correct for data fetching but wrong for URL construction.

## Changes

- **`useTenantPath.ts`**: build URLs from only the tenant-scoped `route.params.tenant`; fall back to bare `localePath` otherwise. Tenant-scoped `/[tenant]/service/...` pages are unchanged; sysadmin close routes (e.g. `/tenants`) now resolve correctly. This is shared code, so it fixes every subpage close button at once.
- **`TenantAdmin/Card.vue`**: fix a related hardcoded route `/sysadmin/tenants` → `/tenants` (the sysadmin app has no `/sysadmin/` URL prefix; the old path 404'd and only "worked" via the confinement-middleware bounce).
- **`packages/web/CLAUDE.md`**: correct stale sysadmin route docs (`/sysadmin/tenants/...` → `/tenants/...`) that caused the `Card.vue` mistake.

## Test plan

- Broad investigation confirmed the dual-resolution defect is fully contained to `useTenantPath`; all other `tenantId` usages feed SDK params / cache keys (not URLs), and the sysadmin app doesn't mount tenant-app nav components.
- `pnpm lint` passes clean (exit 0) in both `packages/web` and `packages/sysadmin-web`.
- Manual: on a sysadmin tenant overview page, the × button now navigates to the tenant list (`/{locale}/tenants`).

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>`
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [ ] CLA signed
- [ ] Tests added or updated where relevant (no frontend test harness configured; `make test` is a no-op for `web`/`sysadmin-web`)
