### PR TITLE
fix(ci-cd): Publish npm backports under a per-line dist-tag

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -72,4 +72,18 @@ jobs:
             echo "${PKG_NAME}@${PKG_VERSION} is already on the registry — skipping."
             exit 0
           fi
-          npm publish --provenance --access public
+          # A backport/hotfix publishes a version lower than the current `latest`
+          # dist-tag. npm refuses to implicitly move `latest` backwards, so pin such
+          # releases to a per-line dist-tag (release-X.Y) instead of moving `latest`.
+          # Newer releases (the normal main path) keep the implicit `latest`.
+          PUBLISH_ARGS=(--provenance --access public)
+          LATEST="$(npm view "${PKG_NAME}@latest" version 2>/dev/null || true)"
+          if [ -n "$LATEST" ] && [ "$LATEST" != "$PKG_VERSION" ]; then
+            HIGHEST="$(printf '%s\n%s\n' "$PKG_VERSION" "$LATEST" | sort -V | tail -n1)"
+            if [ "$HIGHEST" = "$LATEST" ]; then
+              LINE_TAG="release-$(printf '%s' "$PKG_VERSION" | cut -d. -f1-2)"
+              PUBLISH_ARGS+=(--tag "$LINE_TAG")
+              echo "Backport publish: ${PKG_VERSION} < latest ${LATEST}; using dist-tag ${LINE_TAG} (not moving 'latest')."
+            fi
+          fi
+          npm publish "${PUBLISH_ARGS[@]}"


### PR DESCRIPTION
## Problem

Publishing a hotfix/backport of `@swiss-ai-hub/web` fails at `npm publish`:

```
npm error Cannot implicitly apply the "latest" tag because previously published version 0.310.0 is higher than the new version 0.308.1. You must specify a tag using --tag.
```

npm refuses to move the `latest` dist-tag backwards when the version being published is lower than the current `latest`. The publish step always ran `npm publish --provenance --access public` (implicit `latest`), so any release from an older line (e.g. `hotfix/0.308` while `main` is on `0.310.x`) breaks.

## Fix

Before publishing, compare the version against the registry's current `latest`:

- If the new version is **lower** than `latest`, publish under a per-line dist-tag `release-<major>.<minor>` (e.g. `release-0.308`) and leave `latest` untouched.
- Otherwise (the normal `main` path, newest version), publish with the implicit `latest` exactly as before.

The exact-version skip guard is unchanged. PyPI is unaffected (pip resolves the highest version; publishing an older one is fine), so only `publish-npm.yml` changes.

## Note

Consumers of a backport install it explicitly, e.g. `npm install @swiss-ai-hub/web@release-0.308` or the exact version.