### PR TITLE
fix(swiss-ai-hub): Fall back across locales in LocaleString.in_locale

### DIFF
--- a/packages/api/swiss_ai_hub/api/routes/thread/thread_controller.py
+++ b/packages/api/swiss_ai_hub/api/routes/thread/thread_controller.py
@@ -7,6 +7,7 @@ from swiss_ai_hub.core.auth.access.access_checker import AccessChecker
 from swiss_ai_hub.core.auth.dependencies.auth_handler import AuthHandler
 from swiss_ai_hub.core.auth.identity.user_identity import UserIdentity
 from swiss_ai_hub.core.i18n import LocaleHandler
+from swiss_ai_hub.core.persistence.messaging.entities.types.thread_sort import SortOrder
 from swiss_ai_hub.core.routes import TenantScopedController
 
 from swiss_ai_hub.api.i18n.api_locale_string import ApiLocaleString
@@ -20,7 +21,6 @@ from swiss_ai_hub.api.routes.thread.dto.create_thread_request import CreateThrea
 from swiss_ai_hub.api.routes.thread.dto.open_chat_hitl_response import OpenChatHitlResponse
 from swiss_ai_hub.api.routes.thread.dto.paginated_threads_response import PaginatedThreadsResponse
 from swiss_ai_hub.api.routes.thread.dto.thread_dto import ThreadDTO
-from swiss_ai_hub.core.persistence.messaging.entities.types.thread_sort import SortOrder
 from swiss_ai_hub.api.routes.thread.thread_service import ThreadService
 
 

--- a/packages/api/swiss_ai_hub/api/routes/thread/thread_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/thread/thread_service.py
@@ -17,7 +17,6 @@ from openai.types.chat import (
 )
 from openai.types.chat.chat_completion_content_part_image_param import ImageURL
 from openai.types.chat.chat_completion_content_part_input_audio_param import InputAudio
-from swiss_ai_hub.core.persistence.messaging.entities.types.thread_sort import SortOrder
 from swiss_ai_hub.core.auth.access.access_checker import AccessChecker
 from swiss_ai_hub.core.auth.identity.tenant_identity import TenantIdentity
 from swiss_ai_hub.core.auth.keycloak.keycloak_admin_service import KeycloakAdminService
@@ -31,6 +30,7 @@ from swiss_ai_hub.core.persistence.access.entities.user_tenant_role_entity impor
 from swiss_ai_hub.core.persistence.messaging.entities.persisted_agent_event_entity import PersistedAgentEventEntity
 from swiss_ai_hub.core.persistence.messaging.entities.thread_entity import AgentInstanceRef, ThreadEntity, User
 from swiss_ai_hub.core.persistence.messaging.entities.types.thread_filters import ThreadFilters
+from swiss_ai_hub.core.persistence.messaging.entities.types.thread_sort import SortOrder
 
 from swiss_ai_hub.api.routes.agent.dto.agent_identifier import AgentIdentifier
 from swiss_ai_hub.api.routes.agent.dto.minimal_agent_instance_dto import MinimalAgentInstanceDTO

--- a/packages/api/swiss_ai_hub/api/routes/translation/translation_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/translation/translation_service.py
@@ -55,7 +55,7 @@ class TranslationService:
         """
         Translates fields in a translatable object (LocaleString).
         """
-        source_text = getattr(locale_string, source_locale, None)
+        source_text = locale_string.in_locale(source_locale, fallback=False)
         if not source_text:
             logger.warning(f"No source text found for locale {source_locale}")
             return locale_string

--- a/packages/api/swiss_ai_hub/api/routes/translation/translation_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/translation/translation_service.py
@@ -55,7 +55,7 @@ class TranslationService:
         """
         Translates fields in a translatable object (LocaleString).
         """
-        source_text = locale_string.in_locale(source_locale)
+        source_text = getattr(locale_string, source_locale, None)
         if not source_text:
             logger.warning(f"No source text found for locale {source_locale}")
             return locale_string

--- a/packages/core/swiss_ai_hub/core/i18n/locale_string.py
+++ b/packages/core/swiss_ai_hub/core/i18n/locale_string.py
@@ -54,21 +54,26 @@ class LocaleString(BaseModel):
     fr: Annotated[str | None, Field(description="French")] = None
     it: Annotated[str | None, Field(description="Italian")] = None
 
