### PR TITLE
fix(ui): Show empty-state message on memory list pages

### DIFF
--- a/packages/web/components/Memory/List.vue
+++ b/packages/web/components/Memory/List.vue
@@ -14,6 +14,12 @@
       striped-rows
       @update:selection="handleSelection"
     >
+      <template #empty>
+        <div class="py-8 text-center text-surface-500 dark:text-surface-400">
+          {{ t('memory.list.no_results') }}
+        </div>
+      </template>
+
       <Column
         field="memory"
         :header="t('memory.table.memory')"


### PR DESCRIPTION
## Summary

The memory list table rendered a blank body when there were no memories,
leaving pages like a thread's Memories view looking empty/broken.

Adds an `#empty` slot to the shared `Memory/List.vue` DataTable, showing a
centered "No memories found" message (reusing the existing
`memory.list.no_results` i18n key, already translated in en/de/fr/it).

Because `Memory/List.vue` is shared, this fixes the empty state consistently
across all memory views: thread memories, agent memories, organization
memories, user memories, and the OpenWebUI memories list.

## Changes

- `packages/web/components/Memory/List.vue`: add `#empty` template slot

## Testing

- `pnpm lint` — clean
- No frontend tests are configured for `packages/web` (`make test` is a no-op)
- Manual: open a thread's `/memories` page with no memories → empty message shows
