### PR TITLE
fix(tracing): Bound high-cardinality HTTP server metrics to cut SigNoz cost

### DIFF
--- a/infra/configs/otel/otel-config.build.gpu.yml
+++ b/infra/configs/otel/otel-config.build.gpu.yml
@@ -43,7 +43,22 @@ processors:
   filter/langfuse:
     error_mode: ignore
     traces:
-      span: ['attributes["openinference.span.kind"] == nil']
+      span:
+        - attributes["openinference.span.kind"] == nil
+
+  # Backstop (issue 1496): drop unbounded, high-cardinality HTTP server metrics
+  # (side-effect of FastAPI/ASGI auto-instrumentation) before they reach the paid
+  # backend. Dropping whole metrics needs no histogram re-aggregation. Catches any
+  # emitter (e.g. open-webui) even if suppressed at the application source.
+  filter/metrics_cardinality:
+    error_mode: ignore
+    metrics:
+      metric:
+        - name == "http.server.duration"
+        - name == "http.server.request.duration"
+        - name == "http.server.active_requests"
+        - name == "http.server.request.size"
+        - name == "http.server.response.size"
 exporters:
   # Generic cloud exporter with configurable headers
   # Controlled via environment variables:
@@ -91,7 +106,7 @@ service:
     # Send metrics to cloud backend
     metrics:
       receivers: [otlp]
-      processors: [batch]
+      processors: [filter/metrics_cardinality, batch]
       exporters: [otlp/cloud]
 
     # Send logs to cloud backend

--- a/infra/configs/otel/otel-config.build.gpu.yml
+++ b/infra/configs/otel/otel-config.build.gpu.yml
@@ -59,6 +59,8 @@ processors:
         - name == "http.server.active_requests"
         - name == "http.server.request.size"
         - name == "http.server.response.size"
+        - name == "http.server.request.body.size"
+        - name == "http.server.response.body.size"
 exporters:
   # Generic cloud exporter with configurable headers
   # Controlled via environment variables:

--- a/infra/configs/otel/otel-config.build.yml
+++ b/infra/configs/otel/otel-config.build.yml
@@ -43,7 +43,22 @@ processors:
   filter/langfuse:
     error_mode: ignore
     traces:
-      span: ['attributes["openinference.span.kind"] == nil']
+      span:
+        - attributes["openinference.span.kind"] == nil
+
+  # Backstop (issue 1496): drop unbounded, high-cardinality HTTP server metrics
+  # (side-effect of FastAPI/ASGI auto-instrumentation) before they reach the paid
+  # backend. Dropping whole metrics needs no histogram re-aggregation. Catches any
+  # emitter (e.g. open-webui) even if suppressed at the application source.
+  filter/metrics_cardinality:
+    error_mode: ignore
+    metrics:
+      metric:
+        - name == "http.server.duration"
+        - name == "http.server.request.duration"
+        - name == "http.server.active_requests"
+        - name == "http.server.request.size"
+        - name == "http.server.response.size"
 exporters:
   # Generic cloud exporter with configurable headers
   # Controlled via environment variables:
@@ -91,7 +106,7 @@ service:
     # Send metrics to cloud backend
     metrics:
       receivers: [otlp]
-      processors: [batch]
+      processors: [filter/metrics_cardinality, batch]
       exporters: [otlp/cloud]
 
     # Send logs to cloud backend

--- a/infra/configs/otel/otel-config.build.yml
+++ b/infra/configs/otel/otel-config.build.yml
@@ -59,6 +59,8 @@ processors:
         - name == "http.server.active_requests"
         - name == "http.server.request.size"
         - name == "http.server.response.size"
+        - name == "http.server.request.body.size"
+        - name == "http.server.response.body.size"
 exporters:
   # Generic cloud exporter with configurable headers
   # Controlled via environment variables:

--- a/infra/configs/otel/otel-config.dev.gpu.yml
+++ b/infra/configs/otel/otel-config.dev.gpu.yml
@@ -43,7 +43,22 @@ processors:
   filter/langfuse:
     error_mode: ignore
     traces:
-      span: ['attributes["openinference.span.kind"] == nil']
+      span:
+        - attributes["openinference.span.kind"] == nil
+
+  # Backstop (issue 1496): drop unbounded, high-cardinality HTTP server metrics
+  # (side-effect of FastAPI/ASGI auto-instrumentation) before they reach the paid
+  # backend. Dropping whole metrics needs no histogram re-aggregation. Catches any
+  # emitter (e.g. open-webui) even if suppressed at the application source.
+  filter/metrics_cardinality:
+    error_mode: ignore
+    metrics:
+      metric:
+        - name == "http.server.duration"
+        - name == "http.server.request.duration"
+        - name == "http.server.active_requests"
+        - name == "http.server.request.size"
+        - name == "http.server.response.size"
 exporters:
   # Generic cloud exporter with configurable headers
   # Controlled via environment variables:
@@ -96,5 +111,5 @@ service:
     # Accept metrics but use debug exporter (Langfuse doesn't support metrics via OTEL)
     metrics:
       receivers: [otlp]
-      processors: [batch]
+      processors: [filter/metrics_cardinality, batch]
       exporters: [debug]

--- a/infra/configs/otel/otel-config.dev.gpu.yml
+++ b/infra/configs/otel/otel-config.dev.gpu.yml
@@ -59,6 +59,8 @@ processors:
         - name == "http.server.active_requests"
         - name == "http.server.request.size"
         - name == "http.server.response.size"
+        - name == "http.server.request.body.size"
+        - name == "http.server.response.body.size"
 exporters:
   # Generic cloud exporter with configurable headers
   # Controlled via environment variables:

--- a/infra/configs/otel/otel-config.dev.yml
+++ b/infra/configs/otel/otel-config.dev.yml
@@ -43,7 +43,22 @@ processors:
   filter/langfuse:
     error_mode: ignore
     traces:
-      span: ['attributes["openinference.span.kind"] == nil']
+      span:
+        - attributes["openinference.span.kind"] == nil
+
+  # Backstop (issue 1496): drop unbounded, high-cardinality HTTP server metrics
+  # (side-effect of FastAPI/ASGI auto-instrumentation) before they reach the paid
+  # backend. Dropping whole metrics needs no histogram re-aggregation. Catches any
+  # emitter (e.g. open-webui) even if suppressed at the application source.
+  filter/metrics_cardinality:
+    error_mode: ignore
+    metrics:
+      metric:
+        - name == "http.server.duration"
+        - name == "http.server.request.duration"
+        - name == "http.server.active_requests"
+        - name == "http.server.request.size"
+        - name == "http.server.response.size"
 exporters:
   # Generic cloud exporter with configurable headers
   # Controlled via environment variables:
@@ -96,5 +111,5 @@ service:
     # Accept metrics but use debug exporter (Langfuse doesn't support metrics via OTEL)
     metrics:
       receivers: [otlp]
-      processors: [batch]
+      processors: [filter/metrics_cardinality, batch]
       exporters: [debug]

--- a/infra/configs/otel/otel-config.dev.yml
+++ b/infra/configs/otel/otel-config.dev.yml
@@ -59,6 +59,8 @@ processors:
         - name == "http.server.active_requests"
         - name == "http.server.request.size"
         - name == "http.server.response.size"
+        - name == "http.server.request.body.size"
+        - name == "http.server.response.body.size"
 exporters:
   # Generic cloud exporter with configurable headers
   # Controlled via environment variables:

--- a/infra/configs/otel/otel-config.latest.gpu.yml
+++ b/infra/configs/otel/otel-config.latest.gpu.yml
@@ -43,7 +43,22 @@ processors:
   filter/langfuse:
     error_mode: ignore
     traces:
