### PR TITLE
fix(swiss-ai-hub): Deprovision OpenWebUI model on agent config change

### DIFF
--- a/docs/arc42/decisions/2026_03_05_aihub_manages_openwebui_model_visibility.md
+++ b/docs/arc42/decisions/2026_03_05_aihub_manages_openwebui_model_visibility.md
@@ -34,11 +34,14 @@ following the same provisioner pattern used for Langfuse (`LangfuseProvisioner`)
 3. **Access grants**: For each workspace model, AI-Hub computes which groups have access using `AccessChecker` with
    tenant ceiling enforcement, then sets `access_control` on the model.
 
-The provisioner runs on five triggers — all changes propagate immediately:
+The provisioner runs on six triggers — all changes propagate immediately:
 
 - **Startup** (`provision()`): full sync of groups, workspace models, and access grants
-- **Agent discovery cycle** (`sync_agents()`): when the set of online agent instances changes (checked every 60
-  seconds), syncs workspace models and access grants
+- **Agent discovery cycle** (`sync_agents()`): the periodic reconciler — when the set of online agent instances changes
+  (checked every 60 seconds), syncs workspace models and access grants
+- **Agent config changes** (`sync_known_agents()`): when an agent instance is created, renamed, or deleted, syncs
+  workspace models and access grants immediately (via `AgentConfigChangeHook` MongoEngine signals on
+  `AgentConfigEntityDocument`) instead of waiting for the next discovery cycle
 - **Tenant switch** (`sync_access()`): when a user changes active tenant (via `AuthHandler` hook)
 - **OpenWebUI signup webhook** (`sync_access()`): when a new user signs up (via `WebhookController`)
 - **Access entity changes** (`sync_access()`): when roles, tenants, or user-role assignments are created, updated, or
@@ -57,6 +60,9 @@ The provisioner runs on five triggers — all changes propagate immediately:
   they're only active in production — not during unit tests. No manual notification calls in entity code. Rapid
   mutations are debounced with a 2-second quiet window so bulk operations (e.g. assigning 50 users) collapse into a
   single sync call.
+- **`AgentConfigChangeHook` pattern**: the workspace-model analogue of `AccessChangeHook`. `post_save`/`post_delete`
+  signals on `AgentConfigEntityDocument` trigger `sync_known_agents()` (same debounce, lock, and lifetime-manager
+  wiring). The discovery cycle remains the periodic backstop that reconciles drift.
 - **Distributed locking**: Each sync method (`provision`, `sync_agents`, `sync_access`) acquires a non-blocking Redis
   lock before executing. Concurrent calls across API replicas skip gracefully instead of racing. Locks use separate keys
   per sync type so agent sync and access sync don't block each other.

--- a/docs/docs/2_platform/10_chat_ui/11_integration_architecture/index.en.md
+++ b/docs/docs/2_platform/10_chat_ui/11_integration_architecture/index.en.md
@@ -62,9 +62,10 @@ context, AI-Hub pushes permission state into Open WebUI rather than filtering at
 3. **Access grants**: For each workspace model, AI-Hub computes which groups have access using the platform's permission
    system (with tenant ceiling enforcement), then sets `access_control` on the model
 
-The provisioner runs at API startup, when the set of online agents changes (checked every 60 seconds), when users switch
-tenants, when new users sign up via an Open WebUI webhook, and when roles, tenants, or user-role assignments are
-modified. All access changes propagate immediately.
+The provisioner runs at API startup, when an agent instance is created, renamed, or deleted (reflected immediately in
+the model picker), when the set of online agents changes (the periodic 60-second reconciler), when users switch tenants,
+when new users sign up via an Open WebUI webhook, and when roles, tenants, or user-role assignments are modified. All
+changes propagate immediately.
 
 **Reliability in multi-replica deployments:**
 

--- a/packages/api/swiss_ai_hub/api/runners/lifetime/lifetime_manager.py
+++ b/packages/api/swiss_ai_hub/api/runners/lifetime/lifetime_manager.py
@@ -19,7 +19,7 @@ from swiss_ai_hub.core.infrastructure import (
     RedisSettings,
     S3StorageSettings,
 )
-from swiss_ai_hub.core.persistence import AccessChangeHook
+from swiss_ai_hub.core.persistence import AccessChangeHook, AgentConfigChangeHook
 from swiss_ai_hub.core.subscribers import AgentNCSubscriber, ProcessNCSubscriber
 from swiss_ai_hub.core.topic_managers import AgentTopicManager, ProcessTopicManager
 
