### PR TITLE
fix(ui): Add accessible labels to form controls flagged by SonarCloud

### DIFF
--- a/packages/web/components/Agent/CreateModal.vue
+++ b/packages/web/components/Agent/CreateModal.vue
@@ -33,6 +33,7 @@
             {{ t('agent.create.selectClass') }}
           </label>
           <Select
+            id="agentClass"
             v-model="selectedClass"
             :options="agentClasses"
             option-label="agent_class"

--- a/packages/web/components/Dashboard/Grid.vue
+++ b/packages/web/components/Dashboard/Grid.vue
@@ -33,6 +33,7 @@
                 option-label="label"
                 append-to="self"
                 :placeholder="t('dashboard.select_data_type')"
+                :aria-label="t('dashboard.select_data_type')"
               />
               <Select
                 v-model="agent"
@@ -40,6 +41,7 @@
                 option-label="agent_config.name"
                 append-to="self"
                 :placeholder="t('dashboard.select_agent')"
+                :aria-label="t('dashboard.select_agent')"
                 :loading="agentInstancesAreLoading"
                 show-clear
               />

--- a/packages/web/components/FormKit/AgentSelector.vue
+++ b/packages/web/components/FormKit/AgentSelector.vue
@@ -2,42 +2,22 @@
   <div class="flex flex-col gap-4">
     <!-- Agent Class Selection -->
     <div>
-      <label
-        for="agent-class-select"
-        class="mb-1 block text-sm font-medium"
-      >
+      <label for="agent-class-select" class="mb-1 block text-sm font-medium">
         {{ t('agent.selector.class.label') }}
       </label>
-      <Select
-        id="agent-class-select"
-        v-model="selectedClass"
-        input-id="agent-class-select"
-        :options="filteredClassOptions"
-        option-label="displayName"
-        option-value="name"
-        :placeholder="classPlaceholder ?? t('agent.selector.class.placeholder')"
-        :filter="filter"
-        :loading="isLoading"
-        class="w-full"
-      >
+      <Select v-model="selectedClass" :aria-label="t('agent.selector.class.label')" input-id="agent-class-select"
+        :options="filteredClassOptions" option-label="displayName" option-value="name"
+        :placeholder="classPlaceholder ?? t('agent.selector.class.placeholder')" :filter="filter" :loading="isLoading"
+        class="w-full">
         <template #option="{ option }">
           <div class="flex items-center gap-2">
-            <Icon
-              :name="option.icon || 'mage:robot'"
-              size="1.2em"
-            />
+            <Icon :name="option.icon || 'mage:robot'" size="1.2em" />
             <span>{{ option.displayName }}</span>
           </div>
         </template>
         <template #value="{ value }">
-          <div
-            v-if="value"
-            class="flex items-center gap-2"
-          >
-            <Icon
-              :name="getClassIcon(value)"
-              size="1.2em"
-            />
+          <div v-if="value" class="flex items-center gap-2">
+            <Icon :name="getClassIcon(value)" size="1.2em" />
             <span>{{ getClassDisplayName(value) }}</span>
           </div>
         </template>
@@ -46,42 +26,22 @@
 
     <!-- Agent ID Selection (shown when class selected) -->
     <div v-if="selectedClass">
-      <label
-        for="agent-id-select"
-        class="mb-1 block text-sm font-medium"
-      >
+      <label for="agent-id-select" class="mb-1 block text-sm font-medium">
         {{ t('agent.selector.id.label') }}
       </label>
-      <Select
-        id="agent-id-select"
-        v-model="selectedId"
-        input-id="agent-id-select"
-        :options="idOptions"
-        option-label="displayName"
-        option-value="id"
-        :placeholder="idPlaceholder ?? t('agent.selector.id.placeholder')"
-        :filter="filter"
-        :loading="isLoadingInstances"
-        class="w-full"
-      >
+      <Select v-model="selectedId" :aria-label="t('agent.selector.id.label')" input-id="agent-id-select"
+        :options="idOptions" option-label="displayName" option-value="id"
+        :placeholder="idPlaceholder ?? t('agent.selector.id.placeholder')" :filter="filter"
+        :loading="isLoadingInstances" class="w-full">
         <template #option="{ option }">
           <div class="flex items-center gap-2">
-            <Icon
-              :name="option.icon || 'mage:user'"
-              size="1.2em"
-            />
+            <Icon :name="option.icon || 'mage:user'" size="1.2em" />
             <span>{{ option.displayName }}</span>
           </div>
         </template>
         <template #value="{ value }">
-          <div
-            v-if="value"
-            class="flex items-center gap-2"
-          >
-            <Icon
-              :name="getIdIcon(value)"
-              size="1.2em"
-            />
+          <div v-if="value" class="flex items-center gap-2">
+            <Icon :name="getIdIcon(value)" size="1.2em" />
             <span>{{ getIdDisplayName(value) }}</span>
           </div>
         </template>

--- a/packages/web/components/FormKit/AgentSelector.vue
+++ b/packages/web/components/FormKit/AgentSelector.vue
@@ -2,22 +2,42 @@
   <div class="flex flex-col gap-4">
     <!-- Agent Class Selection -->
     <div>
-      <label for="agent-class-select" class="mb-1 block text-sm font-medium">
+      <label
+        for="agent-class-select"
+        class="mb-1 block text-sm font-medium"
+      >
         {{ t('agent.selector.class.label') }}
       </label>
-      <Select v-model="selectedClass" :aria-label="t('agent.selector.class.label')" input-id="agent-class-select"
-        :options="filteredClassOptions" option-label="displayName" option-value="name"
-        :placeholder="classPlaceholder ?? t('agent.selector.class.placeholder')" :filter="filter" :loading="isLoading"
-        class="w-full">
+      <Select
+        v-model="selectedClass"
+        :aria-label="t('agent.selector.class.label')"
+        input-id="agent-class-select"
+        :options="filteredClassOptions"
+        option-label="displayName"
+        option-value="name"
+        :placeholder="classPlaceholder ?? t('agent.selector.class.placeholder')"
+        :filter="filter"
+        :loading="isLoading"
+        class="w-full"
+      >
         <template #option="{ option }">
           <div class="flex items-center gap-2">
-            <Icon :name="option.icon || 'mage:robot'" size="1.2em" />
+            <Icon
+              :name="option.icon || 'mage:robot'"
+              size="1.2em"
+            />
             <span>{{ option.displayName }}</span>
           </div>
         </template>
         <template #value="{ value }">
