### PR TITLE
fix(ui): Remove duplicate confirmation popup on dataset save

### DIFF
--- a/packages/web/pages/[tenant]/service/datasets/[dataset_id].vue
+++ b/packages/web/pages/[tenant]/service/datasets/[dataset_id].vue
@@ -4,7 +4,6 @@
     close-route="/service/datasets"
     :loading="datasetIsLoading"
   >
-    <ConfirmPopup />
     <div class="flex flex-col gap-3">
       <EvaluationDatasetEdit v-model="editableDataset" />
       <Button


### PR DESCRIPTION
closes https://github.com/bbvch-ai/aihub-core-private/issues/46

## Summary

Saving a dataset showed **two** confirmation popups instead of one. The
dataset detail page (`[dataset_id].vue`) rendered its own `<ConfirmPopup />`
on top of the globally-registered one, so both fired for the same confirm
action.

This removes the redundant page-level `<ConfirmPopup />`, leaving the global
popup to handle the confirmation.

## Result


https://github.com/user-attachments/assets/b7fdcf14-fe62-4598-9b5b-19c33fa0e07e


## Changes

- Remove duplicate `<ConfirmPopup />` from
  `packages/web/pages/[tenant]/service/datasets/[dataset_id].vue`

## Testing

- [x] Add a new question/answer to a dataset and click **Save**
- [x] Verify exactly **one** confirmation popup appears