### PR TITLE
fix(ci-cd): Discover retag images from source_tag not main in set-latest

### DIFF
--- a/.github/workflows/set-latest.yml
+++ b/.github/workflows/set-latest.yml
@@ -59,6 +59,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ inputs.source_tag }}
       - name: Parse custom app images from compose-config.yml
         id: parse
         run: |


### PR DESCRIPTION
## Problem

Promoting a release with **Set latest Tag on Images** (`set-latest.yml`) fails when the tag being promoted was built from a lineage whose image set differs from `main`. Concretely, promoting `v0.308.3` fails with:

```
docker pull ghcr.io/bbvch-ai/aihub-core/memory_writer_agent:v0.308.3
Error response from daemon: manifest unknown
Error: Process completed with exit code 1.
```

## Root cause

`set-latest.yml` derives the **set of images to retag** and the **tag to pull** from two different commits:

- The `discover-images` job checks out **with no `ref`** → it parses `compose-config.yml` from `main` HEAD.
- `retag-docker` then pulls each discovered image at `source_tag`.

`v0.308.3` is a **manual hotfix** release (`release-manual.yml`) cut from the `0.308` lineage, which branched off **before** `memory_writer_agent` was added (PR #1565). The build workflow (`build-agents.yml`) is dispatched with `--ref <tag>`, so it correctly built only the 7 agents present at that tag — `memory_writer_agent:v0.308.3` was never produced. But discovery read `main` (8 agents, incl. `memory_writer_agent`), so `retag-docker` tried to pull a tag that does not exist.

This is a latent bug exposed by two recent additions: the manual-hotfix release path (promotes tags off a divergent lineage) and a new agent that exists on `main` but not on the older hotfix lineage. Previously discovery-off-`main` happened to match the tag's image set.

## Fix

Pin the `discover-images` checkout to `source_tag`, so discovery and build read `compose-config.yml` from the **same commit**. The retag matrix then always equals the images actually built for that tag — correct in both directions (agents added to `main` after the tag, or removed from `main` while still shipped by the tag).

## Test plan

- [ ] Re-run **Set latest Tag on Images** with `source_tag = v0.308.3` from this branch → matrix excludes `memory_writer_agent`, all pulls succeed.
- [ ] Promote a normal `main`-cut release → matrix unchanged from before.