### PR TITLE
fix(swiss-ai-hub): Default LLM temperature form value to 0.0

### DIFF
--- a/packages/agent/app/expert_rag_agent/templates/engineering_expert_rag.py
+++ b/packages/agent/app/expert_rag_agent/templates/engineering_expert_rag.py
@@ -49,7 +49,7 @@ def build() -> ExpertRAGAgentConfig:
         icon="mage:book-open-check",
         llm=LLMConfig(
             model_name="text-generation/gemma-4-31B-it",
-            default_parameter=LLMParameter(temperature=0.1, timeout=120.0),
+            default_parameter=LLMParameter(temperature=0.0, timeout=120.0),
         ),
         number_of_input_tokens=128000,
         context_sufficient_guard=ContextSufficientGuardStepConfig(

--- a/packages/agent/app/rag_agent/templates/shared_knowledge_rag.py
+++ b/packages/agent/app/rag_agent/templates/shared_knowledge_rag.py
@@ -46,7 +46,7 @@ def build() -> RAGAgentConfig:
         icon="mage:book-open",
         llm=LLMConfig(
             model_name="text-generation/gemma-4-31B-it",
-            default_parameter=LLMParameter(temperature=0.1, timeout=120.0),
+            default_parameter=LLMParameter(temperature=0.0, timeout=120.0),
         ),
         number_of_input_tokens=128000,
         context_sufficient_guard=ContextSufficientGuardStepConfig(

--- a/packages/core/swiss_ai_hub/core/generative_ai/resources/models/llm/llm_config.py
+++ b/packages/core/swiss_ai_hub/core/generative_ai/resources/models/llm/llm_config.py
@@ -63,7 +63,7 @@ class LLMParameter(Form):
                 min=0.0,
                 max=2.0,
                 step=0.1,
-                value=0.1,
+                value=0.0,
                 min_fraction_digits=0,
                 max_fraction_digits=1,
             ),


### PR DESCRIPTION
## What

Fixes the remaining part of bbvch-ai/aihub-core-private#17: the agent configuration UI showed a default temperature of **0.1** instead of **0.0** for the Document Intelligence Assistant (RAGAgent) and Company Knowledge Agent (ExpertRAGAgent).

## Root cause — two sources of 0.1

1. **Blueprint form default** — `LLMParameter.as_form()` set the temperature `InputNumber` `value=0.1`, overriding the field's data default of `0.0`. This is the default shown when building a profile from a blank blueprint. (Fixed the same way point 1 was: the retriever config's `as_form()` sets no explicit `value` and relies on the field default.)
2. **Profile template** — both blueprints ship a profile template (`shared_knowledge_rag`, `engineering_expert_rag`) that pre-fills the create form in the web UI via `get_all_templates()` → `applyInitialData`. Both baked in `temperature=0.1`, so the form still showed 0.1 even after fixing (1).

## Changes
- `llm_config.py`: temperature `InputNumber` `value` `0.1` → `0.0`.
- `shared_knowledge_rag.py` / `engineering_expert_rag.py`: template `temperature` `0.1` → `0.0`.

## Verification
- Serialized `LLMConfig.as_form()` → temperature element `value = 0.0`.
- Serialized both `build()` templates → `temperature = 0.0`.
- `packages/agent` RAG + ExpertRAG suites: 27 passed.

## Test plan
- [ ] Open Document Intelligence Assistant / Company Knowledge Agent blueprint and confirm default temperature shows **0.0**.
- [ ] Create a profile from each agent's template and confirm temperature is **0.0**.

Ref: bbvch-ai/aihub-core-private#17