### PR TITLE
fix(swiss-ai-hub): Translate org-memory namespace allow-list into valid Milvus in-filter

### DIFF
--- a/packages/core/swiss_ai_hub/core/infrastructure/mem0/mem0_service.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/mem0/mem0_service.py
@@ -3,6 +3,7 @@ from mem0.configs.base import MemoryConfig
 from swiss_ai_hub.core.i18n.locale_handler import LocaleHandler
 from swiss_ai_hub.core.infrastructure.mem0.graph.patched_memory_graph import PatchedMemoryGraph
 from swiss_ai_hub.core.infrastructure.mem0.patched_async_memory import PatchedAsyncMemory
+from swiss_ai_hub.core.infrastructure.mem0.patched_milvus_db import PatchedMilvusDB
 from swiss_ai_hub.core.infrastructure.mem0.patched_open_ai_embedding import PatchedOpenAIEmbedding
 from swiss_ai_hub.core.infrastructure.mem0.patched_open_aillm import PatchedOpenAILLM
 from swiss_ai_hub.core.infrastructure.mem0.types.memory import Memory
@@ -19,6 +20,7 @@ class Mem0Service:
     ):
         self._config = config
         self._memory = PatchedAsyncMemory(config=config)
+        self._memory.vector_store = PatchedMilvusDB.from_milvus(self._memory.vector_store)
         self._memory.llm = PatchedOpenAILLM.from_llm(self._memory.llm)
         self._memory.embedding_model = PatchedOpenAIEmbedding.from_embedding(self._memory.embedding_model)
         self._memory.graph = PatchedMemoryGraph.from_graph(self._memory.graph, t=t)

--- a/packages/core/swiss_ai_hub/core/infrastructure/mem0/patched_milvus_db.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/mem0/patched_milvus_db.py
@@ -1,0 +1,40 @@
+import logging
+from typing import Self, override
+
+from mem0.vector_stores.milvus import MilvusDB
+
+logger = logging.getLogger(__name__)
+
+
+class PatchedMilvusDB(MilvusDB):
+    """
+    Patches mem0's MilvusDB to support advanced operator filters.
+
+    mem0's _create_filter only renders scalar equality. Any non-string value
+    (e.g. the `{"in": [...]}` shape used for namespace allow-lists) is dumped
+    literally into the expression as `metadata["k"] == {'in': [...]}`, which
+    Milvus rejects with a query-plan parse error. This patch translates the
+    `in` operator into a valid Milvus `in [...]` expression.
+    """
+
+    @classmethod
+    def from_milvus(cls, milvus: MilvusDB) -> Self:
+        """Wrap an existing MilvusDB instance, preserving its client and config."""
+        instance = cls.__new__(cls)
+        instance.__dict__.update(milvus.__dict__)
+        return instance
+
+    @override
+    def _create_filter(self, filters: dict) -> str:
+        operands = []
+        for key, value in filters.items():
+            if isinstance(value, dict) and "in" in value:
+                rendered = ", ".join(self._render_scalar(item) for item in value["in"])
+                operands.append(f'(metadata["{key}"] in [{rendered}])')
+            else:
+                operands.append(f'(metadata["{key}"] == {self._render_scalar(value)})')
+        return " and ".join(operands)
+
+    @staticmethod
+    def _render_scalar(value: object) -> str:
+        return f'"{value}"' if isinstance(value, str) else f"{value}"

--- a/packages/core/swiss_ai_hub/core/infrastructure/mem0/patched_milvus_db.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/mem0/patched_milvus_db.py
@@ -1,9 +1,6 @@
-import logging
 from typing import Self, override
 
 from mem0.vector_stores.milvus import MilvusDB
-
-logger = logging.getLogger(__name__)
 
 
 class PatchedMilvusDB(MilvusDB):
@@ -15,6 +12,10 @@ class PatchedMilvusDB(MilvusDB):
     literally into the expression as `metadata["k"] == {'in': [...]}`, which
     Milvus rejects with a query-plan parse error. This patch translates the
     `in` operator into a valid Milvus `in [...]` expression.
