### PR TITLE
chore(ci-cd): Remove unused extract-release-notes make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,20 +110,6 @@ changelog:
 	/bin/bash ./generate-changelog.sh
 	@uv run mdformat --number $$(git ls-files '*.md' | grep -v 'docs/whitepaper/chapters/')
 
-# Extract release notes for a specific version from CHANGELOG.md (TAG=v0.267.1, OUTPUT=release-notes.md)
-OUTPUT ?= release-notes.md
-extract-release-notes:
-	@if ! echo "$(TAG)" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-(nightly|staging)\.[0-9]+)?$$'; then \
-		echo "ERROR: Invalid TAG format '$(TAG)'. Expected vMAJOR.MINOR.PATCH or a channel pre-release (e.g. v0.267.1, v0.267.1-nightly.42)"; \
-		exit 1; \
-	fi
-	@awk -v ver="$(TAG)" 'index($$0, "## [" ver "]") == 1 {found=1; next} found && /^## \[/{exit} found{print}' CHANGELOG.md | sed '/^_\{3,\}/d' > $(OUTPUT)
-	@if [ ! -s $(OUTPUT) ]; then \
-		echo "No changelog section found for $(TAG), using fallback"; \
-		echo "Release $(TAG)" > $(OUTPUT); \
-	fi
-	@echo "Release notes for $(TAG) written to $(OUTPUT) ($$(wc -c < $(OUTPUT)) bytes)"
-
 # Check licenses across all dependencies
 license-check:
 	@echo "Checking licenses..."


### PR DESCRIPTION
Removes the `extract-release-notes` Makefile target (and its `OUTPUT` variable). It is now dead code: `create-release.yml` switched to `gh release create --generate-notes` (with `--notes-start-tag` for staging/stable), so nothing calls `make extract-release-notes` anymore.

Follow-up cleanup after the nightly/staging/promote versioning migration (#1628).