-      span: ['attributes["openinference.span.kind"] == nil']
+      span:
+        - attributes["openinference.span.kind"] == nil
+
+  # Backstop (issue 1496): drop unbounded, high-cardinality HTTP server metrics
+  # (side-effect of FastAPI/ASGI auto-instrumentation) before they reach the paid
+  # backend. Dropping whole metrics needs no histogram re-aggregation. Catches any
+  # emitter (e.g. open-webui) even if suppressed at the application source.
+  filter/metrics_cardinality:
+    error_mode: ignore
+    metrics:
+      metric:
+        - name == "http.server.duration"
+        - name == "http.server.request.duration"
+        - name == "http.server.active_requests"
+        - name == "http.server.request.size"
+        - name == "http.server.response.size"
 exporters:
   # Generic cloud exporter with configurable headers
   # Controlled via environment variables:
@@ -91,7 +106,7 @@ service:
     # Send metrics to cloud backend
     metrics:
       receivers: [otlp]
-      processors: [batch]
+      processors: [filter/metrics_cardinality, batch]
       exporters: [otlp/cloud]
 
     # Send logs to cloud backend

--- a/infra/configs/otel/otel-config.latest.gpu.yml
+++ b/infra/configs/otel/otel-config.latest.gpu.yml
@@ -59,6 +59,8 @@ processors:
         - name == "http.server.active_requests"
         - name == "http.server.request.size"
         - name == "http.server.response.size"
+        - name == "http.server.request.body.size"
+        - name == "http.server.response.body.size"
 exporters:
   # Generic cloud exporter with configurable headers
   # Controlled via environment variables:

--- a/infra/configs/otel/otel-config.latest.yml
+++ b/infra/configs/otel/otel-config.latest.yml
@@ -43,7 +43,22 @@ processors:
   filter/langfuse:
     error_mode: ignore
     traces:
-      span: ['attributes["openinference.span.kind"] == nil']
+      span:
+        - attributes["openinference.span.kind"] == nil
+
+  # Backstop (issue 1496): drop unbounded, high-cardinality HTTP server metrics
+  # (side-effect of FastAPI/ASGI auto-instrumentation) before they reach the paid
+  # backend. Dropping whole metrics needs no histogram re-aggregation. Catches any
+  # emitter (e.g. open-webui) even if suppressed at the application source.
+  filter/metrics_cardinality:
+    error_mode: ignore
+    metrics:
+      metric:
+        - name == "http.server.duration"
+        - name == "http.server.request.duration"
+        - name == "http.server.active_requests"
+        - name == "http.server.request.size"
+        - name == "http.server.response.size"
 exporters:
   # Generic cloud exporter with configurable headers
   # Controlled via environment variables:
@@ -91,7 +106,7 @@ service:
     # Send metrics to cloud backend
     metrics:
       receivers: [otlp]
-      processors: [batch]
+      processors: [filter/metrics_cardinality, batch]
       exporters: [otlp/cloud]
 
     # Send logs to cloud backend

--- a/infra/configs/otel/otel-config.latest.yml
+++ b/infra/configs/otel/otel-config.latest.yml
@@ -59,6 +59,8 @@ processors:
         - name == "http.server.active_requests"
         - name == "http.server.request.size"
         - name == "http.server.response.size"
+        - name == "http.server.request.body.size"
+        - name == "http.server.response.body.size"
 exporters:
   # Generic cloud exporter with configurable headers
   # Controlled via environment variables:

--- a/infra/configs/otel/otel-config.local.gpu.yml
+++ b/infra/configs/otel/otel-config.local.gpu.yml
@@ -43,7 +43,22 @@ processors:
   filter/langfuse:
     error_mode: ignore
     traces:
-      span: ['attributes["openinference.span.kind"] == nil']
+      span:
+        - attributes["openinference.span.kind"] == nil
+
+  # Backstop (issue 1496): drop unbounded, high-cardinality HTTP server metrics
+  # (side-effect of FastAPI/ASGI auto-instrumentation) before they reach the paid
+  # backend. Dropping whole metrics needs no histogram re-aggregation. Catches any
+  # emitter (e.g. open-webui) even if suppressed at the application source.
+  filter/metrics_cardinality:
+    error_mode: ignore
+    metrics:
+      metric:
+        - name == "http.server.duration"
+        - name == "http.server.request.duration"
+        - name == "http.server.active_requests"
+        - name == "http.server.request.size"
+        - name == "http.server.response.size"
 exporters:
   # Generic cloud exporter with configurable headers
   # Controlled via environment variables:
