### PR TITLE
fix(swiss-ai-hub): Prevent duplicate OpenWebUI groups in role sync

### DIFF
--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_client.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_client.py
@@ -68,7 +68,9 @@ class OpenWebuiClient:
             for group in response.resources:
                 if group.display_name == name:
                     logger.warning(
-                        "OpenWebUI group '%s' already exists; reusing it instead of creating a duplicate", name
+                        "OpenWebUI group '%s' already exists (id=%s); reusing it instead of creating a duplicate",
+                        name,
+                        group.id,
                     )
                     return group
             return await client.create(Group(display_name=name))

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_client.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_client.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any
@@ -8,6 +9,8 @@ from scim2_models import Group, GroupMember, User
 
 from swiss_ai_hub.core.infrastructure.openwebui.access_grant import AccessGrant
 from swiss_ai_hub.core.infrastructure.openwebui.openwebui_token_service import OpenWebuiTokenService
+
+logger = logging.getLogger(__name__)
 
 SCIM_BASE_PATH = "/api/v1/scim/v2"
 MODELS_ENDPOINT = "/api/v1/models"
@@ -54,10 +57,26 @@ class OpenWebuiClient:
             return list(response.resources)
 
     async def create_group(self, name: str, scim: AsyncSCIMClient | None = None) -> Group:
+        """Creates a group, or returns the existing one if a group with this display name already exists.
+
+        OpenWebUI/SCIM does not enforce unique display names, so a blind create can produce duplicate
+        same-named groups (which breaks role-to-group sync). This makes creation idempotent.
+        """
+
+        async def _create(client: AsyncSCIMClient) -> Group:
+            response = await client.query(Group)
+            for group in response.resources:
+                if group.display_name == name:
+                    logger.warning(
+                        "OpenWebUI group '%s' already exists; reusing it instead of creating a duplicate", name
+                    )
+                    return group
+            return await client.create(Group(display_name=name))
+
         if scim:
-            return await scim.create(Group(display_name=name))
+            return await _create(scim)
         async with self.scim_session() as s:
-            return await s.create(Group(display_name=name))
+            return await _create(s)
 
     async def delete_group(self, group_id: str, scim: AsyncSCIMClient | None = None) -> None:
         if scim:

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_provisioner.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_provisioner.py
@@ -50,9 +50,17 @@ class OpenWebuiProvisioner:
         self._redis = redis
 
     @asynccontextmanager
-    async def _sync_lock(self, key: str) -> AsyncIterator[bool]:
+    async def _sync_lock(self, key: str, *, blocking: bool = False) -> AsyncIterator[bool]:
+        """Acquires a Redis lock for the given key.
+
+        ``blocking=False`` (default): skip the work if another instance holds it — used for whole-sync
+        operations that are safe to drop because the holder already covers the same work.
+        ``blocking=True``: wait (up to the lock timeout) for the holder to finish — used for the group
+        critical section, which must run rather than be skipped, but must never run concurrently.
+        """
         lock = self._redis.lock(key, timeout=_LOCK_TIMEOUT)
-        if not await lock.acquire(blocking=False):
+        blocking_timeout = _LOCK_TIMEOUT if blocking else None
+        if not await lock.acquire(blocking=blocking, blocking_timeout=blocking_timeout):
             logger.debug("OpenWebUI %s skipped: another instance is syncing", key.rsplit(":", 1)[-1])
             yield False
             return
@@ -168,6 +176,19 @@ class OpenWebuiProvisioner:
                 await self._openwebui.update_group_members(aihub_groups[group_name].id, owui_member_ids, scim=scim)
 
     async def _sync_groups(self) -> None:
+        """Serializes group reconciliation across all callers (``provision`` and ``sync_access``).
+
+        ``create_group`` is not atomic at the SCIM layer, so two concurrent ``_sync_groups`` runs would
+        both observe a group as missing and each create it, yielding duplicate same-named groups. This
+        dedicated blocking lock guarantees the create/delete section runs one-at-a-time across processes.
+        """
+        async with self._sync_lock("openwebui:sync:groups", blocking=True) as acquired:
+            if not acquired:
+                logger.warning("OpenWebUI group sync skipped: timed out waiting for the group-sync lock")
+                return
+            await self._sync_groups_locked()
+
+    async def _sync_groups_locked(self) -> None:
         tenants = [
             {"name": t.name, "id": str(t.id), "access_rules": t.access_rules} for t in TenantMetadataEntity.objects()
         ]

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_provisioner.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_provisioner.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import httpx
 from redis.asyncio import Redis