-          <div v-if="value" class="flex items-center gap-2">
-            <Icon :name="getClassIcon(value)" size="1.2em" />
+          <div
+            v-if="value"
+            class="flex items-center gap-2"
+          >
+            <Icon
+              :name="getClassIcon(value)"
+              size="1.2em"
+            />
             <span>{{ getClassDisplayName(value) }}</span>
           </div>
         </template>
@@ -26,22 +46,42 @@
 
     <!-- Agent ID Selection (shown when class selected) -->
     <div v-if="selectedClass">
-      <label for="agent-id-select" class="mb-1 block text-sm font-medium">
+      <label
+        for="agent-id-select"
+        class="mb-1 block text-sm font-medium"
+      >
         {{ t('agent.selector.id.label') }}
       </label>
-      <Select v-model="selectedId" :aria-label="t('agent.selector.id.label')" input-id="agent-id-select"
-        :options="idOptions" option-label="displayName" option-value="id"
-        :placeholder="idPlaceholder ?? t('agent.selector.id.placeholder')" :filter="filter"
-        :loading="isLoadingInstances" class="w-full">
+      <Select
+        v-model="selectedId"
+        :aria-label="t('agent.selector.id.label')"
+        input-id="agent-id-select"
+        :options="idOptions"
+        option-label="displayName"
+        option-value="id"
+        :placeholder="idPlaceholder ?? t('agent.selector.id.placeholder')"
+        :filter="filter"
+        :loading="isLoadingInstances"
+        class="w-full"
+      >
         <template #option="{ option }">
           <div class="flex items-center gap-2">
-            <Icon :name="option.icon || 'mage:user'" size="1.2em" />
+            <Icon
+              :name="option.icon || 'mage:user'"
+              size="1.2em"
+            />
             <span>{{ option.displayName }}</span>
           </div>
         </template>
         <template #value="{ value }">
-          <div v-if="value" class="flex items-center gap-2">
-            <Icon :name="getIdIcon(value)" size="1.2em" />
+          <div
+            v-if="value"
+            class="flex items-center gap-2"
+          >
+            <Icon
+              :name="getIdIcon(value)"
+              size="1.2em"
+            />
             <span>{{ getIdDisplayName(value) }}</span>
           </div>
         </template>

--- a/packages/web/components/FormKit/AgentSelector.vue
+++ b/packages/web/components/FormKit/AgentSelector.vue
@@ -9,6 +9,7 @@
         {{ t('agent.selector.class.label') }}
       </label>
       <Select
+        id="agent-class-select"
         v-model="selectedClass"
         input-id="agent-class-select"
         :options="filteredClassOptions"
@@ -52,6 +53,7 @@
         {{ t('agent.selector.id.label') }}
       </label>
       <Select
+        id="agent-id-select"
         v-model="selectedId"
         input-id="agent-id-select"
         :options="idOptions"

--- a/packages/web/components/FormKit/IconSelector.vue
+++ b/packages/web/components/FormKit/IconSelector.vue
@@ -17,6 +17,7 @@
     <!-- Editable Select -->
     <Select
       v-model="selectedIcon"
+      :aria-label="placeholder"
       :options="iconOptions"
       :editable="true"
       :placeholder="placeholder"

--- a/packages/web/components/FormKit/LocaleInput.vue
+++ b/packages/web/components/FormKit/LocaleInput.vue
@@ -46,6 +46,7 @@
       <Textarea
         v-else
         v-model="currentValue"
+        :aria-label="localizedPlaceholder"
         :placeholder="localizedPlaceholder"
         :rows="rows"
         class="w-full"

--- a/packages/web/components/FormKit/ModelSelect.vue
+++ b/packages/web/components/FormKit/ModelSelect.vue
@@ -4,6 +4,7 @@
     :options="models"
     option-label="model_name"
     option-value="model_name"
+    :aria-label="placeholder ?? t('common.selectModel')"
     :placeholder="placeholder ?? t('common.selectModel')"
     :filter="filter"
     :show-clear="showClear"

--- a/packages/web/components/FormKit/VectorStoreInput.vue
+++ b/packages/web/components/FormKit/VectorStoreInput.vue
@@ -2,22 +2,42 @@
   <div class="flex flex-col gap-4">
     <!-- Database Selection -->
     <div>
-      <label for="vector-store-database-select" class="mb-1 block text-sm font-medium">
+      <label
+        for="vector-store-database-select"
+        class="mb-1 block text-sm font-medium"
+      >
         {{ t('lib.vectorStore.database.label') }}
       </label>
-      <Select :aria-label="t('lib.vectorStore.database.label')" v-model="selectedDatabase"
-        input-id="vector-store-database-select" :options="databaseOptions" option-label="displayName"
-        option-value="name" :placeholder="databasePlaceholder ?? t('common.selectDatabase')" :filter="filter"
-        :loading="isLoading" class="w-full">
+      <Select
+        v-model="selectedDatabase"
+        :aria-label="t('lib.vectorStore.database.label')"
+        input-id="vector-store-database-select"
+        :options="databaseOptions"
+        option-label="displayName"
+        option-value="name"
+        :placeholder="databasePlaceholder ?? t('common.selectDatabase')"
+        :filter="filter"
+        :loading="isLoading"
+        class="w-full"
+      >
         <template #option="{ option }">
           <div class="flex items-center gap-2">
-            <Icon name="mage:database" size="1.2em" />
+            <Icon
+              name="mage:database"
+              size="1.2em"
+            />
             <span>{{ option.displayName }}</span>
           </div>
         </template>
         <template #value="{ value }">
-          <div v-if="value" class="flex items-center gap-2">
-            <Icon name="mage:database" size="1.2em" />
+          <div
+            v-if="value"
+            class="flex items-center gap-2"
+          >
+            <Icon
+              name="mage:database"
+              size="1.2em"
+            />
             <span>{{ getDatabaseDisplayName(value) }}</span>
           </div>
         </template>
@@ -26,16 +46,29 @@
 
     <!-- Namespace Selection (shown when database selected) -->
     <div v-if="selectedDatabase">
-      <label for="vector-store-namespaces-select" class="mb-1 block text-sm font-medium">
+      <label
+        for="vector-store-namespaces-select"
+        class="mb-1 block text-sm font-medium"
+      >
         {{ t('lib.vectorStore.namespaces.label') }}
       </label>