+
+    Written against mem0 1.0.11: this @override replaces MilvusDB._create_filter
+    wholesale, so re-diff the upstream method on any mem0 bump — a fix or new
+    operator added there would otherwise be silently lost.
     """
 
     @classmethod
@@ -36,5 +37,6 @@ class PatchedMilvusDB(MilvusDB):
         return " and ".join(operands)
 
     @staticmethod
-    def _render_scalar(value: object) -> str:
-        return f'"{value}"' if isinstance(value, str) else f"{value}"
+    def _render_scalar(value: str) -> str:
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'

--- a/packages/core/swiss_ai_hub/core/infrastructure/mem0/tests/unit/test_patched_milvus_db.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/mem0/tests/unit/test_patched_milvus_db.py
@@ -21,6 +21,14 @@ def test_in_operator_renders_milvus_in_clause():
     assert expression == '(metadata["_tenant_namespace"] in ["bbv vietnam", "QC Community"])'
 
 
+def test_string_values_escape_quotes():
+    assert _filter({"_tenant_namespace": 'say "hi"'}) == '(metadata["_tenant_namespace"] == "say \\"hi\\"")'
+
+
+def test_string_values_escape_backslashes():
+    assert _filter({"_tenant_namespace": "a\\b"}) == '(metadata["_tenant_namespace"] == "a\\\\b")'
+
+
 def test_mixed_filters_join_with_and():
     expression = _filter(
         {

--- a/packages/core/swiss_ai_hub/core/infrastructure/mem0/tests/unit/test_patched_milvus_db.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/mem0/tests/unit/test_patched_milvus_db.py
@@ -1,0 +1,34 @@
+"""Unit tests for PatchedMilvusDB._create_filter.
+
+mem0's MilvusDB renders any non-string filter value literally, so the
+`{"in": [...]}` namespace allow-list becomes `== {'in': [...]}` and Milvus
+rejects the query plan. These tests pin the corrected `in [...]` translation.
+"""
+
+from swiss_ai_hub.core.infrastructure.mem0.patched_milvus_db import PatchedMilvusDB
+
+
+def _filter(filters: dict) -> str:
+    return PatchedMilvusDB._create_filter(PatchedMilvusDB.__new__(PatchedMilvusDB), filters)
+
+
+def test_scalar_string_uses_quoted_equality():
+    assert _filter({"_tenant_id": "ACME"}) == '(metadata["_tenant_id"] == "ACME")'
+
+
+def test_in_operator_renders_milvus_in_clause():
+    expression = _filter({"_tenant_namespace": {"in": ["bbv vietnam", "QC Community"]}})
+    assert expression == '(metadata["_tenant_namespace"] in ["bbv vietnam", "QC Community"])'
+
+
+def test_mixed_filters_join_with_and():
+    expression = _filter(
+        {
+            "_type": "organization_memory",
+            "_tenant_namespace": {"in": ["dept-x", "dept-y"]},
+        }
+    )
+    assert expression == (
+        '(metadata["_type"] == "organization_memory") '
+        'and (metadata["_tenant_namespace"] in ["dept-x", "dept-y"])'
+    )

--- a/packages/core/swiss_ai_hub/core/infrastructure/mem0/tests/unit/test_patched_milvus_db.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/mem0/tests/unit/test_patched_milvus_db.py
@@ -29,6 +29,5 @@ def test_mixed_filters_join_with_and():
         }
     )
     assert expression == (
-        '(metadata["_type"] == "organization_memory") '
-        'and (metadata["_tenant_namespace"] in ["dept-x", "dept-y"])'
+        '(metadata["_type"] == "organization_memory") and (metadata["_tenant_namespace"] in ["dept-x", "dept-y"])'
     )


### PR DESCRIPTION
## Issue

bbvch-ai/aihub-core-private#44 — Agent errors when more than one "Allowed namespaces" is configured.

## Root cause

With a single namespace, `Mem0Service.search` builds a bare string equality filter, which mem0 renders fine. With **multiple** namespaces it builds `{"in": [...]}`, but mem0 1.0.11's `MilvusDB._create_filter` only handles `str` values (`== "x"`). Any non-string value is dumped into the expression literally:

```
(metadata["_tenant_namespace"] == {'in': ['bbv vietnam', 'QC Community']})
```

Milvus rejects this query plan (`mismatched input "in"`), so org-memory retrieval crashes the agent.

## Fix

Follows the existing "patch mem0" pattern in this folder (`PatchedAsyncMemory`, `PatchedMemoryGraph`, `PatchedOpenAIEmbedding`, `PatchedOpenAILLM`):

- **`patched_milvus_db.py`** (new) — `PatchedMilvusDB` overrides `_create_filter` to translate `{"in": [...]}` into a valid Milvus `metadata["k"] in ["a", "b"]` clause, with proper string quoting. `from_milvus()` wraps the existing instance, preserving its client/collection config.
- **`mem0_service.py`** — wires the patch onto `self._memory.vector_store`, alongside the other patches.
- **`test_patched_milvus_db.py`** (new) — covers scalar equality, the `in` translation, and mixed-filter joining.

Single-namespace and no-namespace paths are unchanged; only the multi-namespace case is affected.

## Verification

The exact filter from the issue now renders as:

```
... and (metadata["_tenant_namespace"] in ["bbv vietnam", "QC Community"]) and ...
```

`uv run pytest .../mem0/tests/unit` → **10 passed**.

## Test plan

- [ ] Configure an org-memory agent with 2+ allowed namespaces and confirm retrieval no longer errors
- [ ] Confirm single-namespace agents still work
