### PR TITLE
fix(swiss-ai-hub): Delete OpenWebUI base models shadowing provisioned models

### DIFF
--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_client.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_client.py
@@ -160,6 +160,16 @@ class OpenWebuiClient:
         data = response.json()
         return data.get("items", []) if isinstance(data, dict) else data
 
+    async def list_base_models(self, http: httpx.AsyncClient) -> list[dict[str, Any]]:
+        """Lists registry entries that override a raw provider model (``base_model_id`` unset).
+
+        ``list_models`` cannot see these: OpenWebUI's search filters on ``base_model_id != None``, so
+        base-model overrides are invisible to it — and to the workspace UI that renders it.
+        """
+        response = await http.get(f"{self._base_url}{MODELS_ENDPOINT}/base", headers=self._jwt_headers)
+        response.raise_for_status()
+        return response.json()
+
     async def create_model(self, http: httpx.AsyncClient, model_data: dict[str, Any]) -> dict[str, Any]:
         model_data.setdefault("params", {})
         response = await http.post(

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_provisioner.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_provisioner.py
@@ -360,7 +360,29 @@ class OpenWebuiProvisioner:
             "meta": {"description": f"AI-Hub model: {model.litellm_name}"},
         }
 
+    async def _delete_shadowing_base_models(self, http: httpx.AsyncClient, models: list[AvailableModel]) -> None:
+        """Removes registry entries that shadow the raw LiteLLM models our workspace models point at.
+
+        ``_build_llm_model_data`` depends on those bases staying unregistered. Once an entry exists for one,
+        OpenWebUI's ``has_base_model_access`` walks workspace model -> base and denies everyone without a
+        grant on that entry, so the model stays visible in the picker but chatting with it fails with
+        "Model not found". Saving a raw model in the OpenWebUI workspace creates exactly such an entry, so
+        reassert the invariant on every sync.
+        """
+        shadowing_ids = {m.get("id", "") for m in await self._openwebui.list_base_models(http)}
+
+        for model in models:
+            if model.litellm_name not in shadowing_ids:
+                continue
+            await self._openwebui.delete_model(http, model.litellm_name)
+            logger.warning(
+                f"OpenWebUI: Deleted registry entry '{model.litellm_name}' shadowing the raw LiteLLM model — "
+                f"it denied every non-admin access to the workspace model above it"
+            )
+
     async def _sync_llm_workspace_models(self, http: httpx.AsyncClient, models: list[AvailableModel]) -> None:
+        await self._delete_shadowing_base_models(http, models)
+
         existing_models = await self._openwebui.list_models(http)
         existing_aihub = {m["id"]: m for m in existing_models if m.get("id", "").startswith(AIHUB_LLM_MODEL_PREFIX)}
 

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_provisioner_llm_models.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_provisioner_llm_models.py
@@ -45,6 +45,14 @@ def _litellm_returning(entries: list[dict]):
         yield
 
 
+@pytest.fixture(autouse=True)
+def _unregistered_base_models(provisioner: OpenWebuiProvisioner):
+    """Defaults every sync to the healthy state — raw bases carry no registry entry. Tests that
+    exercise the shadowing repair override this with their own ``list_base_models`` patch."""
+    with patch.object(provisioner._openwebui, "list_base_models", return_value=[]):
+        yield
+
+
 class TestGetAvailableLlmModels:
     @pytest.mark.asyncio
     async def test_keeps_only_chat_models(self, provisioner: OpenWebuiProvisioner) -> None:
@@ -158,6 +166,65 @@ class TestSyncLlmWorkspaceModels:
             await provisioner._sync_llm_workspace_models(mock_client, [])
 
             mock_create.assert_not_called()
