### PR TITLE
fix(swiss-ai-hub): Pin agent_id to instance key on update to fix SSE hang

### DIFF
--- a/packages/api/playground/testing/tests/agent/test_agent_service_unit_tests.py
+++ b/packages/api/playground/testing/tests/agent/test_agent_service_unit_tests.py
@@ -515,3 +515,42 @@ class TestDeleteAgentInstanceCleanup:
         assert exc_info.value.status_code == 404
         mock_revoke.assert_not_called()
         mock_delete_role.assert_not_called()
+
+
+class TestUpdateAgentInstanceLocksAgentId:
+    """update_agent_instance keeps config_data['agent_id'] pinned to the immutable instance key."""
+
+    @staticmethod
+    def _mock_update_dependencies(stack: ExitStack, config_entity: Mock) -> None:
+        class_entity = Mock()
+        class_entity.agent_config_specs.agent_class = "TestAgent"
+        class_entity.agent_config_specs.agent_config_schema = {}
+        class_entity.form = []
+        stack.enter_context(patch(f"{_MODULE}.AgentClassEntity.get_by_agent_class", return_value=class_entity))
+        stack.enter_context(patch(f"{_MODULE}.AccessChecker"))
+        stack.enter_context(patch(f"{_MODULE}.ModelCreationService"))
+        stack.enter_context(patch(f"{_MODULE}.ConfigAuthorizationService"))
+        helper = stack.enter_context(patch(f"{_MODULE}.InstanceConfigHelper"))
+        helper.normalize_form_configuration.side_effect = lambda configuration: configuration
+        helper.apply_metadata_to_entity.side_effect = lambda _config_instance, entity: entity
+        config_doc = stack.enter_context(patch(f"{_MODULE}.AgentConfigEntityDocument"))
+        config_doc.find_for_class_and_id.return_value = config_entity
+
+    @pytest.mark.asyncio
+    async def test_form_cannot_change_agent_id(self):
+        """A diverging agent_id in the submitted form must be overwritten with the URL key before saving."""
+        config_entity = Mock()
+
+        with ExitStack() as stack:
+            self._mock_update_dependencies(stack, config_entity)
+            result = await AgentService.update_agent_instance(
+                "TestAgent",
+                "intructed_agent_02",
+                {"agent_id": "instructed_agent_02", "system_prompt": "hi"},
+                Mock(spec=LocaleHandler),
+                user=Mock(),
+            )
+
+        assert config_entity.config_data["agent_id"] == "intructed_agent_02"
+        assert result["agent_id"] == "intructed_agent_02"
+        config_entity.save.assert_called_once()

--- a/packages/api/swiss_ai_hub/api/routes/agent/agent_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/agent/agent_service.py
@@ -377,10 +377,9 @@ class AgentService:
 
         config_entity = InstanceConfigHelper.apply_metadata_to_entity(config_instance, config_entity)
 
-        # agent_id is the immutable instance key. An edited form value must never diverge from it:
-        # the running agent builds its NATS topic from config_data["agent_id"], while the API and
-        # OpenWebUI address the instance by the entity key — a mismatch silently breaks the SSE stop
-        # signal (is_primary_agent), leaving the chat spinning forever with no title/follow-up.
+        # Pin agent_id to the immutable instance key: the agent publishes under config_data["agent_id"]
+        # while the SSE handler addresses it by the entity key, and a mismatch silently fails the
+        # is_primary_agent stop check (stream never closes -> no title/follow-up). Mirrors create.
         configuration["agent_id"] = agent_id
         config_entity.config_data = configuration
         config_entity.save()

--- a/packages/api/swiss_ai_hub/api/routes/agent/agent_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/agent/agent_service.py
@@ -377,6 +377,11 @@ class AgentService:
 
         config_entity = InstanceConfigHelper.apply_metadata_to_entity(config_instance, config_entity)
 
+        # agent_id is the immutable instance key. An edited form value must never diverge from it:
+        # the running agent builds its NATS topic from config_data["agent_id"], while the API and
+        # OpenWebUI address the instance by the entity key — a mismatch silently breaks the SSE stop
+        # signal (is_primary_agent), leaving the chat spinning forever with no title/follow-up.
+        configuration["agent_id"] = agent_id
         config_entity.config_data = configuration
         config_entity.save()
 

--- a/packages/web/pages/[tenant]/service/agents/[agent_class]-[agent_id]/configuration.vue
+++ b/packages/web/pages/[tenant]/service/agents/[agent_class]-[agent_id]/configuration.vue
@@ -34,6 +34,8 @@
 </template>
 
 <script setup lang="ts">