-      <MultiSelect v-model="selectedNamespaces" input-id="vector-store-namespaces-select" :options="namespaceOptions"
-        option-label="displayName" option-value="name"
-        :placeholder="namespacePlaceholder ?? t('lib.vectorStore.namespaces.placeholder')" :filter="filter"
-        display="chip" class="w-full">
+      <MultiSelect
+        v-model="selectedNamespaces"
+        input-id="vector-store-namespaces-select"
+        :options="namespaceOptions"
+        option-label="displayName"
+        option-value="name"
+        :placeholder="namespacePlaceholder ?? t('lib.vectorStore.namespaces.placeholder')"
+        :filter="filter"
+        display="chip"
+        class="w-full"
+      >
         <template #option="{ option }">
           <div class="flex items-center gap-2">
-            <Icon name="mage:folder" size="1.2em" />
+            <Icon
+              name="mage:folder"
+              size="1.2em"
+            />
             <span>{{ option.displayName }}</span>
           </div>
         </template>
@@ -47,7 +80,10 @@
 
     <!-- Allowed metadata filter fields (shown when database selected) -->
     <div v-if="selectedDatabase">
-      <label for="vector-store-filter-fields-input" class="mb-1 block text-sm font-medium">
+      <label
+        for="vector-store-filter-fields-input"
+        class="mb-1 block text-sm font-medium"
+      >
         {{ t('lib.vectorStore.allowedFilterFields.label') }}
       </label>
       <ChipsInput :context="chipsInputContext" />

--- a/packages/web/components/FormKit/VectorStoreInput.vue
+++ b/packages/web/components/FormKit/VectorStoreInput.vue
@@ -9,6 +9,7 @@
         {{ t('lib.vectorStore.database.label') }}
       </label>
       <Select
+        id="vector-store-database-select"
         v-model="selectedDatabase"
         input-id="vector-store-database-select"
         :options="databaseOptions"

--- a/packages/web/components/FormKit/VectorStoreInput.vue
+++ b/packages/web/components/FormKit/VectorStoreInput.vue
@@ -2,42 +2,22 @@
   <div class="flex flex-col gap-4">
     <!-- Database Selection -->
     <div>
-      <label
-        for="vector-store-database-select"
-        class="mb-1 block text-sm font-medium"
-      >
+      <label for="vector-store-database-select" class="mb-1 block text-sm font-medium">
         {{ t('lib.vectorStore.database.label') }}
       </label>
-      <Select
-        id="vector-store-database-select"
-        v-model="selectedDatabase"
-        input-id="vector-store-database-select"
-        :options="databaseOptions"
-        option-label="displayName"
-        option-value="name"
-        :placeholder="databasePlaceholder ?? t('common.selectDatabase')"
-        :filter="filter"
-        :loading="isLoading"
-        class="w-full"
-      >
+      <Select :aria-label="t('lib.vectorStore.database.label')" v-model="selectedDatabase"
+        input-id="vector-store-database-select" :options="databaseOptions" option-label="displayName"
+        option-value="name" :placeholder="databasePlaceholder ?? t('common.selectDatabase')" :filter="filter"
+        :loading="isLoading" class="w-full">
         <template #option="{ option }">
           <div class="flex items-center gap-2">
-            <Icon
-              name="mage:database"
-              size="1.2em"
-            />
+            <Icon name="mage:database" size="1.2em" />
             <span>{{ option.displayName }}</span>
           </div>
         </template>
         <template #value="{ value }">
-          <div
-            v-if="value"
-            class="flex items-center gap-2"
-          >
-            <Icon
-              name="mage:database"
-              size="1.2em"
-            />
+          <div v-if="value" class="flex items-center gap-2">
+            <Icon name="mage:database" size="1.2em" />
             <span>{{ getDatabaseDisplayName(value) }}</span>
           </div>
         </template>
@@ -46,29 +26,16 @@
 
     <!-- Namespace Selection (shown when database selected) -->
     <div v-if="selectedDatabase">
-      <label
-        for="vector-store-namespaces-select"
-        class="mb-1 block text-sm font-medium"
-      >
+      <label for="vector-store-namespaces-select" class="mb-1 block text-sm font-medium">
         {{ t('lib.vectorStore.namespaces.label') }}
       </label>
-      <MultiSelect
-        v-model="selectedNamespaces"
-        input-id="vector-store-namespaces-select"
-        :options="namespaceOptions"
-        option-label="displayName"
-        option-value="name"
-        :placeholder="namespacePlaceholder ?? t('lib.vectorStore.namespaces.placeholder')"
-        :filter="filter"
-        display="chip"
-        class="w-full"
-      >
+      <MultiSelect v-model="selectedNamespaces" input-id="vector-store-namespaces-select" :options="namespaceOptions"
+        option-label="displayName" option-value="name"
+        :placeholder="namespacePlaceholder ?? t('lib.vectorStore.namespaces.placeholder')" :filter="filter"
+        display="chip" class="w-full">
         <template #option="{ option }">
           <div class="flex items-center gap-2">
-            <Icon
-              name="mage:folder"
-              size="1.2em"
-            />
+            <Icon name="mage:folder" size="1.2em" />
             <span>{{ option.displayName }}</span>
           </div>
         </template>
@@ -80,10 +47,7 @@
 
     <!-- Allowed metadata filter fields (shown when database selected) -->
     <div v-if="selectedDatabase">
-      <label
-        for="vector-store-filter-fields-input"
-        class="mb-1 block text-sm font-medium"
-      >
+      <label for="vector-store-filter-fields-input" class="mb-1 block text-sm font-medium">
         {{ t('lib.vectorStore.allowedFilterFields.label') }}
       </label>
       <ChipsInput :context="chipsInputContext" />

--- a/packages/web/components/Knowledge/Document/UploadModal.vue
+++ b/packages/web/components/Knowledge/Document/UploadModal.vue
@@ -58,7 +58,9 @@
         <p class="text-sm font-medium">
           {{ t('knowledge.documents.upload.target_location.label') }}
         </p>
-        <div class="flex items-center gap-2 rounded-lg border border-surface-200 bg-surface-50 p-3 dark:border-surface-700 dark:bg-surface-800">
+        <div
+          class="flex items-center gap-2 rounded-lg border border-surface-200 bg-surface-50 p-3 dark:border-surface-700 dark:bg-surface-800"
+        >
           <i
             class="pi pi-database text-surface-400"
             style="font-size: 1rem"
@@ -122,6 +124,7 @@
       type="file"
       multiple
       :accept="acceptedFileTypesString"
+      :aria-label="t('knowledge.documents.upload.actions.upload')"
       class="hidden"
       @change="handleFileSelect"
     >