+            mock_delete.assert_not_called()
+
+
+class TestDeleteShadowingBaseModels:
+    """A registry entry at a workspace model's ``base_model_id`` makes OpenWebUI's
+    ``has_base_model_access`` deny every user without a grant on it, so the model stays in the picker
+    but chat fails with "Model not found". Saving a raw model in the OpenWebUI workspace creates exactly
+    such an entry. It is only reachable via ``list_base_models``: OpenWebUI's model search filters on
+    ``base_model_id != None``, so ``list_models`` can never return it."""
+
+    @pytest.mark.asyncio
+    async def test_deletes_entry_shadowing_the_raw_base_model(self, provisioner: OpenWebuiProvisioner) -> None:
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        with (
+            patch.object(
+                provisioner._openwebui, "list_base_models", return_value=[{"id": "text-generation/gemma-4-31B-it"}]
+            ),
+            patch.object(
+                provisioner._openwebui, "list_models", return_value=[{"id": _GEMMA_ID, "name": "gemma-4-31B-it"}]
+            ),
+            patch.object(provisioner._openwebui, "delete_model") as mock_delete,
+        ):
+            await provisioner._sync_llm_workspace_models(mock_client, [_GEMMA])
+
+            mock_delete.assert_called_once_with(mock_client, "text-generation/gemma-4-31B-it")
+
+    @pytest.mark.asyncio
+    async def test_leaves_unregistered_base_alone(self, provisioner: OpenWebuiProvisioner) -> None:
+        """The healthy state: the raw model has no registry entry, so there is nothing to repair."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        with (
+            patch.object(provisioner._openwebui, "list_base_models", return_value=[]),
+            patch.object(
+                provisioner._openwebui, "list_models", return_value=[{"id": _GEMMA_ID, "name": "gemma-4-31B-it"}]
+            ),
+            patch.object(provisioner._openwebui, "delete_model") as mock_delete,
+        ):
+            await provisioner._sync_llm_workspace_models(mock_client, [_GEMMA])
+
+            mock_delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_does_not_delete_unrelated_base_models(self, provisioner: OpenWebuiProvisioner) -> None:
+        """Only bases of models we actually provision are repaired; foreign entries are left untouched."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        with (
+            patch.object(
+                provisioner._openwebui, "list_base_models", return_value=[{"id": "text-generation/some-other-model"}]
+            ),
+            patch.object(
+                provisioner._openwebui, "list_models", return_value=[{"id": _GEMMA_ID, "name": "gemma-4-31B-it"}]
+            ),
+            patch.object(provisioner._openwebui, "delete_model") as mock_delete,
+        ):
+            await provisioner._sync_llm_workspace_models(mock_client, [_GEMMA])
+
             mock_delete.assert_not_called()
 
 


### PR DESCRIPTION
## Problem

In Nightly and Staging, a user with a role granting a model (Kimi-K2.6, Qwen, Ministral, gemma) got
**`Model not found`** when chatting with it in OpenWebUI. Only Apertus worked. Local was unaffected.

The model was visible in the picker, the access grants existed, and our API served the model fine —
the chat request never reached our API at all.

## Root cause

Our workspace models point `base_model_id` at the raw LiteLLM model and gate access through their own
grants:

```
id:            aihub-model-text-generation-Kimi-K2.6   ← what the user picks
base_model_id: text-generation/Kimi-K2.6               ← the raw LiteLLM model
access_grants: [aihub:{tenant}:{role} ...]             ← who may use it
```

This relies on the raw model having **no OpenWebUI registry entry**. OpenWebUI's `has_base_model_access`
walks the `base_model_id` chain and requires a read grant at *every* hop — an absent base is treated as a
raw provider model and allowed through; a *registered* base with no grants denies every non-admin.

An admin had opened the raw `text-generation/*` models in the OpenWebUI Workspace and saved them (to set
`function_calling: native` and capability toggles). Saving creates a private base-model row, owner = that
admin, `access_grants: []`. From then on every non-admin was denied at the base hop, and OpenWebUI reported
it as `Model not found` — its deliberately vague wording for an access denial — without ever calling us.

Apertus was the only model nobody had edited, hence the only one that worked. Local had zero such rows.

The provisioner already *documented* this invariant in `_build_llm_model_data`; nothing enforced it.

## Fix

`OpenWebuiProvisioner._delete_shadowing_base_models()` runs on every sync and deletes any base-model entry
shadowing a model we provision. Only ids equal to a provisioned model's `base_model_id` are touched —
workspace models, agents and unrelated base models are left alone.

These entries are **invisible to `list_models()`**, and to the OpenWebUI Workspace UI built on it, because
OpenWebUI's model search filters on `base_model_id != None` — base-model overrides can never appear there.
They are read via `GET /api/v1/models/base` instead (new `OpenWebuiClient.list_base_models()`).


## Testing

- Reproduced locally by inserting Nightly's exact row shape into OpenWebUI's `model` table → Kimi failed with
  the identical `400 {"detail":"Model not found"}` and no request to our API, while Apertus kept working.
- Restarted the API → provisioner deleted the row → Kimi chats again.
- 3 new unit tests: repairs the shadowing entry, leaves the healthy (unregistered) state alone, ignores
  unrelated base models.
- `1015 passed` in `packages/core`.

## Deployment

No manual action needed in Nightly/Staging — the provisioner runs at API startup, so the six stray rows are
cleaned automatically on deploy.