@@ -230,6 +230,10 @@ async def lifetime_manager(app: FastAPI) -> AsyncGenerator:
 
         # Re-sync OpenWebUI when access entities change (active tenant switches notify explicitly)
         AccessChangeHook.connect(openwebui_provisioner)
+
+        # Re-sync OpenWebUI workspace models when agent configs are created/renamed/deleted, so the
+        # model picker reflects the change immediately instead of on the next periodic discovery cycle
+        AgentConfigChangeHook.connect(openwebui_provisioner)
 
         # Yield control back to FastAPI to start serving requests
         yield

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_provisioner.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_provisioner.py
@@ -118,6 +118,14 @@ class OpenWebuiProvisioner:
 
             logger.info(f"OpenWebUI sync: Updated {len(online_agents)} agent workspace models")
 
+    async def sync_known_agents(self) -> None:
+        """Reconciles workspace models against the currently-known online agents in the DB.
+
+        Lets agent-config mutations (create/rename/delete) reflect in the OpenWebUI model picker
+        immediately instead of waiting for the next periodic discovery cycle.
+        """
+        await self.sync_agents(self._get_known_online_agents())
+
     async def sync_access(self) -> None:
         async with self._sync_lock("openwebui:sync:access") as acquired:
             if not acquired:

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_agent_config_change_hook_debounce.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_agent_config_change_hook_debounce.py
@@ -1,0 +1,95 @@
+import asyncio
+import gc
+
+import pytest
+from mongoengine import signals
+
+from swiss_ai_hub.core.persistence.agents.agent_config_change_hook import AgentConfigChangeHook
+from swiss_ai_hub.core.persistence.agents.agent_config_entity_document import AgentConfigEntityDocument
+
+
+class TestSignalSubscriptionSurvives:
+    """Regression for the weak-ref GC bug: a locally-defined closure wired with blinker's default
+    weak reference is collected the instant ``connect`` returns, silently dropping the subscription
+    so no config change ever triggers an OpenWebUI re-sync."""
+
+    def test_connect_subscription_survives_gc(self):
+        was_connected = AgentConfigChangeHook._connected
+        AgentConfigChangeHook._connected = False
+
+        class _DummyProvisioner:
+            async def sync_known_agents(self) -> None:
+                pass
+
+        try:
+            AgentConfigChangeHook.connect(_DummyProvisioner())
+            gc.collect()  # a weakly-referenced local closure would be collected here
+
+            assert list(signals.post_save.receivers_for(AgentConfigEntityDocument)), (
+                "post_save receiver was dropped — connect must use weak=False"
+            )
+            assert list(signals.post_delete.receivers_for(AgentConfigEntityDocument)), (
+                "post_delete receiver was dropped — connect must use weak=False"
+            )
+        finally:
+            for sig in (signals.post_save, signals.post_delete):
+                for receiver in list(sig.receivers_for(AgentConfigEntityDocument)):
+                    sig.disconnect(receiver, sender=AgentConfigEntityDocument)
+            AgentConfigChangeHook._connected = was_connected
+            AgentConfigChangeHook._provisioner = None
+
+
+class TestDebounce:
+    @pytest.mark.asyncio
+    async def test_multiple_schedules_result_in_single_sync(self):
+        call_count = 0
+
+        async def mock_sync():
+            nonlocal call_count
+            call_count += 1
+
+        original_debounced = AgentConfigChangeHook._debounced_sync
+
+        async def patched_debounced():
+            await asyncio.sleep(0.1)
+            await mock_sync()
+
+        AgentConfigChangeHook._debounced_sync = classmethod(lambda cls: patched_debounced())
+
+        try:
+            AgentConfigChangeHook._schedule_sync()
+            AgentConfigChangeHook._schedule_sync()
+            AgentConfigChangeHook._schedule_sync()
+
+            await asyncio.sleep(0.3)
+
+            assert call_count == 1
+        finally:
+            AgentConfigChangeHook._debounced_sync = original_debounced
+            AgentConfigChangeHook._debounce_task = None
+
+    @pytest.mark.asyncio
+    async def test_schedule_cancels_previous_task(self):
+        AgentConfigChangeHook._debounce_task = None
+
+        async def slow_sync():
+            await asyncio.sleep(10)
+
+        AgentConfigChangeHook._debounced_sync = classmethod(lambda cls: slow_sync())
+
+        try:
+            AgentConfigChangeHook._schedule_sync()
+            first_task = AgentConfigChangeHook._debounce_task
+
+            AgentConfigChangeHook._schedule_sync()
+            second_task = AgentConfigChangeHook._debounce_task
+
+            # Yield control so cancellation propagates
+            await asyncio.sleep(0)
+
+            assert first_task.cancelled()
+            assert not second_task.cancelled()
+
+            second_task.cancel()
+        finally:
+            AgentConfigChangeHook._debounce_task = None