@@ -91,7 +106,7 @@ service:
     # Send metrics to cloud backend
     metrics:
       receivers: [otlp]
-      processors: [batch]
+      processors: [filter/metrics_cardinality, batch]
       exporters: [otlp/cloud]
 
     # Send logs to cloud backend

--- a/infra/configs/otel/otel-config.local.gpu.yml
+++ b/infra/configs/otel/otel-config.local.gpu.yml
@@ -59,6 +59,8 @@ processors:
         - name == "http.server.active_requests"
         - name == "http.server.request.size"
         - name == "http.server.response.size"
+        - name == "http.server.request.body.size"
+        - name == "http.server.response.body.size"
 exporters:
   # Generic cloud exporter with configurable headers
   # Controlled via environment variables:

--- a/infra/configs/otel/otel-config.local.yml
+++ b/infra/configs/otel/otel-config.local.yml
@@ -43,7 +43,22 @@ processors:
   filter/langfuse:
     error_mode: ignore
     traces:
-      span: ['attributes["openinference.span.kind"] == nil']
+      span:
+        - attributes["openinference.span.kind"] == nil
+
+  # Backstop (issue 1496): drop unbounded, high-cardinality HTTP server metrics
+  # (side-effect of FastAPI/ASGI auto-instrumentation) before they reach the paid
+  # backend. Dropping whole metrics needs no histogram re-aggregation. Catches any
+  # emitter (e.g. open-webui) even if suppressed at the application source.
+  filter/metrics_cardinality:
+    error_mode: ignore
+    metrics:
+      metric:
+        - name == "http.server.duration"
+        - name == "http.server.request.duration"
+        - name == "http.server.active_requests"
+        - name == "http.server.request.size"
+        - name == "http.server.response.size"
 exporters:
   # Generic cloud exporter with configurable headers
   # Controlled via environment variables:
@@ -91,7 +106,7 @@ service:
     # Send metrics to cloud backend
     metrics:
       receivers: [otlp]
-      processors: [batch]
+      processors: [filter/metrics_cardinality, batch]
       exporters: [otlp/cloud]
 
     # Send logs to cloud backend

--- a/infra/configs/otel/otel-config.local.yml
+++ b/infra/configs/otel/otel-config.local.yml
@@ -59,6 +59,8 @@ processors:
         - name == "http.server.active_requests"
         - name == "http.server.request.size"
         - name == "http.server.response.size"
+        - name == "http.server.request.body.size"
+        - name == "http.server.response.body.size"
 exporters:
   # Generic cloud exporter with configurable headers
   # Controlled via environment variables:

--- a/infra/configs/otel/otel-config.nightly.gpu.yml
+++ b/infra/configs/otel/otel-config.nightly.gpu.yml
@@ -43,7 +43,22 @@ processors:
   filter/langfuse:
     error_mode: ignore
     traces:
-      span: ['attributes["openinference.span.kind"] == nil']
+      span:
+        - attributes["openinference.span.kind"] == nil
+
+  # Backstop (issue 1496): drop unbounded, high-cardinality HTTP server metrics
+  # (side-effect of FastAPI/ASGI auto-instrumentation) before they reach the paid
+  # backend. Dropping whole metrics needs no histogram re-aggregation. Catches any
+  # emitter (e.g. open-webui) even if suppressed at the application source.
+  filter/metrics_cardinality:
+    error_mode: ignore
+    metrics:
+      metric:
+        - name == "http.server.duration"
+        - name == "http.server.request.duration"
+        - name == "http.server.active_requests"
+        - name == "http.server.request.size"
+        - name == "http.server.response.size"
 exporters:
   # Generic cloud exporter with configurable headers
   # Controlled via environment variables:
