### PR TITLE
chore(swiss-ai-hub): Temporarily disable meta-question, title, and follow-up steps

### DIFF
--- a/packages/agent/swiss_ai_hub/agent/agents/expert_rag_agent/expert_rag_agent.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/expert_rag_agent/expert_rag_agent.py
@@ -54,11 +54,6 @@ from swiss_ai_hub.agent.agents.rag_agent.events.limit_chat_history_with_context_
 )
 from swiss_ai_hub.agent.agents.rag_agent.events.user_requests_expert_event import UserRequestsExpertEvent
 from swiss_ai_hub.agent.context.run.run_context import RunContext
-from swiss_ai_hub.agent.context.thread.thread_context import ThreadContext
-from swiss_ai_hub.agent.conversation_metadata.conversation_metadata_step_functions import (
-    do_generate_follow_up_questions,
-    do_generate_title,
-)
 from swiss_ai_hub.agent.i18n.agent_locale_string import AgentLocaleString
 from swiss_ai_hub.agent.rag.preconditions import (
     check_context_ready_for_history_limit_with_expert,
@@ -238,6 +233,12 @@ class ExpertRAGAgent(Agent):
         t: LocaleHandler,
     ) -> MetaQuestionDetectedEvent | NotAMetaQuestionEvent:
         """Gate every chat message: classify it as a meta question or release the normal pipeline."""
+        # TEMP: meta-question detection disabled pending investigation. The if/else below always routes
+        # to the normal pipeline (still emits the NotAMetaQuestionEvent gate token, so downstream
+        # gating/preconditions are unaffected). Flip META_QUESTION_DETECTION_ENABLED to re-enable.
+        META_QUESTION_DETECTION_ENABLED = False
+        if not META_QUESTION_DETECTION_ENABLED:
+            return NotAMetaQuestionEvent(reasoning="meta-question detection temporarily disabled")
         return await do_detect_meta_question(
             user_query=event.user_query,
             llm_config=agent_config.llm,
@@ -722,49 +723,52 @@ class ExpertRAGAgent(Agent):
             as_stop_step=False,
         )
 
-    @step(
-        name=AgentLocaleString.from_i18n_path("agent.conversation_metadata.steps.title.name"),
-        description=AgentLocaleString.from_i18n_path("agent.conversation_metadata.steps.title.description"),
-        icon="mdi:format-title",
-        stop_on_error=False,
-    )
-    async def generate_conversation_title_step(
-        self,
-        llm_event: LLMEvent,
-        agent_config: ExpertRAGAgentConfig,
-        thread_context: ThreadContext,
-        displayer: EventDisplayer,
-        t: LocaleHandler,
-    ) -> None:
-        """Generate a stable conversation title once per thread (deferred until a topic is identifiable)."""
-        await do_generate_title(
-            chat_messages=llm_event.chat_messages,
-            llm_config=agent_config.llm,
-            displayer=displayer,
-            t=t,
-            thread_context=thread_context,
-        )
+    # TEMP: conversation title + follow-up question steps disabled pending investigation. They are
+    # fire-and-forget (stop_on_error=False) with no downstream consumers, so commenting them out only
+    # drops the title/follow-up display events. Re-enable by uncommenting both @step methods below.
+    # @step(
+    #     name=AgentLocaleString.from_i18n_path("agent.conversation_metadata.steps.title.name"),
+    #     description=AgentLocaleString.from_i18n_path("agent.conversation_metadata.steps.title.description"),
+    #     icon="mdi:format-title",
+    #     stop_on_error=False,
+    # )
+    # async def generate_conversation_title_step(
+    #     self,
+    #     llm_event: LLMEvent,
+    #     agent_config: ExpertRAGAgentConfig,
+    #     thread_context: ThreadContext,
+    #     displayer: EventDisplayer,
+    #     t: LocaleHandler,
+    # ) -> None:
+    #     """Generate a stable conversation title once per thread (deferred until a topic is identifiable)."""
+    #     await do_generate_title(
+    #         chat_messages=llm_event.chat_messages,
+    #         llm_config=agent_config.llm,
+    #         displayer=displayer,
+    #         t=t,
+    #         thread_context=thread_context,
+    #     )
 