--- a/packages/core/swiss_ai_hub/core/persistence/__init__.py
+++ b/packages/core/swiss_ai_hub/core/persistence/__init__.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from swiss_ai_hub.core.persistence.access.entities.tenant_metadata_entity import TenantMetadataEntity
     from swiss_ai_hub.core.persistence.access.entities.user_tenant_role_entity import UserTenantRoleEntity
     from swiss_ai_hub.core.persistence.agents.agent_class_entity import AgentClassEntity
+    from swiss_ai_hub.core.persistence.agents.agent_config_change_hook import AgentConfigChangeHook
     from swiss_ai_hub.core.persistence.agents.agent_config_entity_document import AgentConfigEntityDocument
     from swiss_ai_hub.core.persistence.i18n.locale_string_entity import LocaleStringEntity
     from swiss_ai_hub.core.persistence.messaging.entities.persisted_agent_event_entity import (
@@ -87,6 +88,7 @@ if TYPE_CHECKING:
 __all__ = [
     "AccessChangeHook",
     "AgentClassEntity",
+    "AgentConfigChangeHook",
     "AgentConfigEntityDocument",
     "AgentInSpecsEntity",
     "AgentInstanceRef",
@@ -156,6 +158,7 @@ __all__ = [
 _LAZY_IMPORTS = {
     "AccessChangeHook": "swiss_ai_hub.core.persistence.access.access_change_hook",
     "AgentClassEntity": "swiss_ai_hub.core.persistence.agents.agent_class_entity",
+    "AgentConfigChangeHook": "swiss_ai_hub.core.persistence.agents.agent_config_change_hook",
     "AgentConfigEntityDocument": "swiss_ai_hub.core.persistence.agents.agent_config_entity_document",
     "AgentInSpecsEntity": "swiss_ai_hub.core.persistence.process.process_class_entity",
     "AgentInstanceRef": "swiss_ai_hub.core.persistence.messaging.entities.thread_entity",

--- a/packages/core/swiss_ai_hub/core/persistence/agents/agent_config_change_hook.py
+++ b/packages/core/swiss_ai_hub/core/persistence/agents/agent_config_change_hook.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from mongoengine import signals
+
+from swiss_ai_hub.core.persistence.agents.agent_config_entity_document import AgentConfigEntityDocument
+
+if TYPE_CHECKING:
+    from swiss_ai_hub.core.infrastructure.openwebui.openwebui_provisioner import OpenWebuiProvisioner
+
+logger = logging.getLogger(__name__)
+
+_DEBOUNCE_SECONDS = 2.0
+
+
+class AgentConfigChangeHook:
+    """Reflects agent-config mutations into OpenWebUI workspace models immediately.
+
+    Without this, a created/renamed/deleted agent only appears in (or disappears from) the
+    OpenWebUI model picker on the next periodic discovery cycle. Wiring the config entity's
+    save/delete signals to a debounced ``sync_known_agents`` closes that lag window.
+    """
+
+    _connected: ClassVar[bool] = False
+    _debounce_task: ClassVar[asyncio.Task | None] = None
+    _provisioner: ClassVar[OpenWebuiProvisioner | None] = None
+
+    @classmethod
+    def connect(cls, provisioner: OpenWebuiProvisioner) -> None:
+        """Wires MongoEngine signals to sync OpenWebUI agents on any config save/delete.
+
+        Rapid mutations are debounced: only the last change in a 2-second quiet window triggers sync.
+        """
+        if cls._connected:
+            return
+
+        cls._provisioner = provisioner
+
+        def _on_change(sender: type, document: Any, **kwargs: Any) -> None:
+            logger.info("Agent config changed (%s), scheduling OpenWebUI agent sync", sender.__name__)
+            cls._schedule_sync()
+
+        # weak=False is required: ``_on_change`` is a local closure with no other strong reference, so
+        # blinker's default weak ref would let it be garbage-collected the moment ``connect`` returns,
+        # silently dropping the subscription so no config change ever triggers an OpenWebUI re-sync.
+        signals.post_save.connect(_on_change, sender=AgentConfigEntityDocument, weak=False)
+        signals.post_delete.connect(_on_change, sender=AgentConfigEntityDocument, weak=False)
+
+        logger.info("AgentConfigChangeHook connected for %s", AgentConfigEntityDocument.__name__)
+        cls._connected = True
+
+    @classmethod
+    def notify(cls) -> None:
+        """Explicitly schedule an OpenWebUI agent sync from outside the signal system."""
+        if not cls._connected:
+            return
+        logger.info("Explicit agent config change notification, scheduling OpenWebUI agent sync")
+        cls._schedule_sync()
+
+    @classmethod
+    def _schedule_sync(cls) -> None:
+        if cls._debounce_task and not cls._debounce_task.done():
+            cls._debounce_task.cancel()
+        cls._debounce_task = asyncio.create_task(cls._debounced_sync())
+
+    @classmethod
+    async def _debounced_sync(cls) -> None:
+        await asyncio.sleep(_DEBOUNCE_SECONDS)
+        await cls._provisioner.sync_known_agents()

--- a/packages/web/components/Agent/Card.vue
+++ b/packages/web/components/Agent/Card.vue
@@ -100,6 +100,7 @@ const route = useRoute()
 const { t } = useI18n()
 const toast = useToast()
 const confirm = useConfirm()
+const tenantPath = useTenantPath()
 const { tenantId } = useTenant()
 const { deleteAgentInstance, isDeleting } = useDeleteAgentInstance()
 const { exportAgentInstance } = useExportAgentInstance()
@@ -122,6 +123,13 @@ function confirmDelete() {
 
 async function handleDelete() {
   try {
+    // When the deleted agent's own detail page is open, leave it first: the delete invalidates the
+    // instance query, and a still-mounted detail page would refetch the now-missing agent and raise
+    // a 404 error toast. Navigating away deactivates that query so it is only marked stale, not refetched.
+    if (isActive.value) {
+      await navigateTo(tenantPath('/service/agents'))
+    }
+
     await deleteAgentInstance({
       agentClass: props.agent.agent_class,
       agentId: props.agent.agent_id,


### PR DESCRIPTION
## Problem

Fixes bbvch-ai/aihub-core-private#67 — a deleted AI Assistant kept appearing in the Chat **Model** dropdown, and deleting a second time (or deleting while on the agent's detail page) surfaced a 404 error.

## Root cause

OpenWebUI workspace models (which populate the Chat model picker) were reconciled **only** by the periodic agent-discovery loop (~every 60s). `create/delete_agent_instance` never triggered a re-provision, so a deleted agent lingered in the picker until the next cycle.

## Changes

- **`OpenWebuiProvisioner.sync_known_agents()`** — reconciles workspace models against the currently-known online agents in the DB (reuses the existing diff-based `sync_agents` + `_get_known_online_agents`).
- **`AgentConfigChangeHook`** (new) — the workspace-model analogue of `AccessChangeHook`: `post_save`/`post_delete` MongoEngine signals on `AgentConfigEntityDocument` trigger a 2s-debounced `sync_known_agents()`. Wired in the API lifetime manager next to `AccessChangeHook`. Covers create, rename, and delete immediately; the discovery loop remains the periodic backstop.
- **Frontend `Agent/Card.vue`** — when deleting the agent whose detail page is currently open, navigate to the list *before* deleting, so the instance query goes inactive and never refetches the now-missing agent into a 404 toast.
- **Docs** — updated ADR `2026_03_05_aihub_manages_openwebui_model_visibility` and the Chat UI integration-architecture page to record the new immediate sync trigger.

## Test plan

- [x] core (openwebui + persistence): 166 passed, incl. 3 new `AgentConfigChangeHook` tests (GC-survival + debounce)
- [x] api (agent unit + discovery/provisioner-sync): 32 passed
- [x] api (full-lifespan agent API — exercises the wired hook): 4 passed
- [x] api (config DB-ops + auth): 29 passed
- [x] ruff clean on all changed files
- [x] Manually verified on `latest`: deleted agent no longer shows in the Chat model picker; no 404 when deleting from the detail page

## Notes

- Follows the existing `AccessChangeHook` pattern (no new abstraction); not wired into `sysadmin-api` (which deliberately omits provisioners).