### PR TITLE
fix(ci-cd): Trigger bump-main workflow only on release branch creation

### DIFF
--- a/.github/workflows/bump-main-target.yml
+++ b/.github/workflows/bump-main-target.yml
@@ -16,15 +16,18 @@
 # released version) is done by hand, since it is not triggered by a release cut.
 # =============================================================================
 name: Bump main to next target
-on: create
+on:
+  push:
+    branches:
+      - 'release/**'
 permissions:
   contents: write
   pull-requests: write
 jobs:
   bump:
     name: Open bump PR
-    # `create` also fires for tags and non-release branches; only act on release/*.
-    if: github.event.ref_type == 'branch' && startsWith(github.event.ref, 'release/')
+    # push to release/** also fires on later commits; only act on branch creation.
+    if: github.event.created
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
     steps:
@@ -39,7 +42,7 @@ jobs:
         id: t
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REF: ${{ github.event.ref }}
+          REF: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           core="$(grep -m1 -E '^version = ' pyproject.toml | sed -E 's/^version = "([^"]+)".*/\1/')"
@@ -92,7 +95,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEXT: ${{ steps.t.outputs.next }}
           BRANCH: ${{ steps.t.outputs.branch }}
-          CUT_REF: ${{ github.event.ref }}
+          CUT_REF: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Problem

The `bump-main-target.yml` workflow used `on: create`, which fires for **every** branch and tag created in the repo (nightly tags, staging tags, the bump branch itself, etc.). Each of these produced a **skipped** workflow run — a lot of noise in the Actions tab even though only `release/*` branches do real work.

## Fix

- Switch the trigger to `on: push` filtered to `release/**`, so the workflow is **never invoked** for tags or unrelated branches — no more skipped runs.
- Guard the job with `if: github.event.created` so it only acts on branch **creation**, not on subsequent commits to a release branch.
- Replace `github.event.ref` with `github.ref_name` (push events use a fully-qualified ref like `refs/heads/release/0.317`; `ref_name` gives the short `release/0.317` the validation logic expects).

## Note

Branches created via git push (the normal release-cut flow) fire a push event with `created: true`, so behaviour is unchanged for real release cuts. Branches created purely via the GitHub UI/API (no push) would not trigger — acceptable given release branches are always cut by pushing.