@@ -91,7 +106,7 @@ service:
     # Send metrics to cloud backend
     metrics:
       receivers: [otlp]
-      processors: [batch]
+      processors: [filter/metrics_cardinality, batch]
       exporters: [otlp/cloud]
 
     # Send logs to cloud backend

--- a/infra/configs/otel/otel-config.nightly.gpu.yml
+++ b/infra/configs/otel/otel-config.nightly.gpu.yml
@@ -59,6 +59,8 @@ processors:
         - name == "http.server.active_requests"
         - name == "http.server.request.size"
         - name == "http.server.response.size"
+        - name == "http.server.request.body.size"
+        - name == "http.server.response.body.size"
 exporters:
   # Generic cloud exporter with configurable headers
   # Controlled via environment variables:

--- a/infra/configs/otel/otel-config.nightly.yml
+++ b/infra/configs/otel/otel-config.nightly.yml
@@ -43,7 +43,22 @@ processors:
   filter/langfuse:
     error_mode: ignore
     traces:
-      span: ['attributes["openinference.span.kind"] == nil']
+      span:
+        - attributes["openinference.span.kind"] == nil
+
+  # Backstop (issue 1496): drop unbounded, high-cardinality HTTP server metrics
+  # (side-effect of FastAPI/ASGI auto-instrumentation) before they reach the paid
+  # backend. Dropping whole metrics needs no histogram re-aggregation. Catches any
+  # emitter (e.g. open-webui) even if suppressed at the application source.
+  filter/metrics_cardinality:
+    error_mode: ignore
+    metrics:
+      metric:
+        - name == "http.server.duration"
+        - name == "http.server.request.duration"
+        - name == "http.server.active_requests"
+        - name == "http.server.request.size"
+        - name == "http.server.response.size"
 exporters:
   # Generic cloud exporter with configurable headers
   # Controlled via environment variables:
@@ -91,7 +106,7 @@ service:
     # Send metrics to cloud backend
     metrics:
       receivers: [otlp]
-      processors: [batch]
+      processors: [filter/metrics_cardinality, batch]
       exporters: [otlp/cloud]
 
     # Send logs to cloud backend

--- a/infra/configs/otel/otel-config.nightly.yml
+++ b/infra/configs/otel/otel-config.nightly.yml
@@ -59,6 +59,8 @@ processors:
         - name == "http.server.active_requests"
         - name == "http.server.request.size"
         - name == "http.server.response.size"
+        - name == "http.server.request.body.size"
+        - name == "http.server.response.body.size"
 exporters:
   # Generic cloud exporter with configurable headers
   # Controlled via environment variables:

--- a/infra/deployment/templates/configs/otel-config.yml.j2
+++ b/infra/deployment/templates/configs/otel-config.yml.j2
@@ -55,6 +55,20 @@ processors:
       span:
         - 'attributes["openinference.span.kind"] == nil'
 
+  # Backstop (issue 1496): drop unbounded, high-cardinality HTTP server metrics
+  # (side-effect of FastAPI/ASGI auto-instrumentation) before they reach the paid
+  # backend. Dropping whole metrics needs no histogram re-aggregation. Catches any
+  # emitter (e.g. open-webui) even if suppressed at the application source.
+  filter/metrics_cardinality:
+    error_mode: ignore
+    metrics:
+      metric:
+        - 'name == "http.server.duration"'
+        - 'name == "http.server.request.duration"'
+        - 'name == "http.server.active_requests"'
+        - 'name == "http.server.request.size"'
+        - 'name == "http.server.response.size"'
+
 exporters:
   # Generic cloud exporter with configurable headers
   # Controlled via environment variables:
@@ -113,7 +127,7 @@ service:
     # Accept metrics but use debug exporter (Langfuse doesn't support metrics via OTEL)
     metrics:
       receivers: [otlp]
-      processors: [batch]
+      processors: [filter/metrics_cardinality, batch]
       exporters: [debug]
     {%- else %}
     # Send traces to cloud backend
