### PR TITLE
fix(swiss-ai-hub): Delete OpenWebUI base models shadowing provisioned models

### DIFF
--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_client.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_client.py
@@ -160,6 +160,16 @@ class OpenWebuiClient:
         data = response.json()
         return data.get("items", []) if isinstance(data, dict) else data
 
+    async def list_base_models(self, http: httpx.AsyncClient) -> list[dict[str, Any]]:
+        """Lists registry entries that override a raw provider model (``base_model_id`` unset).
+
+        ``list_models`` cannot see these: OpenWebUI's search filters on ``base_model_id != None``, so
+        base-model overrides are invisible to it — and to the workspace UI that renders it.
+        """
+        response = await http.get(f"{self._base_url}{MODELS_ENDPOINT}/base", headers=self._jwt_headers)
+        response.raise_for_status()
+        return response.json()
+
     async def create_model(self, http: httpx.AsyncClient, model_data: dict[str, Any]) -> dict[str, Any]:
         model_data.setdefault("params", {})
         response = await http.post(

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_provisioner.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_provisioner.py
@@ -495,6 +495,35 @@ class OpenWebuiProvisioner:
             if role.tenant_id in tenant_name_by_id
         }
 
+    async def _delete_shadowing_base_models(
+        self, http: httpx.AsyncClient, managed_models: list[dict[str, Any]]
+    ) -> None:
+        """Removes registry entries that shadow the raw models our workspace models point at.
+
+        Both ``_build_model_data`` and ``_build_llm_model_data`` depend on those bases staying
+        unregistered. Once an entry exists for one, OpenWebUI's ``has_base_model_access`` walks
+        workspace model -> base and denies everyone lacking a grant on that entry, so the model stays
+        visible in the picker but chatting with it fails with "Model not found". Saving the model list
+        in the OpenWebUI workspace (``POST /models/sync``) writes such an entry for every model it
+        renders, so reassert the invariant on every sync rather than cleaning up once.
+
+        Derived from each workspace model's own ``base_model_id`` so agent pipes and raw LiteLLM
+        models are covered by the same pass.
+        """
+        shadowing_ids = {m.get("id", "") for m in await self._openwebui.list_base_models(http)}
+        preset_by_base = {
+            m["base_model_id"]: m["id"]
+            for m in managed_models
+            if m.get("base_model_id") and m["base_model_id"] in shadowing_ids
+        }
+
+        for base_model_id, preset_id in preset_by_base.items():
+            await self._openwebui.delete_model(http, base_model_id)
+            logger.warning(
+                f"OpenWebUI: Deleted registry entry '{base_model_id}' shadowing the raw model behind "
+                f"'{preset_id}' — it denied every non-admin access to the workspace model above it"
+            )
+
     async def _sync_access_grants(self, http: httpx.AsyncClient) -> None:
         existing_models = await self._openwebui.list_models(http)
         aihub_models = [
@@ -503,6 +532,8 @@ class OpenWebuiProvisioner:
 
         if not aihub_models:
             return
+
+        await self._delete_shadowing_base_models(http, aihub_models)
 
         async with self._openwebui.scim_session() as scim:
             all_groups = await self._openwebui.list_groups(scim=scim)

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/conftest.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/conftest.py
@@ -3,9 +3,21 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from swiss_ai_hub.core.infrastructure.openwebui.openwebui_client import OpenWebuiClient
 from swiss_ai_hub.core.infrastructure.openwebui.openwebui_provisioner import OpenWebuiProvisioner
 
 _MOCK_SCIM = MagicMock(name="mock_scim_client")
+
+
+@pytest.fixture(autouse=True)
+def unregistered_base_models():
+    """Defaults every sync to the healthy state — raw bases carry no registry entry.
+
+    Tests exercising the shadowing repair shadow this with their own instance-level
+    ``list_base_models`` patch, which takes precedence over this class-level one.
+    """
+    with patch.object(OpenWebuiClient, "list_base_models", return_value=[]):
+        yield
 
 
 @asynccontextmanager

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_provisioner_access.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_provisioner_access.py
@@ -7,6 +7,7 @@ from scim2_models import Group
 from swiss_ai_hub.core.infrastructure.openwebui.access_grant import AccessGrant
 from swiss_ai_hub.core.infrastructure.openwebui.openwebui_provisioner import (
     AIHUB_AGENT_PREFIX,
+    AIHUB_LLM_MODEL_PREFIX,
     OpenWebuiProvisioner,
 )
 
@@ -393,6 +394,75 @@ class TestBuildRoleRules:
             mock_role.objects.return_value = [orphan]
 
             assert OpenWebuiProvisioner._build_role_rules() == {}
+
+
+class TestDeleteShadowingBaseModels:
+    """A registry entry at a workspace model's ``base_model_id`` makes OpenWebUI's
+    ``has_base_model_access`` deny every non-admin without a grant on it, so the model stays in the
+    picker but chat fails with "Model not found". ``POST /models/sync`` — which the OpenWebUI workspace
+    issues when an admin saves the model list — writes such an entry for every model it renders.
+    Only ``list_base_models`` can see them: OpenWebUI's model search filters on
+    ``base_model_id != None``, so ``list_models`` never returns them."""
+
+    @staticmethod
+    def _sync_with(provisioner: OpenWebuiProvisioner, workspace_models, base_models):
+        return (
+            patch.object(provisioner._openwebui, "list_models", return_value=workspace_models),
+            patch.object(provisioner._openwebui, "list_base_models", return_value=base_models),
+            patch.object(provisioner._openwebui, "list_groups", return_value=[]),
+        )
+
+    @pytest.mark.asyncio
+    async def test_deletes_entry_shadowing_an_llm_base(self, provisioner: OpenWebuiProvisioner) -> None:
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        workspace = [{"id": f"{AIHUB_LLM_MODEL_PREFIX}text-generation-Kimi", "base_model_id": "text-generation/Kimi"}]
+        list_models, list_base, list_groups = self._sync_with(provisioner, workspace, [{"id": "text-generation/Kimi"}])
+
+        with list_models, list_base, list_groups, patch.object(provisioner._openwebui, "delete_model") as mock_delete:
+            await provisioner._sync_access_grants(mock_client)
+
+            mock_delete.assert_called_once_with(mock_client, "text-generation/Kimi")
+
+    @pytest.mark.asyncio
+    async def test_deletes_entry_shadowing_an_agent_pipe(self, provisioner: OpenWebuiProvisioner) -> None:
+        """The half #1595 never covered: agent presets point at ``aihub-pipeline.*`` bases, which
+        shadow identically once the workspace materialises a row for them."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        workspace = [{"id": f"{AIHUB_AGENT_PREFIX}RAGAgent-doc", "base_model_id": "aihub-pipeline.RAGAgent.doc"}]
+        list_models, list_base, list_groups = self._sync_with(
+            provisioner, workspace, [{"id": "aihub-pipeline.RAGAgent.doc"}]
+        )
+
+        with list_models, list_base, list_groups, patch.object(provisioner._openwebui, "delete_model") as mock_delete:
+            await provisioner._sync_access_grants(mock_client)
+
+            mock_delete.assert_called_once_with(mock_client, "aihub-pipeline.RAGAgent.doc")
+
+    @pytest.mark.asyncio
+    async def test_leaves_unregistered_base_alone(self, provisioner: OpenWebuiProvisioner) -> None:
+        """The healthy state: the raw model has no registry entry, so there is nothing to repair."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        workspace = [{"id": f"{AIHUB_AGENT_PREFIX}RAGAgent-doc", "base_model_id": "aihub-pipeline.RAGAgent.doc"}]
+        list_models, list_base, list_groups = self._sync_with(provisioner, workspace, [])
+
+        with list_models, list_base, list_groups, patch.object(provisioner._openwebui, "delete_model") as mock_delete:
+            await provisioner._sync_access_grants(mock_client)
+
+            mock_delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_does_not_delete_foreign_base_models(self, provisioner: OpenWebuiProvisioner) -> None:
+        """Only bases of models we provision are repaired; entries owned by anyone else stay put."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        workspace = [{"id": f"{AIHUB_AGENT_PREFIX}RAGAgent-doc", "base_model_id": "aihub-pipeline.RAGAgent.doc"}]
+        list_models, list_base, list_groups = self._sync_with(
+            provisioner, workspace, [{"id": "text-generation/somebody-elses-model"}]
+        )
+
+        with list_models, list_base, list_groups, patch.object(provisioner._openwebui, "delete_model") as mock_delete:
+            await provisioner._sync_access_grants(mock_client)
+
+            mock_delete.assert_not_called()
 
 
 class TestCrossTenantIsolation:


### PR DESCRIPTION
## Summary

Chatting with any agent or LLM in Open WebUI can fail with `Model not found` while the model
is still visible in the picker. The cause is an Open WebUI registry entry shadowing the raw
model a workspace model points at. This reasserts, on every provisioner sync, the invariant
our workspace models already depend on: those bases must stay unregistered.

Restores #1595, which landed on `hotfix/0.308` and was never forward-ported to `main`, and
extends it to the agent bases it never covered.

closes https://github.com/bbvch-ai/aihub-core-private/issues/103

## Changes

- `OpenWebuiClient.list_base_models()` — reads `/api/v1/models/base`. Base-model overrides are
  invisible to `list_models` because Open WebUI's model search filters on `base_model_id != None`.
- `OpenWebuiProvisioner._delete_shadowing_base_models()` — deletes registry entries sitting at a
  managed workspace model's `base_model_id`. Targets are derived from each workspace model's own
  pointer, so agent pipes (`aihub-pipeline.*`) and raw LiteLLM models (`capability/name`) are
  repaired by the same pass with no per-type branching.
- Called from `_sync_access_grants`, which `provision`, `sync_agents` and `sync_access` all reach,
  so every sync path reasserts it. #1595 hung it off `_sync_llm_workspace_models`, which is why it
  only ever fixed LLMs.
- Tests: 4 cases (LLM base, agent pipe base, unregistered base untouched, foreign base untouched)
  plus an autouse fixture defaulting `list_base_models` to `[]`.

## Root cause

Workspace models point `base_model_id` at the raw model behind them and gate access through their
own grants. That relies on the raw model having no registry entry — `has_base_model_access` walks
the chain and breaks out at `base_model_info is None`, treating it as a raw provider model.

Creating an entry for that id flips the behaviour, in one of two ways:

| Entry state | Mechanism | Result |
|---|---|---|
| `is_active: true`, `access_grants: []` | `has_base_model_access` denies | **403** — admins unaffected |
| `is_active: false` | `get_all_models` drops the base from `app.state.MODELS` | **400** — breaks admins too |

Both surface as `Model not found`. Triage rule: **admins can still chat it → grants; nobody can →
inactive entry.**

Toggling a raw model in Open WebUI's admin settings creates such an entry via `POST /models/create`.

An ownership escape hatch (`user_id == base_model_info.user_id`) is why this looked random — an
agent worked for whoever owned its base row and failed for everyone else.

## Test plan

- `make test` in `packages/core` — 107 pass in the Open WebUI suite, including the 4 new cases.
- Mutation-checked: removing the call fails exactly the two positive cases, leaving the two
  negative ones passing.
- End-to-end on a local stack against the real trigger: toggled a raw model in admin settings →
  shadow row created (`is_active: false`) → chat failed with `Model not found` for a `role: user`
  account → provisioner sync → row deleted → chat restored, without touching any grants.
- Also verified for an agent base (`aihub-pipeline.RAGAgent.*`), which fails and recovers identically.

## Notes for reviewers

**This deletes rows Open WebUI created.** If an operator deliberately configures a base model, it
will be removed on the next reconcile with a warning log. That is the intended trade — see the
table above for why granting those rows instead is worse: a granted base row is directly chattable,
bypassing the workspace model's gating entirely.

**Healing is not instant.** The reconcile is gated behind the agent-set hash
(`_AGENTS_HASH_TTL = 3600`), so with a stable agent fleet and no config or access changes, repair
can lag up to an hour. Decoupling the Open WebUI reconcile from that gate, and adding a manual
resync endpoint, are follow-ups rather than part of this fix.