--- a/packages/web/components/Knowledge/Namespace/EditModal.vue
+++ b/packages/web/components/Knowledge/Namespace/EditModal.vue
@@ -28,6 +28,7 @@
           <span class="ml-1 text-xs text-gray-400">(optional)</span>
         </label>
         <InputText
+          id="edit-namespace-display-name-input"
           v-model="displayName"
           input-id="edit-namespace-display-name-input"
           :placeholder="t('knowledge.form.display_name.placeholder')"

--- a/packages/web/components/Knowledge/Namespace/EditModal.vue
+++ b/packages/web/components/Knowledge/Namespace/EditModal.vue
@@ -1,75 +1,41 @@
 <template>
-  <Dialog
-    :visible="modelValue"
-    modal
-    :header="t('knowledge.form.edit.title')"
-    :style="{ width: '35rem' }"
-    @update:visible="emit('update:modelValue', $event)"
-  >
+  <Dialog :visible="modelValue" modal :header="t('knowledge.form.edit.title')" :style="{ width: '35rem' }"
+    @update:visible="emit('update:modelValue', $event)">
     <div class="flex flex-col gap-4">
       <div class="flex flex-col gap-2">
         <p class="text-sm font-medium">
           {{ t('knowledge.form.folder_name.label') }}
         </p>
-        <InputText
-          :value="namespace?.name || ''"
-          disabled
-          class="bg-surface-100 dark:bg-surface-800"
-        />
+        <InputText :value="namespace?.name || ''" disabled class="bg-surface-100 dark:bg-surface-800" />
         <small class="text-gray-500">{{ t('knowledge.form.folder_name.edit_help') }}</small>
       </div>
 
       <div class="flex flex-col gap-2">
-        <label
-          for="edit-namespace-display-name-input"
-          class="text-sm font-medium"
-        >
+        <label for="edit-namespace-display-name-input" class="text-sm font-medium">
           {{ t('knowledge.form.display_name.label') }}
           <span class="ml-1 text-xs text-gray-400">(optional)</span>
         </label>
-        <InputText
-          id="edit-namespace-display-name-input"
-          v-model="displayName"
-          input-id="edit-namespace-display-name-input"
-          :placeholder="t('knowledge.form.display_name.placeholder')"
-        />
+        <InputText id="edit-namespace-display-name-input" v-model="displayName"
+          :placeholder="t('knowledge.form.display_name.placeholder')" />
         <small class="text-gray-500">{{ t('knowledge.form.display_name.help') }}</small>
       </div>
 
       <div class="flex flex-col gap-2">
-        <label
-          for="edit-namespace-description-textarea"
-          class="text-sm font-medium"
-        >
+        <label for="edit-namespace-description-textarea" class="text-sm font-medium">
           {{ t('knowledge.form.description.label') }}
           <span class="ml-1 text-xs text-gray-400">(optional)</span>
         </label>
-        <Textarea
-          v-model="description"
-          input-id="edit-namespace-description-textarea"
-          :placeholder="t('knowledge.form.description.placeholder')"
-          rows="3"
-        />
+        <Textarea v-model="description" input-id="edit-namespace-description-textarea"
+          :placeholder="t('knowledge.form.description.placeholder')" rows="3" />
         <small class="text-gray-500">{{ t('knowledge.form.description.help') }}</small>
       </div>
 
-      <small
-        v-if="error"
-        class="text-red-500"
-      >{{ error }}</small>
+      <small v-if="error" class="text-red-500">{{ error }}</small>
     </div>
     <template #footer>
       <div class="flex justify-end gap-2">
-        <Button
-          :label="t('knowledge.actions.cancel')"
-          severity="secondary"
-          outlined
-          @click="closeModal"
-        />
-        <Button
-          :label="t('knowledge.actions.save')"
-          @click="handleSave"
-        />
+        <Button :label="t('knowledge.actions.cancel')" severity="secondary" outlined @click="closeModal" />
+        <Button :label="t('knowledge.actions.save')" @click="handleSave" />
       </div>
     </template>
   </Dialog>

--- a/packages/web/components/Knowledge/Namespace/EditModal.vue
+++ b/packages/web/components/Knowledge/Namespace/EditModal.vue
@@ -1,41 +1,74 @@
 <template>
-  <Dialog :visible="modelValue" modal :header="t('knowledge.form.edit.title')" :style="{ width: '35rem' }"
-    @update:visible="emit('update:modelValue', $event)">
+  <Dialog
+    :visible="modelValue"
+    modal
+    :header="t('knowledge.form.edit.title')"
+    :style="{ width: '35rem' }"
+    @update:visible="emit('update:modelValue', $event)"
+  >
     <div class="flex flex-col gap-4">
       <div class="flex flex-col gap-2">
         <p class="text-sm font-medium">
           {{ t('knowledge.form.folder_name.label') }}
         </p>
-        <InputText :value="namespace?.name || ''" disabled class="bg-surface-100 dark:bg-surface-800" />
+        <InputText
+          :value="namespace?.name || ''"
+          disabled
+          class="bg-surface-100 dark:bg-surface-800"
+        />
         <small class="text-gray-500">{{ t('knowledge.form.folder_name.edit_help') }}</small>
       </div>
 
       <div class="flex flex-col gap-2">
-        <label for="edit-namespace-display-name-input" class="text-sm font-medium">
+        <label
+          for="edit-namespace-display-name-input"
+          class="text-sm font-medium"
+        >
           {{ t('knowledge.form.display_name.label') }}
           <span class="ml-1 text-xs text-gray-400">(optional)</span>
         </label>
-        <InputText id="edit-namespace-display-name-input" v-model="displayName"
-          :placeholder="t('knowledge.form.display_name.placeholder')" />
+        <InputText
+          id="edit-namespace-display-name-input"
+          v-model="displayName"
+          :placeholder="t('knowledge.form.display_name.placeholder')"
+        />
         <small class="text-gray-500">{{ t('knowledge.form.display_name.help') }}</small>
       </div>
 
       <div class="flex flex-col gap-2">
-        <label for="edit-namespace-description-textarea" class="text-sm font-medium">
+        <label
+          for="edit-namespace-description-textarea"
+          class="text-sm font-medium"
+        >
           {{ t('knowledge.form.description.label') }}
           <span class="ml-1 text-xs text-gray-400">(optional)</span>
         </label>
-        <Textarea v-model="description" input-id="edit-namespace-description-textarea"
-          :placeholder="t('knowledge.form.description.placeholder')" rows="3" />
+        <Textarea
+          v-model="description"
+          input-id="edit-namespace-description-textarea"
+          :placeholder="t('knowledge.form.description.placeholder')"
+          rows="3"
+        />
         <small class="text-gray-500">{{ t('knowledge.form.description.help') }}</small>
       </div>
 
