### PR TITLE
fix(ui): Fix dashboard widget popover dismissal and timeseries legend overlap

### DIFF
--- a/packages/web/components/Dashboard/Grid.vue
+++ b/packages/web/components/Dashboard/Grid.vue
@@ -31,12 +31,14 @@
                 v-model="event"
                 :options="eventOptions"
                 option-label="label"
+                append-to="self"
                 :placeholder="t('dashboard.select_data_type')"
               />
               <Select
                 v-model="agent"
                 :options="agentInstances"
                 option-label="agent_config.name"
+                append-to="self"
                 :placeholder="t('dashboard.select_agent')"
                 :loading="agentInstancesAreLoading"
                 show-clear

--- a/packages/web/components/Event/Timeseries.vue
+++ b/packages/web/components/Event/Timeseries.vue
@@ -156,6 +156,7 @@ const chartOptions = computed<ApexOptions>(() => {
       {
         breakpoint: 480,
         options: {
+          chart: { offsetY: 0 },
           legend: {
             position: 'bottom',
             offsetX: -10,

--- a/packages/web/components/Event/Timeseries.vue
+++ b/packages/web/components/Event/Timeseries.vue
@@ -124,6 +124,7 @@ const chartOptions = computed<ApexOptions>(() => {
       type: 'bar',
       height: props.height,
       stacked: true,
+      offsetY: 20,
       toolbar: {
         show: false,
       },
@@ -193,7 +194,7 @@ const chartOptions = computed<ApexOptions>(() => {
       show: true,
       showForSingleSeries: true,
       position: 'top',
-      offsetY: 0,
+      offsetY: 35,
     },
     fill: {
       opacity: 1,


### PR DESCRIPTION
## Summary

Fixes two dashboard widget UI issues. closes bbvch-ai/aihub-core-test#15

### 1. Widget popover closes when selecting an option (Chrome)

In the "Add widget" popover, picking a value in the **data type** or **agent**
`Select` dismissed the entire popover — but only in Chrome; Firefox worked.

Both the `Popover` and the `Select` teleport their overlays to `<body>` by
default, so the dropdown is not a DOM descendant of the popover. When an option
is clicked, it is detached from the DOM as the dropdown closes, so by the time
the popover's outside-click check runs, `container.contains(event.target)` is
`false` and the popover dismisses itself. Chrome and Firefox only differ in the
timing of detachment vs. the click handler, which is why it appeared correct in
Firefox.

Setting `append-to="self"` renders the `Select` overlays inside the popover, so
option clicks register as inside clicks in every browser.

Result:

https://github.com/user-attachments/assets/05724fa8-fabe-4ea5-b445-4cf853db78b9

### 2. Timeseries legend overlaps stacked bars

The top legend sat on top of the stacked bar series. Adjusted the chart body and
legend offsets so the legend clears the bars.

Result:
<img width="1516" height="691" alt="Screenshot 2026-06-16 122829" src="https://github.com/user-attachments/assets/e25df279-845d-46cd-9447-53bddc0b9797" />

## Changes

- `packages/web/components/Dashboard/Grid.vue` — `append-to="self"` on both widget `Select`s
- `packages/web/components/Event/Timeseries.vue` — chart/legend `offsetY` adjustments

## Test plan

- [x] In Chrome, open the dashboard "Add widget" popover and select a data type and an agent — popover stays open
- [x] Confirm the same still works in Firefox
- [x] Verify the timeseries legend no longer overlaps the stacked bars