-    def in_locale(self, locale: str) -> str | None:
+    def in_locale(self, locale: str, fallback: bool = True) -> str | None:
         """Extract the string for a locale, falling back to other locales if it is unset.
 
-        Mirrors `LocaleHandler.extract_multi_locale`: requested locale → default locale →
-        first populated locale in the whitelist. Returns None only when every locale is empty.
+        With `fallback` (the default), mirrors `LocaleHandler.extract_multi_locale`:
+        requested locale → default locale → first populated locale in the whitelist;
+        unlike that method it returns None instead of raising when every locale is empty.
+
+        Pass `fallback=False` to read exactly the requested locale (no substitution) — for
+        callers that need the requested language verbatim or want their own fallback order.
         """
+        value = getattr(self, locale, None)
+        if value or not fallback:
+            return value
+
         from swiss_ai_hub.core.i18n.locale_handler import LocaleHandler
 
-        value = getattr(self, locale, None)
-        if value:
-            return value
-        fallback_value = getattr(self, LocaleHandler.DEFAULT_LOCALE, None)
-        if fallback_value:
-            return fallback_value
-        return next((getattr(self, field) for field in LocaleHandler.LOCALE_WHITE_LIST if getattr(self, field)), None)
+        for field in (LocaleHandler.DEFAULT_LOCALE, *LocaleHandler.LOCALE_WHITE_LIST):
+            if fallback_value := getattr(self, field, None):
+                return fallback_value
+        return None
 
     @classmethod
     def from_i18n_path(cls, path: str) -> LocaleString:

--- a/packages/core/swiss_ai_hub/core/i18n/locale_string.py
+++ b/packages/core/swiss_ai_hub/core/i18n/locale_string.py
@@ -55,8 +55,20 @@ class LocaleString(BaseModel):
     it: Annotated[str | None, Field(description="Italian")] = None
 
     def in_locale(self, locale: str) -> str | None:
-        """Extract the string for a specific locale."""
-        return getattr(self, locale, None)
+        """Extract the string for a locale, falling back to other locales if it is unset.
+
+        Mirrors `LocaleHandler.extract_multi_locale`: requested locale → default locale →
+        first populated locale in the whitelist. Returns None only when every locale is empty.
+        """
+        from swiss_ai_hub.core.i18n.locale_handler import LocaleHandler
+
+        value = getattr(self, locale, None)
+        if value:
+            return value
+        fallback_value = getattr(self, LocaleHandler.DEFAULT_LOCALE, None)
+        if fallback_value:
+            return fallback_value
+        return next((getattr(self, field) for field in LocaleHandler.LOCALE_WHITE_LIST if getattr(self, field)), None)
 
     @classmethod
     def from_i18n_path(cls, path: str) -> LocaleString:

--- a/packages/core/swiss_ai_hub/core/i18n/tests/unit/test_locale_string.py
+++ b/packages/core/swiss_ai_hub/core/i18n/tests/unit/test_locale_string.py
@@ -1,0 +1,25 @@
+from swiss_ai_hub.core.i18n.locale_string import LocaleString
+
+
+def test_in_locale_returns_requested_locale():
+    locale_string = LocaleString(de="Hallo", en="Hello", fr="Bonjour", it="Ciao")
+    assert locale_string.in_locale("en") == "Hello"
+
+
+def test_in_locale_falls_back_to_default_locale_when_requested_is_unset():
+    locale_string = LocaleString(de="Hallo", fr="Bonjour")
+    assert locale_string.in_locale("en") == "Hallo"
+
+
+def test_in_locale_falls_back_to_first_available_when_default_is_unset():
+    locale_string = LocaleString(it="Ciao")
+    assert locale_string.in_locale("en") == "Ciao"
+
+
+def test_in_locale_unknown_locale_falls_back_instead_of_returning_none():
+    locale_string = LocaleString(de="Hallo", en="Hello")
+    assert locale_string.in_locale("es") == "Hallo"
+
+
+def test_in_locale_returns_none_when_every_locale_is_empty():
+    assert LocaleString().in_locale("en") is None

