### PR TITLE
fix(deploy): Route mirrored images through the global registry prefix

### DIFF
--- a/infra/deployment/compose-config.yml
+++ b/infra/deployment/compose-config.yml
@@ -37,7 +37,7 @@ image_tags:
   mineru_api: mineru-api:v2.7.5
   mineru_vlm: mineru-vlm:v2.7.5
   jupyter: minimal-notebook:notebook-7.0.6
-  otel_collector: otel/opentelemetry-collector-contrib:latest
+  otel_collector: otel/opentelemetry-collector-contrib:0.154.0
   traefik: traefik:v3.6.2
   docker_socket_proxy: tecnativa/docker-socket-proxy:0.3
   postgres_ferretdb: postgres-documentdb:17.0.106.0-ferretdb-2.5.0
@@ -45,13 +45,14 @@ image_tags:
   presidio_anonymizer: presidio-anonymizer:2.2.359
   oauth2proxy: ghcr.io/bbvch-ai/bbvch-ai/oauth2-proxy:latest
   open_webui: open-webui:v0.9.5
+  open_webui_init: postgres:17
   playwright: playwright:v1.58.0-jammy
   vllm: vllm-openai:v0.15.1
-  speaches: ghcr.io/speaches-ai/speaches:latest-cuda-12.6.3
+  speaches: speaches-ai/speaches:latest-cuda-12.6.3
   pgbouncer: pgbouncer:v1.24.1-p1
-  rclone: ghcr.io/bbvch-ai/aihub-core/rclone:1.71.2
+  rclone: rclone:1.71.2
   keycloak: keycloak:26.5.4
-  keycloak-config-cli: keycloak-config-cli:6.5.0-26.5.4
+  keycloak_config_cli: keycloak-config-cli:6.5.0-26.5.4
   searxng: searxng:2026.4.29-cba0cffa8
 
   # --- Custom Application Services ---

--- a/infra/deployment/generate_compose.py
+++ b/infra/deployment/generate_compose.py
@@ -184,7 +184,7 @@ DOCKER_LICENSE_ALIASES = {
     "backup-webserver": "dagster",
     "backup-daemon": "dagster",
     "otel-collector": "opentelemetry-collector-contrib",
-    "openwebui-init": "open-webui",
+    "openwebui-init": "postgres",
     "keycloak-config": "keycloak-config-cli",
 }
 

--- a/infra/deployment/templates/docker-compose.yml.j2
+++ b/infra/deployment/templates/docker-compose.yml.j2
@@ -1142,7 +1142,7 @@ services:
   {{ service_license('keycloak-config') }}
   keycloak-config:
     container_name: keycloak-config
-    image: {{ global.registry_prefix }}{{ image_tags['keycloak-config-cli'] }}
+    image: {{ global.registry_prefix }}{{ image_tags.keycloak_config_cli }}
     restart: on-failure
     environment:
       KEYCLOAK_URL: http://keycloak:8080
@@ -1271,7 +1271,7 @@ services:
   {{ service_license('rclone') }}
   rclone:
     container_name: rclone
-    image: {{ image_tags.rclone }}
+    image: {{ global.registry_prefix }}{{ image_tags.rclone }}
     restart: unless-stopped
     command:
       - "rcd"
@@ -1711,7 +1711,7 @@ services:
   {{ service_license('speaches') }}
   speaches:
     container_name: speaches
-    image: {{ image_tags.speaches }}
+    image: {{ global.registry_prefix }}{{ image_tags.speaches }}
     restart: unless-stopped
     {%- if stage in ['dev', 'local', 'build'] %}
     ports:
@@ -2055,7 +2055,7 @@ services:
   {{ service_license('otel-collector') }}
   otel-collector:
     container_name: otel-collector
-    image: {{ image_tags.otel_collector }}
+    image: {{ global.registry_prefix }}{{ image_tags.otel_collector }}
     restart: always
     command: [ "--config=/etc/otel-config.yml" ]
     environment:
@@ -2412,7 +2412,7 @@ services:
   {{ service_license('openwebui-init') }}
   openwebui-init:
     container_name: openwebui-init
