### PR TITLE
doc(swiss-ai-hub): Fix broken agent code example in root README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,14 +287,16 @@ This agent retrieves documents from the knowledge base, answers with an LLM when
 human expert via Teams or Slack when it is not, pausing the workflow until the expert responds:
 
 ```python
-from swiss_ai_hub.agent import Agent, AgentConfig, AgentRunner, step
-from swiss_ai_hub.core.events import UserMessageEvent, LLMStopEvent, StopEvent
-from swiss_ai_hub.core.events.semantic import RetrieverEvent
-from swiss_ai_hub.core.events.guard import ContextSufficientEvent, ContextInsufficientEvent
-from swiss_ai_hub.core.events.botl import BotInTheLoop
+from swiss_ai_hub.agent import Agent, AgentRunner, step
+from swiss_ai_hub.core.agents import AgentConfig
+from swiss_ai_hub.core.events.agent import (
+    UserMessageEvent, LLMStopEvent, StopEvent, RetrieverEvent,
+    ContextSufficientAcceptEvent, ContextInsufficientRejectEvent, BotInTheLoop,
+)
 from swiss_ai_hub.core.displayers import EventDisplayer
-from swiss_ai_hub.core.retrievers import KnowledgeRetriever
+from swiss_ai_hub.core.generative_ai.retrievers.knowledge_retriever import KnowledgeRetriever
 from swiss_ai_hub.core.i18n import LocaleString, LocaleHandler
+from llama_index.core.base.llms.types import ChatMessage
 
 class ExpertQAAgent(Agent):
     name = LocaleString(en="Expert QA")
@@ -311,16 +313,16 @@ class ExpertQAAgent(Agent):
 
     # Step 2: emit a guard event — the runtime routes each type to a different step
     @step()
-    async def check_context(self, event: RetrieverEvent) -> ContextSufficientEvent | ContextInsufficientEvent:
+    async def check_context(self, event: RetrieverEvent) -> ContextSufficientAcceptEvent | ContextInsufficientRejectEvent:
         if event.nodes:
-            return ContextSufficientEvent()  # documents found → routes to respond()
-        return ContextInsufficientEvent()  # no documents → routes to escalate()
+            return ContextSufficientAcceptEvent()  # documents found → routes to respond()
+        return ContextInsufficientRejectEvent()  # no documents → routes to escalate()
 
-    # Step 3a: only triggered by ContextSufficientEvent
+    # Step 3a: only triggered by ContextSufficientAcceptEvent
     # the runtime also injects RetrieverEvent and UserMessageEvent from earlier in the run
     @step()
     async def respond(
-        self, _: ContextSufficientEvent, retrieval: RetrieverEvent, start: UserMessageEvent,
+        self, _: ContextSufficientAcceptEvent, retrieval: RetrieverEvent, start: UserMessageEvent,
         config: AgentConfig, displayer: EventDisplayer,
     ) -> LLMStopEvent:
         context = "\n\n".join(node.content for node in retrieval.nodes)  # build context from documents
@@ -328,11 +330,11 @@ class ExpertQAAgent(Agent):
         async with config.llm.cost_reporting_llm(displayer) as llm:  # tracks token usage and cost
             return await displayer.display_llm_stream(config.llm, llm, messages, as_stop_step=True)  # stream to chat UI
 
-    # Step 3b: only triggered by ContextInsufficientEvent — sends question to a Teams/Slack channel
+    # Step 3b: only triggered by ContextInsufficientRejectEvent — sends question to a Teams/Slack channel
     # BotInTheLoop pauses the workflow until the expert responds
     @step()
     async def escalate(
-        self, _: ContextInsufficientEvent, start: UserMessageEvent, config: AgentConfig,
+        self, _: ContextInsufficientRejectEvent, start: UserMessageEvent, config: AgentConfig,
     ) -> BotInTheLoop.request:
         return BotInTheLoop.invoke(question=start.user_query, user=start.user, channel_config=config.channel)
 
@@ -348,8 +350,8 @@ await runner.run_forever()
 ```
 
 On startup the agent registers itself: it appears in the chat UI, gets a configuration form in the admin panel, and
-receives full distributed tracing through Langfuse. The runtime routes `ContextSufficientEvent` to `respond` and
-`ContextInsufficientEvent` to `escalate`; steps never call each other. `BotInTheLoop` sends the question to a configured
+receives full distributed tracing through Langfuse. The runtime routes `ContextSufficientAcceptEvent` to `respond` and
+`ContextInsufficientRejectEvent` to `escalate`; steps never call each other. `BotInTheLoop` sends the question to a configured
 Teams or Slack expert channel and pauses the workflow; when the expert responds, the dispatcher resumes at
 `relay_expert`.
 


### PR DESCRIPTION
﻿## Summary

Fixes the broken agent code example in the root `README.md` (the front-door OSS demo, also synced into `docs/docs/6_code_deep_dive/1_introduction/index.en.md`). The example previously failed on copy-paste due to wrong import paths and class names.

Closes #1223

## Changes

- **Imports corrected** in the `ExpertQAAgent` example:
  - `AgentConfig` moved off the `swiss_ai_hub.agent` line -> `from swiss_ai_hub.core.agents import AgentConfig`
  - All 7 events consolidated into the public interface `from swiss_ai_hub.core.events.agent import (...)`
  - `KnowledgeRetriever` -> full module path `swiss_ai_hub.core.generative_ai.retrievers.knowledge_retriever` (the package `__init__.py` is empty, so the path suggested in the issue would not resolve)
  - Added the missing `from llama_index.core.base.llms.types import ChatMessage` (used at line 327 but never imported)
- **Class names fixed** across signatures, bodies, comments, and the prose paragraph:
  - `ContextSufficientEvent` -> `ContextSufficientAcceptEvent`
  - `ContextInsufficientEvent` -> `ContextInsufficientRejectEvent`

## Verification (acceptance criteria)

- [x] All imports resolve against the current codebase (verified via `importlib` + `hasattr`, 16/16 symbols PASS)
- [x] All class names match exports
- [x] Smoke test imports cleanly (`uv run python` exit 0, no traceback)
- [x] `sync-docs.sh` re-run; synced introduction doc is byte-identical to the README example block

Docs note: the synced `index.en.md` is a gitignored build artifact (`docs/.gitignore`), so the only committed change is `README.md`.
