### PR TITLE
fix(ci-cd): Make ghcr.io login non-fatal in test_backend action

### DIFF
--- a/.github/actions/CLAUDE.md
+++ b/.github/actions/CLAUDE.md
@@ -67,6 +67,9 @@ cache key. Runs `nuxi prepare` before linting to generate Nuxt type stubs.
 - `swiss_llm_cloud_*`: Swiss LLM Cloud secrets (API, embedding, reranking, whisper, OCR) added to `.env.dev`
 - `regenerate_compose`: runs `make generate-compose` before starting Docker services
 - Health check polling: waits up to 10 minutes for Docker services to become healthy
+- Pre-pull login is **best-effort**: the `docker login ghcr.io` in the pre-pull step must not fail the job
+  (`|| echo "::warning::..."`). The mirrored images under `ghcr.io/bbvch-ai/aihub-core/*` are public, so an
+  expired/absent `PAT_GITHUB_READ_PACKAGES` still lets anonymous pulls succeed. Do NOT make this login fatal again.
 
 **pytest_coverage_comment**: Downloads `{working_directory}-pytest-report` and `{working_directory}-coverage-report`
 artifacts from `test_backend`, posts formatted coverage report as PR comment via

--- a/.github/actions/test_backend/action.yml
+++ b/.github/actions/test_backend/action.yml
@@ -96,7 +96,10 @@ runs:
       if: inputs.docker_compose_services != ''
       shell: bash
       run: |
-        echo "${{ inputs.github_token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        # Login is best-effort: the mirrored images under ghcr.io/bbvch-ai/aihub-core are public,
+        # so an expired/absent token must not fail the job — anonymous pulls still succeed.
+        echo "${{ inputs.github_token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin \
+          || echo "::warning::ghcr.io login failed (token may be expired); continuing with anonymous pulls"
 
         # Pre-pull images in parallel to use cache effectively
         echo "Pre-pulling Docker images for faster startup..."


### PR DESCRIPTION
## Summary

The `Test Modules` jobs (and `main` itself) are currently red. Root cause is **not** any application code — it is the `docker login ghcr.io` step in `.github/actions/test_backend/action.yml`:

```
echo "$TOKEN" | docker login ghcr.io -u $ACTOR --password-stdin
Error response from daemon: Get "https://ghcr.io/v2/": denied: denied
##[error]Process completed with exit code 1.
```

The `PAT_GITHUB_READ_PACKAGES` credential has expired/been revoked, so `docker login` exits non-zero. That line had **no `|| true`**, so it hard-fails the step before any image is pulled. The `docker compose ... pull` line right below already tolerates failure (`|| true`).

Meanwhile the mirrored images under `ghcr.io/bbvch-ai/aihub-core/*` are now **public** — verified by anonymous pull (`nats`, `litellm`, `milvus` all return HTTP 200 with an anonymous token). So the login is no longer required to pull them.

## Change

Make the login **best-effort**: keep authenticating when a valid token is present (to benefit from higher rate limits), but emit a warning and continue when login fails instead of killing the job. Anonymous pulls of the public images succeed regardless.

```bash
echo "$TOKEN" | docker login ghcr.io -u $ACTOR --password-stdin \
  || echo "::warning::ghcr.io login failed (token may be expired); continuing with anonymous pulls"
```

This unblocks CI for **both `main` and all open PRs** without depending on the perishable token.

## Notes

- Renewing `PAT_GITHUB_READ_PACKAGES` (org admin) is an orthogonal, optional follow-up; it is no longer required for these public images.
- Only `packages/pipeline` tests pass today because its matrix has empty `docker_compose_services`, so the login step is skipped (`if: inputs.docker_compose_services != ''`).

## Test plan

- [ ] CI `Test Modules` jobs reach the test phase (no longer fail at the login step)
- [ ] A `::warning::` appears for the login if the token is still invalid, but the job proceeds
