### PR TITLE
fix(ui): Fix select-all/deselect-all in knowledge document list

### DIFF
--- a/packages/web/components/Knowledge/Document/List.vue
+++ b/packages/web/components/Knowledge/Document/List.vue
@@ -24,6 +24,8 @@
     :sort-order="sortOrder"
     removable-sort
     size="small"
+    :select-all="allDeletableSelected"
+    @select-all-change="onSelectAllChange"
     @row-click="handleRowClick"
     @sort="handleSort"
   >
@@ -38,9 +40,7 @@
     >
       <template #body="{ data }">
         <div class="flex items-center gap-2">
-          <p
-            class="font-bold"
-          >
+          <p class="font-bold">
             {{ data.document_title }}
           </p>
           <div
@@ -91,9 +91,7 @@
       :header="t('document.list.number_of_pages')"
     >
       <template #body="{ data }">
-        <Badge
-          :value="data.number_of_pages ?? '-'"
-        />
+        <Badge :value="data.number_of_pages ?? '-'" />
       </template>
     </Column>
     <Column
@@ -184,16 +182,15 @@ watch(
   { immediate: true },
 )
 
-// Drop any selected document that is no longer deletable — either picked by "select all" while
-// processing, or flipped to "deleting" by a single-row delete after it was already selected.
-watch(
-  () => checkedDocuments.value.filter(document => !isDocumentDeletable(document)).length,
-  (nonDeletableCount) => {
-    if (nonDeletableCount > 0) {
-      checkedDocuments.value = checkedDocuments.value.filter(isDocumentDeletable)
-    }
-  },
+const deletableDocuments = computed(() => props.documents.filter(isDocumentDeletable))
+
+const allDeletableSelected = computed(
+  () => deletableDocuments.value.length > 0 && checkedDocuments.value.length === deletableDocuments.value.length,
 )
+
+const onSelectAllChange = ({ checked }: { checked: boolean }) => {
+  checkedDocuments.value = checked ? [...deletableDocuments.value] : []
+}
 
 const handleRowClick = (event: DataTableRowClickEvent) => {
   const document = event.data as DocumentDto
@@ -243,6 +240,7 @@ const handleDelete = async (document: DocumentDto) => {
       documentId: document.id,
     })
     schedule([document.id])
+    checkedDocuments.value = checkedDocuments.value.filter(selected => selected.id !== document.id)
     toast.add({
       severity: 'success',
       summary: t('document.delete.success'),


### PR DESCRIPTION
closes https://github.com/bbvch-ai/aihub-core-private/issues/50

## What

Fixes the select-all header checkbox in the knowledge document list (`Knowledge/Document/List.vue`). Previously, after selecting all rows you could not deselect them — clicking the header checkbox did nothing.

https://github.com/user-attachments/assets/621bc094-4a7c-49ee-a5cd-2ccd1da674ef


## Why

PrimeVue's built-in `DataTable` marks the header checkbox as "checked" only when **every** row is in the selection. Processing/deleting rows are not selectable (they carry `pointer-events-none`), so the selection could never contain all rows. As a result the header checkbox stayed permanently unchecked, and clicking it always toggled toward *select* rather than *deselect*.

The old code masked half of this with a self-mutating `watch` that pruned non-deletable rows out of the selection after "select all" — which also fed the checkbox-never-checked problem and fired twice on every selection change.

## How

- Take control of select-all via `:select-all="allDeletableSelected"` + `@select-all-change="onSelectAllChange"`, so the header state is derived from the deletable rows and the toggle is handled explicitly. "Select all" now selects only deletable rows, and deselect-all works.
- Remove the self-mutating pruning `watch` (source of the deselect bug and the double-fire). Selection can no longer pick up non-deletable rows: select-all filters them, and individual non-deletable checkboxes are already unclickable.
- Handle the one remaining case explicitly: when a selected row is single-deleted (flips to "deleting"), remove it from the selection in `handleDelete`.

## Notes

- Select-all is page-scoped (server-side pagination): it selects the currently loaded page's deletable rows, matching prior behavior. Cross-page "select everything" would require a separate bulk mechanism and is out of scope.

## Test plan

- [ ] Select all → only deletable rows are selected; header checkbox lights up.
- [ ] Click header checkbox again → selection clears (deselect-all works).
- [ ] With a processing/deleting row present, it is never selected via select-all and its checkbox is not clickable.
- [ ] Select a row, then single-delete it → it is removed from the selection and the "N selected" banner updates.
- [ ] Batch delete still works and clears the selection.
