### PR TITLE
fix(swiss-ai-hub): Paginate SCIM list_users/list_groups

### DIFF
--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_client.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_client.py
@@ -1,11 +1,11 @@
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any
+from typing import Any, TypeVar, cast
 
 import httpx
 from scim2_client.engines.httpx import AsyncSCIMClient
-from scim2_models import Group, GroupMember, User
+from scim2_models import Group, GroupMember, ListResponse, Resource, SearchRequest, User
 
 from swiss_ai_hub.core.infrastructure.openwebui.access_grant import AccessGrant
 from swiss_ai_hub.core.infrastructure.openwebui.openwebui_token_service import OpenWebuiTokenService
@@ -14,6 +14,12 @@ logger = logging.getLogger(__name__)
 
 SCIM_BASE_PATH = "/api/v1/scim/v2"
 MODELS_ENDPOINT = "/api/v1/models"
+
+# SCIM list endpoints are paginated; OpenWebUI defaults to a small page size, so a
+# bare query returns only the first page. Fetch in batches of this size until done.
+SCIM_PAGE_SIZE = 100
+
+R = TypeVar("R", bound=Resource)
 
 
 class OpenWebuiClient:
@@ -44,17 +50,39 @@ class OpenWebuiClient:
         token = OpenWebuiTokenService.generate_token(self._secret_key, user_id=self._service_account_id)
         return {"Authorization": f"Bearer {token}"}
 
+    @staticmethod
+    async def _query_all(client: AsyncSCIMClient, model: type[R]) -> list[R]:
+        """Returns every resource of ``model``, following SCIM pagination.
+
+        ``client.query(model)`` returns a single page, and OpenWebUI's SCIM default
+        page size is small — so a bare query silently drops every resource past the
+        first page (e.g. users/groups never get synced once the directory grows).
+        Loop on ``startIndex`` until all ``totalResults`` are retrieved.
+        """
+        results: list[R] = []
+        start = 1
+        while True:
+            response = cast(
+                ListResponse[R],
+                await client.query(model, search_request=SearchRequest(start_index=start, count=SCIM_PAGE_SIZE)),
+            )
+            batch = list(response.resources or [])
+            results.extend(batch)
+            total = response.total_results
+            if not batch or len(batch) < SCIM_PAGE_SIZE or (total is not None and len(results) >= total):
+                break
+            start += len(batch)
+        return results
+
     # ------------------------------------------------------------------
     # Group methods (SCIM 2.0 via scim2-client)
     # ------------------------------------------------------------------
 
     async def list_groups(self, scim: AsyncSCIMClient | None = None) -> list[Group]:
         if scim:
-            response = await scim.query(Group)
-            return list(response.resources)
+            return await self._query_all(scim, Group)
         async with self.scim_session() as s:
-            response = await s.query(Group)
-            return list(response.resources)
+            return await self._query_all(s, Group)
 
     async def create_group(self, name: str, scim: AsyncSCIMClient | None = None) -> Group:
         """Creates a group, or returns the existing one if a group with this display name already exists.
@@ -64,8 +92,7 @@ class OpenWebuiClient:
         """
 
         async def _create(client: AsyncSCIMClient) -> Group:
