### PR TITLE
fix(rag): Force knowledge base file download via Content-Disposition

### DIFF
--- a/docs/arc42/decisions/2026_07_23_upgrade_seaweedfs_to_4_01_for_content_disposition.md
+++ b/docs/arc42/decisions/2026_07_23_upgrade_seaweedfs_to_4_01_for_content_disposition.md
@@ -1,0 +1,89 @@
+# Upgrade SeaweedFS 3.97 → 4.01 to Honor Presigned Content-Disposition
+
+## Context
+
+Clicking **Download** on a knowledge base file opened previewable types (pdf, image, txt, md) **inline in a new browser
+tab** instead of prompting a save dialog, while non-previewable types (e.g. `.docx`) already downloaded — an
+inconsistent, confusing experience (issue #51). The download button calls `window.open(presignedUrl)`, and our S3
+objects carry **no `Content-Disposition`** header, so the browser renders previewable content inline.
+
+The clean, memory-safe fix is to force `Content-Disposition: attachment` on the presigned GET URL via the S3
+`response-content-disposition` query override — a native streaming download with no in-browser buffering. But
+**SeaweedFS 3.97 silently ignores that override**: it returns the object with default headers regardless. This is an
+upstream bug, fixed in [PR #7559](https://github.com/seaweedfs/seaweedfs/pull/7559) ("s3api: Fix
+response-content-disposition query parameter not being honored"), first released in **SeaweedFS 4.01** (2025-11-28).
+
+The alternative — a client-side blob download (`fetch` → Blob → `<a download>`) — works on 3.97 but buffers the **entire
+file in browser memory** with no streaming or progress, which is unacceptable for large documents.
+
+`ghcr.io/bbvch-ai/aihub-core/seaweedfs` is a **mirror** of the upstream `chrislusf/seaweedfs` image (via
+`make mirror-image`), pinned in `infra/deployment/compose-config.yml`. Moving from 3.97 to 4.01 crosses a **major
+version boundary** (4.00 + 4.01) that carries real architectural and operational changes, so this is a deliberate
+decision, not a routine tag bump.
+
+## Decision Drivers
+
+- **Correctness + memory safety** — the download must stream to disk natively, not buffer in the browser. Only the
+  `Content-Disposition` approach satisfies both, and only ≥4.01 honors it.
+- **No blast-radius regressions** — every service reads/writes the same `seaweedfs-s3` gateway (Milvus, Langfuse,
+  ClickHouse backups, OpenWebUI, LiteLLM, the ingestion pipeline, agent uploads, and the backup/restore service). The
+  upgrade must not break any of them.
+- **Data continuity** — existing on-disk volume data and the etcd-backed filer metadata must survive the major bump.
+- **Minimal, reversible code surface** — the application change should be small and default to today's behavior for all
+  existing callers.
+
+## Decision
+
+Upgrade SeaweedFS **3.97 → 4.01** and use the now-honored override to force downloads only where intended.
+
+1. **Version bump.** `infra/deployment/compose-config.yml` `image_tags.seaweedfs: seaweedfs:3.97 → 4.01`; mirror 4.01
+   into GHCR (`make mirror-image`) before non-dev stages pull it; `make generate-compose` regenerates all 10 compose
+   files (master/volume/filer/s3).
+
+2. **Opt-in disposition, defaulting to current behavior.** `S3AnonymousFileAccessService.generate_sas_url` gains an
+   optional `response_content_disposition: str | None = None`; when set, it is passed as `ResponseContentDisposition`
+   into the presigned `get_object`. Default `None` preserves inline behavior, so the other callers of this shared method
+   (RAG figure signing per ADR `2026_07_10_inline_rag_figures_as_base64`, and the generic file controller) are
+   untouched — no new abstraction.
+
+3. **Download vs preview split at the endpoint.** The knowledge document-URL endpoint gains a `download: bool = False`
+   query param, threaded to `KnowledgeService.get_document_url(..., as_attachment=)`, which builds
+   `attachment; filename="<key-basename>"`. The frontend **Download** button requests `download=true` and triggers the
+   URL via a programmatic anchor click (no orphan blank tab); **"Open original document"** keeps inline preview
+   (`download=false`, the default).
+
+### Breaking-change awareness (3.97 → 4.01)
+
+The 4.x line is a genuine architectural shift, not just the disposition fix:
+
+- **Direct S3 → volume-server data path** (4.01 #7481, #7518) — S3 no longer routes object data through the filer;
+  volume reads/writes require **JWT** (3.99 #7376, 4.01 #7514). All four SeaweedFS services share
+  `WEED_JWT_SIGNING_KEY`, so internal auth continues to work.
+- **Non-root container user** (4.00 #7399) + **`/data` ownership/permission fix** (4.01 #7451) — the primary upgrade
+  risk on existing deployments. In our dev volumes the data files are already owned by the host user, so no
+  permission break occurred; **production upgrades must verify (and if needed `chown`) the mounted volume ownership.**
+- **Bucket-policy enforcement** (4.01 #7471), **auto-create bucket** (4.01 #7549), path/virtual-style addressing
+  changes (3.99 #7357), and S3 error-code changes (3.98: 400 vs 500) — none affected our path-style, explicit-identity
+  configuration.
+
+## Consequences
+
+### Positive
+
+- **The download bug is fixed the right way** — native, streaming, per-request `Content-Disposition: attachment`;
+  verified live on 4.01 (preview URL returns no disposition; attachment URL returns `attachment; filename="..."`).
+- **Minimal, reversible code change** — one optional kwarg + one query param; every pre-existing caller keeps its exact
+  behavior.
+- **Whole S3 blast radius re-verified on 4.01** — knowledge ingestion, agent uploads, RAG retrieval, Langfuse traces,
+  OpenWebUI uploads, and a full `backup_asset_job` (postgres/ferretdb/neo4j/clickhouse/valkey/nats/milvus artifacts
+  written + `head_object` confirmed) all pass. Existing volume data and buckets survived the bump intact.
+
+### Trade-offs
+
+- **We track a major upstream version** whose direct-volume-access + JWT model is newer and less battle-tested for us
+  than 3.97; upstream 4.x regressions could surface in future point releases.
+- **Production rollout needs the two operational steps** the dev upgrade could skip: mirror 4.01 to GHCR first, and
+  verify/adjust volume-mount ownership for the non-root container user before starting.
+- **Filename header is not RFC 6266-encoded** — the attachment filename is the S3 key basename interpolated directly;
+  unusual characters (embedded quotes, non-ASCII, control chars) are not escaped. Acceptable because keys derive from
+  constrained upload filenames, but a future hardening could add `filename*=UTF-8''<encoded>`.

--- a/infra/deployment/compose-config.yml
+++ b/infra/deployment/compose-config.yml
@@ -20,7 +20,7 @@ global:
 # -------------------------------------------------------------------
 image_tags:
   # --- Core Infrastructure (mostly static) ---
-  seaweedfs: seaweedfs:3.97
+  seaweedfs: seaweedfs:4.01
   aws_cli: aws-cli-alpine:3.22.1
   etcd: etcd:v3.5.25
   milvus: milvus:v2.6.7

--- a/infra/docker-compose.build.gpu.yml
+++ b/infra/docker-compose.build.gpu.yml
@@ -85,7 +85,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-master:
     container_name: seaweedfs-master
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     expose:
       - '9333'   # Master HTTP port
@@ -123,7 +123,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-volume:
     container_name: seaweedfs-volume
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     expose: ['8080', '18080']
     command: >
@@ -155,7 +155,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-filer:
     container_name: seaweedfs-filer
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     ports: [8889:8888, '18888']
     command: >
@@ -207,7 +207,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-s3:
     container_name: seaweedfs-s3
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     ports: [9000:9000]
     volumes:

--- a/infra/docker-compose.build.yml
+++ b/infra/docker-compose.build.yml
@@ -85,7 +85,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-master:
     container_name: seaweedfs-master
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     expose:
       - '9333'   # Master HTTP port
@@ -123,7 +123,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-volume:
     container_name: seaweedfs-volume
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     expose: ['8080', '18080']
     command: >
@@ -155,7 +155,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-filer:
     container_name: seaweedfs-filer
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     ports: [8889:8888, '18888']
     command: >
@@ -207,7 +207,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-s3:
     container_name: seaweedfs-s3
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     ports: [9000:9000]
     volumes:

--- a/infra/docker-compose.dev.gpu.yml
+++ b/infra/docker-compose.dev.gpu.yml
@@ -31,7 +31,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-master:
     container_name: seaweedfs-master
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     expose:
       - '9333'   # Master HTTP port
@@ -69,7 +69,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-volume:
     container_name: seaweedfs-volume
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     expose: ['8080', '18080']
     command: >
@@ -101,7 +101,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-filer:
     container_name: seaweedfs-filer
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     ports: [8889:8888, '18888']
     command: >
@@ -153,7 +153,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-s3:
     container_name: seaweedfs-s3
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     ports: [9000:9000]
     volumes:

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -31,7 +31,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-master:
     container_name: seaweedfs-master
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     expose:
       - '9333'   # Master HTTP port
@@ -69,7 +69,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-volume:
     container_name: seaweedfs-volume
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     expose: ['8080', '18080']
     command: >
@@ -101,7 +101,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-filer:
     container_name: seaweedfs-filer
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     ports: [8889:8888, '18888']
     command: >
@@ -153,7 +153,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-s3:
     container_name: seaweedfs-s3
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     ports: [9000:9000]
     volumes:

--- a/infra/docker-compose.latest.gpu.yml
+++ b/infra/docker-compose.latest.gpu.yml
@@ -85,7 +85,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-master:
     container_name: seaweedfs-master
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     command: >
       master
@@ -120,7 +120,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-volume:
     container_name: seaweedfs-volume
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     command: >
       volume
@@ -151,7 +151,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-filer:
     container_name: seaweedfs-filer
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     command: >
       filer
@@ -202,7 +202,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-s3:
     container_name: seaweedfs-s3
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     volumes:
       - ./configs/seaweedfs/s3-entrypoint.sh:/usr/local/bin/s3-entrypoint.sh:ro

--- a/infra/docker-compose.latest.yml
+++ b/infra/docker-compose.latest.yml
@@ -85,7 +85,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-master:
     container_name: seaweedfs-master
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     command: >
       master
@@ -120,7 +120,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-volume:
     container_name: seaweedfs-volume
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     command: >
       volume
@@ -151,7 +151,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-filer:
     container_name: seaweedfs-filer
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     command: >
       filer
@@ -202,7 +202,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-s3:
     container_name: seaweedfs-s3
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     volumes:
       - ./configs/seaweedfs/s3-entrypoint.sh:/usr/local/bin/s3-entrypoint.sh:ro

--- a/infra/docker-compose.local.gpu.yml
+++ b/infra/docker-compose.local.gpu.yml
@@ -85,7 +85,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-master:
     container_name: seaweedfs-master
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     expose:
       - '9333'   # Master HTTP port
@@ -123,7 +123,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-volume:
     container_name: seaweedfs-volume
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     expose: ['8080', '18080']
     command: >
@@ -155,7 +155,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-filer:
     container_name: seaweedfs-filer
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     ports: [8889:8888, '18888']
     command: >
@@ -207,7 +207,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-s3:
     container_name: seaweedfs-s3
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     ports: [9000:9000]
     volumes:

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -85,7 +85,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-master:
     container_name: seaweedfs-master
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     expose:
       - '9333'   # Master HTTP port
@@ -123,7 +123,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-volume:
     container_name: seaweedfs-volume
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     expose: ['8080', '18080']
     command: >
@@ -155,7 +155,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-filer:
     container_name: seaweedfs-filer
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     ports: [8889:8888, '18888']
     command: >
@@ -207,7 +207,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-s3:
     container_name: seaweedfs-s3
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     ports: [9000:9000]
     volumes:

--- a/infra/docker-compose.nightly.gpu.yml
+++ b/infra/docker-compose.nightly.gpu.yml
@@ -85,7 +85,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-master:
     container_name: seaweedfs-master
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     command: >
       master
@@ -120,7 +120,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-volume:
     container_name: seaweedfs-volume
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     command: >
       volume
@@ -151,7 +151,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-filer:
     container_name: seaweedfs-filer
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     command: >
       filer
@@ -202,7 +202,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-s3:
     container_name: seaweedfs-s3
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     volumes:
       - ./configs/seaweedfs/s3-entrypoint.sh:/usr/local/bin/s3-entrypoint.sh:ro

--- a/infra/docker-compose.nightly.yml
+++ b/infra/docker-compose.nightly.yml
@@ -85,7 +85,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-master:
     container_name: seaweedfs-master
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     command: >
       master
@@ -120,7 +120,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-volume:
     container_name: seaweedfs-volume
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     command: >
       volume
@@ -151,7 +151,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-filer:
     container_name: seaweedfs-filer
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     command: >
       filer
@@ -202,7 +202,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   seaweedfs-s3:
     container_name: seaweedfs-s3
-    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:3.97
+    image: ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01
     restart: always
     volumes:
       - ./configs/seaweedfs/s3-entrypoint.sh:/usr/local/bin/s3-entrypoint.sh:ro

--- a/packages/api/playground/testing/tests/knowledge/test_knowledge_document_url_service_unit_tests.py
+++ b/packages/api/playground/testing/tests/knowledge/test_knowledge_document_url_service_unit_tests.py
@@ -1,0 +1,47 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from swiss_ai_hub.api.routes.knowledge.knowledge_service import KnowledgeService
+
+_SERVICE_MODULE = "swiss_ai_hub.api.routes.knowledge.knowledge_service"
+
+DB = "tenant-db"
+NAMESPACE = "my-namespace"
+DOCUMENT_ID = "doc-123"
+SOURCE = f"s3://my-bucket/{NAMESPACE}/report.pdf"
+
+
+@pytest.fixture
+def s3_service():
+    service = MagicMock()
+    service.generate_sas_url.return_value = "https://public/signed"
+    return service
+
+
+@pytest.fixture
+def url_mocks():
+    ref_doc = MagicMock()
+    ref_doc.data.metadata.source = SOURCE
+    with (
+        patch.object(KnowledgeService, "_ensure_db_exists"),
+        patch(f"{_SERVICE_MODULE}.RefDoc") as ref_doc_cls,
+    ):
+        ref_doc_cls.by_id_and_namespace.return_value = ref_doc
+        yield ref_doc_cls
+
+
+class TestGetDocumentUrl:
+    def test_preview_url_has_no_disposition(self, url_mocks, s3_service):
+        KnowledgeService.get_document_url(DB, NAMESPACE, DOCUMENT_ID, s3_service)
+
+        s3_service.generate_sas_url.assert_called_once_with(
+            "my-bucket", f"{NAMESPACE}/report.pdf", response_content_disposition=None
+        )
+
+    def test_attachment_url_forces_download_with_filename(self, url_mocks, s3_service):
+        KnowledgeService.get_document_url(DB, NAMESPACE, DOCUMENT_ID, s3_service, as_attachment=True)
+
+        s3_service.generate_sas_url.assert_called_once_with(
+            "my-bucket", f"{NAMESPACE}/report.pdf", response_content_disposition='attachment; filename="report.pdf"'
+        )

--- a/packages/api/swiss_ai_hub/api/routes/knowledge/knowledge_controller.py
+++ b/packages/api/swiss_ai_hub/api/routes/knowledge/knowledge_controller.py
@@ -318,12 +318,19 @@ class KnowledgeController(TenantScopedController):
                 UserIdentity, Security(self.user_with_permission("aihub.user.knowledge.{database}.{namespace}"))
             ],
             s3_service: Annotated[S3AnonymousFileAccessService, Depends(use_s3_service)],
+            download: Annotated[
+                bool, Query(description="Force a browser download (Content-Disposition: attachment) instead of preview")
+            ] = False,
         ) -> SignedUrlDto:
-            """Generates a presigned URL for downloading a document's source file."""
+            """Generates a presigned URL for a document's source file (inline preview, or attachment download)."""
             if database in ["admin", "local", "config"]:
                 raise HTTPException(status_code=403, detail=self._NOT_AUTHORIZED_TO_VIEW_DATABASE_DETAIL)
             url = KnowledgeService.get_document_url(
-                db=database, namespace=namespace, document_id=document_id, s3_service=s3_service
+                db=database,
+                namespace=namespace,
+                document_id=document_id,
+                s3_service=s3_service,
+                as_attachment=download,
             )
             return SignedUrlDto(url=url)
 

--- a/packages/api/swiss_ai_hub/api/routes/knowledge/knowledge_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/knowledge/knowledge_service.py
@@ -437,8 +437,18 @@ class KnowledgeService:
 
     @staticmethod
     @trace_fn
-    def get_document_url(db: str, namespace: str, document_id: str, s3_service: S3AnonymousFileAccessService) -> str:
-        """Generates a presigned S3 URL for a document's source file."""
+    def get_document_url(
+        db: str,
+        namespace: str,
+        document_id: str,
+        s3_service: S3AnonymousFileAccessService,
+        as_attachment: bool = False,
+    ) -> str:
+        """Generates a presigned S3 URL for a document's source file.
+
+        `as_attachment` forces a browser download via `Content-Disposition: attachment`
+        instead of inline preview (requires SeaweedFS ≥ 4.01 to honor the override).
+        """
         KnowledgeService._ensure_db_exists(db)
         try:
             ref_doc = RefDoc.by_id_and_namespace(db_alias=db, doc_id=document_id, namespace=namespace)
@@ -449,7 +459,11 @@ class KnowledgeService:
         parts = source.split("/", 1)
         container = parts[0]
         file_path = parts[1] if len(parts) > 1 else ""
-        return s3_service.generate_sas_url(container, file_path)
+        content_disposition = None
+        if as_attachment:
+            filename = file_path.rsplit("/", 1)[-1]
+            content_disposition = f'attachment; filename="{filename}"'
+        return s3_service.generate_sas_url(container, file_path, response_content_disposition=content_disposition)
 
     @staticmethod
     def get_supported_file_types() -> list[str]:

--- a/packages/core/swiss_ai_hub/core/generative_ai/document/accessor/s3_anonymous_file_access_service.py
+++ b/packages/core/swiss_ai_hub/core/generative_ai/document/accessor/s3_anonymous_file_access_service.py
@@ -50,7 +50,14 @@ class S3AnonymousFileAccessService:
         self._s3_config = s3_settings
 
     @trace_fn
-    def generate_sas_url(self, container: str, file_path: str, lifetime_hours: int = 24, internal: bool = False) -> str:
+    def generate_sas_url(
+        self,
+        container: str,
+        file_path: str,
+        lifetime_hours: int = 24,
+        internal: bool = False,
+        response_content_disposition: str | None = None,
+    ) -> str:
         """
         Generate a presigned URL for temporary read-only access to an S3 object.
 
@@ -65,6 +72,11 @@ class S3AnonymousFileAccessService:
         Docker DNS rather than the public domain. Signing is offline, so this works from
         the host even when the in-cluster host is not resolvable there.
 
+        `response_content_disposition` sets the S3 `response-content-disposition` query
+        override so the server returns a `Content-Disposition` header (e.g.
+        `attachment; filename="..."` to force a browser download). Requires SeaweedFS
+        ≥ 4.01, which is the first version to honor the override.
+
         The maximum lifetime for presigned URLs is 7 days (168 hours).
         """
         if not container or not container.strip():
@@ -74,12 +86,16 @@ class S3AnonymousFileAccessService:
         if lifetime_hours <= 0 or lifetime_hours > 168:  # 7 days max
             raise ValueError("Lifetime must be between 1 and 168 hours")
 
+        params = {"Bucket": container, "Key": file_path}
+        if response_content_disposition:
+            params["ResponseContentDisposition"] = response_content_disposition
+
         signing_client = self._s3_internal_client if internal else self._s3_public_client
         try:
             # so the URL is accessible from browsers
             presigned_url = signing_client.generate_presigned_url(
                 "get_object",
-                Params={"Bucket": container, "Key": file_path},
+                Params=params,
                 ExpiresIn=int(lifetime_hours * 3600),  # Convert hours to seconds
             )
             logger.debug(f"Generated presigned URL for {container}/{file_path}, expires in {lifetime_hours}h")

--- a/packages/core/swiss_ai_hub/core/generative_ai/document/accessor/tests/unit/test_s3_anonymous_file_access_service.py
+++ b/packages/core/swiss_ai_hub/core/generative_ai/document/accessor/tests/unit/test_s3_anonymous_file_access_service.py
@@ -99,6 +99,31 @@ def test_generate_sas_url_uses_internal_client_when_internal():
     s3_client.generate_presigned_url.assert_not_called()
 
 
+def test_generate_sas_url_omits_disposition_by_default():
+    s3_public_client = MagicMock()
+    s3_public_client.generate_presigned_url.return_value = "https://public/signed"
+    service = _create_service()
+    service._s3_public_client = s3_public_client
+
+    service.generate_sas_url("my-bucket", "path/to/figure.png")
+
+    params = s3_public_client.generate_presigned_url.call_args.kwargs["Params"]
+    assert "ResponseContentDisposition" not in params
+
+
+def test_generate_sas_url_sets_response_content_disposition():
+    s3_public_client = MagicMock()
+    s3_public_client.generate_presigned_url.return_value = "https://public/signed"
+    service = _create_service()
+    service._s3_public_client = s3_public_client
+
+    disposition = 'attachment; filename="report.pdf"'
+    service.generate_sas_url("my-bucket", "ns/report.pdf", response_content_disposition=disposition)
+
+    params = s3_public_client.generate_presigned_url.call_args.kwargs["Params"]
+    assert params["ResponseContentDisposition"] == disposition
+
+
 def test_delete_file_calls_delete_object():
     s3_client = MagicMock()
     service = _create_service(s3_client)

--- a/packages/web/components/Knowledge/Document/List.vue
+++ b/packages/web/components/Knowledge/Document/List.vue
@@ -215,8 +215,13 @@ const handleSort = (event: DataTableSortEvent) => {
 const downloadFile = async (documentId: string) => {
   const database = route.params.db as string
   const namespace = route.params.namespace as string
-  const url = await getDocumentSourceUrl(tenantId.value!, database, namespace, documentId)
-  window.open(url, '_blank')
+  const url = await getDocumentSourceUrl(tenantId.value!, database, namespace, documentId, true)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.rel = 'noopener'
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
 }
 
 const confirmDelete = (document: DocumentDto) => {

--- a/packages/web/composables/document/useDocumentUrl.ts
+++ b/packages/web/composables/document/useDocumentUrl.ts
@@ -1,7 +1,7 @@
 import { getDocumentUrl } from '@core/sdk/client'
 
 export const useDocumentUrl = () => {
-  const getDocumentSourceUrl = async (tenantId: string, database: string, namespace: string, documentId: string): Promise<string> => {
+  const getDocumentSourceUrl = async (tenantId: string, database: string, namespace: string, documentId: string, download = false): Promise<string> => {
     const { url } = await getDocumentUrl({
       composable: '$fetch',
       path: {
@@ -10,6 +10,7 @@ export const useDocumentUrl = () => {
         namespace,
         document_id: documentId,
       },
+      query: { download },
     })
     return url
   }

--- a/packages/web/sdk/client/sdk.gen.ts
+++ b/packages/web/sdk/client/sdk.gen.ts
@@ -3020,7 +3020,7 @@ export const getSupportedFileTypes = <
 /**
  * Get signed document URL
  *
- * Generates a presigned URL for downloading a document's source file.
+ * Generates a presigned URL for a document's source file (inline preview, or attachment download).
  */
 export const getDocumentUrl = <
   TComposable extends Composable = "$fetch",

--- a/packages/web/sdk/client/types.gen.ts
+++ b/packages/web/sdk/client/types.gen.ts
@@ -28483,7 +28483,14 @@ export type GetDocumentUrlData = {
      */
     document_id: string;
   };
-  query?: never;
+  query?: {
+    /**
+     * Download
+     *
+     * Force a browser download (Content-Disposition: attachment) instead of preview
+     */
+    download?: boolean;
+  };
   url: "/{tenant_id}/knowledge/databases/{database}/namespaces/{namespace}/documents/{document_id}/url";
 };
 


### PR DESCRIPTION
## What

Fixes the knowledge base **Download** button opening previewable files (pdf, image, txt, md) inline in a new tab instead of downloading them (bbvch-ai/aihub-core-private#51).

Root cause: the download button used `window.open(presignedUrl)` and our S3 objects carry no `Content-Disposition`, so browsers render previewable types inline. The fix forces `Content-Disposition: attachment` on the presigned URL — but SeaweedFS 3.97 ignores the `response-content-disposition` override (upstream bug, fixed in [PR #7559](https://github.com/seaweedfs/seaweedfs/pull/7559), first released in **SeaweedFS 4.01**). So this bumps SeaweedFS 3.97 → 4.01 and uses the now-honored override.

## Changes

- **core**: `S3AnonymousFileAccessService.generate_sas_url` gains optional `response_content_disposition` (defaults `None` → existing callers, incl. RAG figure signing and `file_controller`, unchanged).
- **api**: knowledge document-URL endpoint gains `download: bool = False`, threaded to `get_document_url(as_attachment=)` which builds `attachment; filename="<basename>"`.
- **web**: Download button requests `download=true` and triggers via an anchor click (no orphan blank tab); "Open original document" keeps inline preview. SDK regenerated.
- **deploy**: `compose-config.yml` SeaweedFS `3.97 → 4.01` + regenerated compose files.
- **ADR**: `docs/arc42/decisions/2026_07_23_upgrade_seaweedfs_to_4_01_for_content_disposition.md`.

## Testing

Unit: core 15 passed, api 12 passed (preview → no disposition; attachment → exact header).

Verified live on **SeaweedFS 4.01** dev stack:
- [x] Preview URL → no `Content-Disposition`; attachment URL → `attachment; filename="..."` (real KB file downloads)
- [x] KB ingestion pipeline
- [x] Agent file uploads
- [x] Chat + RAG file retrieval
- [x] Langfuse traces
- [x] OpenWebUI file upload
- [x] Backup/restore (`backup_asset_job` — postgres/ferretdb/neo4j/clickhouse/valkey/nats/milvus artifacts written, `head_object` confirmed)
- [x] Existing volume data + buckets survived the major bump

## Deploy note

`ghcr.io/bbvch-ai/aihub-core/seaweedfs:4.01` must be mirrored to GHCR (`make mirror-image`) before non-dev stages pull it. Production upgrade should verify/adjust volume-mount ownership (4.00/4.01 non-root container user; #7399/#7451).

Closes bbvch-ai/aihub-core-private#51
