### PR TITLE
fix(swiss-ai-hub): Restore evaluation dataset loading and drop stray dataset 404

### DIFF
--- a/packages/core/swiss_ai_hub/core/infrastructure/langfuse/langfuse_settings.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/langfuse/langfuse_settings.py
@@ -29,7 +29,7 @@ class LangfuseSettings(EnvironmentSettings):
         return Langfuse(
             public_key=self.PUBLIC_KEY,
             secret_key=self.SECRET_KEY.get_secret_value(),
-            host=self.BASE_URL,
+            base_url=self.BASE_URL,
             timeout=self.TIMEOUT,
             tracing_enabled=False,
         )

--- a/packages/web/composables/evaluation/useDataset.ts
+++ b/packages/web/composables/evaluation/useDataset.ts
@@ -10,11 +10,14 @@ export const useDataset = defineQuery(() => {
     staleTime: minutesToMilliseconds(5),
     enabled: useTenantReady('dataset_id'),
     query: async () => {
+      const datasetId = route.params.dataset_id as string | undefined
+      if (!datasetId) return
+
       return await getDataset({
         composable: '$fetch',
         path: {
           tenant_id: tenantId.value!,
-          dataset_id: route.params.dataset_id as string,
+          dataset_id: datasetId,
         },
       })
     },


### PR DESCRIPTION
closes https://github.com/bbvch-ai/aihub-core-test/issues/25

## Summary

Fixes two issues behind the dataset id not found error:

1. **Datasets not loading at all** — the Langfuse client was configured with the
   deprecated `host=` argument instead of `base_url=`. This was preventing me 
  from procceeding in order to reproduce the issue in local deployment. It could also be the reason why we could never     fetch the langfuse data at all.
2. **Stray `GET /datasets/{dataset_id}` 404** — `useDataset` could fire with an
   undefined route id during navigation.

## Result


https://github.com/user-attachments/assets/ff0f9a67-c23a-4f53-9ed1-bad987204e19



## Root cause

**1. Langfuse URL precedence (`tracing`)**
The Langfuse SDK resolves its server URL in a fixed order:

`base_url` arg → `LANGFUSE_BASE_URL` env → `host` arg → `LANGFUSE_HOST` env → cloud default

We passed the URL via `host` (3rd), which sits *below* the `LANGFUSE_BASE_URL`
env var (2nd). Wherever that env var diverged from the settings value (e.g. a
quote-wrapped `.env` value leaking into `os.environ`, which the SDK reads raw),
it shadowed our correct value and the client hit the wrong server → empty
datasets. Containerized deployments (nightly/latest) set a clean
`LANGFUSE_BASE_URL`, so they were never affected — masking the bug.
Moving to `base_url` (1st) makes our value win regardless of environment.

**2. Route-reactive query firing early (`ui`)**
`useDataset` is a global `defineQuery` singleton whose key reacts to the route.
On the flat `/datasets/:id` route it could evaluate before `dataset_id` binds,
calling `getDataset` with `undefined` → `/datasets/%7Bdataset_id%7D` → 404.
The query now bails when the route param is absent.

## Changes
- `fix(tracing)`: pass Langfuse server URL via `base_url` instead of `host`
- `fix(ui)`: skip the dataset query while `dataset_id` is unresolved

## Testing
- Enter a dataset: single `GET`, no `%7Bdataset_id%7D` 404.
- Datasets list and detail load against the configured Langfuse instance.