### PR TITLE
feat(ci-cd): Stop per-merge bump, switch nightly to channel tags

### DIFF
--- a/.github/actions/compute-version/action.yml
+++ b/.github/actions/compute-version/action.yml
@@ -1,10 +1,15 @@
 ---
 name: Compute Channel Version
 description: Derive a channel-suffixed version from the pyproject core version and git height.
-# Reads the clean semver from the root pyproject.toml and appends a channel
-# pre-release identifier. The build number is the git height (commit count),
-# which is deterministic and monotonic. Requires the caller to have checked out
-# the repository with `fetch-depth: 0` so `git rev-list --count` sees full history.
+# Reads the clean semver from the [project] table of the root pyproject.toml and
+# appends a channel pre-release identifier. The build number is the git height
+# (commit count), which is deterministic and monotonic. Requires the caller to
+# have checked out with `fetch-depth: 0` so `git rev-list --count` sees full
+# history.
+#
+# Bumping pyproject.toml is the deliberate act that opens a new core-version
+# window; merges to main do NOT bump it, so the core only moves when someone
+# changes pyproject (see the versioning process doc).
 inputs:
   channel:
     description: 'Release channel: nightly, staging, or stable'
@@ -29,12 +34,26 @@ runs:
         CHANNEL: ${{ inputs.channel }}
       run: |
         set -euo pipefail