-    @step(
-        name=AgentLocaleString.from_i18n_path("agent.conversation_metadata.steps.follow_ups.name"),
-        description=AgentLocaleString.from_i18n_path("agent.conversation_metadata.steps.follow_ups.description"),
-        icon="mdi:comment-question-outline",
-        stop_on_error=False,
-    )
-    async def generate_follow_up_questions_step(
-        self,
-        llm_event: LLMEvent,
-        agent_config: ExpertRAGAgentConfig,
-        displayer: EventDisplayer,
-        t: LocaleHandler,
-    ) -> None:
-        """Suggest follow-up questions for the latest answer."""
-        await do_generate_follow_up_questions(
-            chat_messages=llm_event.chat_messages,
-            llm_config=agent_config.llm,
-            displayer=displayer,
-            t=t,
-        )
+    # @step(
+    #     name=AgentLocaleString.from_i18n_path("agent.conversation_metadata.steps.follow_ups.name"),
+    #     description=AgentLocaleString.from_i18n_path("agent.conversation_metadata.steps.follow_ups.description"),
+    #     icon="mdi:comment-question-outline",
+    #     stop_on_error=False,
+    # )
+    # async def generate_follow_up_questions_step(
+    #     self,
+    #     llm_event: LLMEvent,
+    #     agent_config: ExpertRAGAgentConfig,
+    #     displayer: EventDisplayer,
+    #     t: LocaleHandler,
+    # ) -> None:
+    #     """Suggest follow-up questions for the latest answer."""
+    #     await do_generate_follow_up_questions(
+    #         chat_messages=llm_event.chat_messages,
+    #         llm_config=agent_config.llm,
+    #         displayer=displayer,
+    #         t=t,
+    #     )
 
     @step(
         name=AgentLocaleString.from_i18n_path("agent.rag_agent.steps.store_user_memory.name"),

--- a/packages/agent/swiss_ai_hub/agent/agents/few_shot_agent/few_shot_agent.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/few_shot_agent/few_shot_agent.py
@@ -72,6 +72,12 @@ class FewShotAgent(Agent):
         t: LocaleHandler,
     ) -> MetaQuestionDetectedEvent | NotAMetaQuestionEvent:
         """Gate every chat message: classify it as a meta question or release the normal pipeline."""
+        # TEMP: meta-question detection disabled pending investigation. The if/else below always routes
+        # to the normal pipeline (still emits the NotAMetaQuestionEvent gate token, so downstream
+        # gating/preconditions are unaffected). Flip META_QUESTION_DETECTION_ENABLED to re-enable.
+        META_QUESTION_DETECTION_ENABLED = False
+        if not META_QUESTION_DETECTION_ENABLED:
+            return NotAMetaQuestionEvent(reasoning="meta-question detection temporarily disabled")
         return await do_detect_meta_question(
             user_query=event.user_query,
             llm_config=agent_config.llm,

--- a/packages/agent/swiss_ai_hub/agent/agents/llm_wrapping_agent/llm_wrapping_agent.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/llm_wrapping_agent/llm_wrapping_agent.py
@@ -49,6 +49,12 @@ class LLMWrappingAgent(Agent):
         t: LocaleHandler,
     ) -> MetaQuestionDetectedEvent | NotAMetaQuestionEvent:
         """Gate every chat message: classify it as a meta question or release the normal pipeline."""
