### PR TITLE
fix(ci-cd): Enable manual hotfix releases via source_ref and npm backport dist-tag

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -72,4 +72,33 @@ jobs:
             echo "${PKG_NAME}@${PKG_VERSION} is already on the registry — skipping."
             exit 0
           fi
-          npm publish --provenance --access public
+          # A backport/hotfix publishes a version lower than the current `latest`
+          # dist-tag. npm refuses to implicitly move `latest` backwards, so pin such
+          # releases to a per-line dist-tag (release-X.Y) instead of moving `latest`.
+          # Newer releases (the normal main path) keep the implicit `latest`.
+          PUBLISH_ARGS=(--provenance --access public)
+          # Resolve the registry's current `latest`. E404 (package/tag not yet
+          # published — the first-publish case) is treated as empty; any other
+          # npm failure (e.g. registry unreachable) fails loudly rather than
+          # silently falling through to an implicit `latest` publish.
+          set +e
+          LATEST_OUT="$(npm view "${PKG_NAME}@latest" version 2>&1)"
+          LATEST_RC=$?
+          set -e
+          if [ "$LATEST_RC" -eq 0 ]; then
+            LATEST="$LATEST_OUT"
+          elif printf '%s' "$LATEST_OUT" | grep -q 'E404'; then
+            LATEST=""
+          else
+            echo "::error::Could not query the current 'latest' version from npm: $LATEST_OUT"
+            exit 1
+          fi
+          if [ -n "$LATEST" ] && [ "$LATEST" != "$PKG_VERSION" ]; then
+            HIGHEST="$(printf '%s\n%s\n' "$PKG_VERSION" "$LATEST" | sort -V | tail -n1)"
+            if [ "$HIGHEST" = "$LATEST" ]; then
+              LINE_TAG="release-$(printf '%s' "$PKG_VERSION" | cut -d. -f1-2)"
+              PUBLISH_ARGS+=(--tag "$LINE_TAG")
+              echo "Backport publish: ${PKG_VERSION} < latest ${LATEST}; using dist-tag ${LINE_TAG} (not moving 'latest')."
+            fi
+          fi
+          npm publish "${PUBLISH_ARGS[@]}"

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -12,10 +12,12 @@
 #   set-latest.yml).
 #
 # USAGE:
-#   1. In the GitHub UI, pick this workflow and select the branch to release
-#      from (the branch tip is what gets tagged). The workflow file must exist
-#      on that branch, so merge this to `main` for future branches to inherit.
-#   2. Provide `release_version` as a strict vMAJOR.MINOR.PATCH tag (e.g.
+#   1. In the GitHub UI, run this workflow from `main` (the "Use workflow from"
+#      dropdown only lists branches that contain this file, so keep it on `main`).
+#   2. Set `source_ref` to the branch/ref you actually want to tag — e.g.
+#      `hotfix/0.308`. Leave it empty to tag the branch selected in the dropdown.
+#      The tip of that ref is what gets tagged.
+#   3. Provide `release_version` as a strict vMAJOR.MINOR.PATCH tag (e.g.
 #      v0.308.1). It is validated because publish-npm / publish-pypi guard that
 #      the tagged commit's package.json / pyproject.toml version matches.
 #
@@ -30,14 +32,20 @@
 #
 # =============================================================================
 name: Manual Tag, Gen-Changelog & Release
-run-name: Manual Tag & Release - ${{ github.event.inputs.release_version }}
+run-name: Manual Tag & Release - ${{ github.event.inputs.release_version }} (${{ github.event.inputs.source_ref || github.ref_name }})
 on:
   workflow_dispatch:
     inputs:
       release_version:
         description: Release version tag to cut (e.g., v0.308.1)
         required: true
+      source_ref:
+        description: Branch/ref to tag (e.g., hotfix/0.308). Empty = the branch selected above.
+        required: false
+        default: ''
 concurrency:
+  # Release versions are globally unique, so the version alone is the correct
+  # lock even now that any source_ref can be tagged.
   group: release-manual-${{ github.event.inputs.release_version }}
   cancel-in-progress: false
 jobs:
@@ -49,30 +57,37 @@ jobs:
       contents: write
     outputs:
       version: ${{ steps.validate.outputs.version }}
+      source_ref: ${{ steps.validate.outputs.source_ref }}
     steps:
-      - name: Validate version & branch
+      - name: Validate version & resolve source ref
         id: validate
         env:
           VERSION: ${{ github.event.inputs.release_version }}
-          BRANCH: ${{ github.ref_name }}
+          INPUT_SOURCE_REF: ${{ github.event.inputs.source_ref }}
+          SELECTED_BRANCH: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           if ! printf '%s' "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::'$VERSION' is not a valid vMAJOR.MINOR.PATCH release tag."
             exit 1
           fi
-          # Soft correlation check: hotfix/X.Y branches should cut vX.Y.* tags.
-          if [[ "$BRANCH" =~ ^hotfix/([0-9]+)\.([0-9]+)$ ]]; then
-            PREFIX="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}."
+          # Tag the ref the user asked for; fall back to the dropdown branch.
+          SOURCE_REF="${INPUT_SOURCE_REF:-$SELECTED_BRANCH}"
+          echo "Tagging ref: $SOURCE_REF"
+          # Soft correlation check: hotfix/X.Y or release/X.Y refs should cut vX.Y.* tags.
+          if [[ "$SOURCE_REF" =~ ^(hotfix|release)/([0-9]+)\.([0-9]+)$ ]]; then
+            PREFIX="v${BASH_REMATCH[2]}.${BASH_REMATCH[3]}."
             case "$VERSION" in
               "$PREFIX"*) : ;;
-              *) echo "::warning::Version $VERSION does not match branch $BRANCH (expected ${PREFIX}*)" ;;
+              *) echo "::warning::Version $VERSION does not match ref $SOURCE_REF (expected ${PREFIX}*)" ;;
             esac
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-      - name: Checkout branch
+          echo "source_ref=$SOURCE_REF" >> "$GITHUB_OUTPUT"
+      - name: Checkout source ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          ref: ${{ steps.validate.outputs.source_ref }}
           fetch-depth: 0
       - name: Guard - tag must not already exist
         env:
@@ -129,6 +144,7 @@ jobs:
           # Move the annotated tag onto the release commit and push only the tag.
           git tag -f -a "$VERSION" -m "Release $VERSION"
           git push origin "refs/tags/$VERSION"
+
           echo "Tagged $(git rev-parse --short HEAD) as $VERSION and pushed the tag."
   fan-out:
     name: Dispatch Downstream Release Workflows


### PR DESCRIPTION
Combines and supersedes #1598 and #1599 — the two changes needed to cut a hotfix release from an older branch.

## 1. `release-manual.yml`: `source_ref` input

The "Use workflow from" dropdown only lists branches that contain `release-manual.yml` (i.e. `main`), so a hotfix branch like `hotfix/0.308` cannot be selected. Adds an optional `source_ref` input: run from `main` and set `source_ref` to the branch/ref to tag; empty falls back to the selected branch (unchanged behaviour). Checkout and the `hotfix/X.Y` -> `vX.Y.*` soft warning now use the resolved ref.

## 2. `publish-npm.yml`: per-line dist-tag for backports

A backport publishes a version lower than the current `latest`, which npm rejects:

```
npm error Cannot implicitly apply the "latest" tag because previously published version 0.310.0 is higher than the new version 0.308.1.
```

Before publishing, compare against the registry `latest`: if lower, publish under `release-<major>.<minor>` (e.g. `release-0.308`) and leave `latest` untouched; otherwise keep the implicit `latest` (normal main path). PyPI is unaffected.

## Usage

Actions -> Manual Tag, Gen-Changelog & Release -> Run workflow: branch `main`, `source_ref = hotfix/0.308`, `release_version = v0.308.3`.