### PR TITLE
fix(iac): Seed Keycloak superuser username equal to email

### DIFF
--- a/infra/configs/keycloak/aihub-realm.build.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.build.gpu.json
@@ -70,7 +70,7 @@
   ],
   "users": [
     {
-      "username": "$(env:SUPERUSER_USERNAME)",
+      "username": "$(env:SUPERUSER_EMAIL)",
       "email": "$(env:SUPERUSER_EMAIL)",
       "firstName": "$(env:SUPERUSER_FIRSTNAME)",
       "lastName": "$(env:SUPERUSER_LASTNAME)",

--- a/infra/configs/keycloak/aihub-realm.build.json
+++ b/infra/configs/keycloak/aihub-realm.build.json
@@ -70,7 +70,7 @@
   ],
   "users": [
     {
-      "username": "$(env:SUPERUSER_USERNAME)",
+      "username": "$(env:SUPERUSER_EMAIL)",
       "email": "$(env:SUPERUSER_EMAIL)",
       "firstName": "$(env:SUPERUSER_FIRSTNAME)",
       "lastName": "$(env:SUPERUSER_LASTNAME)",

--- a/infra/configs/keycloak/aihub-realm.dev.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.dev.gpu.json
@@ -70,7 +70,7 @@
   ],
   "users": [
     {
-      "username": "$(env:SUPERUSER_USERNAME)",
+      "username": "$(env:SUPERUSER_EMAIL)",
       "email": "$(env:SUPERUSER_EMAIL)",
       "firstName": "$(env:SUPERUSER_FIRSTNAME)",
       "lastName": "$(env:SUPERUSER_LASTNAME)",

--- a/infra/configs/keycloak/aihub-realm.dev.json
+++ b/infra/configs/keycloak/aihub-realm.dev.json
@@ -70,7 +70,7 @@
   ],
   "users": [
     {
-      "username": "$(env:SUPERUSER_USERNAME)",
+      "username": "$(env:SUPERUSER_EMAIL)",
       "email": "$(env:SUPERUSER_EMAIL)",
       "firstName": "$(env:SUPERUSER_FIRSTNAME)",
       "lastName": "$(env:SUPERUSER_LASTNAME)",

--- a/infra/configs/keycloak/aihub-realm.latest.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.latest.gpu.json
@@ -70,7 +70,7 @@
   ],
   "users": [
     {
-      "username": "$(env:SUPERUSER_USERNAME)",
+      "username": "$(env:SUPERUSER_EMAIL)",
       "email": "$(env:SUPERUSER_EMAIL)",
       "firstName": "$(env:SUPERUSER_FIRSTNAME)",
       "lastName": "$(env:SUPERUSER_LASTNAME)",

--- a/infra/configs/keycloak/aihub-realm.latest.json
+++ b/infra/configs/keycloak/aihub-realm.latest.json
@@ -70,7 +70,7 @@
   ],
   "users": [
     {
-      "username": "$(env:SUPERUSER_USERNAME)",
+      "username": "$(env:SUPERUSER_EMAIL)",
       "email": "$(env:SUPERUSER_EMAIL)",
       "firstName": "$(env:SUPERUSER_FIRSTNAME)",
       "lastName": "$(env:SUPERUSER_LASTNAME)",

--- a/infra/configs/keycloak/aihub-realm.local.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.local.gpu.json
@@ -70,7 +70,7 @@
   ],
   "users": [
     {
-      "username": "$(env:SUPERUSER_USERNAME)",
+      "username": "$(env:SUPERUSER_EMAIL)",
       "email": "$(env:SUPERUSER_EMAIL)",
       "firstName": "$(env:SUPERUSER_FIRSTNAME)",
       "lastName": "$(env:SUPERUSER_LASTNAME)",

--- a/infra/configs/keycloak/aihub-realm.local.json
+++ b/infra/configs/keycloak/aihub-realm.local.json
@@ -70,7 +70,7 @@
   ],
   "users": [
     {
-      "username": "$(env:SUPERUSER_USERNAME)",
+      "username": "$(env:SUPERUSER_EMAIL)",
       "email": "$(env:SUPERUSER_EMAIL)",
       "firstName": "$(env:SUPERUSER_FIRSTNAME)",
       "lastName": "$(env:SUPERUSER_LASTNAME)",

--- a/infra/configs/keycloak/aihub-realm.nightly.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.nightly.gpu.json
@@ -70,7 +70,7 @@
   ],
   "users": [
     {
-      "username": "$(env:SUPERUSER_USERNAME)",
+      "username": "$(env:SUPERUSER_EMAIL)",
       "email": "$(env:SUPERUSER_EMAIL)",
       "firstName": "$(env:SUPERUSER_FIRSTNAME)",
       "lastName": "$(env:SUPERUSER_LASTNAME)",

--- a/infra/configs/keycloak/aihub-realm.nightly.json
+++ b/infra/configs/keycloak/aihub-realm.nightly.json
@@ -70,7 +70,7 @@
   ],
   "users": [
     {
-      "username": "$(env:SUPERUSER_USERNAME)",
+      "username": "$(env:SUPERUSER_EMAIL)",
       "email": "$(env:SUPERUSER_EMAIL)",
       "firstName": "$(env:SUPERUSER_FIRSTNAME)",
       "lastName": "$(env:SUPERUSER_LASTNAME)",

--- a/infra/deployment/templates/configs/keycloak/bootstrap/users-superuser.json.j2
+++ b/infra/deployment/templates/configs/keycloak/bootstrap/users-superuser.json.j2
@@ -14,7 +14,7 @@
   "realm": "aihub",
   "users": [
     {
-      "username": "$(env:SUPERUSER_USERNAME)",
+      "username": "$(env:SUPERUSER_EMAIL)",
       "email": "$(env:SUPERUSER_EMAIL)",
       "firstName": "$(env:SUPERUSER_FIRSTNAME)",
       "lastName": "$(env:SUPERUSER_LASTNAME)",


### PR DESCRIPTION
Fixes #1426

## Root cause

The `aihub` realm enforces `registrationEmailAsUsername: true` + `editUsernameAllowed: false`, so Keycloak requires `username == email`. The superuser is seeded with `username=$(env:SUPERUSER_USERNAME)` ≠ `email=$(env:SUPERUSER_EMAIL)`. Keycloak automatically rewrites `username → email`, so the documented `admin` login stops resolving — only the email works (`user_not_found` for `admin` in the login events).

Verified on Keycloak **26.5.4**: the rewrite happens **at `--import-realm` time**, not after a later save — so `username` is already the email immediately after the first boot and `admin` never logs in. (This refines the original "tolerates initially / breaks on first save" wording in the issue.)

## Fix

Seed the superuser with `username == email` so the realm invariant holds and Keycloak has nothing to rewrite.

`infra/deployment/templates/configs/keycloak/bootstrap/users-superuser.json.j2`:
```diff
-      "username": "$(env:SUPERUSER_USERNAME)",
+      "username": "$(env:SUPERUSER_EMAIL)",
       "email": "$(env:SUPERUSER_EMAIL)",
```
Then `make generate-compose` to regenerate the 10 `aihub-realm.{stage}.json` files.

## Notes

- This is a **bootstrap-only** template, so it fixes **fresh deployments**. Existing deployments already log in with the email (the normalized value) and are unaffected — no migration needed.
- `SUPERUSER_EMAIL` is already the identity anchor in code (`find_user_by_email` for the bearer token, tenant assignment, Langfuse). `SUPERUSER_USERNAME` is now effectively unused in the seed; a follow-up could remove it entirely.

## Test plan

- [x] Reproduced on Keycloak 26.5.4 via `--import-realm`: seeded `username=admin` → normalized to email at import → `admin` login fails, email login succeeds.
- [x] `make generate-compose` regenerates all 10 realm files with `username = $(env:SUPERUSER_EMAIL)`.
- [ ] Fresh deployment: superuser logs in with `SUPERUSER_EMAIL`, account survives admin-console saves / group assignment without breaking.