### PR TITLE
fix(ui): Scope document select-all to the current page

### DIFF
--- a/packages/web/components/Knowledge/Document/List.vue
+++ b/packages/web/components/Knowledge/Document/List.vue
@@ -1,125 +1,54 @@
 <template>
-  <div
-    v-if="checkedDocuments.length > 0"
-    class="mb-2 flex items-center justify-between"
-  >
+  <div v-if="checkedDocuments.length > 0" class="mb-2 flex items-center justify-between">
     <p class="text-sm">
       {{ t('document.list.selected_count', { count: checkedDocuments.length }) }}
     </p>
-    <Button
-      size="small"
-      severity="danger"
-      icon="pi pi-trash"
-      :label="t('document.delete.button_selected')"
-      :loading="isBatchDeleting"
-      @click="confirmBatchDelete"
-    />
+    <Button size="small" severity="danger" icon="pi pi-trash" :label="t('document.delete.button_selected')"
+      :loading="isBatchDeleting" @click="confirmBatchDelete" />
   </div>
-  <DataTable
-    v-model:selection="checkedDocuments"
-    :value="documents"
-    table-style="min-width: 50rem"
-    :row-class="getRowClass"
-    :sort-field="sortField ?? undefined"
-    :sort-order="sortOrder"
-    removable-sort
-    size="small"
-    :select-all="allDeletableSelected"
-    @select-all-change="onSelectAllChange"
-    @row-click="handleRowClick"
-    @sort="handleSort"
-  >
-    <Column
-      selection-mode="multiple"
-      header-style="width: 3rem"
-    />
-    <Column
-      field="document_title"
-      :header="t('document.list.title')"
-      sortable
-    >
+  <DataTable v-model:selection="checkedDocuments" :value="documents" table-style="min-width: 50rem"
+    :row-class="getRowClass" :sort-field="sortField ?? undefined" :sort-order="sortOrder" removable-sort size="small"
+    :select-all="allDeletableSelected" @select-all-change="onSelectAllChange" @row-click="handleRowClick"
+    @sort="handleSort">
+    <Column selection-mode="multiple" header-style="width: 3rem" />
+    <Column field="document_title" :header="t('document.list.title')" sortable>
       <template #body="{ data }">
         <div class="flex items-center gap-2">
           <p class="font-bold">
             {{ data.document_title }}
           </p>
-          <div
-            v-if="isDocumentDeleting(data)"
-            class="flex items-center gap-2"
-          >
-            <Tag
-              :value="t('document.delete.deleting')"
-              size="small"
-              icon="pi pi-trash"
-              severity="danger"
-            />
+          <div v-if="isDocumentDeleting(data)" class="flex items-center gap-2">
+            <Tag :value="t('document.delete.deleting')" size="small" icon="pi pi-trash" severity="danger" />
           </div>
-          <div
-            v-else-if="!data.is_ingested"
-            class="flex items-center gap-2"
-          >
-            <Tag
-              :value="t('document.list.is_processing')"
-              size="small"
-              icon="pi pi-clock"
-              severity="info"
-            />
+          <div v-else-if="!data.is_ingested" class="flex items-center gap-2">
+            <Tag :value="t('document.list.is_processing')" size="small" icon="pi pi-clock" severity="info" />
           </div>
         </div>
       </template>
     </Column>
-    <Column
-      field="created_at"
-      :header="t('document.list.created')"
-      sortable
-    >
+    <Column field="created_at" :header="t('document.list.created')" sortable>
       <template #body="{ data }">
         <p>{{ formatted(data.created_at) }}</p>
       </template>
     </Column>
-    <Column
-      field="updated_at"
-      :header="t('document.list.updated_at')"
-      sortable
-    >
+    <Column field="updated_at" :header="t('document.list.updated_at')" sortable>
       <template #body="{ data }">
         <p>{{ formatted(data.updated_at) }}</p>
       </template>
     </Column>
-    <Column
-      field="number_of_pages"
-      :header="t('document.list.number_of_pages')"
-    >
+    <Column field="number_of_pages" :header="t('document.list.number_of_pages')">
       <template #body="{ data }">
         <Badge :value="data.number_of_pages ?? '-'" />
       </template>
     </Column>
-    <Column
-      field="source"
-      :header="t('document.list.actions')"
-    >
+    <Column field="source" :header="t('document.list.actions')">
       <template #body="{ data }">
         <div class="flex items-center gap-2">
