### PR TITLE
fix(swiss-ai-hub): Default LLM temperature to 0.0 across agent types

### DIFF
--- a/packages/core/swiss_ai_hub/core/generative_ai/resources/models/llm/llm_config.py
+++ b/packages/core/swiss_ai_hub/core/generative_ai/resources/models/llm/llm_config.py
@@ -63,7 +63,7 @@ class LLMParameter(Form):
                 min=0.0,
                 max=2.0,
                 step=0.1,
-                value=0.1,
+                value=0.0,
                 min_fraction_digits=0,
                 max_fraction_digits=1,
             ),


### PR DESCRIPTION
## What

Fixes the temperature part of bbvch-ai/aihub-core-private#17: the "Create New Agent" form defaulted temperature to **0.1** instead of **0.0**. The documented default for every agent type that exposes temperature is `0.0`.

## Root cause

`LLMParameter.as_form()` set the temperature `InputNumber` `value=0.1`, overriding the field's `0.0` data default. Every agent type builds its LLM form via `LLMConfig.as_form()`, so this single value drove the create-form default for **all** agent types (Document Intelligence Assistant, Company Knowledge Agent, Document Navigation Assistant, etc.).

## Change

- `llm_config.py`: temperature `InputNumber` `value` `0.1` → `0.0`, matching the field's data default and the docs.

## Verification
- `LLMConfig.as_form()` serializes the temperature element `value = 0.0`.
- Ruff check + format clean.
- Tests: core 71 passed (form / resources / agents); agent 27 passed (RAG + ExpertRAG).
- Docs already document `0.0` for all agent types — code now matches.

> Note: in an existing deployment the stored `agent_classes` form must be refreshed by restarting the agent services (re-runs discovery) for the new `0.0` default to appear in the UI.

## Test plan
- [ ] Create a new Document Intelligence Assistant / Company Knowledge Agent / Document Navigation Assistant and confirm the default temperature shows **0.0**.

Ref: bbvch-ai/aihub-core-private#17