-        core="$(grep -m1 -E '^version = ' pyproject.toml | sed -E 's/^version = "([^"]+)".*/\1/')"
+        # Read version only from the [project] table, so an earlier `version =`
+        # line in some other table cannot be picked up by mistake.
+        core="$(awk '
+          /^\[/ { in_project = ($0 == "[project]") }
+          in_project && /^version[[:space:]]*=/ {
+            sub(/^version[[:space:]]*=[[:space:]]*"/, "")
+            sub(/".*/, "")
+            print
+            exit
+          }
+        ' pyproject.toml)"
         if ! printf '%s' "$core" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-          echo "::error::Could not read a clean semver from pyproject.toml (got '$core')."
+          echo "::error::Could not read a clean semver from the [project] version in pyproject.toml (got '$core')."
           exit 1
         fi
         build="$(git rev-list --count HEAD)"
+        if ! printf '%s' "$build" | grep -Eq '^[0-9]+$'; then
+          echo "::error::git-height is not numeric (got '$build'). Ensure a full-history checkout (fetch-depth: 0)."
+          exit 1
+        fi
         case "$CHANNEL" in
           nightly) version="v${core}-nightly.${build}" ;;
           staging) version="v${core}-staging.${build}" ;;

--- a/.github/actions/compute-version/action.yml
+++ b/.github/actions/compute-version/action.yml
@@ -1,0 +1,49 @@
+---
+name: Compute Channel Version
+description: Derive a channel-suffixed version from the pyproject core version and git height.
+# Reads the clean semver from the root pyproject.toml and appends a channel
+# pre-release identifier. The build number is the git height (commit count),
+# which is deterministic and monotonic. Requires the caller to have checked out
+# the repository with `fetch-depth: 0` so `git rev-list --count` sees full history.
+inputs:
+  channel:
+    description: 'Release channel: nightly, staging, or stable'
+    required: true
+outputs:
+  version:
+    description: 'Full tag including the v prefix, e.g. v0.314.0-nightly.42'
+    value: ${{ steps.compute.outputs.version }}
+  core:
+    description: 'Core semver with v prefix, e.g. v0.314.0'
+    value: ${{ steps.compute.outputs.core }}
+  build:
+    description: 'Build number (git height)'
+    value: ${{ steps.compute.outputs.build }}
+runs:
+  using: composite
+  steps:
+    - name: Compute version
+      id: compute
+      shell: bash
+      env:
+        CHANNEL: ${{ inputs.channel }}
+      run: |
+        set -euo pipefail
+        core="$(grep -m1 -E '^version = ' pyproject.toml | sed -E 's/^version = "([^"]+)".*/\1/')"
+        if ! printf '%s' "$core" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+          echo "::error::Could not read a clean semver from pyproject.toml (got '$core')."
+          exit 1
+        fi
+        build="$(git rev-list --count HEAD)"
+        case "$CHANNEL" in
+          nightly) version="v${core}-nightly.${build}" ;;
+          staging) version="v${core}-staging.${build}" ;;
+          stable)  version="v${core}" ;;
+          *) echo "::error::Unknown channel '$CHANNEL' (expected nightly, staging, or stable)."; exit 1 ;;
+        esac
+        {
+          echo "core=v${core}"
+          echo "build=${build}"
+          echo "version=${version}"
+        } >> "$GITHUB_OUTPUT"
+        echo "Computed ${CHANNEL} version: ${version}"

--- a/.github/workflows/add-tag.yml
+++ b/.github/workflows/add-tag.yml
@@ -1,5 +1,17 @@
 ---
-name: Auto Tag, Gen-Changelog & Release
+# =============================================================================
+# Nightly Tag & Build
+# =============================================================================
+# On every PR merged to main, cut an immutable nightly tag and move the rolling
+# `nightly` pointer, then dispatch the build + bundle workflows. This is the
+# lightweight trunk path: no version bump, no changelog commit, no force-push to
+# main. Those release-time concerns move to the promote workflow (see the
+# versioning process doc, Phase 3).
+#
+# Version: v<core>-nightly.<git-height>, where <core> is the clean semver in
+# pyproject.toml and <git-height> is the commit count on main.
+# =============================================================================
+name: Nightly Tag & Build
 on:
   pull_request:
     types: [closed]
@@ -8,410 +20,64 @@ permissions:
   contents: write
   actions: read
 jobs:
-  compute-and-initial-tag:
-    name: Compute Version & Initial Tag
-    if: github.event.pull_request.merged == true || github.event_name == 'push'
+  nightly-tag:
+    name: Tag nightly & move pointer
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-slim
     timeout-minutes: 10
     outputs:
-      version: ${{ steps.create-tag.outputs.version }}
+      version: ${{ steps.compute.outputs.version }}
     steps:
-      - name: Checkout the repository
+      # Deploy key (not GITHUB_TOKEN): moving the rolling `nightly` tag between
+      # commits can touch workflow files, which GITHUB_TOKEN may not push. The
+      # RELEASE_FINALIZE_DEPLOY_KEY bypasses that restriction (same key used by
+      # set-latest.yml). fetch-depth 0 is required for git-height.
+      - name: Checkout main (full history)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          fetch-depth: 0  # Important: fetch all history for git diff to work
-      - name: Create new version number & tag
-        id: create-tag
-        env:
-          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
-        run: |
-          # List all tags that match the pattern 'v*' and check if the list is empty
-          tags=$(git tag -l "v*")
-          if [ -z "$tags" ]; then
-            echo "No version tags found, starting with v0.0.0"
-            latest_tag="v0.0.0"
-          else
-            # Get the latest tag matching 'v*'
-            latest_tag=$(git tag -l "v*" | sort -V | tail -n 1)
-          fi
-          echo "Latest tag: $latest_tag"
-
-          # Remove the 'v' prefix for version manipulation
-          version_number=${latest_tag#"v"}
-
-          # Split into components
-          major=$(echo "$version_number" | cut -d. -f1)
-          minor=$(echo "$version_number" | cut -d. -f2)
-          patch=$(echo "$version_number" | cut -d. -f3)
-
-          # Check PR labels to determine version bump type
-          # Default to patch if no label is found
-          bump_type="patch"
-          echo "PR Labels: $PR_LABELS"
-
-          # Check for version bump labels
-          if echo "$PR_LABELS" | grep -q '"major"'; then
-            bump_type="major"
-            echo "Found 'major' label - will bump major version"
-          elif echo "$PR_LABELS" | grep -q '"minor"'; then
-            bump_type="minor"
-            echo "Found 'minor' label - will bump minor version"
-          elif echo "$PR_LABELS" | grep -q '"patch"'; then
-            bump_type="patch"
-            echo "Found 'patch' label - will bump patch version"
-          else
-            echo "No version label found - defaulting to patch bump"
-          fi
-
-          # Perform the version bump based on the determined type
-          case $bump_type in
-            major)
-              new_major=$((major + 1))
-              new_minor=0
-              new_patch=0
-              ;;
-            minor)
-              new_major=$major
-              new_minor=$((minor + 1))
-              new_patch=0
-              ;;
-            patch)
-              new_major=$major
-              new_minor=$minor
-              new_patch=$((patch + 1))
-              ;;
-          esac
-          new_tag="v$new_major.$new_minor.$new_patch"
-          echo "New tag: $new_tag (bump type: $bump_type)"
-
-          # Expose it to subsequent steps via outputs (not just GITHUB_ENV).
-          echo "version=$new_tag" >> $GITHUB_OUTPUT
-      - name: Tag the commit and push the tag
-        env:
-          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
-        run: |
-          set -euo pipefail
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          TAG_NAME="${{ steps.create-tag.outputs.version }}"
-          TAG_MESSAGE="Initial Tag for: $TAG_NAME"
-
-          # Check if tag already exists (locally or remotely)
-          if git rev-parse "$TAG_NAME" >/dev/null 2>&1 || git ls-remote --tags origin | grep -q "refs/tags/$TAG_NAME$"; then
-            echo "Error: Tag $TAG_NAME already exists. Aborting."
-            exit 1
-          fi
-
-          # Create annotated tag
-          TARGET_SHA="$MERGE_COMMIT_SHA"
-          if [ -z "$TARGET_SHA" ] || [ "$TARGET_SHA" == "null" ] ; then
-            # For squash/rebase merges, use the base branch tip after merge
-            git fetch origin main
-            TARGET_SHA="$(git rev-parse origin/main)"
-          fi
-          git tag -a "$TAG_NAME" -m "$TAG_MESSAGE" "$TARGET_SHA"
-
-          # Verify tag exists locally
-          if ! git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
-            echo "Error: Failed to create tag $TAG_NAME."
-            exit 1
-          fi
-
-          # Push the tag
-          echo "Pushing tag $TAG_NAME..."
-          git push origin "$TAG_NAME"
-
-          # Verify the tag was pushed successfully
-          echo "Verifying tag was pushed..."
-          git fetch origin --tags
-          if git tag -l "$TAG_NAME" | grep -q "^$TAG_NAME$"; then
-            echo "Success: Tag $TAG_NAME confirmed on remote."
-
-            # Show it's now the latest tag (consistent with your tag discovery logic)
-            latest_tag=$(git tag -l "v*" | sort -V | tail -n 1)
-            echo "Latest tag is now: $latest_tag"
-          else
-            echo "Error: Tag $TAG_NAME not found after push."
-            echo ""
-            echo "Available tags (last 10):"
-            git tag -l "v*" | sort -V | tail -10
-            echo ""
-            echo "Expected: $TAG_NAME"
-            exit 1
-          fi
-  changelog:
-    name: Generate Changelog
-    needs: [compute-and-initial-tag]
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 30
-    continue-on-error: true
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          fetch-depth: 0
-      - name: Use Python 3.13
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: '3.13'
-      - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
-        with:
-          enable-cache: true
-      - name: Install Dependencies
-        run: uv sync --all-packages --dev --frozen
-      - name: Setup LLM for Changelog Generation
-        env:
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-        run: |
-          echo "Installing llm and llm-gemini plugin..."
-          uv tool install llm --with llm-gemini
-          echo "Setting Gemini API key..."
-          llm keys set gemini --value "$GEMINI_API_KEY"
-          echo "Ensuring changelog script is executable..."
-          chmod +x ./generate-changelog.sh
-      - name: Generate Changelog
-        id: changelog_generator
-        run: make changelog
-      - name: Upload changelog artifact
-        if: ${{ hashFiles('CHANGELOG.md') != '' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: changelog
-          path: CHANGELOG.md
-  license-report:
-    name: Generate License Report
-    needs: [compute-and-initial-tag]
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 20
-    continue-on-error: true
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          fetch-depth: 0
-      - name: Use Python 3.13
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: '3.13'
-      - name: Install additional dependencies for license check
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y jq
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: 25.x
-      - name: Install pnpm via corepack
-        run: |
-          npm install -g --ignore-scripts corepack@0.34.7
-          corepack enable pnpm
-          corepack install
-        working-directory: packages/web
-      - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
-        with:
-          enable-cache: true
-      - name: Install Dependencies
-        run: uv sync --all-packages --dev --frozen
-      - name: Update License Report
-        id: license_generator
-        run: |
-          chmod +x ./generate-license.sh
-          make license-check
-      - name: Upload license artifact
-        if: ${{ hashFiles('LICENSE_REPORT.md') != '' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: licenses
-          path: LICENSE_REPORT.md
-  env-docs:
-    name: Generate Environment Variables Reference
-    needs: [compute-and-initial-tag]
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 15
-    continue-on-error: true
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          fetch-depth: 0
-      - name: Use Python 3.13
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: '3.13'
-      - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
-        with:
-          enable-cache: true
-      - name: Install Dependencies
-        run: uv sync --all-packages --dev --frozen
-      - name: Generate compose files
-        run: make generate-compose
-      - name: Generate environment-variables reference page
-        run: make generate-env-docs
-      - name: Upload env-docs artifact
-        if: ${{ hashFiles('docs/docs/2_platform/3_deployment_guide/9_environment_variables/index.en.md') != '' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: env-docs
-          path: docs/docs/2_platform/3_deployment_guide/9_environment_variables/index.en.md
-  sync-docs:
-    name: Sync Documentation Translations
-    needs: [compute-and-initial-tag]
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 60
-    continue-on-error: true
-    steps:
-      - name: Checkout the repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          fetch-depth: 0
-      - name: Setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
-        with:
-          package_json_file: docs/package.json
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: '25'
-          cache: pnpm
-          cache-dependency-path: docs/pnpm-lock.yaml
-      - name: Install dependencies
-        working-directory: ./docs
-        run: pnpm install
-      - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
-        with:
-          enable-cache: true
-      - name: Setup LLM for translation
-        env:
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-        run: |
-          echo "Installing llm and llm-gemini plugin..."
-          uv tool install llm --with llm-gemini
-          echo "Setting Gemini API key..."
-          llm keys set gemini --value "$GEMINI_API_KEY"
-      - name: Sync documentation
-        working-directory: ./docs
-        run: pnpm run docs:sync
-      - name: Upload docs artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: docs
-          path: docs/
-  finalize-release:
-    name: Commit Artifacts & Finalize Tag
-    needs:
-      - compute-and-initial-tag
-      - changelog
-      - license-report
-      - env-docs
-      - sync-docs
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 15
-    steps:
-      # Authenticate via a deploy key (not the default GITHUB_TOKEN) because this
-      # job amends the merge commit and force-pushes it to `main`. The `main`
-      # branch is protected (PR-only, required status checks, no force-push), and
-      # GITHUB_TOKEN cannot bypass those rules. The deploy key stored in
-      # RELEASE_FINALIZE_DEPLOY_KEY is registered with bypass permissions, so
-      # pushes from this step are accepted.
-      - name: Checkout the repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
+          ref: main
           fetch-depth: 0
           ssh-key: ${{ secrets.RELEASE_FINALIZE_DEPLOY_KEY }}
-      - name: Download changelog (if any)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+      - name: Compute nightly version
+        id: compute
+        uses: ./.github/actions/compute-version
         with:
-          name: changelog
-          path: .
-        continue-on-error: true
-      - name: Download licenses (if any)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-        with:
-          name: licenses
-          path: .
-        continue-on-error: true
-      - name: Download env-docs (if any)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-        with:
-          name: env-docs
-          path: docs/docs/2_platform/3_deployment_guide/9_environment_variables/
-        continue-on-error: true
-      - name: Download docs (if any)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-        with:
-          name: docs
-          path: docs/
-        continue-on-error: true
-      - name: Set up Python 3.13
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: '3.13'
-      - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
-        with:
-          enable-cache: true
-      - name: Increment version in project files
+          channel: nightly
+      - name: Create nightly tag and move the nightly pointer
         env:
-          VERSION: ${{ needs.compute-and-initial-tag.outputs.version }}
+          VERSION: ${{ steps.compute.outputs.version }}
         run: |
-          PEP_VERSION="${VERSION#v}"
-          make version-bump VERSION="$PEP_VERSION"
-      - name: Generate and lint Docker Compose files
-        run: |
-          make generate-compose
-          make format-yaml
-      - name: Commit Changelog, License Report, Version Update and Finalize Tag
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-        run: |
-          VERSION="${{ needs.compute-and-initial-tag.outputs.version }}"
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          TARGET="$(git rev-parse HEAD)"
 
-          # Detect changes (only if files exist and differ)
-          changed=false
-          if [ -f CHANGELOG.md ]; then
-            if [ -n "$(git status --porcelain CHANGELOG.md)" ]; then
-              git add CHANGELOG.md
-              changed=true
-              echo "Changelog updated."
-            fi
+          # Immutable per-merge tag. The annotated message embeds the full
+          # version so the Ansible deploy can resolve it from the tag object
+          # (see roles/aihub_application/tasks/fetch.yml in aihub-playbook).
+          if git rev-parse "$VERSION" >/dev/null 2>&1 \
+            || git ls-remote --tags origin | grep -q "refs/tags/$VERSION$"; then
+            echo "::notice::Tag $VERSION already exists; not recreating."
+          else
+            git tag -a "$VERSION" -m "Release $VERSION" "$TARGET"
+            git push origin "refs/tags/$VERSION"
           fi
-          if [ -f LICENSE_REPORT.md ]; then
-            if [ -n "$(git status --porcelain LICENSE_REPORT.md)" ]; then
-              git add LICENSE_REPORT.md
-              changed=true
-              echo "License report updated."
-            fi
-          fi
-          if [ -n "$(git status --porcelain docs/)" ]; then
-            git add docs/
-            changed=true
-            echo "Documentation translations updated."
-          fi
-          git add -A
-          git commit --amend --no-edit || echo "No file changes to commit."
-          git push origin HEAD:"$BASE_REF" --force-with-lease
-          echo "Creating final tag $VERSION and pushing..."
-          git tag -a -f "${VERSION}" -m "Release ${VERSION}"
-          git push origin "refs/tags/${VERSION}" --force
-          echo "Setting 'nightly' tag to same commit as $VERSION..."
-          git tag -f nightly "${VERSION}"
+
+          # Rolling pointer: newest nightly. Annotated so its message carries
+          # the full version for the deploy to parse.
+          git tag -f -a nightly "$TARGET" -m "Release $VERSION"
           git push origin refs/tags/nightly --force
+          echo "Tagged $TARGET as $VERSION and moved 'nightly'."
   notify-release:
-    name: Notify Release Dispatch
-    needs: [finalize-release, compute-and-initial-tag]
+    name: Dispatch build & bundle
+    needs: nightly-tag
     runs-on: ubuntu-slim
     timeout-minutes: 5
     steps:
       - name: Dispatch release-ready
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ needs.compute-and-initial-tag.outputs.version }}
+          VERSION: ${{ needs.nightly-tag.outputs.version }}
         run: |-
           gh api repos/${{ github.repository }}/dispatches \
             -F event_type=release-ready \

--- a/.github/workflows/add-tag.yml
+++ b/.github/workflows/add-tag.yml
@@ -2,19 +2,21 @@
 # =============================================================================
 # Nightly Tag & Build
 # =============================================================================
-# On every PR merged to main, cut an immutable nightly tag and move the rolling
-# `nightly` pointer, then dispatch the build + bundle workflows. This is the
-# lightweight trunk path: no version bump, no changelog commit, no force-push to
-# main. Those release-time concerns move to the promote workflow (see the
-# versioning process doc, Phase 3).
+# On every push to main (each merged PR), cut an immutable nightly tag and move
+# the rolling `nightly` pointer, then dispatch the build + bundle workflows.
+# Lightweight trunk path: no version bump, no changelog commit, no force-push.
+#
+# Triggered on `push` (not `pull_request`) on purpose: push events run the
+# workflow file from the pushed commit, so merging THIS change activates the new
+# scheme on that very merge. pull_request events run the base branch's (old)
+# copy, which would let the old workflow handle its own replacement.
 #
 # Version: v<core>-nightly.<git-height>, where <core> is the clean semver in
 # pyproject.toml and <git-height> is the commit count on main.
 # =============================================================================
 name: Nightly Tag & Build
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
 permissions:
   contents: write
@@ -27,7 +29,6 @@ concurrency:
 jobs:
   nightly-tag:
     name: Tag nightly & move pointer
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-slim
     timeout-minutes: 10
     outputs:

--- a/.github/workflows/add-tag.yml
+++ b/.github/workflows/add-tag.yml
@@ -19,6 +19,11 @@ on:
 permissions:
   contents: write
   actions: read
+concurrency:
+  # Serialise nightly tagging: two near-simultaneous merges must not race on the
+  # rolling `nightly` pointer (force-push race) or move it backwards.
+  group: nightly-tag
+  cancel-in-progress: false
 jobs:
   nightly-tag:
     name: Tag nightly & move pointer
@@ -27,11 +32,14 @@ jobs:
     timeout-minutes: 10
     outputs:
       version: ${{ steps.compute.outputs.version }}
+      created: ${{ steps.tag.outputs.created }}
     steps:
-      # Deploy key (not GITHUB_TOKEN): moving the rolling `nightly` tag between
-      # commits can touch workflow files, which GITHUB_TOKEN may not push. The
-      # RELEASE_FINALIZE_DEPLOY_KEY bypasses that restriction (same key used by
-      # set-latest.yml). fetch-depth 0 is required for git-height.
+      # Deploy key (not GITHUB_TOKEN): pushing any tag whose target commit
+      # differs in .github/workflows/** content requires the `workflow` scope,
+      # which GITHUB_TOKEN cannot hold. That covers both the immutable per-merge
+      # tag and the moving `nightly` pointer, so both use
+      # RELEASE_FINALIZE_DEPLOY_KEY (same key as set-latest.yml). fetch-depth 0
+      # is required for git-height.
       - name: Checkout main (full history)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -44,6 +52,7 @@ jobs:
         with:
           channel: nightly
       - name: Create nightly tag and move the nightly pointer
+        id: tag
         env:
           VERSION: ${{ steps.compute.outputs.version }}
         run: |
@@ -57,10 +66,12 @@ jobs:
           # (see roles/aihub_application/tasks/fetch.yml in aihub-playbook).
           if git rev-parse "$VERSION" >/dev/null 2>&1 \
             || git ls-remote --tags origin | grep -q "refs/tags/$VERSION$"; then
-            echo "::notice::Tag $VERSION already exists; not recreating."
+            echo "::notice::Tag $VERSION already exists; not recreating or dispatching."
+            echo "created=false" >> "$GITHUB_OUTPUT"
           else
             git tag -a "$VERSION" -m "Release $VERSION" "$TARGET"
             git push origin "refs/tags/$VERSION"
+            echo "created=true" >> "$GITHUB_OUTPUT"
           fi
 
           # Rolling pointer: newest nightly. Annotated so its message carries
@@ -71,6 +82,9 @@ jobs:
   notify-release:
     name: Dispatch build & bundle
     needs: nightly-tag
+    # Skip when the tag already existed (e.g. a workflow re-run): the Release is
+    # already there and gh release create would fail.
+    if: needs.nightly-tag.outputs.created == 'true'
     runs-on: ubuntu-slim
     timeout-minutes: 5
     steps:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -74,16 +74,40 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           tar -czf "swissaihub-${VERSION}.tar.gz" -C "dist/release" "swissaihub-${VERSION}"
           tar -czf "swissaihub-${VERSION}-gpu.tar.gz" -C "dist/release" "swissaihub-${VERSION}-gpu"
-      - name: Extract changelog for this version
-        run: make extract-release-notes TAG="${{ steps.version.outputs.version }}"
-      - name: Create GitHub Release
+      - name: Create GitHub Release with auto-generated notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |-
+          set -euo pipefail
           VERSION="${{ steps.version.outputs.version }}"
+
+          # Auto-generate the "What's Changed" PR list (title + #number + author
+          # + full-changelog compare link) so release managers can trace each PR
+          # back to its ticket and see the features/bugs in the release.
+          #
+          # Baseline matters: for STAGING and STABLE releases we start the notes
+          # at the last STABLE tag, so they list EVERY PR in the release, not
+          # just the delta since the previous pre-release. Nightly keeps the
+          # default baseline (delta since the previous nightly).
+          ARGS=(--generate-notes)
+          case "$VERSION" in
+            *-nightly.*) : ;;
+            *)
+              core="${VERSION%-*}"
+              last_stable="$(git tag -l 'v*' \
+                | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+                | grep -vx "$core" \
+                | sort -V | tail -1)"
+              if [ -n "$last_stable" ]; then
+                ARGS+=(--notes-start-tag "$last_stable")
+                echo "Release-scope notes: ${last_stable}..${VERSION}"
+              fi
+              ;;
+          esac
+
           gh release create "${VERSION}" \
             --title "Swiss AI Hub ${VERSION}" \
-            --notes-file release-notes.md \
+            "${ARGS[@]}" \
             --prerelease \
             --latest=false \
             "swissaihub-${VERSION}.tar.gz" \

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,10 +1,12 @@
 ---
 name: Publish @swiss-ai-hub/web to npm
 run-name: Publish web to npm - ${{ github.event.client_payload.release_version || github.event.inputs.release_version || 'manual' }}
-# Publishes @swiss-ai-hub/web to npm via OIDC trusted publishing on release.
+# Publishes @swiss-ai-hub/web to npm via OIDC trusted publishing.
+# Only invoked at promote time for a flat, latest release (never on nightly or
+# staging). Triggered via workflow_dispatch by the promote workflow or manually;
+# the release-ready repository_dispatch trigger was removed so per-merge nightly
+# builds do not publish.
 on:
-  repository_dispatch:
-    types: [release-ready]
   workflow_dispatch:
     inputs:
       release_version:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,12 +1,14 @@
 ---
 name: Publish Python packages to PyPI
 run-name: Publish PyPI - ${{ github.event.client_payload.release_version || github.event.inputs.release_version || 'manual' }}
-# Publishes the Swiss AI Hub Python distributions to PyPI via OIDC trusted publishing on release.
+# Publishes the Swiss AI Hub Python distributions to PyPI via OIDC trusted publishing.
+# Only invoked at promote time for a flat, latest release (never on nightly or
+# staging). Triggered via workflow_dispatch by the promote workflow or manually;
+# the release-ready repository_dispatch trigger was removed so per-merge nightly
+# builds do not publish.
 # Excludes swiss-ai-hub-sysadmin-api, which ships as a Docker image rather than a PyPI library. The
 # jambo fork (swiss-ai-hub-jambo) is published from its own repository, not here.
 on:
-  repository_dispatch:
-    types: [release-ready]
   workflow_dispatch:
     inputs:
       release_version:

--- a/Makefile
+++ b/Makefile
@@ -113,8 +113,8 @@ changelog:
 # Extract release notes for a specific version from CHANGELOG.md (TAG=v0.267.1, OUTPUT=release-notes.md)
 OUTPUT ?= release-notes.md
 extract-release-notes:
-	@if ! echo "$(TAG)" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$$'; then \
-		echo "ERROR: Invalid TAG format '$(TAG)'. Expected vMAJOR.MINOR.PATCH (e.g. v0.267.1)"; \
+	@if ! echo "$(TAG)" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-(nightly|staging)\.[0-9]+)?$$'; then \
+		echo "ERROR: Invalid TAG format '$(TAG)'. Expected vMAJOR.MINOR.PATCH or a channel pre-release (e.g. v0.267.1, v0.267.1-nightly.42)"; \
 		exit 1; \
 	fi
 	@awk -v ver="$(TAG)" 'index($$0, "## [" ver "]") == 1 {found=1; next} found && /^## \[/{exit} found{print}' CHANGELOG.md | sed '/^_\{3,\}/d' > $(OUTPUT)

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ pr-ready:
 	@$(MAKE) format-md
 	@$(MAKE) format-yaml
 
-TAG ?= v0.316.3
+TAG ?= v0.317.0
 
 changelog:
 	@echo "Generating changelog"

--- a/packages/agent/pyproject.toml
+++ b/packages/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "swiss-ai-hub-agent"
-version = "0.316.3"
+version = "0.317.0"
 description = "Swiss AI Hub Agent SDK: build transparent, workflow-based, event-driven AI agents."
 requires-python = ">=3.13, <3.14"
 authors = [
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "swiss-ai-hub-core==0.316.3",
+    "swiss-ai-hub-core==0.317.0",
     "fastmcp>=3.0.0",
     "llama-index-llms-openai>=0.6.12",
     "llama-index-llms-azure-openai>=0.4.2",

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "swiss-ai-hub-api"
-version = "0.316.3"
+version = "0.317.0"
 description = "Swiss AI Hub REST API, WebSocket gateway, and MCP server (FastAPI) for the Swiss AI Agent Protocol."
 requires-python = ">=3.13, <3.14"
 authors = [
@@ -24,7 +24,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "swiss-ai-hub-core==0.316.3",
+    "swiss-ai-hub-core==0.317.0",
     "azure-identity>=1.19.0",
     "azure-mgmt-cosmosdb>=9.7.0",
     "azure-mgmt-resource>=23.2.0",

--- a/packages/backup/pyproject.toml
+++ b/packages/backup/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "swiss-ai-hub-backup"
-version = "0.316.3"
+version = "0.317.0"
 description = "Backup and restore orchestration for AI-Hub data services"
 requires-python = ">=3.13, <3.14"
 authors = [

--- a/packages/bot/pyproject.toml
+++ b/packages/bot/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "swiss-ai-hub-bot"
-version = "0.316.3"
+version = "0.317.0"
 description = "Swiss AI Hub Bot SDK: connect users to AI agents via MS Teams, Slack, and web chat."
 requires-python = ">=3.13, <3.14"
 authors = [
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "swiss-ai-hub-core==0.316.3",
+    "swiss-ai-hub-core==0.317.0",
     "azure-identity>=1.19.0",
     "azure-mgmt-cosmosdb>=9.7.0",
     "azure-mgmt-resource>=23.2.0",

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "swiss-ai-hub-core"
-version = "0.316.3"
+version = "0.317.0"
 description = "Foundational shared library for the Swiss AI Hub platform: event-driven Swiss AI Agent Protocol, auth, and AI/ML utilities."
 requires-python = ">=3.13, <3.14"
 authors = [

--- a/packages/meta/pyproject.toml
+++ b/packages/meta/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "swiss-ai-hub"
-version = "0.316.3"
+version = "0.317.0"
 description = "Meta-package that installs the full Swiss AI Hub Python SDK (core, agent, api, bot, pipeline, process)."
 requires-python = ">=3.13, <3.14"
 authors = [
@@ -26,12 +26,12 @@ classifiers = [
 # Apache-2.0 meta-package would propagate AGPL obligations to every consumer of `pip install
 # swiss-ai-hub`. Install it explicitly with `pip install swiss-ai-hub-backup` when needed.
 dependencies = [
-    "swiss-ai-hub-core==0.316.3",
-    "swiss-ai-hub-agent==0.316.3",
-    "swiss-ai-hub-api==0.316.3",
-    "swiss-ai-hub-bot==0.316.3",
-    "swiss-ai-hub-pipeline==0.316.3",
-    "swiss-ai-hub-process==0.316.3",
+    "swiss-ai-hub-core==0.317.0",
+    "swiss-ai-hub-agent==0.317.0",
+    "swiss-ai-hub-api==0.317.0",
+    "swiss-ai-hub-bot==0.317.0",
+    "swiss-ai-hub-pipeline==0.317.0",
+    "swiss-ai-hub-process==0.317.0",
 ]
 
 [project.urls]

--- a/packages/pipeline/pyproject.toml
+++ b/packages/pipeline/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "swiss-ai-hub-pipeline"
-version = "0.316.3"
+version = "0.317.0"
 description = "Swiss AI Hub Pipeline SDK: Dagster-based document ingestion, parsing, embedding, and vector storage for RAG."
 requires-python = ">=3.13, <3.14"
 authors = [
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "swiss-ai-hub-core==0.316.3",
+    "swiss-ai-hub-core==0.317.0",
     "dagster-webserver>=1.11.2",
     "dagster-postgres>=0.27.2",
     "dagster-azure>=0.27.2",

--- a/packages/process/pyproject.toml
+++ b/packages/process/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "swiss-ai-hub-process"
-version = "0.316.3"
+version = "0.317.0"
 description = "Swiss AI Hub Process SDK: orchestrate multi-entity business processes across agents, humans, and programs."
 requires-python = ">=3.13, <3.14"
 authors = [
@@ -23,14 +23,14 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "swiss-ai-hub-core==0.316.3",
+    "swiss-ai-hub-core==0.317.0",
     "uvicorn[standard]>=0.34.0",
     "httpx>=0.28.1",
 ]
 
 [dependency-groups]
 dev = [
-    "swiss-ai-hub-agent==0.316.3",
+    "swiss-ai-hub-agent==0.317.0",
     "asgi-lifespan>=2.1.0",
 ]
 

--- a/packages/sysadmin-api/pyproject.toml
+++ b/packages/sysadmin-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "swiss-ai-hub-sysadmin-api"
-version = "0.316.3"
+version = "0.317.0"
 description = "Swiss AI Hub system administration plane (multi-tenant management API)"
 requires-python = ">=3.13, <3.14"
 authors = [

--- a/packages/sysadmin-web/package.json
+++ b/packages/sysadmin-web/package.json
@@ -2,7 +2,7 @@
   "name": "@swiss-ai-hub/sysadmin-web",
   "license": "AGPL-3.0-or-later",
   "type": "module",
-  "version": "0.316.3",
+  "version": "0.317.0",
   "description": "Swiss AI Hub - System administration UI (Nuxt 3 layer over @swiss-ai-hub/web)",
   "main": "./nuxt.config.ts",
   "private": false,

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -3,7 +3,7 @@
   "license": "AGPL-3.0-or-later",
   "author": "bbv Software Services AG (https://www.bbv.ch)",
   "type": "module",
-  "version": "0.316.3",
+  "version": "0.317.0",
   "description": "Swiss AI Hub - Admin & Management UI (Nuxt 3 layer)",
   "main": "./nuxt.config.ts",
   "repository": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "swiss-ai-hub-workspace"
-version = "0.316.3"
+version = "0.317.0"
 requires-python = ">=3.13, <3.14"
 description = "Swiss AI Hub Monorepo Workspace"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -1288,8 +1288,8 @@ name = "faiss-cpu"
 version = "1.13.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "packaging" },
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "packaging", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/c9/671f66f6b31ec48e5825d36435f0cb91189fa8bb6b50724029dbff4ca83c/faiss_cpu-1.13.2-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a9064eb34f8f64438dd5b95c8f03a780b1a3f0b99c46eeacb1f0b5d15fc02dc1", size = 3452776, upload-time = "2025-12-24T10:27:01.419Z" },
@@ -3102,10 +3102,10 @@ name = "milvus-lite"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "faiss-cpu" },
-    { name = "grpcio" },
-    { name = "numpy" },
-    { name = "pyarrow" },
+    { name = "faiss-cpu", marker = "sys_platform != 'win32'" },
+    { name = "grpcio", marker = "sys_platform != 'win32'" },
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "pyarrow", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/9a/d80d260e6fe1246818a8ef782c374ba9c6ca46ca3b987c14eabe914ef805/milvus_lite-3.0.tar.gz", hash = "sha256:2c35d0d046b1faae3402cde1fb73d65f51ee8c6aba65f54de1dda46f7bb18b9b", size = 589749, upload-time = "2026-05-13T07:14:05.827Z" }
 wheels = [
@@ -4113,7 +4113,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -5256,8 +5256,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -5417,7 +5417,7 @@ wheels = [
 
 [[package]]
 name = "swiss-ai-hub"
-version = "0.316.3"
+version = "0.317.0"
 source = { editable = "packages/meta" }
 dependencies = [
     { name = "swiss-ai-hub-agent" },
@@ -5440,7 +5440,7 @@ requires-dist = [
 
 [[package]]
 name = "swiss-ai-hub-agent"
-version = "0.316.3"
+version = "0.317.0"
 source = { editable = "packages/agent" }
 dependencies = [
     { name = "fastmcp" },
@@ -5475,7 +5475,7 @@ dev = [
 
 [[package]]
 name = "swiss-ai-hub-api"
-version = "0.316.3"
+version = "0.317.0"
 source = { editable = "packages/api" }
 dependencies = [
     { name = "audioop-lts" },
@@ -5530,7 +5530,7 @@ dev = [{ name = "asgi-lifespan", specifier = ">=2.1.0" }]
 
 [[package]]
 name = "swiss-ai-hub-backup"
-version = "0.316.3"
+version = "0.317.0"
 source = { editable = "packages/backup" }
 dependencies = [
     { name = "boto3" },
@@ -5587,7 +5587,7 @@ dev = [
 
 [[package]]
 name = "swiss-ai-hub-bot"
-version = "0.316.3"
+version = "0.317.0"
 source = { editable = "packages/bot" }
 dependencies = [
     { name = "azure-identity" },
@@ -5632,7 +5632,7 @@ dev = [{ name = "asgi-lifespan", specifier = ">=2.1.0" }]
 
 [[package]]
 name = "swiss-ai-hub-core"
-version = "0.316.3"
+version = "0.317.0"
 source = { editable = "packages/core" }
 dependencies = [
     { name = "adlfs" },
@@ -5797,7 +5797,7 @@ wheels = [
 
 [[package]]
 name = "swiss-ai-hub-pipeline"
-version = "0.316.3"
+version = "0.317.0"
 source = { editable = "packages/pipeline" }
 dependencies = [
     { name = "apprise" },
@@ -5827,7 +5827,7 @@ dev = []
 
 [[package]]
 name = "swiss-ai-hub-process"
-version = "0.316.3"
+version = "0.317.0"
 source = { editable = "packages/process" }
 dependencies = [
     { name = "httpx" },
@@ -5856,7 +5856,7 @@ dev = [
 
 [[package]]
 name = "swiss-ai-hub-sysadmin-api"
-version = "0.316.3"
+version = "0.317.0"
 source = { editable = "packages/sysadmin-api" }
 dependencies = [
     { name = "gunicorn" },
@@ -5883,7 +5883,7 @@ dev = [{ name = "asgi-lifespan", specifier = ">=2.1.0" }]
 
 [[package]]
 name = "swiss-ai-hub-workspace"
-version = "0.316.3"
+version = "0.317.0"
 source = { virtual = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
**Phase 1 of the versioning migration.** Stops the old behaviour where every PR merged to `main` auto-bumps the patch and tags a fresh `vX.Y.Z`.

From now on, a merge to `main` produces **`vX.Y.Z-nightly.<git-height>`** and moves the rolling `nightly` pointer. No version bump, no changelog commit, no force-push to `main`. Nightly no longer publishes packages.

- New `compute-version` composite action (pyproject core + git height).
- `add-tag.yml` rewritten to the lightweight nightly path.
- `publish-npm.yml` / `publish-pypi.yml`: dropped the `release-ready` trigger (nightly does not publish).
- `extract-release-notes` accepts channel pre-release tags.

Smallest self-contained step. Staging / promote / forward-port / auto-bump follow in a stacked PR. Merge the companion **aihub-playbook#13** (tag resolution) together with or before this so deploys can resolve the suffixed tags.
