### PR TITLE
fix(ui): Populate role editor from cached role data

### DIFF
--- a/packages/web/pages/[tenant]/service/roles/[role_id].vue
+++ b/packages/web/pages/[tenant]/service/roles/[role_id].vue
@@ -6,9 +6,7 @@
     size="small"
   >
     <div class="flex flex-col gap-4">
-      <RoleEdit
-        v-model="clonedRole"
-      />
+      <RoleEdit v-model="clonedRole" />
       <div class="flex justify-end">
         <Button
           type="button"
@@ -40,12 +38,12 @@ const clonedRole = ref<CreateRoleRequest>({
   description: '',
   access_rules: [],
 })
-watch(role, (newRole: RoleResponse) => {
+watch(role, (newRole: RoleResponse | undefined) => {
   if (!newRole) {
     return
   }
   clonedRole.value = cloneDeep(newRole)
-})
+}, { immediate: true })
 
 const saveRole = async () => {
   await updateRole({ roleId: role.value.id, updatedRole: clonedRole.value, tenantId: tenantId.value! })


### PR DESCRIPTION
## Problem

Opening a role showed its name, description and access rules the first time,
but returning to that same role later rendered an empty editor.

closes bbvch-ai/aihub-core-private#84

https://github.com/user-attachments/assets/72260ca4-2854-486c-b38d-40f16230b668


## Root cause

Three things combine:

1. `pages/[tenant]/service/roles/[role_id].vue` is keyed by route path, so
   navigating between roles **remounts** the page. `clonedRole` resets to
   `{ name: '', description: '', access_rules: [] }` on every mount.
2. The `watch(role, ...)` that copies query data into `clonedRole` was not
   `immediate`, so it only ran when the value *changed*.
3. `useRole` sets `staleTime: 5min`. On a revisit the query key already holds
   fresh cached data, so `role.value` is populated at setup time and never
   changes — the watch never fires and the form stays on the empty object.

The first visit worked by accident: on a cold fetch `roleIsLoading` is true,
and `StructuralColumn` withholds its slot while loading, so `RoleEdit` did not
mount until the data had arrived. On a cache hit that delay disappears.

## Change

Added `{ immediate: true }` to the watch, and widened the callback parameter to
`RoleResponse | undefined` — the immediate tick can run before data exists, and
the existing early-return guard already handles it.

## Test plan

- [x] Open role A — name, description and access rules render
- [x] Open role B, then return to role A within 5 minutes — all fields still render
- [x] Existing rules on a revisited role show **no** "New" tag; only rules added in the current session do
- [x] Save on a revisited role persists the correct values (not an empty role)