### PR TITLE
fix(ui): Disable delete functionality for auto-sync documents

### DIFF
--- a/packages/web/components/Knowledge/Document/List.vue
+++ b/packages/web/components/Knowledge/Document/List.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="checkedDocuments.length > 0"
+    v-if="!autoSync && checkedDocuments.length > 0"
     class="mb-2 flex items-center justify-between"
   >
     <p class="text-sm">
@@ -28,6 +28,7 @@
     @sort="handleSort"
   >
     <Column
+      v-if="!autoSync"
       selection-mode="multiple"
       header-style="width: 3rem"
     />
@@ -112,7 +113,7 @@
             @click.stop="() => downloadFile(data.id)"
           />
           <Button
-            v-if="!isDocumentDeleting(data)"
+            v-if="!autoSync && !isDocumentDeleting(data)"
             v-tooltip.top="t('document.delete.button')"
             rounded
             size="small"
@@ -152,6 +153,7 @@ const props = defineProps<{
   documents: DocumentDto[]
   sortField: string | null
   sortOrder: 1 | -1
+  autoSync?: boolean
 }>()
 
 const emit = defineEmits<{

--- a/packages/web/pages/[tenant]/service/knowledge/[db]/[namespace].vue
+++ b/packages/web/pages/[tenant]/service/knowledge/[db]/[namespace].vue
@@ -30,6 +30,7 @@
       :documents="documents"
       :sort-field="sortState.field"
       :sort-order="sortState.order"
+      :auto-sync="currentDatabase?.auto_sync"
       @selected="toDocument"
       @sort="handleSort"
       @deleted="handleDeleted"


### PR DESCRIPTION
## What

Auto-sync knowledge databases are managed entirely by the sync pipeline, so their documents should not be manually deletable from the UI — the same way the upload button is already hidden for them.

## Changes

- Pass the database's `auto_sync` flag from the namespace page into `KnowledgeDocumentList` via a new `autoSync` prop.
- In `List.vue`, gate all three delete entry points behind `!autoSync`:
  - the batch-delete action bar
  - the multi-select column (no point selecting rows that can't be deleted)
  - the per-row trash button

Download remains available, so auto-sync DBs are effectively read-only in the UI.

## Notes

This is a UI-only guard, mirroring how uploads are gated (the backend doesn't reject uploads/deletes for auto-sync DBs either). Let me know if server-side enforcement is wanted for defense in depth.

## Test plan

- [ ] Open a namespace in an **auto-sync** DB → no delete buttons, no selection checkboxes, no batch bar; download still works.
- [ ] Open a namespace in a **regular** DB → single + batch delete still work as before.