### PR TITLE
chore(swiss-ai-hub): Bump main target to v0.318.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ pr-ready:
 	@$(MAKE) format-md
 	@$(MAKE) format-yaml
 
-TAG ?= v0.317.0
+TAG ?= v0.318.0
 
 changelog:
 	@echo "Generating changelog"

--- a/packages/agent/pyproject.toml
+++ b/packages/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "swiss-ai-hub-agent"
-version = "0.317.0"
+version = "0.318.0"
 description = "Swiss AI Hub Agent SDK: build transparent, workflow-based, event-driven AI agents."
 requires-python = ">=3.13, <3.14"
 authors = [
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "swiss-ai-hub-core==0.317.0",
+    "swiss-ai-hub-core==0.318.0",
     "fastmcp>=3.0.0",
     "llama-index-llms-openai>=0.6.12",
     "llama-index-llms-azure-openai>=0.4.2",

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "swiss-ai-hub-api"
-version = "0.317.0"
+version = "0.318.0"
 description = "Swiss AI Hub REST API, WebSocket gateway, and MCP server (FastAPI) for the Swiss AI Agent Protocol."
 requires-python = ">=3.13, <3.14"
 authors = [
@@ -24,7 +24,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "swiss-ai-hub-core==0.317.0",
+    "swiss-ai-hub-core==0.318.0",
     "azure-identity>=1.19.0",
     "azure-mgmt-cosmosdb>=9.7.0",
     "azure-mgmt-resource>=23.2.0",

--- a/packages/backup/pyproject.toml
+++ b/packages/backup/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "swiss-ai-hub-backup"
-version = "0.317.0"
+version = "0.318.0"
 description = "Backup and restore orchestration for AI-Hub data services"
 requires-python = ">=3.13, <3.14"
 authors = [

--- a/packages/bot/pyproject.toml
+++ b/packages/bot/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "swiss-ai-hub-bot"
-version = "0.317.0"
+version = "0.318.0"
 description = "Swiss AI Hub Bot SDK: connect users to AI agents via MS Teams, Slack, and web chat."
 requires-python = ">=3.13, <3.14"
 authors = [
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "swiss-ai-hub-core==0.317.0",
+    "swiss-ai-hub-core==0.318.0",
     "azure-identity>=1.19.0",
     "azure-mgmt-cosmosdb>=9.7.0",
     "azure-mgmt-resource>=23.2.0",

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "swiss-ai-hub-core"
-version = "0.317.0"
+version = "0.318.0"
 description = "Foundational shared library for the Swiss AI Hub platform: event-driven Swiss AI Agent Protocol, auth, and AI/ML utilities."
 requires-python = ">=3.13, <3.14"
 authors = [

--- a/packages/meta/pyproject.toml
+++ b/packages/meta/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "swiss-ai-hub"
-version = "0.317.0"
+version = "0.318.0"
 description = "Meta-package that installs the full Swiss AI Hub Python SDK (core, agent, api, bot, pipeline, process)."
 requires-python = ">=3.13, <3.14"
 authors = [
@@ -26,12 +26,12 @@ classifiers = [
 # Apache-2.0 meta-package would propagate AGPL obligations to every consumer of `pip install
 # swiss-ai-hub`. Install it explicitly with `pip install swiss-ai-hub-backup` when needed.
 dependencies = [
-    "swiss-ai-hub-core==0.317.0",
-    "swiss-ai-hub-agent==0.317.0",
-    "swiss-ai-hub-api==0.317.0",
-    "swiss-ai-hub-bot==0.317.0",
-    "swiss-ai-hub-pipeline==0.317.0",
-    "swiss-ai-hub-process==0.317.0",
+    "swiss-ai-hub-core==0.318.0",
+    "swiss-ai-hub-agent==0.318.0",
+    "swiss-ai-hub-api==0.318.0",
+    "swiss-ai-hub-bot==0.318.0",
+    "swiss-ai-hub-pipeline==0.318.0",
+    "swiss-ai-hub-process==0.318.0",
 ]
 
 [project.urls]

--- a/packages/pipeline/pyproject.toml
+++ b/packages/pipeline/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "swiss-ai-hub-pipeline"
-version = "0.317.0"
+version = "0.318.0"
 description = "Swiss AI Hub Pipeline SDK: Dagster-based document ingestion, parsing, embedding, and vector storage for RAG."
 requires-python = ">=3.13, <3.14"
 authors = [
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "swiss-ai-hub-core==0.317.0",
+    "swiss-ai-hub-core==0.318.0",
     "dagster-webserver>=1.11.2",
     "dagster-postgres>=0.27.2",
     "dagster-azure>=0.27.2",

--- a/packages/process/pyproject.toml
+++ b/packages/process/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "swiss-ai-hub-process"
-version = "0.317.0"
+version = "0.318.0"
 description = "Swiss AI Hub Process SDK: orchestrate multi-entity business processes across agents, humans, and programs."
 requires-python = ">=3.13, <3.14"
 authors = [
@@ -23,14 +23,14 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "swiss-ai-hub-core==0.317.0",
+    "swiss-ai-hub-core==0.318.0",
     "uvicorn[standard]>=0.34.0",
     "httpx>=0.28.1",
 ]
 
 [dependency-groups]
 dev = [
-    "swiss-ai-hub-agent==0.317.0",
+    "swiss-ai-hub-agent==0.318.0",
     "asgi-lifespan>=2.1.0",
 ]
 

--- a/packages/sysadmin-api/pyproject.toml
+++ b/packages/sysadmin-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "swiss-ai-hub-sysadmin-api"
-version = "0.317.0"
+version = "0.318.0"
 description = "Swiss AI Hub system administration plane (multi-tenant management API)"
 requires-python = ">=3.13, <3.14"
 authors = [

--- a/packages/sysadmin-web/package.json
+++ b/packages/sysadmin-web/package.json
@@ -2,7 +2,7 @@
   "name": "@swiss-ai-hub/sysadmin-web",
   "license": "AGPL-3.0-or-later",
   "type": "module",
-  "version": "0.317.0",
+  "version": "0.318.0",
   "description": "Swiss AI Hub - System administration UI (Nuxt 3 layer over @swiss-ai-hub/web)",
   "main": "./nuxt.config.ts",
   "private": false,

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -3,7 +3,7 @@
   "license": "AGPL-3.0-or-later",
   "author": "bbv Software Services AG (https://www.bbv.ch)",
   "type": "module",
-  "version": "0.317.0",
+  "version": "0.318.0",
   "description": "Swiss AI Hub - Admin & Management UI (Nuxt 3 layer)",
   "main": "./nuxt.config.ts",
   "repository": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "swiss-ai-hub-workspace"
-version = "0.317.0"
+version = "0.318.0"
 requires-python = ">=3.13, <3.14"
 description = "Swiss AI Hub Monorepo Workspace"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -1288,8 +1288,8 @@ name = "faiss-cpu"
 version = "1.13.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "sys_platform != 'win32'" },
-    { name = "packaging", marker = "sys_platform != 'win32'" },
+    { name = "numpy" },
+    { name = "packaging" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/c9/671f66f6b31ec48e5825d36435f0cb91189fa8bb6b50724029dbff4ca83c/faiss_cpu-1.13.2-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a9064eb34f8f64438dd5b95c8f03a780b1a3f0b99c46eeacb1f0b5d15fc02dc1", size = 3452776, upload-time = "2025-12-24T10:27:01.419Z" },
@@ -3102,10 +3102,10 @@ name = "milvus-lite"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "faiss-cpu", marker = "sys_platform != 'win32'" },
-    { name = "grpcio", marker = "sys_platform != 'win32'" },
-    { name = "numpy", marker = "sys_platform != 'win32'" },
-    { name = "pyarrow", marker = "sys_platform != 'win32'" },
+    { name = "faiss-cpu" },
+    { name = "grpcio" },
+    { name = "numpy" },
+    { name = "pyarrow" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/9a/d80d260e6fe1246818a8ef782c374ba9c6ca46ca3b987c14eabe914ef805/milvus_lite-3.0.tar.gz", hash = "sha256:2c35d0d046b1faae3402cde1fb73d65f51ee8c6aba65f54de1dda46f7bb18b9b", size = 589749, upload-time = "2026-05-13T07:14:05.827Z" }
 wheels = [
@@ -4113,7 +4113,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -5256,8 +5256,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -5417,7 +5417,7 @@ wheels = [
 
 [[package]]
 name = "swiss-ai-hub"
-version = "0.317.0"
+version = "0.318.0"
 source = { editable = "packages/meta" }
 dependencies = [
     { name = "swiss-ai-hub-agent" },
@@ -5440,7 +5440,7 @@ requires-dist = [
 
 [[package]]
 name = "swiss-ai-hub-agent"
-version = "0.317.0"
+version = "0.318.0"
 source = { editable = "packages/agent" }
 dependencies = [
     { name = "fastmcp" },
@@ -5475,7 +5475,7 @@ dev = [
 
 [[package]]
 name = "swiss-ai-hub-api"
-version = "0.317.0"
+version = "0.318.0"
 source = { editable = "packages/api" }
 dependencies = [
     { name = "audioop-lts" },
@@ -5530,7 +5530,7 @@ dev = [{ name = "asgi-lifespan", specifier = ">=2.1.0" }]
 
 [[package]]
 name = "swiss-ai-hub-backup"
-version = "0.317.0"
+version = "0.318.0"
 source = { editable = "packages/backup" }
 dependencies = [
     { name = "boto3" },
@@ -5587,7 +5587,7 @@ dev = [
 
 [[package]]
 name = "swiss-ai-hub-bot"
-version = "0.317.0"
+version = "0.318.0"
 source = { editable = "packages/bot" }
 dependencies = [
     { name = "azure-identity" },
@@ -5632,7 +5632,7 @@ dev = [{ name = "asgi-lifespan", specifier = ">=2.1.0" }]
 
 [[package]]
 name = "swiss-ai-hub-core"
-version = "0.317.0"
+version = "0.318.0"
 source = { editable = "packages/core" }
 dependencies = [
     { name = "adlfs" },
@@ -5797,7 +5797,7 @@ wheels = [
 
 [[package]]
 name = "swiss-ai-hub-pipeline"
-version = "0.317.0"
+version = "0.318.0"
 source = { editable = "packages/pipeline" }
 dependencies = [
     { name = "apprise" },
@@ -5827,7 +5827,7 @@ dev = []
 
 [[package]]
 name = "swiss-ai-hub-process"
-version = "0.317.0"
+version = "0.318.0"
 source = { editable = "packages/process" }
 dependencies = [
     { name = "httpx" },
@@ -5856,7 +5856,7 @@ dev = [
 
 [[package]]
 name = "swiss-ai-hub-sysadmin-api"
-version = "0.317.0"
+version = "0.318.0"
 source = { editable = "packages/sysadmin-api" }
 dependencies = [
     { name = "gunicorn" },
@@ -5883,7 +5883,7 @@ dev = [{ name = "asgi-lifespan", specifier = ">=2.1.0" }]
 
 [[package]]
 name = "swiss-ai-hub-workspace"
-version = "0.317.0"
+version = "0.318.0"
 source = { virtual = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Automated: `release/0.317` was cut, so main moves to the next minor **v0.318.0** so nightly builds stop claiming the version being stabilised on the release branch. Merge to resume nightlies on the new target.