### PR TITLE
fix(swiss-ai-hub): Isolate user-memory writes per agent

### DIFF
--- a/packages/core/swiss_ai_hub/core/infrastructure/mem0/mem0_service.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/mem0/mem0_service.py
@@ -57,9 +57,16 @@ class Mem0Service:
         }
         # Filter out None values and empty strings
         metadata = {k: str(v) for k, v in metadata.items() if v is not None and v != ""}
+        # Native agent_id scopes mem0's infer-time reconciliation (its ADD/UPDATE/DELETE search over
+        # existing memories) to the writing agent, so one agent's write can no longer rewrite or delete
+        # another agent's user memories. mem0 reconciles on native keys, not on our `_agent_id` metadata.
+        # Org memory is left unscoped (infer=False, intentionally tenant-shared). Reads stay cross-agent
+        # shared — the read path passes agent_id=None deliberately.
+        native_agent_id = agent_id if memory_type == MemoryType.USER_MEMORY else None
         added_memory = await self._memory.add(
             messages,
             user_id=owner_id,
+            agent_id=native_agent_id,
             metadata=metadata,
             infer=infer,
         )

--- a/packages/core/swiss_ai_hub/core/infrastructure/mem0/tests/unit/test_mem0_service_add_scoping.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/mem0/tests/unit/test_mem0_service_add_scoping.py
@@ -1,0 +1,69 @@
+"""Unit tests for Mem0Service.add_memory native-agent_id scoping.
+
+User memory must pass mem0's native `agent_id` so infer-time reconciliation
+(ADD/UPDATE/DELETE over existing memories) is scoped to the writing agent — one
+agent can no longer rewrite or delete another agent's user memories. Organization
+memory stays unscoped (native `agent_id` omitted), matching its intentionally
+tenant-shared behavior.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from swiss_ai_hub.core.infrastructure.mem0.mem0_service import Mem0Service
+from swiss_ai_hub.core.infrastructure.mem0.types.memory_type import MemoryType
+
+
+@pytest.fixture
+def mem0_service() -> Mem0Service:
+    """Build a Mem0Service with all heavy collaborators mocked out."""
+    with (
+        patch("swiss_ai_hub.core.infrastructure.mem0.mem0_service.PatchedAsyncMemory") as mock_memory_cls,
+        patch("swiss_ai_hub.core.infrastructure.mem0.mem0_service.PatchedOpenAILLM"),
+        patch("swiss_ai_hub.core.infrastructure.mem0.mem0_service.PatchedOpenAIEmbedding"),
+        patch("swiss_ai_hub.core.infrastructure.mem0.mem0_service.PatchedMemoryGraph"),
+    ):
+        mock_memory = MagicMock()
+        mock_memory.add = AsyncMock(return_value={"results": []})
+        mock_memory_cls.return_value = mock_memory
+        service = Mem0Service(config=MagicMock(), t=MagicMock())
+    return service
+
+
+def _captured_native_agent_id(service: Mem0Service):
+    """Return the native `agent_id` kwarg from the most recent _memory.add call."""
+    return service._memory.add.await_args.kwargs["agent_id"]
+
+
+@pytest.mark.asyncio
+async def test_user_memory_add_passes_native_agent_id(mem0_service):
+    await mem0_service.add_memory(
+        messages=[{"role": "user", "content": "I prefer Python", "name": "u1"}],
+        owner_id="u1",
+        memory_type=MemoryType.USER_MEMORY,
+        user_id="u1",
+        agent_id="rag_agent/1",
+        thread_id="t1",
+        display_id="d1",
+        run_id="r1",
+    )
+    assert _captured_native_agent_id(mem0_service) == "rag_agent/1"
+
+
+@pytest.mark.asyncio
+async def test_org_memory_add_omits_native_agent_id(mem0_service):
+    await mem0_service.add_memory(
+        messages=[{"role": "user", "content": "Company policy X", "name": "u1"}],
+        owner_id="ACME",
+        memory_type=MemoryType.ORGANIZATION_MEMORY,
+        user_id="u1",
+        agent_id="rag_agent/1",
+        thread_id="t1",
+        display_id="d1",
+        run_id="r1",
+        tenant_id="ACME",
+        tenant_namespace="dept-x",
+        infer=False,
+    )
+    assert _captured_native_agent_id(mem0_service) is None


### PR DESCRIPTION
## What

Scope mem0's infer-time reconciliation to the writing agent by passing mem0's **native** `agent_id` on user-memory writes.

## Why

mem0 reconciles memories (its ADD/UPDATE/DELETE search over existing memories during `infer`) on its native keys — not on our `_agent_id` metadata. Because we previously wrote user memories without a native `agent_id`, one agent's write could rewrite or delete another agent's user memories for the same user.

## How

- `add_memory` now derives `native_agent_id = agent_id` for `USER_MEMORY`, and passes it to `self._memory.add(...)`.
- Organization memory stays **unscoped** (native `agent_id` omitted) — it is intentionally tenant-shared (`infer=False`).
- Reads remain cross-agent shared: the read path still passes `agent_id=None` deliberately.

## Migration / behavioral change

⚠️ **Legacy user memories in Milvus were written without a native `agent_id`.** After this change, a scoped `add(agent_id="...", infer=True)` will **not** see those legacy memories during its reconciliation search, so it can re-store facts that already exist — producing **duplicates** (legacy record + new scoped record) on the first runs after deploy.

- This is **not a correctness bug** for this PR — the isolation goal is met, and duplicates self-resolve as agents re-write memories under their own scope over time.
- Operators should expect some duplicate user memories immediately after deploy.
- Follow-up (optional): a one-off backfill to stamp legacy records with their writing agent's native `agent_id` (recoverable from the existing `_agent_id` metadata) would eliminate the duplicate window.

## Tests

New unit tests in `test_mem0_service_add_scoping.py`:
- user-memory add passes the native `agent_id`
- org-memory add omits the native `agent_id`