+        # TEMP: meta-question detection disabled pending investigation. The if/else below always routes
+        # to the normal pipeline (still emits the NotAMetaQuestionEvent gate token, so downstream
+        # gating/preconditions are unaffected). Flip META_QUESTION_DETECTION_ENABLED to re-enable.
+        META_QUESTION_DETECTION_ENABLED = False
+        if not META_QUESTION_DETECTION_ENABLED:
+            return NotAMetaQuestionEvent(reasoning="meta-question detection temporarily disabled")
         return await do_detect_meta_question(
             user_query=event.user_query,
             llm_config=agent_config.llm,

--- a/packages/agent/swiss_ai_hub/agent/agents/mcp_react_agent/mcp_react_agent.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/mcp_react_agent/mcp_react_agent.py
@@ -80,6 +80,12 @@ class McpReactAgent(Agent):
         t: LocaleHandler,
     ) -> MetaQuestionDetectedEvent | NotAMetaQuestionEvent:
         """Gate every chat message: classify it as a meta question or release the normal pipeline."""
+        # TEMP: meta-question detection disabled pending investigation. The if/else below always routes
+        # to the normal pipeline (still emits the NotAMetaQuestionEvent gate token, so downstream
+        # gating/preconditions are unaffected). Flip META_QUESTION_DETECTION_ENABLED to re-enable.
+        META_QUESTION_DETECTION_ENABLED = False
+        if not META_QUESTION_DETECTION_ENABLED:
+            return NotAMetaQuestionEvent(reasoning="meta-question detection temporarily disabled")
         return await do_detect_meta_question(
             user_query=event.user_query,
             llm_config=agent_config.llm,

--- a/packages/agent/swiss_ai_hub/agent/agents/namespace_selection_agent/namespace_selection_agent.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/namespace_selection_agent/namespace_selection_agent.py
@@ -146,6 +146,12 @@ class NamespaceSelectionAgent(Agent):
         t: LocaleHandler,
     ) -> MetaQuestionDetectedEvent | NotAMetaQuestionEvent:
         """Gate every chat message: classify it as a meta question or release the normal pipeline."""
+        # TEMP: meta-question detection disabled pending investigation. The if/else below always routes
+        # to the normal pipeline (still emits the NotAMetaQuestionEvent gate token, so downstream
+        # gating/preconditions are unaffected). Flip META_QUESTION_DETECTION_ENABLED to re-enable.
+        META_QUESTION_DETECTION_ENABLED = False
+        if not META_QUESTION_DETECTION_ENABLED:
+            return NotAMetaQuestionEvent(reasoning="meta-question detection temporarily disabled")
         return await do_detect_meta_question(
             user_query=event.user_query,
             llm_config=agent_config.llm,

--- a/packages/agent/swiss_ai_hub/agent/agents/rag_agent/rag_agent.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/rag_agent/rag_agent.py
@@ -45,10 +45,6 @@ from swiss_ai_hub.agent.agents.rag_agent.events.limit_chat_history_with_context_
 )
 from swiss_ai_hub.agent.context.run.run_context import RunContext
 from swiss_ai_hub.agent.context.thread.thread_context import ThreadContext
-from swiss_ai_hub.agent.conversation_metadata.conversation_metadata_step_functions import (
-    do_generate_follow_up_questions,
-    do_generate_title,
-)
 from swiss_ai_hub.agent.i18n.agent_locale_string import AgentLocaleString
 from swiss_ai_hub.agent.rag.preconditions import (
     check_context_ready_for_history_limit,
@@ -211,6 +207,12 @@ class RAGAgent(Agent):
         t: LocaleHandler,
     ) -> MetaQuestionDetectedEvent | NotAMetaQuestionEvent:
         """Gate every chat message: classify it as a meta question or release the normal pipeline."""
+        # TEMP: meta-question detection disabled pending investigation. The if/else below always routes
+        # to the normal pipeline (still emits the NotAMetaQuestionEvent gate token, so downstream
+        # gating/preconditions are unaffected). Flip META_QUESTION_DETECTION_ENABLED to re-enable.
+        META_QUESTION_DETECTION_ENABLED = False
+        if not META_QUESTION_DETECTION_ENABLED:
+            return NotAMetaQuestionEvent(reasoning="meta-question detection temporarily disabled")
         return await do_detect_meta_question(
             user_query=event.user_query,
             llm_config=agent_config.llm,
@@ -554,49 +556,52 @@ class RAGAgent(Agent):
             as_stop_step=False,
         )
 