@@ -125,7 +139,7 @@ service:
     # Send metrics to cloud backend
     metrics:
       receivers: [otlp]
-      processors: [batch]
+      processors: [filter/metrics_cardinality, batch]
       exporters: [otlp/cloud]
 
     # Send logs to cloud backend

--- a/infra/deployment/templates/configs/otel-config.yml.j2
+++ b/infra/deployment/templates/configs/otel-config.yml.j2
@@ -68,6 +68,8 @@ processors:
         - 'name == "http.server.active_requests"'
         - 'name == "http.server.request.size"'
         - 'name == "http.server.response.size"'
+        - 'name == "http.server.request.body.size"'
+        - 'name == "http.server.response.body.size"'
 
 exporters:
   # Generic cloud exporter with configurable headers

--- a/packages/api/playground/testing/tests/runners/test_api_runner_otel.py
+++ b/packages/api/playground/testing/tests/runners/test_api_runner_otel.py
@@ -1,0 +1,13 @@
+from swiss_ai_hub.api.runners.api_runner import CAPTURED_REQUEST_HEADERS
+
+
+def test_captured_request_headers_is_a_bounded_allowlist() -> None:
+    """Regression guard for issue #1496: header capture must not be the catch-all [".*"].
+
+    Capturing every header re-inflated trace/metric cardinality; the allowlist must stay
+    small and explicit.
+    """
+    assert CAPTURED_REQUEST_HEADERS != [".*"]
+    assert ".*" not in CAPTURED_REQUEST_HEADERS
+    assert 0 < len(CAPTURED_REQUEST_HEADERS) <= 5
+    assert all(isinstance(header, str) for header in CAPTURED_REQUEST_HEADERS)

--- a/packages/api/swiss_ai_hub/api/runners/api_runner.py
+++ b/packages/api/swiss_ai_hub/api/runners/api_runner.py
@@ -208,7 +208,6 @@ class ApiRunner(Runner):
             self._api_app,
             exclude_spans=["receive", "send"],
             http_capture_headers_server_request=CAPTURED_REQUEST_HEADERS,
-            http_capture_headers_sanitize_fields=["authorization"],
             meter_provider=NoOpMeterProvider(),
         )
         logger.info("FastAPI application instrumented with OpenTelemetry")

--- a/packages/api/swiss_ai_hub/api/runners/api_runner.py
+++ b/packages/api/swiss_ai_hub/api/runners/api_runner.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from fastmcp import FastMCP
 from fastmcp.server.openapi import MCPType, RouteMap
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.metrics import NoOpMeterProvider
 from starlette.applications import Starlette
 from starlette.middleware.cors import CORSMiddleware
 from starlette.routing import Mount
@@ -21,6 +22,11 @@ from swiss_ai_hub.api.routes.process.process_controller import ProcessController
 from swiss_ai_hub.api.runners.lifetime.lifetime_manager import lifetime_manager
 
 logger = logging.getLogger(__name__)
+
+# Bounded allowlist of request headers captured as span attributes. Capturing every
+# header ([".*"]) added high-cardinality attributes (user-agent, traceparent, cookie,
+# content-length) that inflated trace/metric cardinality — see issue #1496.
+CAPTURED_REQUEST_HEADERS = ["content-type", "accept", "accept-language"]
 
 
 class ApiRunner(Runner):
@@ -195,11 +201,15 @@ class ApiRunner(Runner):
             logger.info("OpenTelemetry instrumentation disabled: OTEL_ENABLED=False")
             return
 
+        # NoOpMeterProvider suppresses the http.server.duration histogram that FastAPI
+        # instrumentation emits as a side-effect. Metrics are not deliberately used here
+        # and the unbounded histogram was the SigNoz cost driver — see issue #1496.
         FastAPIInstrumentor.instrument_app(
             self._api_app,
             exclude_spans=["receive", "send"],
-            http_capture_headers_server_request=[".*"],
+            http_capture_headers_server_request=CAPTURED_REQUEST_HEADERS,
             http_capture_headers_sanitize_fields=["authorization"],
+            meter_provider=NoOpMeterProvider(),
         )
         logger.info("FastAPI application instrumented with OpenTelemetry")
         logger.info("Note: Core OpenTelemetry, MongoDB, and HTTP client configuration handled in lifetime_manager")

