### PR TITLE
fix(ui): Bind @vueuse/router to vue-router 4.6.4 to fix WeakMap crash on agent/thread lists

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -138,16 +138,25 @@ npm ls @vue/runtime-core                # must print exactly one version: 3.5.17
 The same single-instance requirement applies to **PrimeVue** (its theme system is a global singleton); pinning the
 `primevue` peer to one version is enough — it does not need an override.
 
-> **Optional — silence a `vue-router` peer warning.** `@vueuse/router` declares a `vue-router@^4` peer, but some
-> transitive dependencies may pull in `vue-router` 5.x, which can surface a peer-range warning on install. It is
-> harmless (the layer does not depend on that resolution), but if you want it gone, pin `vue-router` to `4.6.4` **scoped
-> to `@vueuse/router`** so it never affects the router Nuxt itself uses:
+> **Important — pin `vue-router` so `@vueuse/router` uses Nuxt's router.** `@vueuse/router` declares a `vue-router` peer
+> whose range also accepts `vue-router` 5.x, which some transitive deps (e.g. `@nuxtjs/i18n` / `unplugin-vue-router`)
+> legitimately pull in. If `@vueuse/router` resolves to that 5.x copy while the Nuxt app runs `vue-router` 4.x, the two
+> use **different injection keys**: `useRouter()` returns `undefined` inside `@vueuse/router`, and `useRouteQuery` then
+> throws `TypeError: Invalid value used as weak map key` (notably inside Pinia-Colada `defineQuery` setups, which run
+> outside component inject context). This is **not** harmless — it white-screens the affected pages.
+>
+> pnpm `overrides` do **not** constrain peerDependency resolution, so a `@vueuse/router>vue-router` override is not
+> enough (it silently stops working the moment a higher `vue-router` lands in range). Pin it reliably by declaring
+> `vue-router` as a **direct dependency** of your app package at the version Nuxt uses — the peer then binds to that
+> copy, while the other major can remain for `@nuxtjs/i18n`:
 >
 > ```jsonc
-> // npm:  "overrides":  { "@vueuse/router": { "vue-router": "4.6.4" } }
-> // Yarn: "resolutions": { "@vueuse/router/vue-router": "4.6.4" }
-> // pnpm: "pnpm": { "overrides": { "@vueuse/router>vue-router": "4.6.4" } }
+> // packages/web/package.json
+> { "dependencies": { "vue-router": "4.6.4" } }
 > ```
+>
+> Verify with `pnpm why vue-router` (`@vueuse/router` must show `4.6.4`) and `pnpm build` (`nuxt generate` must succeed —
+> forcing a single `vue-router` major instead breaks `@nuxtjs/i18n`, which needs 5.x).
 
 ## Quick start
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -89,6 +89,7 @@
     "tailwindcss-animate": "^1.0.7",
     "tailwindcss-primeui": "^0.6.1",
     "uuid": "^11.1.1",
+    "vue-router": "4.6.4",
     "vue3-apexcharts": "^1.11.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,7 +129,7 @@ importers:
         version: 13.9.0(nuxt@3.21.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.6)(@types/node@22.19.19)(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.4(jiti@1.21.7))(ioredis@5.10.1)(lightningcss@1.32.0)(optionator@0.9.4)(rollup@4.60.3)(terser@5.47.1)(typescript@5.9.3)(vite@7.3.3(@types/node@22.19.19)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.9.0))(yaml@2.9.0))(vue@3.5.17(typescript@5.9.3))
       '@vueuse/router':
         specifier: ^13.9.0
-        version: 13.9.0(vue-router@5.0.7(@pinia/colada@1.3.0(pinia@3.0.4(typescript@5.9.3)(vue@3.5.17(typescript@5.9.3)))(vue@3.5.17(typescript@5.9.3)))(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.17(typescript@5.9.3)))(vue@3.5.17(typescript@5.9.3)))(vue@3.5.17(typescript@5.9.3))
+        version: 13.9.0(vue-router@4.6.4(vue@3.5.17(typescript@5.9.3)))(vue@3.5.17(typescript@5.9.3))
       apexcharts:
         specifier: ^4.7.0
         version: 4.7.0
@@ -199,6 +199,9 @@ importers:
       vue:
         specifier: 3.5.17
         version: 3.5.17(typescript@5.9.3)