-    image: {{ global.registry_prefix }}postgres:17
+    image: {{ global.registry_prefix }}{{ image_tags.open_webui_init }}
     restart: on-failure
     depends_on:
       open-webui:
@@ -2596,7 +2596,7 @@ services:
   {{ service_license('docker-socket-proxy') }}
   docker-socket-proxy:
     container_name: docker-socket-proxy
-    image: "{{ image_tags.docker_socket_proxy }}"
+    image: "{{ global.registry_prefix }}{{ image_tags.docker_socket_proxy }}"
     restart: always
     # Required for Docker socket access in SELinux/AppArmor environments
     privileged: true

--- a/infra/docker-compose.build.gpu.yml
+++ b/infra/docker-compose.build.gpu.yml
@@ -1518,7 +1518,7 @@ services:
   # License: MIT — third-party (see LICENSE_REPORT.md)
   speaches:
     container_name: speaches
-    image: ghcr.io/speaches-ai/speaches:latest-cuda-12.6.3
+    image: ghcr.io/bbvch-ai/aihub-core/speaches-ai/speaches:latest-cuda-12.6.3
     restart: unless-stopped
     ports: [8185:8000]
     volumes:
@@ -1837,7 +1837,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   otel-collector:
     container_name: otel-collector
-    image: otel/opentelemetry-collector-contrib:latest
+    image: ghcr.io/bbvch-ai/aihub-core/otel/opentelemetry-collector-contrib:0.154.0
     restart: always
     command: [--config=/etc/otel-config.yml]
     environment:
@@ -2323,7 +2323,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   docker-socket-proxy:
     container_name: docker-socket-proxy
-    image: tecnativa/docker-socket-proxy:0.3
+    image: ghcr.io/bbvch-ai/aihub-core/tecnativa/docker-socket-proxy:0.3
     restart: always
     # Required for Docker socket access in SELinux/AppArmor environments
     privileged: true

--- a/infra/docker-compose.build.yml
+++ b/infra/docker-compose.build.yml
@@ -1617,7 +1617,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   otel-collector:
     container_name: otel-collector
-    image: otel/opentelemetry-collector-contrib:latest
+    image: ghcr.io/bbvch-ai/aihub-core/otel/opentelemetry-collector-contrib:0.154.0
     restart: always
     command: [--config=/etc/otel-config.yml]
     environment:
@@ -2103,7 +2103,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   docker-socket-proxy:
     container_name: docker-socket-proxy
-    image: tecnativa/docker-socket-proxy:0.3
+    image: ghcr.io/bbvch-ai/aihub-core/tecnativa/docker-socket-proxy:0.3
     restart: always
     # Required for Docker socket access in SELinux/AppArmor environments
     privileged: true

--- a/infra/docker-compose.dev.gpu.yml
+++ b/infra/docker-compose.dev.gpu.yml
@@ -1215,7 +1215,7 @@ services:
   # License: MIT — third-party (see LICENSE_REPORT.md)
   speaches:
     container_name: speaches
-    image: ghcr.io/speaches-ai/speaches:latest-cuda-12.6.3
+    image: ghcr.io/bbvch-ai/aihub-core/speaches-ai/speaches:latest-cuda-12.6.3
     restart: unless-stopped
     ports: [8185:8000]
     volumes:
@@ -1525,7 +1525,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   otel-collector:
     container_name: otel-collector
-    image: otel/opentelemetry-collector-contrib:latest
+    image: ghcr.io/bbvch-ai/aihub-core/otel/opentelemetry-collector-contrib:0.154.0
     restart: always
     command: [--config=/etc/otel-config.yml]
     environment:

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -1305,7 +1305,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   otel-collector:
     container_name: otel-collector
-    image: otel/opentelemetry-collector-contrib:latest
+    image: ghcr.io/bbvch-ai/aihub-core/otel/opentelemetry-collector-contrib:0.154.0
     restart: always
     command: [--config=/etc/otel-config.yml]
     environment:

--- a/infra/docker-compose.latest.gpu.yml
+++ b/infra/docker-compose.latest.gpu.yml
@@ -1484,7 +1484,7 @@ services:
   # License: MIT — third-party (see LICENSE_REPORT.md)
   speaches:
     container_name: speaches
-    image: ghcr.io/speaches-ai/speaches:latest-cuda-12.6.3
+    image: ghcr.io/bbvch-ai/aihub-core/speaches-ai/speaches:latest-cuda-12.6.3
     restart: unless-stopped
     volumes:
       - ${VOLUME_ROOT:-./.docker-volumes}/speaches-models:/home/ubuntu/.cache/huggingface/hub
@@ -1795,7 +1795,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   otel-collector:
     container_name: otel-collector
-    image: otel/opentelemetry-collector-contrib:latest
+    image: ghcr.io/bbvch-ai/aihub-core/otel/opentelemetry-collector-contrib:0.154.0
     restart: always
     command: [--config=/etc/otel-config.yml]
     environment:
@@ -2275,7 +2275,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   docker-socket-proxy:
     container_name: docker-socket-proxy
-    image: tecnativa/docker-socket-proxy:0.3
+    image: ghcr.io/bbvch-ai/aihub-core/tecnativa/docker-socket-proxy:0.3
     restart: always
     # Required for Docker socket access in SELinux/AppArmor environments
     privileged: true

--- a/infra/docker-compose.latest.yml
+++ b/infra/docker-compose.latest.yml
@@ -1581,7 +1581,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   otel-collector:
     container_name: otel-collector
-    image: otel/opentelemetry-collector-contrib:latest
+    image: ghcr.io/bbvch-ai/aihub-core/otel/opentelemetry-collector-contrib:0.154.0
     restart: always
     command: [--config=/etc/otel-config.yml]
     environment:
@@ -2061,7 +2061,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   docker-socket-proxy:
     container_name: docker-socket-proxy
-    image: tecnativa/docker-socket-proxy:0.3
+    image: ghcr.io/bbvch-ai/aihub-core/tecnativa/docker-socket-proxy:0.3
     restart: always
     # Required for Docker socket access in SELinux/AppArmor environments
     privileged: true

--- a/infra/docker-compose.local.gpu.yml
+++ b/infra/docker-compose.local.gpu.yml
@@ -1511,7 +1511,7 @@ services:
   # License: MIT — third-party (see LICENSE_REPORT.md)
   speaches:
     container_name: speaches
-    image: ghcr.io/speaches-ai/speaches:latest-cuda-12.6.3
+    image: ghcr.io/bbvch-ai/aihub-core/speaches-ai/speaches:latest-cuda-12.6.3
     restart: unless-stopped
     ports: [8185:8000]
     volumes:
@@ -1830,7 +1830,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   otel-collector:
     container_name: otel-collector
-    image: otel/opentelemetry-collector-contrib:latest
+    image: ghcr.io/bbvch-ai/aihub-core/otel/opentelemetry-collector-contrib:0.154.0
     restart: always
     command: [--config=/etc/otel-config.yml]
     environment:
@@ -2312,7 +2312,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   docker-socket-proxy:
     container_name: docker-socket-proxy
-    image: tecnativa/docker-socket-proxy:0.3
+    image: ghcr.io/bbvch-ai/aihub-core/tecnativa/docker-socket-proxy:0.3
     restart: always
     # Required for Docker socket access in SELinux/AppArmor environments
     privileged: true

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -1610,7 +1610,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   otel-collector:
     container_name: otel-collector
-    image: otel/opentelemetry-collector-contrib:latest
+    image: ghcr.io/bbvch-ai/aihub-core/otel/opentelemetry-collector-contrib:0.154.0
     restart: always
     command: [--config=/etc/otel-config.yml]
     environment:
@@ -2092,7 +2092,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   docker-socket-proxy:
     container_name: docker-socket-proxy
-    image: tecnativa/docker-socket-proxy:0.3
+    image: ghcr.io/bbvch-ai/aihub-core/tecnativa/docker-socket-proxy:0.3
     restart: always
     # Required for Docker socket access in SELinux/AppArmor environments
     privileged: true