-          <Button
-            v-if="data.source"
-            v-tooltip.top="t('document.list.download')"
-            rounded
-            size="small"
-            variant="outlined"
-            icon="pi pi-download"
-            @click.stop="() => downloadFile(data.id)"
-          />
-          <Button
-            v-if="!isDocumentDeleting(data)"
-            v-tooltip.top="t('document.delete.button')"
-            rounded
-            size="small"
-            variant="outlined"
-            severity="danger"
-            icon="pi pi-trash"
-            :loading="isDeleting"
-            @click.stop="() => confirmDelete(data)"
-          />
+          <Button v-if="data.source" v-tooltip.top="t('document.list.download')" rounded size="small" variant="outlined"
+            icon="pi pi-download" @click.stop="() => downloadFile(data.id)" />
+          <Button v-if="!isDocumentDeleting(data)" v-tooltip.top="t('document.delete.button')" rounded size="small"
+            variant="outlined" severity="danger" icon="pi pi-trash" :loading="isDeleting"
+            @click.stop="() => confirmDelete(data)" />
         </div>
       </template>
     </Column>
@@ -185,11 +114,16 @@ watch(
 const deletableDocuments = computed(() => props.documents.filter(isDocumentDeletable))
 
 const allDeletableSelected = computed(
-  () => deletableDocuments.value.length > 0 && checkedDocuments.value.length === deletableDocuments.value.length,
+  () => deletableDocuments.value.length > 0
+    && deletableDocuments.value.every(document => checkedDocuments.value.some(selected => selected.id === document.id)),
 )
 
 const onSelectAllChange = ({ checked }: { checked: boolean }) => {
-  checkedDocuments.value = checked ? [...deletableDocuments.value] : []
+  const pageIds = new Set(deletableDocuments.value.map(document => document.id))
+  const selectionFromOtherPages = checkedDocuments.value.filter(selected => !pageIds.has(selected.id))
+  checkedDocuments.value = checked
+    ? [...selectionFromOtherPages, ...deletableDocuments.value]
+    : selectionFromOtherPages
 }
 
 const handleRowClick = (event: DataTableRowClickEvent) => {

--- a/packages/web/components/Knowledge/Document/List.vue
+++ b/packages/web/components/Knowledge/Document/List.vue
@@ -1,54 +1,126 @@
 <template>
-  <div v-if="checkedDocuments.length > 0" class="mb-2 flex items-center justify-between">
+  <div
+    v-if="checkedDocuments.length > 0"
+    class="mb-2 flex items-center justify-between"
+  >
     <p class="text-sm">
       {{ t('document.list.selected_count', { count: checkedDocuments.length }) }}
     </p>
-    <Button size="small" severity="danger" icon="pi pi-trash" :label="t('document.delete.button_selected')"
-      :loading="isBatchDeleting" @click="confirmBatchDelete" />
+    <Button
+      size="small"
+      severity="danger"
+      icon="pi pi-trash"
+      :label="t('document.delete.button_selected')"
+      :loading="isBatchDeleting"
+      @click="confirmBatchDelete"
+    />
   </div>
-  <DataTable v-model:selection="checkedDocuments" :value="documents" table-style="min-width: 50rem"
-    :row-class="getRowClass" :sort-field="sortField ?? undefined" :sort-order="sortOrder" removable-sort size="small"
-    :select-all="allDeletableSelected" @select-all-change="onSelectAllChange" @row-click="handleRowClick"
-    @sort="handleSort">
-    <Column selection-mode="multiple" header-style="width: 3rem" />
-    <Column field="document_title" :header="t('document.list.title')" sortable>
+  <DataTable
+    v-model:selection="checkedDocuments"
+    :value="documents"
+    data-key="id"
+    table-style="min-width: 50rem"
+    :row-class="getRowClass"
+    :sort-field="sortField ?? undefined"
+    :sort-order="sortOrder"
+    removable-sort
+    size="small"
+    :select-all="allDeletableSelected"
+    @select-all-change="onSelectAllChange"
+    @row-click="handleRowClick"
+    @sort="handleSort"
+  >
+    <Column
+      selection-mode="multiple"
+      header-style="width: 3rem"
+    />
+    <Column
+      field="document_title"
+      :header="t('document.list.title')"
+      sortable
+    >
       <template #body="{ data }">
         <div class="flex items-center gap-2">
           <p class="font-bold">
             {{ data.document_title }}
           </p>
-          <div v-if="isDocumentDeleting(data)" class="flex items-center gap-2">
-            <Tag :value="t('document.delete.deleting')" size="small" icon="pi pi-trash" severity="danger" />
+          <div
+            v-if="isDocumentDeleting(data)"
+            class="flex items-center gap-2"
+          >
+            <Tag
+              :value="t('document.delete.deleting')"
+              size="small"
+              icon="pi pi-trash"
+              severity="danger"
+            />
           </div>
-          <div v-else-if="!data.is_ingested" class="flex items-center gap-2">
-            <Tag :value="t('document.list.is_processing')" size="small" icon="pi pi-clock" severity="info" />
+          <div
+            v-else-if="!data.is_ingested"
+            class="flex items-center gap-2"
+          >
+            <Tag
+              :value="t('document.list.is_processing')"
+              size="small"
+              icon="pi pi-clock"
+              severity="info"
+            />
           </div>
         </div>
       </template>
     </Column>
-    <Column field="created_at" :header="t('document.list.created')" sortable>
+    <Column
+      field="created_at"
+      :header="t('document.list.created')"
+      sortable
+    >
       <template #body="{ data }">
         <p>{{ formatted(data.created_at) }}</p>
       </template>
     </Column>
-    <Column field="updated_at" :header="t('document.list.updated_at')" sortable>
+    <Column
+      field="updated_at"
+      :header="t('document.list.updated_at')"
+      sortable
+    >
       <template #body="{ data }">
         <p>{{ formatted(data.updated_at) }}</p>
       </template>
     </Column>
-    <Column field="number_of_pages" :header="t('document.list.number_of_pages')">
+    <Column
+      field="number_of_pages"
+      :header="t('document.list.number_of_pages')"
+    >
       <template #body="{ data }">
         <Badge :value="data.number_of_pages ?? '-'" />
       </template>
     </Column>
-    <Column field="source" :header="t('document.list.actions')">
+    <Column
+      field="source"
+      :header="t('document.list.actions')"
+    >
       <template #body="{ data }">
         <div class="flex items-center gap-2">
-          <Button v-if="data.source" v-tooltip.top="t('document.list.download')" rounded size="small" variant="outlined"
-            icon="pi pi-download" @click.stop="() => downloadFile(data.id)" />
-          <Button v-if="!isDocumentDeleting(data)" v-tooltip.top="t('document.delete.button')" rounded size="small"
-            variant="outlined" severity="danger" icon="pi pi-trash" :loading="isDeleting"
-            @click.stop="() => confirmDelete(data)" />
+          <Button
+            v-if="data.source"
+            v-tooltip.top="t('document.list.download')"
+            rounded
+            size="small"
+            variant="outlined"
+            icon="pi pi-download"
+            @click.stop="() => downloadFile(data.id)"
+          />
+          <Button
+            v-if="!isDocumentDeleting(data)"
+            v-tooltip.top="t('document.delete.button')"
+            rounded
+            size="small"
+            variant="outlined"
+            severity="danger"
+            icon="pi pi-trash"
+            :loading="isDeleting"
+            @click.stop="() => confirmDelete(data)"
+          />
         </div>
       </template>
     </Column>


### PR DESCRIPTION
## What

Makes the "select all" header checkbox in the knowledge document list (`Knowledge/Document/List.vue`) operate **per page**, so selecting/deselecting all on one page no longer wipes selections made on other pages.

addresses a fix/enchancement on Thongs comment https://github.com/bbvch-ai/aihub-core-private/issues/50#issuecomment-5043626168 for issue https://github.com/bbvch-ai/aihub-core-private/issues/50

https://github.com/user-attachments/assets/6b828632-7b04-4e57-aa08-e29a52dc31ab


## Why

QC reported: with a selection spanning pages, clicking "select all" on page 2 checked page 2's rows but cleared page 1's. The previous implementation replaced the entire selection on every header toggle (`[...deletableDocuments]` on check, `[]` on uncheck), so it clobbered rows chosen on other pages.

## How

- **`onSelectAllChange` is now per-page.** On check it unions the current page's deletable rows into the existing selection; on uncheck it removes only the current page's rows — both keyed by `id` — leaving other pages' selections intact.
- **`allDeletableSelected` uses set membership (`every`) instead of a count match.** Once the selection spans pages a length comparison is wrong (e.g. page 1's 10 + page 2's 10 ≠ page 2's 10); `every` answers "is every row on *this* page selected," which is the correct per-page header state.
- **Added `data-key="id"` to the DataTable.** Without it PrimeVue matched selection to rows by deep object comparison, which is fragile across the refetch that runs on every page change (new `DocumentDto` instances). Matching by `id` keeps selection rendering consistent with the id-based select-all logic.

## Behavior (QC scenario)

1. Page 1 → select all → 10 selected, header checked.
2. Page 2 → manually pick 2 → banner shows 12; page 1's 10 preserved.
3. Page 2 → select all → adds the rest of page 2; page 1's 10 untouched → header checked on page 2.
4. Page 2 → deselect all → drops only page 2's rows → back to page 1's 10.

## Test plan

- [x] Select-all on page 1, paginate to page 2 → page 1's selection is preserved (banner count unchanged).
- [x] Select-all on page 2 → page 2 rows added, page 1 rows still selected; page 2 header shows checked.
- [x] Deselect-all on page 2 → only page 2 rows removed; page 1 selection intact.