-            response = await client.query(Group)
-            for group in response.resources:
+            for group in await self._query_all(client, Group):
                 if group.display_name == name:
                     logger.warning(
                         "OpenWebUI group '%s' already exists (id=%s); reusing it instead of creating a duplicate",
@@ -107,11 +134,9 @@ class OpenWebuiClient:
 
     async def list_users(self, scim: AsyncSCIMClient | None = None) -> list[User]:
         if scim:
-            response = await scim.query(User)
-            return list(response.resources)
+            return await self._query_all(scim, User)
         async with self.scim_session() as s:
-            response = await s.query(User)
-            return list(response.resources)
+            return await self._query_all(s, User)
 
     # ------------------------------------------------------------------
     # Model methods (proprietary API + JWT auth)

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_client.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_client.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any, TypeVar, cast
+from typing import Any, cast
 
 import httpx
 from scim2_client.engines.httpx import AsyncSCIMClient
@@ -16,10 +16,12 @@ SCIM_BASE_PATH = "/api/v1/scim/v2"
 MODELS_ENDPOINT = "/api/v1/models"
 
 # SCIM list endpoints are paginated; OpenWebUI defaults to a small page size, so a
-# bare query returns only the first page. Fetch in batches of this size until done.
+# bare query returns only the first page. Request this many per page (the server may
+# still cap it lower — pagination keys off the response, not this value).
 SCIM_PAGE_SIZE = 100
 
-R = TypeVar("R", bound=Resource)
+# Backstop so a server that ignores startIndex can't spin the provisioner forever.
+MAX_SCIM_PAGES = 10_000
 
 
 class OpenWebuiClient:
@@ -51,17 +53,21 @@ class OpenWebuiClient:
         return {"Authorization": f"Bearer {token}"}
 
     @staticmethod
-    async def _query_all(client: AsyncSCIMClient, model: type[R]) -> list[R]:
+    async def _query_all[R: Resource](client: AsyncSCIMClient, model: type[R]) -> list[R]:
         """Returns every resource of ``model``, following SCIM pagination.
 
         ``client.query(model)`` returns a single page, and OpenWebUI's SCIM default
         page size is small — so a bare query silently drops every resource past the
         first page (e.g. users/groups never get synced once the directory grows).
-        Loop on ``startIndex`` until all ``totalResults`` are retrieved.
+        Loop on ``startIndex`` until every resource is retrieved.
+
+        Termination keys off the server's reported ``itemsPerPage``/``totalResults``,
+        not our requested ``count``: the server may cap the page size below what we
+        ask, so ``len(batch) < SCIM_PAGE_SIZE`` would stop early and drop the rest.
         """
         results: list[R] = []
         start = 1
-        while True:
+        for _ in range(MAX_SCIM_PAGES):
             response = cast(
                 ListResponse[R],
                 await client.query(model, search_request=SearchRequest(start_index=start, count=SCIM_PAGE_SIZE)),
@@ -69,9 +75,15 @@ class OpenWebuiClient:
             batch = list(response.resources or [])
             results.extend(batch)
             total = response.total_results
-            if not batch or len(batch) < SCIM_PAGE_SIZE or (total is not None and len(results) >= total):
+            if total is not None and len(results) >= total:
+                break
+            # Server-reported page size — fall back to the batch length if absent.
+            page_size = response.items_per_page or len(batch)
+            if not batch or len(batch) < page_size:
                 break
             start += len(batch)
+        else:
+            raise RuntimeError(f"SCIM pagination for {model.__name__} exceeded {MAX_SCIM_PAGES} pages")
         return results
 
     # ------------------------------------------------------------------

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_client.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_client.py
@@ -124,12 +124,44 @@ def _scim_group(display_name: str, group_id: str) -> Group:
     return group
 
 
+def _list_response(
+    resources: list, *, total_results: int | None = -1, items_per_page: int | None = -1
+) -> SimpleNamespace:
+    """A SCIM ListResponse stub carrying the fields `_query_all` reads.
+
+    `total_results`/`items_per_page` default to `len(resources)`; pass `None`
+    explicitly to simulate a server that omits them.
+    """
+    return SimpleNamespace(
+        resources=resources,
+        total_results=len(resources) if total_results == -1 else total_results,
+        items_per_page=len(resources) if items_per_page == -1 else items_per_page,
+    )
+
+
+def _paged_query(pages: list[list]):
+    """side_effect returning each page in turn, keyed on the requested startIndex."""
+    offsets = {}
+    cursor = 1
+    for page in pages:
+        offsets[cursor] = page
+        cursor += len(page)
+    total = sum(len(p) for p in pages)
+    page_size = max((len(p) for p in pages), default=0)
+
+    async def fake_query(model: type, search_request=None, **kwargs):  # noqa: ANN001
+        page = offsets.get(search_request.start_index, [])
+        return _list_response(page, total_results=total, items_per_page=page_size)
+
+    return fake_query
+
+
 class TestCreateGroupIdempotent:
     @pytest.mark.asyncio
     async def test_reuses_existing_group_with_same_name(self, owui_client: OpenWebuiClient) -> None:
         existing = _scim_group("aihub:T:R", "grp-existing")
         scim = AsyncMock()
-        scim.query.return_value = SimpleNamespace(resources=[existing], total_results=1)
+        scim.query.return_value = _list_response([existing])
 
         result = await owui_client.create_group("aihub:T:R", scim=scim)
 
@@ -140,9 +172,7 @@ class TestCreateGroupIdempotent:
     async def test_creates_when_no_group_with_that_name_exists(self, owui_client: OpenWebuiClient) -> None:
         created = _scim_group("aihub:T:R", "grp-new")
         scim = AsyncMock()
-        scim.query.return_value = SimpleNamespace(
-            resources=[_scim_group("aihub:Other:Role", "grp-other")], total_results=1
-        )
+        scim.query.return_value = _list_response([_scim_group("aihub:Other:Role", "grp-other")])
         scim.create.return_value = created
 
         result = await owui_client.create_group("aihub:T:R", scim=scim)
@@ -150,30 +180,76 @@ class TestCreateGroupIdempotent:
         assert result is created
         scim.create.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    async def test_dedup_scan_walks_all_pages(self, owui_client: OpenWebuiClient) -> None:
+        # Target group lives on the SECOND page; create must still find it, not duplicate.
+        page1 = [_scim_group(f"aihub:X:{i}", f"g{i}") for i in range(SCIM_PAGE_SIZE)]
+        target = _scim_group("aihub:T:R", "grp-target")
+        scim = AsyncMock()
+        scim.query.side_effect = _paged_query([page1, [target]])
+
+        result = await owui_client.create_group("aihub:T:R", scim=scim)
+
+        assert result is target
+        scim.create.assert_not_called()
+        assert scim.query.await_count == 2
+
 
 class TestScimPagination:
     @pytest.mark.asyncio
     async def test_list_users_follows_all_pages(self, owui_client: OpenWebuiClient) -> None:
-        total = SCIM_PAGE_SIZE + 25  # spans two pages
         page1 = [User(user_name=f"u{i}@x") for i in range(SCIM_PAGE_SIZE)]
-        page2 = [User(user_name=f"u{i}@x") for i in range(SCIM_PAGE_SIZE, total)]
+        page2 = [User(user_name=f"u{i}@x") for i in range(SCIM_PAGE_SIZE, SCIM_PAGE_SIZE + 25)]
+        scim = AsyncMock()
+        scim.query.side_effect = _paged_query([page1, page2])
+
+        result = await owui_client.list_users(scim=scim)
+
+        assert len(result) == SCIM_PAGE_SIZE + 25
+        assert scim.query.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_list_users_respects_server_capped_page_size(self, owui_client: OpenWebuiClient) -> None:
+        # We ask for SCIM_PAGE_SIZE but the server caps each page at 20 (itemsPerPage=20).
+        # Termination must follow the server's page size, not our requested count.
+        cap = 20
+        total = 45
+        users = [User(user_name=f"u{i}@x") for i in range(total)]
         scim = AsyncMock()
 
         async def fake_query(model: type, search_request=None, **kwargs):  # noqa: ANN001
-            resources = page1 if search_request.start_index == 1 else page2
-            return SimpleNamespace(resources=resources, total_results=total)
+            start = search_request.start_index - 1
+            return _list_response(users[start : start + cap], total_results=total, items_per_page=cap)
 
         scim.query.side_effect = fake_query
 
         result = await owui_client.list_users(scim=scim)
 
         assert len(result) == total
+        assert scim.query.await_count == 3  # 20 + 20 + 5
+
+    @pytest.mark.asyncio
+    async def test_list_users_handles_missing_total_results(self, owui_client: OpenWebuiClient) -> None:
+        # Server omits totalResults; termination relies on a short page.
+        page1 = [User(user_name=f"u{i}@x") for i in range(SCIM_PAGE_SIZE)]
+        page2 = [User(user_name=f"u{i}@x") for i in range(SCIM_PAGE_SIZE, SCIM_PAGE_SIZE + 10)]
+        scim = AsyncMock()
+
+        async def fake_query(model: type, search_request=None, **kwargs):  # noqa: ANN001
+            page = page1 if search_request.start_index == 1 else page2
+            return _list_response(page, total_results=None, items_per_page=SCIM_PAGE_SIZE)
+
+        scim.query.side_effect = fake_query
+
+        result = await owui_client.list_users(scim=scim)
+
+        assert len(result) == SCIM_PAGE_SIZE + 10
         assert scim.query.await_count == 2
 
     @pytest.mark.asyncio
     async def test_list_groups_stops_on_short_page(self, owui_client: OpenWebuiClient) -> None:
         scim = AsyncMock()
-        scim.query.return_value = SimpleNamespace(resources=[_scim_group("aihub:T:R", "g1")], total_results=1)
+        scim.query.return_value = _list_response([_scim_group("aihub:T:R", "g1")])
 
         result = await owui_client.list_groups(scim=scim)
 

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_client.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_client.py
@@ -3,9 +3,9 @@ from unittest.mock import AsyncMock
 
 import httpx
 import pytest
-from scim2_models import Group
+from scim2_models import Group, User
 
-from swiss_ai_hub.core.infrastructure.openwebui.openwebui_client import OpenWebuiClient
+from swiss_ai_hub.core.infrastructure.openwebui.openwebui_client import SCIM_PAGE_SIZE, OpenWebuiClient
 
 BASE_URL = "http://open-webui:8080"
 SECRET_KEY = "test-secret-key-for-jwt-signing"
@@ -129,7 +129,7 @@ class TestCreateGroupIdempotent:
     async def test_reuses_existing_group_with_same_name(self, owui_client: OpenWebuiClient) -> None:
         existing = _scim_group("aihub:T:R", "grp-existing")
         scim = AsyncMock()
-        scim.query.return_value = SimpleNamespace(resources=[existing])
+        scim.query.return_value = SimpleNamespace(resources=[existing], total_results=1)
 
         result = await owui_client.create_group("aihub:T:R", scim=scim)
 
@@ -140,10 +140,42 @@ class TestCreateGroupIdempotent:
     async def test_creates_when_no_group_with_that_name_exists(self, owui_client: OpenWebuiClient) -> None:
         created = _scim_group("aihub:T:R", "grp-new")
         scim = AsyncMock()
-        scim.query.return_value = SimpleNamespace(resources=[_scim_group("aihub:Other:Role", "grp-other")])
+        scim.query.return_value = SimpleNamespace(
+            resources=[_scim_group("aihub:Other:Role", "grp-other")], total_results=1
+        )
         scim.create.return_value = created
 
         result = await owui_client.create_group("aihub:T:R", scim=scim)
 
         assert result is created
         scim.create.assert_awaited_once()
+
+
+class TestScimPagination:
+    @pytest.mark.asyncio
+    async def test_list_users_follows_all_pages(self, owui_client: OpenWebuiClient) -> None:
+        total = SCIM_PAGE_SIZE + 25  # spans two pages
+        page1 = [User(user_name=f"u{i}@x") for i in range(SCIM_PAGE_SIZE)]
+        page2 = [User(user_name=f"u{i}@x") for i in range(SCIM_PAGE_SIZE, total)]
+        scim = AsyncMock()
+
+        async def fake_query(model: type, search_request=None, **kwargs):  # noqa: ANN001
+            resources = page1 if search_request.start_index == 1 else page2
+            return SimpleNamespace(resources=resources, total_results=total)
+
+        scim.query.side_effect = fake_query
+
+        result = await owui_client.list_users(scim=scim)
+
+        assert len(result) == total
+        assert scim.query.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_list_groups_stops_on_short_page(self, owui_client: OpenWebuiClient) -> None:
+        scim = AsyncMock()
+        scim.query.return_value = SimpleNamespace(resources=[_scim_group("aihub:T:R", "g1")], total_results=1)
+
+        result = await owui_client.list_groups(scim=scim)
+
+        assert len(result) == 1
+        assert scim.query.await_count == 1


### PR DESCRIPTION
## Problem

`OpenWebuiClient.list_users()` and `list_groups()` (and the dedup scan inside `create_group()`) call `scim.query(model)` exactly once and return only `response.resources` — i.e. **only the first SCIM page**. OpenWebUI's SCIM endpoint defaults to a small page size (20), so on any directory larger than one page the rest of the users/groups are silently dropped.

This breaks the OpenWebUI group-membership sync (`OpenWebuiProvisioner._sync_group_memberships`):
- `_build_user_id_mapping` is built from `list_users()` → only the first ~20 users are mapped from Keycloak → OpenWebUI.
- Users outside that first page never get added to their `aihub:<tenant>:<role>` group.
- `update_group_members()` does a full SCIM **replace**, so those users are actively removed from the groups — and since agent workspace-model access is granted per group, **they lose access to all agents**.

### Repro
On a deployment with > (SCIM page size) OpenWebUI users, run the OpenWebUI provisioner. Only the first page of users land in the `aihub:*` groups; everyone else ends up in zero groups and sees no agents. Confirmed live: `list_users()` returned 20 of 43 users.

## Fix

Add `OpenWebuiClient._query_all()`, which follows SCIM pagination (`SearchRequest(start_index, count)`) until all `totalResults` are retrieved, and route `list_users`, `list_groups`, and `create_group`'s dedup scan through it. `SCIM_PAGE_SIZE = 100`.

`create_group` is included because its "does a group with this name already exist?" scan had the same first-page-only blind spot, which could create duplicate same-named groups once group count exceeds a page.

## Tests
- New `TestScimPagination`: `list_users` follows multiple pages (2 SCIM calls, all resources returned); `list_groups` stops on a short page (1 call).
- Updated the existing `create_group` idempotency tests for the paginated path.
- `ruff` clean; all client unit tests pass.