+import type { FormkitElement } from '@core/sdk/client'
+
 const route = useRoute()
 const { tenantId } = useTenant()
 const { agentInstance, agentInstanceIsLoading } = useAgentInstance()
@@ -41,7 +43,14 @@ const { updateAgentInstance } = useUpdateAgentInstance()
 const { t } = useI18n()
 const toast = useToast()
 
-const configForm = computed(() => agentInstance.value?.agent_config?.form || [])
+// agent_id is the immutable instance key. Lock it on the edit form so a changed value can't
+// desync config_data["agent_id"] from the key — a mismatch silently breaks the SSE stop signal
+// and the chat never finishes (the backend also pins it on save; see update_agent_instance).
+const configForm = computed<FormkitElement[]>(() =>
+  (agentInstance.value?.agent_config?.form || []).map(element =>
+    (element.name === 'agent_id' ? { ...element, disabled: true } : element) as FormkitElement,
+  ),
+)
 
 // Pass the saved configuration through unchanged. DynamicConfiguration hydrates it
 // (seedNullableToggles then seedFormDefaults): non-nullable groups are materialised to

--- a/packages/web/pages/[tenant]/service/agents/[agent_class]-[agent_id]/configuration.vue
+++ b/packages/web/pages/[tenant]/service/agents/[agent_class]-[agent_id]/configuration.vue
@@ -43,9 +43,8 @@ const { updateAgentInstance } = useUpdateAgentInstance()
 const { t } = useI18n()
 const toast = useToast()
 
-// agent_id is the immutable instance key. Lock it on the edit form so a changed value can't
-// desync config_data["agent_id"] from the key — a mismatch silently breaks the SSE stop signal
-// and the chat never finishes (the backend also pins it on save; see update_agent_instance).
+// Lock agent_id on edit: it is the immutable instance key, and a divergent value silently breaks
+// the SSE completion check so the chat never finishes. The backend pins it on save too; this is UX.
 const configForm = computed<FormkitElement[]>(() =>
   (agentInstance.value?.agent_config?.form || []).map(element =>
     (element.name === 'agent_id' ? { ...element, disabled: true } : element) as FormkitElement,


### PR DESCRIPTION
## Problem

In OpenWebUI, chatting with certain agent instances rendered the full response but the spinner never stopped — and OpenWebUI's title + follow-up generation (which only fires **after** the stream completes) never ran. The agent itself completed successfully (confirmed via Langfuse trace and the thread overview).

## Root cause

`agent_id` lives in two places for an instance:
1. the **entity key** (`AgentConfigEntityDocument.agent_id`, unique index) — what the API SSE endpoint and OpenWebUI address the instance by;
2. the **`agent_id` field inside the config blob** (`config_data["agent_id"]`) — what the running agent uses to build its NATS topic.

`create_agent_instance` forces them equal (`full_config_data["agent_id"] = request.agent_id`). **`update_agent_instance` did not** — it stored the submitted form configuration verbatim (`config_entity.config_data = configuration`). So editing an instance whose form `agent_id` differs from the key (e.g. a 1-char typo `intructed` vs `instructed`) silently desynced the two.

Consequence: the agent publishes its terminal `LLMStopEvent` under the config-blob id, but the SSE completion handler (`AgentService.send_agent_input_event_stream` → `is_primary_agent = topic.agent_id == agent_id`) compares it against the entity key. Mismatch → `is_primary_agent` is `False` → the stop signal is never set → the SSE stream never closes → OpenWebUI spins forever and never generates a title/follow-up. (Chunk events are not gated by `is_primary_agent`, so content still streams — which is why the answer appears but never "finishes".)

## Fix (two layers)

**Backend (authoritative):** `update_agent_instance` now pins `configuration["agent_id"]` to the immutable instance key before saving, mirroring `create_agent_instance`. Any attempt to change the id via the form is ignored — the config blob can no longer diverge from the key, regardless of the client.

**Frontend (UX):** the `agent_id` field is rendered read-only (`disabled`) on the agent **edit** form (`configuration.vue`), so users don't see an editable field that is silently pinned server-side. Creation is unaffected (the field is set once in `CreateModal`).

## Tests / verification

- Added `TestUpdateAgentInstanceLocksAgentId::test_form_cannot_change_agent_id` — asserts a diverging `agent_id` in the submitted form is overwritten with the URL key before save. Full `test_agent_service_unit_tests.py` passes (24).
- Frontend `pnpm build` passes (no type errors).

## Operational note

Existing mismatched instances must be repaired in data (edit the instance config so the `agent_id` field matches the instance key, or recreate it). This PR prevents new divergence; it does not retroactively fix already-desynced instances.