### PR TITLE
fix(ui): Preserve agent form input across focus refetch (#38)

### DIFF
--- a/packages/web/composables/agent/useAgentClasses.ts
+++ b/packages/web/composables/agent/useAgentClasses.ts
@@ -9,6 +9,9 @@ export const useAgentClasses = defineQuery((options?: { online?: boolean }) => {
   const { data: agentClasses, isPending: agentClassesAreLoading } = useQuery<AgentClassDto[]>({
     key: () => ['tenant', tenantId.value, 'agent-classes', options?.online],
     staleTime: minutesToMilliseconds(5),
+    // A focus refetch replaces the classes array with new object references, which would
+    // reset an in-progress create form (issue #38). Keep the cached value until invalidated.
+    refetchOnWindowFocus: false,
     enabled: useTenantReady(),
     query: async () => {
       return await getAgentClasses({

--- a/packages/web/composables/agent/useAgentInstance.ts
+++ b/packages/web/composables/agent/useAgentInstance.ts
@@ -7,7 +7,7 @@ export const useAgentInstance = defineQuery(() => {
   const { tenantId } = useTenant()
 
   const { data: agentInstance, isPending: agentInstanceIsLoading } = useQuery<FullAgentInstanceDto>({
-    key: () => ['tenant', tenantId.value as string, 'agent-instances', route.params.agent_class as string, route.params.agent_id as string],
+    key: () => ['tenant', tenantId.value, 'agent-instances', route.params.agent_class as string, route.params.agent_id as string],
     staleTime: minutesToMilliseconds(5),
     // A focus refetch after leaving the tab would flip the loading/enabled state and remount
     // the configuration form, discarding unsaved edits (issue #38). Keep the cached value.

--- a/packages/web/composables/agent/useAgentInstance.ts
+++ b/packages/web/composables/agent/useAgentInstance.ts
@@ -7,8 +7,11 @@ export const useAgentInstance = defineQuery(() => {
   const { tenantId } = useTenant()
 
   const { data: agentInstance, isPending: agentInstanceIsLoading } = useQuery<FullAgentInstanceDto>({
-    key: () => ['tenant', tenantId.value, 'agent-instances', route.params.agent_class as string, route.params.agent_id as string],
+    key: () => ['tenant', tenantId.value as string, 'agent-instances', route.params.agent_class as string, route.params.agent_id as string],
     staleTime: minutesToMilliseconds(5),
+    // A focus refetch after leaving the tab would flip the loading/enabled state and remount
+    // the configuration form, discarding unsaved edits (issue #38). Keep the cached value.
+    refetchOnWindowFocus: false,
     enabled: useTenantReady('agent_id', 'agent_class'),
     query: async () => {
       return await getAgentInstance({

--- a/packages/web/composables/form/useCreateInstanceForm.ts
+++ b/packages/web/composables/form/useCreateInstanceForm.ts
@@ -94,9 +94,8 @@ export function useCreateInstanceForm<T extends ClassDataLike>(options: CreateIn
     setNestedValue(formData.value, path, value)
   }
 
-  // Reseed only when the chosen class actually changes. A background refetch of the class
-  // list hands back a new `selectedClassData` reference for the *same* class; reseeding on
-  // that reference churn would wipe everything the user has typed (issue #38).
+  // Reseed only when the chosen class changes; a refetch hands back a new reference for the
+  // same class, and reseeding on that churn would wipe the user's input (issue #38).
   let seededForClass: string | null = null
   watch([selectedClass, selectedClassData], () => {
     if (seededForClass === selectedClass.value) return

--- a/packages/web/composables/form/useCreateInstanceForm.ts
+++ b/packages/web/composables/form/useCreateInstanceForm.ts
@@ -94,22 +94,31 @@ export function useCreateInstanceForm<T extends ClassDataLike>(options: CreateIn
     setNestedValue(formData.value, path, value)
   }
 
-  watch(selectedClassData, (newClass) => {
-    formData.value = newClass?.form && newClass.form.length > 0
+  // Reseed only when the chosen class actually changes. A background refetch of the class
+  // list hands back a new `selectedClassData` reference for the *same* class; reseeding on
+  // that reference churn would wipe everything the user has typed (issue #38).
+  let seededForClass: string | null = null
+  watch([selectedClass, selectedClassData], () => {
+    if (seededForClass === selectedClass.value) return
+    if (!selectedClassData.value) return
+    formData.value = selectedClassData.value.form && selectedClassData.value.form.length > 0
       ? hydrateFormData({}, configForm.value as FormElement[])
       : {}
+    seededForClass = selectedClass.value
   }, { immediate: true })
 
   function applyInitialData(data: Record<string, unknown>) {
     // Hydrate from the template/clone data: nullable toggles follow the data's null-ness,
     // missing leaves fall back to their backend defaults — identical to the edit form.
     formData.value = hydrateFormData(data, configForm.value as FormElement[])
+    seededForClass = selectedClass.value
   }
 
   function resetForm() {
     selectedClass.value = initialClass()
     formData.value = {}
     activeStep.value = 0
+    seededForClass = null
   }
 
   return {

--- a/packages/web/pages/[tenant]/service/agents/[agent_class]-[agent_id]/configuration.vue
+++ b/packages/web/pages/[tenant]/service/agents/[agent_class]-[agent_id]/configuration.vue
@@ -43,13 +43,19 @@ const { updateAgentInstance } = useUpdateAgentInstance()
 const { t } = useI18n()
 const toast = useToast()
 
-// Latch: once the instance has loaded, keep the form mounted. A background refetch (or a
-// transient `enabled` flip while the tenant query revalidates) must not tear the form out
-// of the DOM and re-seed it from server data, which would drop unsaved edits (issue #38).
+// Latch so a background refetch or transient `enabled` flip can't remount the form and
+// re-seed it from server data, dropping unsaved edits (issue #38).
 const hasLoaded = ref(false)
 watch(agentInstance, (value) => {
   if (value) hasLoaded.value = true
 }, { immediate: true })
+
+// Nuxt reuses this instance across param changes; drop the latch on route identity change so
+// the loading state shows until the new agent resolves, instead of the previous form lingering.
+watch(
+  () => `${route.params.agent_class}/${route.params.agent_id}`,
+  () => { hasLoaded.value = false },
+)
 
 // Lock agent_id on edit: it is the immutable instance key, and a divergent value silently breaks
 // the SSE completion check so the chat never finishes. The backend pins it on save too; this is UX.

--- a/packages/web/pages/[tenant]/service/agents/[agent_class]-[agent_id]/configuration.vue
+++ b/packages/web/pages/[tenant]/service/agents/[agent_class]-[agent_id]/configuration.vue
@@ -2,7 +2,7 @@
   <StructuralColumn
     :title="t('agent.configuration.title')"
     close-route="/service/agents"
-    :loading="agentInstanceIsLoading"
+    :loading="agentInstanceIsLoading && !hasLoaded"
     size="normal"
   >
     <div class="flex flex-col gap-3">
@@ -10,7 +10,7 @@
         {{ t('agent.configuration.description') }}
       </p>
       <AgentConfiguration
-        v-if="configForm && configForm.length > 0 && !agentInstanceIsLoading"
+        v-if="hasLoaded && configForm && configForm.length > 0"
         :title="t('agent.configuration.runtimeSettings')"
         :description="agentInstance?.agent_config.description || ''"
         :form="configForm"
@@ -18,7 +18,7 @@
         @submit="submitConfiguration"
       />
       <div
-        v-else-if="agentInstanceIsLoading"
+        v-else-if="!hasLoaded"
         class="text-center text-sm text-surface-500 dark:text-surface-400"
       >
         {{ t('common.loading') }}
@@ -42,6 +42,14 @@ const { agentInstance, agentInstanceIsLoading } = useAgentInstance()
 const { updateAgentInstance } = useUpdateAgentInstance()
 const { t } = useI18n()
 const toast = useToast()
+
+// Latch: once the instance has loaded, keep the form mounted. A background refetch (or a
+// transient `enabled` flip while the tenant query revalidates) must not tear the form out
+// of the DOM and re-seed it from server data, which would drop unsaved edits (issue #38).
+const hasLoaded = ref(false)
+watch(agentInstance, (value) => {
+  if (value) hasLoaded.value = true
+}, { immediate: true })
 
 // Lock agent_id on edit: it is the immutable instance key, and a divergent value silently breaks
 // the SSE completion check so the chat never finishes. The backend pins it on save too; this is UX.


### PR DESCRIPTION
## Problem
When creating or editing an agent, leaving the tab and returning after a while cleared all entered values.

## Root cause
The forms are projections of Pinia Colada queries (`useAgentClasses` / `useAgentInstance`, `staleTime` 5 min). On window refocus, Pinia Colada refetches the stale query and hands back new object references. In the create flow, `useCreateInstanceForm`'s `watch(selectedClassData, …)` fired on that reference churn and reset `formData`. In the edit flow, the transient loading/`enabled` state remounted the configuration form, re-seeding it from server data. Either way, unsaved input was lost.

## Changes
- `useAgentClasses.ts`, `useAgentInstance.ts`: `refetchOnWindowFocus: false` — stop the on-focus refetch that triggers the reset.
- `useCreateInstanceForm.ts`: reseed `formData` only when the selected class key actually changes, not on reference churn from a refetch.
- `configuration.vue`: latch `hasLoaded` so a background refetch/`enabled` flip can't remount and re-seed the edit form.

## Test plan
- Create-agent modal: fill fields, switch tabs, return → input preserved.
- Agent Configuration tab: edit fields, switch tabs, return → input preserved.
- Repro method: temporarily set `staleTime: 0` and switch tabs (see issue thread).