--- a/infra/docker-compose.nightly.gpu.yml
+++ b/infra/docker-compose.nightly.gpu.yml
@@ -1484,7 +1484,7 @@ services:
   # License: MIT — third-party (see LICENSE_REPORT.md)
   speaches:
     container_name: speaches
-    image: ghcr.io/speaches-ai/speaches:latest-cuda-12.6.3
+    image: ghcr.io/bbvch-ai/aihub-core/speaches-ai/speaches:latest-cuda-12.6.3
     restart: unless-stopped
     volumes:
       - ${VOLUME_ROOT:-./.docker-volumes}/speaches-models:/home/ubuntu/.cache/huggingface/hub
@@ -1796,7 +1796,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   otel-collector:
     container_name: otel-collector
-    image: otel/opentelemetry-collector-contrib:latest
+    image: ghcr.io/bbvch-ai/aihub-core/otel/opentelemetry-collector-contrib:0.154.0
     restart: always
     command: [--config=/etc/otel-config.yml]
     environment:
@@ -2276,7 +2276,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   docker-socket-proxy:
     container_name: docker-socket-proxy
-    image: tecnativa/docker-socket-proxy:0.3
+    image: ghcr.io/bbvch-ai/aihub-core/tecnativa/docker-socket-proxy:0.3
     restart: always
     # Required for Docker socket access in SELinux/AppArmor environments
     privileged: true

--- a/infra/docker-compose.nightly.yml
+++ b/infra/docker-compose.nightly.yml
@@ -1581,7 +1581,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   otel-collector:
     container_name: otel-collector
-    image: otel/opentelemetry-collector-contrib:latest
+    image: ghcr.io/bbvch-ai/aihub-core/otel/opentelemetry-collector-contrib:0.154.0
     restart: always
     command: [--config=/etc/otel-config.yml]
     environment:
@@ -2061,7 +2061,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   docker-socket-proxy:
     container_name: docker-socket-proxy
-    image: tecnativa/docker-socket-proxy:0.3
+    image: ghcr.io/bbvch-ai/aihub-core/tecnativa/docker-socket-proxy:0.3
     restart: always
     # Required for Docker socket access in SELinux/AppArmor environments
     privileged: true


### PR DESCRIPTION
## Summary

Normalize all container image references so mirrored images resolve through the global registry prefix, pin the OTEL Collector to an explicit version, and fix config-key naming so the Jinja2 template can reference every tag.

## Changes

- Route `speaches`, `rclone`, `otel-collector`, and `docker-socket-proxy` images through `global.registry_prefix` in `docker-compose.yml.j2` (consistent with the mirrored-registry structure).
- Pin `otel_collector` to `otel/opentelemetry-collector-contrib:0.154.0` instead of the floating `latest` tag.
- Drop the now-redundant `ghcr.io/...` prefixes from `speaches` and `rclone` entries in `compose-config.yml` (the prefix is applied in the template).
- Rename `keycloak-config-cli` → `keycloak_config_cli` so it is a valid Jinja attribute, and reference it via attribute access in the template.
- Introduce `open_webui_init: postgres:17` and use it for the `openwebui-init` image instead of a hardcoded value.
- Regenerate all 10 docker-compose variants via `make generate-compose`.

## Test plan

- Ran `make generate-compose`; the regenerated `infra/docker-compose.*.yml` files are committed and reflect the template/config changes.
- Verified image references in the generated compose files now consistently carry the global registry prefix.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>` (see
  [CONTRIBUTING.md](https://github.com/bbvch-ai/aihub-core/blob/main/CONTRIBUTING.md))
- [ ] Exactly one of `major` / `minor` / `patch` label applied
- [ ] CLA signed — post this exact comment on the PR if the bot hasn't prompted you yet:
  `I have read the CONTRIBUTOR_AGREEMENT and I hereby sign the CLA`
  ([read the agreement](https://github.com/bbvch-ai/aihub-core/blob/main/CONTRIBUTOR_AGREEMENT.md))
- [x] Tests added or updated where relevant