--- a/packages/core/swiss_ai_hub/core/routes/controller.py
+++ b/packages/core/swiss_ai_hub/core/routes/controller.py
@@ -181,10 +181,11 @@ class Controller(abc.ABC):
                 else:
                     span.set_attribute(f"resource.{param_name}", str(param_value))
 
-        # Record the concrete path on http.target; never overwrite http.route, which the
-        # FastAPI instrumentation keeps as the bounded route template. De-templating it
-        # exploded metric/label cardinality (one series per URL) — see issue #1496.
-        span.set_attribute("http.target", request.url.path)
+        # Record the concrete path on url.path (current OTel HTTP semconv; what SigNoz
+        # indexes). Never overwrite http.route, which the FastAPI instrumentation keeps as
+        # the bounded route template — de-templating it exploded metric/label cardinality
+        # (one series per URL) — see issue #1496.
+        span.set_attribute("url.path", request.url.path)
         if client_host := getattr(request.client, "host", None):
             span.set_attribute("client.ip", client_host)
 

--- a/packages/core/swiss_ai_hub/core/routes/controller.py
+++ b/packages/core/swiss_ai_hub/core/routes/controller.py
@@ -181,8 +181,10 @@ class Controller(abc.ABC):
                 else:
                     span.set_attribute(f"resource.{param_name}", str(param_value))
 
-        # Request context
-        span.set_attribute("http.route", request.url.path)
+        # Record the concrete path on http.target; never overwrite http.route, which the
+        # FastAPI instrumentation keeps as the bounded route template. De-templating it
+        # exploded metric/label cardinality (one series per URL) — see issue #1496.
+        span.set_attribute("http.target", request.url.path)
         if client_host := getattr(request.client, "host", None):
             span.set_attribute("client.ip", client_host)
 

