### PR TITLE
fix(ui): Point homepage Platform Overview link to existing architecture page

### DIFF
--- a/docs/index.de.md
+++ b/docs/index.de.md
@@ -1,7 +1,7 @@
 ---
 # https://vitepress.dev/reference/default-theme-home-page
 layout: home
-source_sha: 92f32680a3b8671f48c2358eda18afedec1da677f69e4c27c249c8f46ae348e2
+source_sha: ce2d82fcfea5955b1aeb6f0b3bd5d6b03774074c365006dde1e0a84890659fe5
 
 hero:
   name: Swiss AI Hub
@@ -16,7 +16,7 @@ hero:
       link: /de/docs/1_vision_and_positioning/1_introduction
     - theme: brand
       text: Plattformübersicht
-      link: /de/docs/2_platform/2_architecture/1_core_components/
+      link: /de/docs/2_platform/2_architecture/
 
 features:
   - title: Die Open-Source-KI-Wette

--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -15,7 +15,7 @@ hero:
       link: /docs/1_vision_and_positioning/1_introduction
     - theme: brand
       text: Platform Overview
-      link: /docs/2_platform/2_architecture/1_core_components/
+      link: /docs/2_platform/2_architecture/
 
 features:
   - title: The open-source AI bet


### PR DESCRIPTION
## What

The homepage hero action **Platform Overview** linked to `/docs/2_platform/2_architecture/1_core_components/`, which no longer exists. Repointed it to the immediate existing parent page `/docs/2_platform/2_architecture/`.

## Changes

- `docs/index.en.md` (source of truth): updated the hero action link.
- `docs/index.de.md` (auto-generated German): updated the link to `/de/docs/2_platform/2_architecture/` and refreshed the load-bearing `source_sha` to match the new English hash, so the next `docs:translate` run treats it as in-sync.

## Notes

- Docs-only change; no code paths touched.
- The `llm` CLI was not available locally, so the German file was edited manually rather than via `pnpm run docs:translate`. The edit is a faithful one-line link change with the `source_sha` updated accordingly.

## Test plan

- [ ] Verify `/docs/2_platform/2_architecture/` resolves in the built docs site (EN + DE).