-      <small v-if="error" class="text-red-500">{{ error }}</small>
+      <small
+        v-if="error"
+        class="text-red-500"
+      >{{ error }}</small>
     </div>
     <template #footer>
       <div class="flex justify-end gap-2">
-        <Button :label="t('knowledge.actions.cancel')" severity="secondary" outlined @click="closeModal" />
-        <Button :label="t('knowledge.actions.save')" @click="handleSave" />
+        <Button
+          :label="t('knowledge.actions.cancel')"
+          severity="secondary"
+          outlined
+          @click="closeModal"
+        />
+        <Button
+          :label="t('knowledge.actions.save')"
+          @click="handleSave"
+        />
       </div>
     </template>
   </Dialog>

--- a/packages/web/components/Memory/Edit.vue
+++ b/packages/web/components/Memory/Edit.vue
@@ -5,9 +5,11 @@
         <label
           for="memory-content-textarea"
           class="text-xs font-medium text-gray-700 dark:text-gray-500"
-        >{{ t('memory.edit.memory_content_label') }}</label>
+        >{{
+          t('memory.edit.memory_content_label') }}</label>
         <Textarea
           v-if="isEditing"
+          id="memory-content-textarea"
           v-model="editedData"
           input-id="memory-content-textarea"
           auto-resize

--- a/packages/web/components/Memory/Edit.vue
+++ b/packages/web/components/Memory/Edit.vue
@@ -2,11 +2,23 @@
   <div class="flex h-full flex-col space-y-4">
     <div class="flex-1 space-y-4 overflow-y-auto">
       <div class="space-y-2">
