### PR TITLE
fix(ci-cd): Let manual release tag any branch via source_ref input

### DIFF
--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -12,10 +12,12 @@
 #   set-latest.yml).
 #
 # USAGE:
-#   1. In the GitHub UI, pick this workflow and select the branch to release
-#      from (the branch tip is what gets tagged). The workflow file must exist
-#      on that branch, so merge this to `main` for future branches to inherit.
-#   2. Provide `release_version` as a strict vMAJOR.MINOR.PATCH tag (e.g.
+#   1. In the GitHub UI, run this workflow from `main` (the "Use workflow from"
+#      dropdown only lists branches that contain this file, so keep it on `main`).
+#   2. Set `source_ref` to the branch/ref you actually want to tag — e.g.
+#      `hotfix/0.308`. Leave it empty to tag the branch selected in the dropdown.
+#      The tip of that ref is what gets tagged.
+#   3. Provide `release_version` as a strict vMAJOR.MINOR.PATCH tag (e.g.
 #      v0.308.1). It is validated because publish-npm / publish-pypi guard that
 #      the tagged commit's package.json / pyproject.toml version matches.
 #
@@ -37,6 +39,10 @@ on:
       release_version:
         description: Release version tag to cut (e.g., v0.308.1)
         required: true
+      source_ref:
+        description: Branch/ref to tag (e.g., hotfix/0.308). Empty = the branch selected above.
+        required: false
+        default: ''
 concurrency:
   group: release-manual-${{ github.event.inputs.release_version }}
   cancel-in-progress: false
@@ -49,30 +55,37 @@ jobs:
       contents: write
     outputs:
       version: ${{ steps.validate.outputs.version }}
+      source_ref: ${{ steps.validate.outputs.source_ref }}
     steps:
-      - name: Validate version & branch
+      - name: Validate version & resolve source ref
         id: validate
         env:
           VERSION: ${{ github.event.inputs.release_version }}
-          BRANCH: ${{ github.ref_name }}
+          INPUT_SOURCE_REF: ${{ github.event.inputs.source_ref }}
+          SELECTED_BRANCH: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           if ! printf '%s' "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::'$VERSION' is not a valid vMAJOR.MINOR.PATCH release tag."
             exit 1
           fi
-          # Soft correlation check: hotfix/X.Y branches should cut vX.Y.* tags.
-          if [[ "$BRANCH" =~ ^hotfix/([0-9]+)\.([0-9]+)$ ]]; then
+          # Tag the ref the user asked for; fall back to the dropdown branch.
+          SOURCE_REF="${INPUT_SOURCE_REF:-$SELECTED_BRANCH}"
+          echo "Tagging ref: $SOURCE_REF"
+          # Soft correlation check: hotfix/X.Y refs should cut vX.Y.* tags.
+          if [[ "$SOURCE_REF" =~ ^hotfix/([0-9]+)\.([0-9]+)$ ]]; then
             PREFIX="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}."
             case "$VERSION" in
               "$PREFIX"*) : ;;
-              *) echo "::warning::Version $VERSION does not match branch $BRANCH (expected ${PREFIX}*)" ;;
+              *) echo "::warning::Version $VERSION does not match ref $SOURCE_REF (expected ${PREFIX}*)" ;;
             esac
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-      - name: Checkout branch
+          echo "source_ref=$SOURCE_REF" >> "$GITHUB_OUTPUT"
+      - name: Checkout source ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          ref: ${{ steps.validate.outputs.source_ref }}
           fetch-depth: 0
       - name: Guard - tag must not already exist
         env:
@@ -129,6 +142,7 @@ jobs:
           # Move the annotated tag onto the release commit and push only the tag.
           git tag -f -a "$VERSION" -m "Release $VERSION"
           git push origin "refs/tags/$VERSION"
+
           echo "Tagged $(git rev-parse --short HEAD) as $VERSION and pushed the tag."
   fan-out:
     name: Dispatch Downstream Release Workflows


### PR DESCRIPTION
## Problem

`Manual Tag, Gen-Changelog & Release` only shows the branches that contain `release-manual.yml` in the "Use workflow from" dropdown. Since the file lives on `main`, a hotfix branch like `hotfix/0.308` cannot be selected — so there is no way to cut a release from it.

## Fix

Adds an optional `source_ref` input. Run the workflow from `main` (where the file lives) and set `source_ref` to the branch/ref to tag (e.g. `hotfix/0.308`); the tip of that ref is tagged. Empty falls back to the branch selected in the dropdown, so existing behaviour is preserved.

- `Checkout` now uses `ref: <resolved source_ref>`.
- The `hotfix/X.Y` -> `vX.Y.*` soft warning now checks the resolved ref.
- No change to the fan-out, which already dispatches downstream workflows at the tag.

## Usage

Actions -> Manual Tag, Gen-Changelog & Release -> Run workflow: keep branch `main`, set `source_ref = hotfix/0.308`, `release_version = v0.308.1`.