### PR TITLE
fix(ui): Use correct import/export icons for agent actions

### DIFF
--- a/packages/web/components/Agent/Card.vue
+++ b/packages/web/components/Agent/Card.vue
@@ -6,9 +6,7 @@
   >
     <div class="flex items-center justify-between gap-4">
       <div class="flex items-center justify-start gap-2">
-        <div
-          class="flex items-center justify-center rounded-full bg-white p-3 dark:bg-surface-900"
-        >
+        <div class="flex items-center justify-center rounded-full bg-white p-3 dark:bg-surface-900">
           <Icon
             :name="agent.agent_config.icon"
             size="1.5em"
@@ -45,7 +43,7 @@
         />
         <Button
           v-tooltip.top="t('agent.export.button')"
-          icon="pi pi-download"
+          icon="pi pi-file-export"
           severity="secondary"
           text
           rounded

--- a/packages/web/pages/[tenant]/service/agents.vue
+++ b/packages/web/pages/[tenant]/service/agents.vue
@@ -17,7 +17,7 @@
         />
         <div class="flex items-center gap-4">
           <Button
-            icon="pi pi-upload"
+            icon="pi pi-file-import"
             severity="secondary"
             :label="t('agent.import.button')"
             @click="triggerImport"

--- a/packages/web/pages/[tenant]/service/agents/[agent_class]-[agent_id]/configuration.vue
+++ b/packages/web/pages/[tenant]/service/agents/[agent_class]-[agent_id]/configuration.vue
@@ -11,7 +11,7 @@
           {{ t('agent.configuration.description') }}
         </p>
         <Button
-          icon="pi pi-download"
+          icon="pi pi-file-export"
           severity="secondary"
           :label="t('agent.export.button')"
           class="shrink-0"


### PR DESCRIPTION
## Summary

Replaces the generic upload/download icons on agent import and export buttons with the semantically correct file-import/file-export icons, so the actions read clearly in the UI.

follow through for comment in https://github.com/bbvch-ai/aihub-core/issues/1542

## Changes

- **Agent Card** ([Card.vue](packages/web/components/Agent/Card.vue)): Export button icon `pi pi-download` → `pi pi-file-export`
- **Agents list page** ([agents.vue](packages/web/pages/[tenant]/service/agents.vue)): Import button icon `pi pi-upload` → `pi pi-file-import`
- **Agent configuration page** ([configuration.vue](packages/web/pages/[tenant]/service/agents/[agent_class]-[agent_id]/configuration.vue)): Export button icon `pi pi-download` → `pi pi-file-export`

## Test Plan

- [x] Open the agents list page and confirm the import button shows the file-import icon
- [x] Open an agent card and the agent configuration page, and confirm both export buttons show the file-export icon