-        <label for="memory-content-textarea" class="text-xs font-medium text-gray-700 dark:text-gray-500">{{
+        <label
+          for="memory-content-textarea"
+          class="text-xs font-medium text-gray-700 dark:text-gray-500"
+        >{{
           t('memory.edit.memory_content_label') }}</label>
-        <Textarea v-if="isEditing" id="memory-content-textarea" v-model="editedData" auto-resize rows="5"
-          class="w-full" />
-        <div v-else class="rounded border bg-surface-50 p-3 dark:border-surface-800 dark:bg-surface-950">
+        <Textarea
+          v-if="isEditing"
+          id="memory-content-textarea"
+          v-model="editedData"
+          auto-resize
+          rows="5"
+          class="w-full"
+        />
+        <div
+          v-else
+          class="rounded border bg-surface-50 p-3 dark:border-surface-800 dark:bg-surface-950"
+        >
           {{ memory.memory }}
         </div>
       </div>
@@ -24,14 +36,21 @@
 
         <!-- Agent Link - shown if agent exists -->
         <!-- Follows the AgentAvatar pattern from Thread/Info.vue but simplified -->
-        <div v-if="canNavigateToAgent" class="space-y-2">
+        <div
+          v-if="canNavigateToAgent"
+          class="space-y-2"
+        >
           <p class="text-xs font-medium text-gray-500">
             {{ t('memory.detail.agent_link_label') }}
           </p>
           <div
             class="flex cursor-pointer gap-2 rounded border border-surface-200 p-2 hover:bg-surface-100 dark:border-surface-800 hover:dark:bg-surface-800"
-            @click="navigateToAgent">
-            <Avatar size="normal" icon="pi pi-verified" />
+            @click="navigateToAgent"
+          >
+            <Avatar
+              size="normal"
+              icon="pi pi-verified"
+            />
             <div class="mb-1 flex flex-col justify-center">
               <p class="text-xs font-bold">
                 {{ parsedAgent.agent_class }}
@@ -45,14 +64,21 @@
 
         <!-- Thread/Display Link - shown if both thread_id and display_id exist -->
         <!-- Similar pattern to agent but with thread/conversation icon -->
-        <div v-if="canNavigateToThread" class="space-y-2">
+        <div
+          v-if="canNavigateToThread"
+          class="space-y-2"
+        >
           <p class="text-xs font-medium text-gray-500">
             {{ t('memory.detail.thread_link_label') }}
           </p>
           <div
             class="flex cursor-pointer gap-2 rounded border border-surface-200 p-2 hover:bg-surface-100 dark:border-surface-800 hover:dark:bg-surface-800"
-            @click="navigateToThreadDisplay">
-            <Avatar size="normal" icon="pi pi-comments" />
+            @click="navigateToThreadDisplay"
+          >
+            <Avatar
+              size="normal"
+              icon="pi pi-comments"
+            />
             <div class="mb-1 flex flex-col justify-center">
               <p class="text-xs font-bold">
                 {{ t('memory.detail.thread_title') }}
@@ -67,13 +93,35 @@
     </div>
 
     <div class="flex items-center justify-between border-t pt-4">
-      <Button v-if="!isEditing" :label="t('memory.edit.edit_button')" icon="pi pi-pencil" @click="isEditing = true" />
-      <div v-else class="flex space-x-2">
-        <Button :label="t('memory.edit.save_button')" icon="pi pi-check" @click="handleSave" />
-        <Button :label="t('memory.edit.cancel_button')" icon="pi pi-times" severity="secondary" @click="handleCancel" />
+      <Button
+        v-if="!isEditing"
+        :label="t('memory.edit.edit_button')"
+        icon="pi pi-pencil"
+        @click="isEditing = true"
+      />
+      <div
+        v-else
+        class="flex space-x-2"
+      >
+        <Button
+          :label="t('memory.edit.save_button')"
+          icon="pi pi-check"
+          @click="handleSave"
+        />
+        <Button
+          :label="t('memory.edit.cancel_button')"
+          icon="pi pi-times"
+          severity="secondary"
+          @click="handleCancel"
+        />
       </div>
 
-      <Button :label="t('memory.edit.delete_button')" icon="pi pi-trash" severity="danger" @click="handleDelete" />
+      <Button
+        :label="t('memory.edit.delete_button')"
+        icon="pi pi-trash"
+        severity="danger"
+        @click="handleDelete"
+      />
     </div>
   </div>
 </template>

--- a/packages/web/components/Memory/Edit.vue
+++ b/packages/web/components/Memory/Edit.vue
@@ -2,24 +2,11 @@
   <div class="flex h-full flex-col space-y-4">
     <div class="flex-1 space-y-4 overflow-y-auto">
       <div class="space-y-2">
-        <label
-          for="memory-content-textarea"
-          class="text-xs font-medium text-gray-700 dark:text-gray-500"
-        >{{
+        <label for="memory-content-textarea" class="text-xs font-medium text-gray-700 dark:text-gray-500">{{
           t('memory.edit.memory_content_label') }}</label>
-        <Textarea
-          v-if="isEditing"
-          id="memory-content-textarea"
-          v-model="editedData"
-          input-id="memory-content-textarea"
-          auto-resize
-          rows="5"
-          class="w-full"
-        />
-        <div
-          v-else
-          class="rounded border bg-surface-50 p-3 dark:border-surface-800 dark:bg-surface-950"
-        >
+        <Textarea v-if="isEditing" id="memory-content-textarea" v-model="editedData" auto-resize rows="5"
+          class="w-full" />
+        <div v-else class="rounded border bg-surface-50 p-3 dark:border-surface-800 dark:bg-surface-950">
           {{ memory.memory }}
         </div>
       </div>
@@ -37,21 +24,14 @@
 
         <!-- Agent Link - shown if agent exists -->
         <!-- Follows the AgentAvatar pattern from Thread/Info.vue but simplified -->
-        <div
-          v-if="canNavigateToAgent"
-          class="space-y-2"
-        >
+        <div v-if="canNavigateToAgent" class="space-y-2">
           <p class="text-xs font-medium text-gray-500">
             {{ t('memory.detail.agent_link_label') }}
           </p>
           <div
             class="flex cursor-pointer gap-2 rounded border border-surface-200 p-2 hover:bg-surface-100 dark:border-surface-800 hover:dark:bg-surface-800"
-            @click="navigateToAgent"
-          >
-            <Avatar
-              size="normal"
-              icon="pi pi-verified"
-            />
+            @click="navigateToAgent">
+            <Avatar size="normal" icon="pi pi-verified" />
             <div class="mb-1 flex flex-col justify-center">
               <p class="text-xs font-bold">
                 {{ parsedAgent.agent_class }}
@@ -65,21 +45,14 @@
 
         <!-- Thread/Display Link - shown if both thread_id and display_id exist -->
         <!-- Similar pattern to agent but with thread/conversation icon -->
-        <div
-          v-if="canNavigateToThread"
-          class="space-y-2"
-        >
+        <div v-if="canNavigateToThread" class="space-y-2">
           <p class="text-xs font-medium text-gray-500">
             {{ t('memory.detail.thread_link_label') }}
           </p>
           <div
             class="flex cursor-pointer gap-2 rounded border border-surface-200 p-2 hover:bg-surface-100 dark:border-surface-800 hover:dark:bg-surface-800"
-            @click="navigateToThreadDisplay"
-          >
-            <Avatar
-              size="normal"
-              icon="pi pi-comments"
-            />
+            @click="navigateToThreadDisplay">
+            <Avatar size="normal" icon="pi pi-comments" />
             <div class="mb-1 flex flex-col justify-center">
               <p class="text-xs font-bold">
                 {{ t('memory.detail.thread_title') }}
@@ -94,35 +67,13 @@
     </div>
 
     <div class="flex items-center justify-between border-t pt-4">
-      <Button
-        v-if="!isEditing"
-        :label="t('memory.edit.edit_button')"
-        icon="pi pi-pencil"
-        @click="isEditing = true"
-      />
-      <div
-        v-else
-        class="flex space-x-2"
-      >
-        <Button
-          :label="t('memory.edit.save_button')"
-          icon="pi pi-check"
-          @click="handleSave"
-        />
-        <Button
-          :label="t('memory.edit.cancel_button')"
-          icon="pi pi-times"
-          severity="secondary"
-          @click="handleCancel"
-        />
+      <Button v-if="!isEditing" :label="t('memory.edit.edit_button')" icon="pi pi-pencil" @click="isEditing = true" />
+      <div v-else class="flex space-x-2">
+        <Button :label="t('memory.edit.save_button')" icon="pi pi-check" @click="handleSave" />
+        <Button :label="t('memory.edit.cancel_button')" icon="pi pi-times" severity="secondary" @click="handleCancel" />
       </div>
 
-      <Button
-        :label="t('memory.edit.delete_button')"
-        icon="pi pi-trash"
-        severity="danger"
-        @click="handleDelete"
-      />
+      <Button :label="t('memory.edit.delete_button')" icon="pi pi-trash" severity="danger" @click="handleDelete" />
     </div>
   </div>
 </template>

--- a/packages/web/components/Process/CreateModal.vue
+++ b/packages/web/components/Process/CreateModal.vue
@@ -33,6 +33,7 @@
             {{ t('process.create.selectClass') }}
           </label>
           <Select
+            id="processClass"
             v-model="selectedClass"
             :options="processClasses"
             option-label="process_class"

--- a/packages/web/components/Role/UsageLimitsEditor.vue
+++ b/packages/web/components/Role/UsageLimitsEditor.vue
@@ -54,14 +54,16 @@
                         value="MyAgent.*"
                         severity="secondary"
                         size="small"
-                      /> — {{ t('role.pattern_help_wildcard') }}
+                      /> — {{ t('role.pattern_help_wildcard')
+                      }}
                     </li>
                     <li class="whitespace-nowrap">
                       <Badge
                         value="MyAgent.prod"
                         severity="secondary"
                         size="small"
-                      /> — {{ t('role.pattern_help_specific') }}
+                      /> — {{
+                        t('role.pattern_help_specific') }}
                     </li>
                   </ul>
                 </div>
@@ -119,7 +121,9 @@
           <tr>
             <td class="py-2">
               <div class="flex items-center">
-                <span class="whitespace-nowrap rounded-l border border-r-0 border-surface-300 bg-surface-100 px-2 py-1.5 text-xs text-muted-color dark:border-surface-600 dark:bg-surface-800">
+                <span
+                  class="whitespace-nowrap rounded-l border border-r-0 border-surface-300 bg-surface-100 px-2 py-1.5 text-xs text-muted-color dark:border-surface-600 dark:bg-surface-800"
+                >
                   {{ AGENT_PREFIX }}
                 </span>
                 <InputText
@@ -143,6 +147,7 @@
             <td class="py-2">
               <select
                 v-model="newPeriod"
+                :aria-label="t('role.usage_period')"
                 class="w-full rounded border border-surface-300 bg-surface-0 px-2 py-1.5 text-sm dark:border-surface-600 dark:bg-surface-900"
               >
                 <option

--- a/packages/web/components/User/Settings.vue
+++ b/packages/web/components/User/Settings.vue
@@ -1,38 +1,15 @@
 <template>
-  <Button
-    icon="pi pi-cog"
-    aria-label="Settings"
-    variant="text"
-    size="large"
-    @click="toggle"
-  />
-  <Popover
-    ref="op"
-    class="[--p-popover-background:var(--p-surface-50)] [--p-popover-border-color:var(--p-surface-200)] dark:[--p-popover-background:var(--p-surface-950)] dark:[--p-popover-border-color:var(--p-surface-800)]"
-  >
+  <Button icon="pi pi-cog" aria-label="Settings" variant="text" size="large" @click="toggle" />
+  <Popover ref="op"
+    class="[--p-popover-background:var(--p-surface-50)] [--p-popover-border-color:var(--p-surface-200)] dark:[--p-popover-background:var(--p-surface-950)] dark:[--p-popover-border-color:var(--p-surface-800)]">
     <div class="flex flex-col gap-4 p-2">
       <div class="flex flex-col gap-2">
-        <label
-          for="user-language-select"
-          class="font-medium"
-        >{{ t('user.language') }}</label>
-        <Select
-          id="user-language-select"
-          v-model="selectedLocale"
-          input-id="user-language-select"
-          :options="localeOptions"
-          option-label="name"
-          class="w-full"
-        />
+        <label for="user-language-select" class="font-medium">{{ t('user.language') }}</label>
+        <Select :aria-label="t('user.language')" v-model="selectedLocale" :options="localeOptions" option-label="name"
+          class="w-full" />
       </div>
-      <Button
-        class="w-full"
-        :label="t('user.logout')"
-        variant="text"
-        icon="pi pi-arrow-circle-right"
-        icon-pos="right"
-        @click="auth.logout"
-      />
+      <Button class="w-full" :label="t('user.logout')" variant="text" icon="pi pi-arrow-circle-right" icon-pos="right"
+        @click="auth.logout" />
       <div class="text-center text-xs text-surface-500 dark:text-surface-400">
         {{ t('user.version') }} {{ versionDisplay }}
       </div>

--- a/packages/web/components/User/Settings.vue
+++ b/packages/web/components/User/Settings.vue
@@ -17,6 +17,7 @@
           class="font-medium"
         >{{ t('user.language') }}</label>
         <Select
+          id="user-language-select"
           v-model="selectedLocale"
           input-id="user-language-select"
           :options="localeOptions"

--- a/packages/web/components/User/Settings.vue
+++ b/packages/web/components/User/Settings.vue
@@ -1,15 +1,37 @@
 <template>
-  <Button icon="pi pi-cog" aria-label="Settings" variant="text" size="large" @click="toggle" />
-  <Popover ref="op"
-    class="[--p-popover-background:var(--p-surface-50)] [--p-popover-border-color:var(--p-surface-200)] dark:[--p-popover-background:var(--p-surface-950)] dark:[--p-popover-border-color:var(--p-surface-800)]">
+  <Button
+    icon="pi pi-cog"
+    aria-label="Settings"
+    variant="text"
+    size="large"
+    @click="toggle"
+  />
+  <Popover
+    ref="op"
+    class="[--p-popover-background:var(--p-surface-50)] [--p-popover-border-color:var(--p-surface-200)] dark:[--p-popover-background:var(--p-surface-950)] dark:[--p-popover-border-color:var(--p-surface-800)]"
+  >
     <div class="flex flex-col gap-4 p-2">
       <div class="flex flex-col gap-2">
-        <label for="user-language-select" class="font-medium">{{ t('user.language') }}</label>
-        <Select :aria-label="t('user.language')" v-model="selectedLocale" :options="localeOptions" option-label="name"
-          class="w-full" />
+        <label
+          for="user-language-select"
+          class="font-medium"
+        >{{ t('user.language') }}</label>
+        <Select
+          v-model="selectedLocale"
+          :aria-label="t('user.language')"
+          :options="localeOptions"
+          option-label="name"
+          class="w-full"
+        />
       </div>
-      <Button class="w-full" :label="t('user.logout')" variant="text" icon="pi pi-arrow-circle-right" icon-pos="right"
-        @click="auth.logout" />
+      <Button
+        class="w-full"
+        :label="t('user.logout')"
+        variant="text"
+        icon="pi pi-arrow-circle-right"
+        icon-pos="right"
+        @click="auth.logout"
+      />
       <div class="text-center text-xs text-surface-500 dark:text-surface-400">
         {{ t('user.version') }} {{ versionDisplay }}
       </div>

--- a/packages/web/components/User/Settings.vue
+++ b/packages/web/components/User/Settings.vue
@@ -18,6 +18,7 @@
         >{{ t('user.language') }}</label>
         <Select
           v-model="selectedLocale"
+          input-id="user-language-select"
           :aria-label="t('user.language')"
           :options="localeOptions"
           option-label="name"

--- a/packages/web/i18n/locales/de.yaml
+++ b/packages/web/i18n/locales/de.yaml
@@ -170,6 +170,7 @@ thread:
     title: Hierarchische Ansicht der Turns
   chat:
     title: Chat-Ansicht
+    placeholder: Chat-Eingabe
   memories:
     title: Thread-Erinnerungen
     description: Während {threadName} gesammelte Erinnerungen

--- a/packages/web/i18n/locales/en.yaml
+++ b/packages/web/i18n/locales/en.yaml
@@ -169,6 +169,7 @@ thread:
     title: Hierarchical View on Turns
   chat:
     title: Chat view
+    placeholder: Chat input
   memories:
     title: Thread Memories
     description: Memories collected during {threadName}

--- a/packages/web/i18n/locales/fr.yaml
+++ b/packages/web/i18n/locales/fr.yaml
@@ -169,6 +169,7 @@ thread:
     title: Vue hiérarchique des tours
   chat:
     title: Vue Chat
+    placeholder: Saisie du chat
   memories:
     title: Mémoires du fil de discussion
     description: Mémoires collectées pendant {threadName}

--- a/packages/web/i18n/locales/it.yaml
+++ b/packages/web/i18n/locales/it.yaml
@@ -169,6 +169,7 @@ thread:
     title: Vista gerarchica sui turni
   chat:
     title: Vista Chat
+    placeholder: Input chat
   memories:
     title: Memorie del thread
     description: Memorie raccolte durante {threadName}

--- a/packages/web/pages/[tenant]/service/agents.vue
+++ b/packages/web/pages/[tenant]/service/agents.vue
@@ -21,6 +21,7 @@
             :options="agentClassOptions"
             option-label="label"
             option-value="value"
+            :aria-label="t('agent.list.filter.type_placeholder')"
             :placeholder="t('agent.list.filter.type_placeholder')"
             show-clear
             class="w-52"
@@ -30,6 +31,7 @@
             :options="statusOptions"
             option-label="label"
             option-value="value"
+            :aria-label="t('agent.list.filter.status_placeholder')"
             :placeholder="t('agent.list.filter.status_placeholder')"
             show-clear
             class="w-52"

--- a/packages/web/pages/[tenant]/service/agents/[agent_class]-[agent_id]/chat.vue
+++ b/packages/web/pages/[tenant]/service/agents/[agent_class]-[agent_id]/chat.vue
@@ -13,6 +13,7 @@
             auto-resize
             rows="5"
             cols="30"
+            :aria-label="t('agent.chat.placeholder')"
             :placeholder="t('agent.chat.placeholder')"
             @keydown.enter="submitMessage"
           />

--- a/packages/web/pages/[tenant]/service/threads.vue
+++ b/packages/web/pages/[tenant]/service/threads.vue
@@ -23,6 +23,7 @@
             :options="statusOptions"
             option-label="label"
             option-value="value"
+            :aria-label="t('thread.list.filter.status_placeholder')"
             :placeholder="t('thread.list.filter.status_placeholder')"
             show-clear
             class="w-48"
@@ -32,6 +33,7 @@
             :options="agentInstanceOptions"
             option-label="label"
             option-value="value"
+            :aria-label="t('thread.list.filter.agent_name_placeholder')"
             :placeholder="t('thread.list.filter.agent_name_placeholder')"
             show-clear
             class="w-48"
@@ -41,6 +43,7 @@
             :options="userOptions"
             option-label="label"
             option-value="value"
+            :aria-label="t('thread.list.filter.user_name_placeholder')"
             :placeholder="t('thread.list.filter.user_name_placeholder')"
             show-clear
             class="w-48"

--- a/packages/web/pages/[tenant]/service/threads/[thread_id]/chat.vue
+++ b/packages/web/pages/[tenant]/service/threads/[thread_id]/chat.vue
@@ -1,27 +1,11 @@
 <template>
-  <StructuralColumn
-    :title="t('thread.chat.title')"
-    close-route="/service/threads"
-    :loading="threadIsLoading || threadEventsAreLoading"
-  >
-    <ChatThread
-      :events="threadEvents"
-      :thread="thread"
-    />
+  <StructuralColumn :title="t('thread.chat.title')" close-route="/service/threads"
+    :loading="threadIsLoading || threadEventsAreLoading">
+    <ChatThread :events="threadEvents" :thread="thread" />
     <div class="pt-16">
-      <Textarea
-        v-model="userInput"
-        aria-label="Chat input"
-        class="w-full"
-        auto-resize
-        rows="5"
-        cols="30"
-      />
-      <Button
-        label="Send new Message"
-        class="w-full"
-        @click="submitMessage"
-      />
+      <Textarea v-model="userInput" :aria-label="t('thread.chat.placeholder')" class="w-full" auto-resize rows="5"
+        cols="30" />
+      <Button label="Send new Message" class="w-full" @click="submitMessage" />
     </div>
   </StructuralColumn>
 </template>

--- a/packages/web/pages/[tenant]/service/threads/[thread_id]/chat.vue
+++ b/packages/web/pages/[tenant]/service/threads/[thread_id]/chat.vue
@@ -11,6 +11,7 @@
     <div class="pt-16">
       <Textarea
         v-model="userInput"
+        aria-label="Chat input"
         class="w-full"
         auto-resize
         rows="5"

--- a/packages/web/pages/[tenant]/service/threads/[thread_id]/chat.vue
+++ b/packages/web/pages/[tenant]/service/threads/[thread_id]/chat.vue
@@ -1,11 +1,27 @@
 <template>
-  <StructuralColumn :title="t('thread.chat.title')" close-route="/service/threads"
-    :loading="threadIsLoading || threadEventsAreLoading">
-    <ChatThread :events="threadEvents" :thread="thread" />
+  <StructuralColumn
+    :title="t('thread.chat.title')"
+    close-route="/service/threads"
+    :loading="threadIsLoading || threadEventsAreLoading"
+  >
+    <ChatThread
+      :events="threadEvents"
+      :thread="thread"
+    />
     <div class="pt-16">
-      <Textarea v-model="userInput" :aria-label="t('thread.chat.placeholder')" class="w-full" auto-resize rows="5"
-        cols="30" />
-      <Button label="Send new Message" class="w-full" @click="submitMessage" />
+      <Textarea
+        v-model="userInput"
+        :aria-label="t('thread.chat.placeholder')"
+        class="w-full"
+        auto-resize
+        rows="5"
+        cols="30"
+      />
+      <Button
+        label="Send new Message"
+        class="w-full"
+        @click="submitMessage"
+      />
     </div>
   </StructuralColumn>
 </template>


### PR DESCRIPTION
## What

Resolves SonarCloud quality-gate findings for the `Web:InputWithoutLabelCheck`
rule ("input, select and textarea tags should be labeled") across the admin UI.

Every flagged `Select` / `Textarea` / `<input>` now has an accessible name, so
screen readers announce each control and the SonarHTML gate passes.

## Why

SonarHTML matches tag names case-insensitively, so PrimeVue's PascalCase
`<Select>` / `<Textarea>` components are parsed as native `<select>` / `<textarea>`
and flagged when they lack an associated label — alongside genuine native
`<input>` / `<select>` elements. None of these controls had an accessible name.

## How

Two fixes depending on whether a visible label already exists:

- **Visible `<label for="…">` present** → add a matching `id` so SonarHTML's
  static `id`/`for` association resolves (kept existing `input-id` for correct
  runtime focus association):
  - `Agent/CreateModal`, `Process/CreateModal`, `FormKit/AgentSelector`,
    `FormKit/VectorStoreInput`, `Knowledge/Namespace/EditModal`, `Memory/Edit`,
    `User/Settings`

- **No visible label** → add a bound, localized `:aria-label` (reusing the
  existing placeholder/i18n key):
  - `Dashboard/Grid`, `FormKit/IconSelector`, `FormKit/ModelSelect`,
    `FormKit/LocaleInput`, `Knowledge/Document/UploadModal` (file input),
    `Role/UsageLimitsEditor` (period select), `pages/…/agents.vue`,
    `pages/…/threads.vue`, both chat textareas

## Test plan

- [ ] SonarCloud quality gate passes (no `Web:InputWithoutLabelCheck` issues)
- [x] `pnpm lint` clean

## Notes

- No behavioral/visual changes — labeling/ARIA only.