--- a/packages/core/swiss_ai_hub/core/i18n/tests/unit/test_locale_string.py
+++ b/packages/core/swiss_ai_hub/core/i18n/tests/unit/test_locale_string.py
@@ -21,5 +21,21 @@ def test_in_locale_unknown_locale_falls_back_instead_of_returning_none():
     assert locale_string.in_locale("es") == "Hallo"
 
 
+def test_in_locale_skips_empty_default_locale_and_returns_first_available():
+    locale_string = LocaleString(fr="Bonjour")
+    assert locale_string.in_locale("de") == "Bonjour"
+
+
 def test_in_locale_returns_none_when_every_locale_is_empty():
     assert LocaleString().in_locale("en") is None
+
+
+def test_in_locale_strict_returns_requested_locale():
+    locale_string = LocaleString(de="Hallo", en="Hello")
+    assert locale_string.in_locale("en", fallback=False) == "Hello"
+
+
+def test_in_locale_strict_returns_none_without_falling_back():
+    locale_string = LocaleString(de="Hallo")
+    assert locale_string.in_locale("en", fallback=False) is None
+    assert locale_string.in_locale("es", fallback=False) is None

--- a/packages/core/swiss_ai_hub/core/persistence/messaging/entities/thread_entity.py
+++ b/packages/core/swiss_ai_hub/core/persistence/messaging/entities/thread_entity.py
@@ -4,9 +4,9 @@ from typing import Self
 from bson import ObjectId
 from mongoengine import DateTimeField, Document, EmbeddedDocument, EmbeddedDocumentField, ListField, StringField
 
-from swiss_ai_hub.core.persistence.messaging.entities.types.thread_sort import SortOrder
 from swiss_ai_hub.core.infrastructure.opentelemetry.tracing.decorators.trace_fn import trace_fn
 from swiss_ai_hub.core.persistence.messaging.entities.types.thread_filters import ThreadFilters
+from swiss_ai_hub.core.persistence.messaging.entities.types.thread_sort import SortOrder
 
 
 class User(EmbeddedDocument):


### PR DESCRIPTION
## Summary

`LocaleString.in_locale` returned `None` the moment the requested locale field was unset, even when other languages were populated. It now falls back like `LocaleHandler.extract_multi_locale`, while keeping the translation service's strict source-locale check intact.

## Changes

- `LocaleString.in_locale(locale)` now resolves: requested locale → default locale (`de`) → first populated locale in the whitelist → `None` only when every field is empty. Added `DEFAULT_LOCALE` / `LOCALE_WHITE_LIST` as `ClassVar`s.
- `TranslationService.translate` pinned to a strict `getattr(locale_string, source_locale, None)`. Its "no source text" guard must keep bailing out — otherwise the new fallback would feed the LLM a different language's text while labeling it as the source locale, producing mislabeled translations and leaving the real source field empty.
- Added `test_locale_string.py` covering requested-locale hit, default fallback, first-available fallback, unknown locale, and all-empty.

## Implications (researched callsites)

Three distinct `in_locale` methods exist; only `LocaleString.in_locale` changed:
- `FormkitElement.in_locale(t)` (form elements + API DTOs) — unaffected; already falls back via `LocaleHandler.extract`.
- `LocaleHandler.in_locale(locale)` (bot, dispatchers) — unaffected.
- `LocaleString.in_locale(locale)` — affected callsites are prompt/system-prompt builders (`few_shot_guard`, `agent_description_guard`, `create_few_shot_messages`, `mcp_react_agent`, `few_shot_agent`, `llm_wrapping_agent`, `expert_asking_agent`), where falling back is an improvement over injecting `None`. The only place where fallback would be **wrong** is `TranslationService`, which is explicitly guarded above.

## Test plan

- `uv run pytest swiss_ai_hub/core/i18n/tests/` in `packages/core` → 13 passed.
- No existing test asserted the old "returns None on missing locale" behaviour. The 6 `test_form.py` `Group`/`ALL_FORM_OPTIONS` failures are pre-existing (fail identically on a clean checkout) and unrelated.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>`
- [ ] Exactly one of `major` / `minor` / `patch` label applied
- [ ] CLA signed
- [x] Tests added or updated where relevant