-    @step(
-        name=AgentLocaleString.from_i18n_path("agent.conversation_metadata.steps.title.name"),
-        description=AgentLocaleString.from_i18n_path("agent.conversation_metadata.steps.title.description"),
-        icon="mdi:format-title",
-        stop_on_error=False,
-    )
-    async def generate_conversation_title_step(
-        self,
-        llm_event: LLMEvent,
-        agent_config: RAGAgentConfig,
-        thread_context: ThreadContext,
-        displayer: EventDisplayer,
-        t: LocaleHandler,
-    ) -> None:
-        """Generate a stable conversation title once per thread (deferred until a topic is identifiable)."""
-        await do_generate_title(
-            chat_messages=llm_event.chat_messages,
-            llm_config=agent_config.llm,
-            displayer=displayer,
-            t=t,
-            thread_context=thread_context,
-        )
+    # TEMP: conversation title + follow-up question steps disabled pending investigation. They are
+    # fire-and-forget (stop_on_error=False) with no downstream consumers, so commenting them out only
+    # drops the title/follow-up display events. Re-enable by uncommenting both @step methods below.
+    # @step(
+    #     name=AgentLocaleString.from_i18n_path("agent.conversation_metadata.steps.title.name"),
+    #     description=AgentLocaleString.from_i18n_path("agent.conversation_metadata.steps.title.description"),
+    #     icon="mdi:format-title",
+    #     stop_on_error=False,
+    # )
+    # async def generate_conversation_title_step(
+    #     self,
+    #     llm_event: LLMEvent,
+    #     agent_config: RAGAgentConfig,
+    #     thread_context: ThreadContext,
+    #     displayer: EventDisplayer,
+    #     t: LocaleHandler,
+    # ) -> None:
+    #     """Generate a stable conversation title once per thread (deferred until a topic is identifiable)."""
+    #     await do_generate_title(
+    #         chat_messages=llm_event.chat_messages,
+    #         llm_config=agent_config.llm,
+    #         displayer=displayer,
+    #         t=t,
+    #         thread_context=thread_context,
+    #     )
 
-    @step(
-        name=AgentLocaleString.from_i18n_path("agent.conversation_metadata.steps.follow_ups.name"),
-        description=AgentLocaleString.from_i18n_path("agent.conversation_metadata.steps.follow_ups.description"),
-        icon="mdi:comment-question-outline",
-        stop_on_error=False,
-    )
-    async def generate_follow_up_questions_step(
-        self,
-        llm_event: LLMEvent,
-        agent_config: RAGAgentConfig,
-        displayer: EventDisplayer,
-        t: LocaleHandler,
-    ) -> None:
-        """Suggest follow-up questions for the latest answer."""
-        await do_generate_follow_up_questions(
-            chat_messages=llm_event.chat_messages,
-            llm_config=agent_config.llm,
-            displayer=displayer,
-            t=t,
-        )
+    # @step(
+    #     name=AgentLocaleString.from_i18n_path("agent.conversation_metadata.steps.follow_ups.name"),
+    #     description=AgentLocaleString.from_i18n_path("agent.conversation_metadata.steps.follow_ups.description"),
+    #     icon="mdi:comment-question-outline",
+    #     stop_on_error=False,
+    # )
+    # async def generate_follow_up_questions_step(
+    #     self,
+    #     llm_event: LLMEvent,
+    #     agent_config: RAGAgentConfig,
+    #     displayer: EventDisplayer,
+    #     t: LocaleHandler,
+    # ) -> None:
+    #     """Suggest follow-up questions for the latest answer."""
+    #     await do_generate_follow_up_questions(
+    #         chat_messages=llm_event.chat_messages,
+    #         llm_config=agent_config.llm,
+    #         displayer=displayer,
+    #         t=t,
+    #     )
 
     @step(
         name=AgentLocaleString.from_i18n_path("agent.rag_agent.steps.store_user_memory.name"),

--- a/packages/agent/swiss_ai_hub/agent/agents/rag_agent/tests/features/rag_agent.feature
+++ b/packages/agent/swiss_ai_hub/agent/agents/rag_agent/tests/features/rag_agent.feature
@@ -52,11 +52,13 @@ Feature: RAG Agent
     * a StopEvent is present
     * a RAGSuccessStopEvent is present
 
-  Scenario: Test RAGAgent answers a meta question about itself without retrieval
-    Given a RAGAgent runner with a valid self hosted configuration
-    When the start event is sent with a user query "What can you do?"
-    Then a MetaQuestionDetectedEvent is present
-    * an LLMEvent is present with a generated response
-    * a StopEvent is present
-    * no RetrieverEvent is present
+# TEMP: meta-question detection disabled pending investigation — agent always routes to the normal
+# pipeline, so this scenario cannot hold. Re-enable alongside detect_meta_question_step.
+#  Scenario: Test RAGAgent answers a meta question about itself without retrieval
+#    Given a RAGAgent runner with a valid self hosted configuration
+#    When the start event is sent with a user query "What can you do?"
+#    Then a MetaQuestionDetectedEvent is present
+#    * an LLMEvent is present with a generated response
+#    * a StopEvent is present
+#    * no RetrieverEvent is present
 

--- a/packages/agent/swiss_ai_hub/agent/self_awareness/tests/test_rag_agent_meta_routing.py
+++ b/packages/agent/swiss_ai_hub/agent/self_awareness/tests/test_rag_agent_meta_routing.py
@@ -55,6 +55,7 @@ def _user_message(text: str) -> UserMessageEvent:
     )
 
 