+from redis.exceptions import LockError
 from scim2_client.engines.httpx import AsyncSCIMClient
 from scim2_models import Group, User
 
@@ -27,6 +28,10 @@ AIHUB_GROUP_PREFIX = "aihub:"
 AIHUB_MODEL_PREFIX = "aihub-agent-"
 
 _LOCK_TIMEOUT = 60
+# The group critical section lists all SCIM groups/users + all Keycloak users and then issues one
+# membership update per group, so it can run for a while on large tenants. Its lock TTL must comfortably
+# exceed that worst case, otherwise the lock auto-expires mid-run and a second sync can race it.
+_GROUPS_LOCK_TTL = 600
 
 type AiHubToOwuiUserIdMapping = dict[str, str]
 """Maps AI-Hub user IDs (keys) to OpenWebUI user IDs (values), matched by email."""
@@ -50,16 +55,22 @@ class OpenWebuiProvisioner:
         self._redis = redis
 
     @asynccontextmanager
-    async def _sync_lock(self, key: str, *, blocking: bool = False) -> AsyncIterator[bool]:
+    async def _sync_lock(
+        self, key: str, *, blocking: bool = False, ttl: int = _LOCK_TIMEOUT, wait: int = _LOCK_TIMEOUT
+    ) -> AsyncIterator[bool]:
         """Acquires a Redis lock for the given key.
 
         ``blocking=False`` (default): skip the work if another instance holds it — used for whole-sync
         operations that are safe to drop because the holder already covers the same work.
-        ``blocking=True``: wait (up to the lock timeout) for the holder to finish — used for the group
+        ``blocking=True``: wait up to ``wait`` seconds for the holder to finish — used for the group
         critical section, which must run rather than be skipped, but must never run concurrently.
+
+        ``ttl`` is the lock's auto-expiry and must exceed the worst-case runtime of the protected work,
+        otherwise the lock expires mid-run and a second caller can acquire it. ``wait`` only bounds how
+        long a blocking caller waits, so the two are decoupled.
         """
-        lock = self._redis.lock(key, timeout=_LOCK_TIMEOUT)
-        blocking_timeout = _LOCK_TIMEOUT if blocking else None
+        lock = self._redis.lock(key, timeout=ttl)
+        blocking_timeout = wait if blocking else None
         if not await lock.acquire(blocking=blocking, blocking_timeout=blocking_timeout):
             logger.debug("OpenWebUI %s skipped: another instance is syncing", key.rsplit(":", 1)[-1])
             yield False
@@ -67,7 +78,12 @@ class OpenWebuiProvisioner:
         try:
             yield True
         finally:
-            await lock.release()
+            try:
+                await lock.release()
+            except LockError:
+                # The lock auto-expired (work outran its TTL) and may now be held by another caller;
+                # don't let the release failure mask the outcome of the work we just did.
+                logger.warning("OpenWebUI sync lock '%s' expired before release; consider raising its TTL", key)
 
     async def provision(self) -> None:
         async with self._sync_lock("openwebui:sync:provision") as acquired:
@@ -182,7 +198,7 @@ class OpenWebuiProvisioner:
         both observe a group as missing and each create it, yielding duplicate same-named groups. This
         dedicated blocking lock guarantees the create/delete section runs one-at-a-time across processes.
         """
-        async with self._sync_lock("openwebui:sync:groups", blocking=True) as acquired:
+        async with self._sync_lock("openwebui:sync:groups", blocking=True, ttl=_GROUPS_LOCK_TTL) as acquired:
             if not acquired:
                 logger.warning("OpenWebUI group sync skipped: timed out waiting for the group-sync lock")
                 return

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_client.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_client.py
@@ -1,7 +1,9 @@
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import httpx
 import pytest
+from scim2_models import Group
 
 from swiss_ai_hub.core.infrastructure.openwebui.openwebui_client import OpenWebuiClient
 
@@ -91,3 +93,34 @@ class TestErrorPropagation:
 
         with pytest.raises(httpx.HTTPStatusError):
             await owui_client.delete_model(mock_client, "nonexistent")
+
+
+def _scim_group(display_name: str, group_id: str) -> Group:
+    group = Group(display_name=display_name)
+    group.id = group_id
+    return group
+
+
+class TestCreateGroupIdempotent:
+    @pytest.mark.asyncio
+    async def test_reuses_existing_group_with_same_name(self, owui_client: OpenWebuiClient) -> None:
+        existing = _scim_group("aihub:T:R", "grp-existing")
+        scim = AsyncMock()
+        scim.query.return_value = SimpleNamespace(resources=[existing])
+
+        result = await owui_client.create_group("aihub:T:R", scim=scim)
+
+        assert result is existing
+        scim.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_creates_when_no_group_with_that_name_exists(self, owui_client: OpenWebuiClient) -> None:
+        created = _scim_group("aihub:T:R", "grp-new")
+        scim = AsyncMock()
+        scim.query.return_value = SimpleNamespace(resources=[_scim_group("aihub:Other:Role", "grp-other")])
+        scim.create.return_value = created
+
+        result = await owui_client.create_group("aihub:T:R", scim=scim)
+
+        assert result is created
+        scim.create.assert_awaited_once()

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_provisioner_groups.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_provisioner_groups.py
@@ -310,3 +310,40 @@ class TestSyncGroupsOrchestration:
 
             mock_create.assert_not_called()
             mock_delete.assert_not_called()
+
+
+class TestSyncGroupsLocking:
+    @pytest.mark.asyncio
+    async def test_group_sync_uses_dedicated_blocking_lock(
+        self, provisioner: OpenWebuiProvisioner, mock_redis: MagicMock
+    ) -> None:
+        with (
+            patch(
+                "swiss_ai_hub.core.infrastructure.openwebui.openwebui_provisioner.TenantMetadataEntity"
+            ) as mock_tenant,
+            patch("swiss_ai_hub.core.infrastructure.openwebui.openwebui_provisioner.RoleEntity") as mock_role,
+            patch("swiss_ai_hub.core.infrastructure.openwebui.openwebui_provisioner.UserTenantRoleEntity"),
+            patch("swiss_ai_hub.core.infrastructure.openwebui.openwebui_provisioner.KeycloakAdminService") as mock_kc,
+            patch.object(provisioner._openwebui, "list_groups", return_value=[]),
+            patch.object(provisioner._openwebui, "list_users", return_value=[]),
+        ):
+            mock_tenant.objects.return_value = []
+            mock_role.get_roles_for_tenant.return_value = []
+            mock_kc.get_all_users = AsyncMock(return_value=[])
+
+            await provisioner._sync_groups()
+
+        lock_keys = [call.args[0] for call in mock_redis.lock.call_args_list]
+        assert "openwebui:sync:groups" in lock_keys
+
+    @pytest.mark.asyncio
+    async def test_group_sync_skipped_when_lock_not_acquired(
+        self, provisioner: OpenWebuiProvisioner, mock_redis: MagicMock
+    ) -> None:
+        mock_redis.lock.return_value.acquire = AsyncMock(return_value=False)
+
+        with patch.object(provisioner._openwebui, "list_groups") as mock_list_groups:
+            await provisioner._sync_groups()
+
+        # No group reconciliation happens when the serialization lock is contended.
+        mock_list_groups.assert_not_called()


### PR DESCRIPTION
## Problem

Refs: bbvch-ai/aihub-core-test#23 — *Sometimes users are unable to select a model on the chat screen after logging in ("No result found").*

Root cause is in the OpenWebUI role→group provisioner: it could create **multiple groups with the same display name** (e.g. 4× `aihub:Swiss AI Hub:AIHubUser`). Because membership and model-access grants then land on different group objects, some users end up in a duplicate group that the model doesn't grant access to → the model disappears from their selector.

Two defects combine:
- `_sync_groups()` runs from **both** `provision()` (lock `openwebui:sync:provision`) and `sync_access()` (lock `openwebui:sync:access`) — **disjoint locks**, so concurrent runs each snapshot a group as missing and both create it.
- `create_group` was a blind SCIM create, and OpenWebUI/SCIM does **not** enforce unique display names.

## Fix

- **Serialize group reconciliation** under a dedicated **blocking** lock `openwebui:sync:groups`, so `provision()` and `sync_access()` can no longer race when creating/deleting groups (concurrent callers wait instead of racing).
- **Make `create_group` idempotent**: query first and reuse an existing same-named group instead of creating a duplicate (defense-in-depth even outside the lock).

## Scope

- `packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_provisioner.py`
- `packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_client.py`
- unit tests for both

## Not included
This prevents **new** duplicates. Any duplicate groups already present in a running OpenWebUI must be consolidated once (manual delete in the admin UI, then a re-sync repopulates the survivor) — an automated consolidation pass can be a follow-up.

## Testing
`uv run pytest swiss_ai_hub/core/infrastructure/openwebui/` → **57 passed** (incl. new cases: `create_group` reuse-vs-create, group sync uses the dedicated blocking lock and skips when contended).