+      vue-router:
+        specifier: 4.6.4
+        version: 4.6.4(vue@3.5.17(typescript@5.9.3))
       vue3-apexcharts:
         specifier: ^1.11.1
         version: 1.11.1(apexcharts@4.7.0)(vue@3.5.17(typescript@5.9.3))
@@ -11044,11 +11047,11 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@vueuse/router@13.9.0(vue-router@5.0.7(@pinia/colada@1.3.0(pinia@3.0.4(typescript@5.9.3)(vue@3.5.17(typescript@5.9.3)))(vue@3.5.17(typescript@5.9.3)))(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.17(typescript@5.9.3)))(vue@3.5.17(typescript@5.9.3)))(vue@3.5.17(typescript@5.9.3))':
+  '@vueuse/router@13.9.0(vue-router@4.6.4(vue@3.5.17(typescript@5.9.3)))(vue@3.5.17(typescript@5.9.3))':
     dependencies:
       '@vueuse/shared': 13.9.0(vue@3.5.17(typescript@5.9.3))
       vue: 3.5.17(typescript@5.9.3)
-      vue-router: 5.0.7(@pinia/colada@1.3.0(pinia@3.0.4(typescript@5.9.3)(vue@3.5.17(typescript@5.9.3)))(vue@3.5.17(typescript@5.9.3)))(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.17(typescript@5.9.3)))(vue@3.5.17(typescript@5.9.3))
+      vue-router: 4.6.4(vue@3.5.17(typescript@5.9.3))
 
   '@vueuse/shared@10.11.1(vue@3.5.17(typescript@5.9.3))':
     dependencies:


### PR DESCRIPTION
## Problem

`/service/agents` and `/service/threads` white-screen on load with `TypeError: Invalid value used as weak map key`. The web app is `ssr: false`, so this is a client-side throw (not a server 500).

## Root cause

Two `vue-router` majors coexist in the tree — **and that is expected**: `@nuxtjs/i18n` / `unplugin-vue-router` need `vue-router@5.0.7`, while the Nuxt 3.21 app core uses `vue-router@4.6.4`.

The bug is *which* copy `@vueuse/router` binds to. Its `vue-router` **peer** flipped from `4.6.4` → `5.0.7` during the #1472 lockfile re-resolution. v5's `useRouter()` uses a different injection key than the v4 router the app provides, so it returns `undefined`, and `useRouteQuery` then calls `WeakMap.set(undefined, …)` → throw. It surfaces inside Pinia-Colada `defineQuery` setups (`useAgentInstances`, `useThreads`), which run outside component inject context.

## Why now

`vue-router@5.0.7` was already in the tree before #1472 (for i18n), with `@vueuse/router` correctly pinned to `4.6.4` via the scoped override from #1360. #1472's re-resolution flipped `@vueuse/router` onto the 5.x copy → crash.

## Why the scoped override stopped working

pnpm `overrides` do **not** constrain peerDependency resolution. `@vueuse/router>vue-router: 4.6.4` held only until a higher `vue-router` (5.0.7) became selectable; then the peer resolver picked it.

## Fix

Declare `vue-router@4.6.4` as a **direct dependency** of `packages/web`. The peer of `@vueuse/router` (a direct dep of the same package) then binds to that copy, while `@nuxtjs/i18n` keeps `vue-router@5.0.7`. No application code changes.

Also updated the `packages/web/README.md` "Required dependency overrides" section — the old note wrongly called the v5 peer "harmless" and recommended the ineffective scoped override.

## What was rejected (and why)

Forcing a **single** `vue-router@4.6.4` (global override + pin) **breaks the build**: `nuxt generate` fails with `Could not load @nuxtjs/i18n`, because i18n requires `vue-router` 5.x. Confirmed locally. The two-major coexistence is correct; only `@vueuse/router`'s binding needed fixing.

## Verification (local)

- `pnpm why vue-router` → `@vueuse/router` resolves `vue-router@4.6.4`; `@nuxtjs/i18n` keeps `5.0.7`
- `pnpm --filter @swiss-ai-hub/web build` (`nuxt generate`) → **succeeds**; locale routes `/en /de /fr /it` prerender (i18n loads fine)
- lockfile diff is minimal (only the `@vueuse/router` peer binding + the new direct-dep edge)

## Test plan

- [ ] `/service/agents` — no crash; URL filters (`agent_type`, `agent_status`) work
- [ ] `/service/threads` — no crash; filters work
- [ ] Locale switching / `localePath()` navigation works