+@pytest.mark.skip(reason="TEMP: meta-question detection disabled — agent always routes to the normal pipeline")
 @async_test
 async def test_meta_question_answers_without_retrieval(monkeypatch):
     async def fake_detect(*, user_query, **_):


### PR DESCRIPTION
## Summary

Temporary fix pending investigation: disables the meta-question, conversation-title, and follow-up-question steps across the self-aware agents while keeping the workflows fully functional.

### Meta-question (all 6 self-aware agents)
`detect_meta_question_step` in RAGAgent, ExpertRAGAgent, FewShotAgent, LLMWrappingAgent, McpReactAgent, and NamespaceSelectionAgent now short-circuits behind an `if/else` toggle:

```python
META_QUESTION_DETECTION_ENABLED = False
if not META_QUESTION_DETECTION_ENABLED:
    return NotAMetaQuestionEvent(reasoning="meta-question detection temporarily disabled")
return await do_detect_meta_question(...)  # original path preserved
```

The step still emits the `NotAMetaQuestionEvent` gate token, so all downstream gating/preconditions are untouched and every message routes straight into the normal pipeline — no deadlocks. Both meta `@step` methods stay defined, so the self-awareness wiring contract still passes.

### Title + Follow-up (RAGAgent + ExpertRAGAgent)
The `generate_conversation_title_step` and `generate_follow_up_questions_step` `@step` methods are commented out (fire-and-forget, no downstream consumers — only their display events stop). Now-unused imports removed.

### Tests
- Commented out the "answers a meta question" scenario in `rag_agent.feature`.
- Skipped `test_meta_question_answers_without_retrieval` (force-routes the meta branch, impossible now).
- The detector's own unit tests are untouched and still pass.

## How to re-enable
- Meta-question: flip `META_QUESTION_DETECTION_ENABLED` back to `True` in each detect step.
- Title/Follow-up: uncomment both `@step` methods and re-add their imports (`do_generate_title`, `do_generate_follow_up_questions`, and ExpertRAG's `ThreadContext`).

## Validation
- `ruff format --check` + `ruff check` on all touched files: clean.
- Deterministic affected tests: 68 passed, 4 skipped (self-awareness + namespace/few-shot agents).
- Infra-dependent BDD tests (RAG/ExpertRAG/McpReact) require the dev stack and were not run.

## Note
`McpReactAgent` generates title/follow-up **inline** in its terminal step (not as `@step` methods), so it is untouched by this change.