--- a/packages/core/swiss_ai_hub/core/routes/tests/unit/test_controller_span_enrichment.py
+++ b/packages/core/swiss_ai_hub/core/routes/tests/unit/test_controller_span_enrichment.py
@@ -36,7 +36,9 @@ def test_enrich_span_keeps_http_route_as_template(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(controller_module.trace, "get_current_span", lambda: span)
 
     path = "/api/v1/active/agents/DemoAgent/abc123"
-    Controller._enrich_span_with_context(SimpleNamespace(service_name="demo"), fake_user(), _make_request(path), "aihub.user.agent")
+    Controller._enrich_span_with_context(
+        SimpleNamespace(service_name="demo"), fake_user(), _make_request(path), "aihub.user.agent"
+    )
 
     assert "http.route" not in span.attributes
     assert span.attributes["url.path"] == path

--- a/packages/core/swiss_ai_hub/core/routes/tests/unit/test_controller_span_enrichment.py
+++ b/packages/core/swiss_ai_hub/core/routes/tests/unit/test_controller_span_enrichment.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+
+import pytest
+
+from swiss_ai_hub.core.routes import controller as controller_module
+from swiss_ai_hub.core.routes.controller import Controller
+from swiss_ai_hub.core.testing.auth_utils.test_identity import fake_user
+
+
+class _RecordingSpan:
+    def __init__(self) -> None:
+        self.attributes: dict[str, object] = {}
+
+    def is_recording(self) -> bool:
+        return True
+
+    def set_attribute(self, key: str, value: object) -> None:
+        self.attributes[key] = value
+
+
+def _make_request(path: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        path_params={"tenant_id": "active", "agent_class": "DemoAgent", "agent_id": "abc123"},
+        url=SimpleNamespace(path=path),
+        client=SimpleNamespace(host="10.0.0.1"),
+    )
+
+
+def test_enrich_span_keeps_http_route_as_template(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression guard for issue #1496: never overwrite http.route with the concrete URL.
+
+    De-templating http.route exploded metric/label cardinality; the concrete path must land
+    on url.path instead so the bounded route template survives.
+    """
+    span = _RecordingSpan()
+    monkeypatch.setattr(controller_module.trace, "get_current_span", lambda: span)
+
+    path = "/api/v1/active/agents/DemoAgent/abc123"
+    Controller._enrich_span_with_context(SimpleNamespace(service_name="demo"), fake_user(), _make_request(path), "aihub.user.agent")
+
+    assert "http.route" not in span.attributes
+    assert span.attributes["url.path"] == path


### PR DESCRIPTION
## Summary

Closes #1496. SigNoz cost (~$950) was driven almost entirely by an unbounded, high-cardinality `http.server.duration` histogram from FastAPI/ASGI auto-instrumentation. This bounds the metric at the application source and adds a collector-side backstop so metrics ingestion drops regardless of which service emits it.

## Changes

- **Stop de-templating `http.route`** — `packages/core/.../routes/controller.py` now records the concrete request path on `http.target` and leaves `http.route` as the bounded route template (the instrumentation-set value). Previously every authenticated request overwrote `http.route` with the concrete URL, exploding cardinality per (tenant × agent × thread × …).
- **Narrow request-header capture** — `packages/api/.../runners/api_runner.py` replaces `http_capture_headers_server_request=[".*"]` with a small explicit allowlist (`content-type`, `accept`, `accept-language`), dropping high-cardinality headers (`user-agent`, `traceparent`, `cookie`, `content-length`).
- **Suppress the histogram at the source** — `instrument_app` now receives `meter_provider=NoOpMeterProvider()`, so the unintentional `http.server.duration` histogram is never recorded by the API. (No `MeterProvider`/`Views` exist in the codebase; the histogram was a side-effect of `instrument_app`.)
- **Collector backstop** — `infra/deployment/templates/configs/otel-config.yml.j2` adds a `filter/metrics_cardinality` processor that drops the 5 high-cardinality HTTP server metrics on both `metrics` pipelines (dev debug + cloud). This catches the same metrics from *any* emitter (e.g. `open-webui`, which has `ENABLE_OTEL_METRICS: True`) even if suppressed at the app source. Dropping whole metrics needs no histogram re-aggregation. Includes the 10 regenerated `infra/configs/otel/otel-config.*.yml` files (`make generate-compose`).

No new ADR: this extends the existing tracing ADR (`2025_09_15_adopt_opentelemetry_end_to_end_tracing`); metrics are suppressed, not newly introduced.

## Test plan

Local unit tests do not exercise metrics/tracing wiring, and the acceptance criteria require verification on a SigNoz-connected deployment. Local verification done:

- Import + signature checks: `NoOpMeterProvider` resolves; `instrument_app` accepts `meter_provider`; `api_runner` imports cleanly with the new allowlist constant.
- `packages/core` unit collection is clean (927 tests, no import errors) and the `routes/` unit tests pass. (The full core suite's other failures are the local Docker dev stack being down — `localhost:27017` connection refused — unrelated to this change.)
- `make generate-compose` runs clean; all 10 `otel-config.*.yml` variants carry `filter/metrics_cardinality` on both metrics pipelines; generated YAML validated.

To validate on deployment (nightly/latest, SigNoz-connected):

1. Confirm the dominant `http.server.duration` series source in SigNoz by grouping `_count` by `service.name`.
2. Confirm metrics ingestion volume / cost drops measurably after rollout.
3. Confirm any remaining series are deliberate and bounded.

Note: code evidence suggests the `api` service emits no metrics (NoOp meter provider) and the real emitter may be `open-webui`. The collector backstop covers both. If you want to also stop it at the `open-webui` source, flip `ENABLE_OTEL_METRICS: False` in the compose template — say the word and I'll add it.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>`
- [x] Exactly one of `major` / `minor` / `patch` label applied (`patch`)
- [ ] CLA signed
- [x] Tests added or updated where relevant (n/a — observability wiring; validated via import/collection checks and deployment plan above)
