### PR TITLE
feat(ci-cd): Per-rc releases, drop nightly Release entry, semantic rc.N notes

### DIFF
--- a/.github/workflows/add-tag.yml
+++ b/.github/workflows/add-tag.yml
@@ -3,10 +3,10 @@
 # Nightly Tag & Build
 # =============================================================================
 # On every push to main (each merged PR), cut an immutable nightly tag and move
-# the rolling `nightly` pointer, dispatch the image builds, and refresh the
-# single rolling `nightly` prerelease (the bundle the nightly VM fetches).
+# the rolling `nightly` pointer, then dispatch the image builds and docs.
 # Lightweight trunk path: no version bump, no changelog, no versioned Release,
-# no npm/PyPI. create-release runs here in `nightly` (rolling) mode only.
+# no npm/PyPI. No GitHub Release is published for nightly — only the nightly git
+# tag and the :nightly images (ghcr) are produced.
 #
 # Triggered on `push` (not `pull_request`) on purpose: push events run the
 # workflow file from the pushed commit, so merging THIS change activates the new
@@ -85,8 +85,8 @@ jobs:
   notify-release:
     name: Dispatch build & bundle
     needs: nightly-tag
-    # Skip when the tag already existed (e.g. a workflow re-run): the Release is
-    # already there and gh release create would fail.
+    # Skip when the tag already existed (e.g. a workflow re-run): the images for
+    # this nightly tag were already built and dispatched.
     if: needs.nightly-tag.outputs.created == 'true'
     runs-on: ubuntu-slim
     timeout-minutes: 5
@@ -95,7 +95,7 @@ jobs:
       # (repository_dispatch: [release-ready]) builds the nightly images with
       # secondary_tag=nightly, and deploy-docs.yml publishes the docs. Only
       # create-release.yml stopped listening (it is now workflow_call only).
-      # The rolling nightly bundle is handled by the publish-nightly-bundle job.
+      # No GitHub Release is published for the nightly channel.
       - name: Dispatch release-ready (nightly image builds + docs)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -104,14 +104,3 @@ jobs:
           gh api "repos/${{ github.repository }}/dispatches" \
             -F event_type=release-ready \
             -F "client_payload[release_version]=$VERSION"
-
-  publish-nightly-bundle:
-    name: Refresh rolling nightly prerelease
-    needs: nightly-tag
-    # Skip when the tag already existed (re-run): the pointer/bundle are current.
-    if: needs.nightly-tag.outputs.created == 'true'
-    uses: ./.github/workflows/create-release.yml
-    with:
-      release_version: ${{ needs.nightly-tag.outputs.version }}
-      channel: nightly
-    secrets: inherit

--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -9,8 +9,9 @@
 #                 pointer to it, and work out the changelog base ref.
 #   2. fan-out  - dispatch the per-image build-*.yml at the rc tag, tagging
 #                 images vX.Y.Z-rc.N and the rolling :staging.
-#   3. publish  - create-release.yml (channel=staging): refresh the single
-#                 rolling `staging` prerelease bundle + rc release notes.
+#   3. publish  - create-release.yml (channel=staging): refresh the rolling
+#                 `staging` bundle the QC VM fetches AND publish the immutable,
+#                 preserved per-rc release "Swiss AI Hub vX.Y.Z-rc.N" + rc notes.
 #
 # There is no approval gate: pushing to a release branch deploys the candidate
 # to the QC staging VM directly. QC's sign-off is the gate for promote (flow 4).
@@ -20,7 +21,7 @@
 name: Build Release Candidate
 on:
   push:
-    branches: ['release/**']
+    branches: [release/**]
 permissions:
   contents: write
   actions: write
@@ -107,7 +108,6 @@ jobs:
           fi
           echo "notes_from=$notes_from" >> "$GITHUB_OUTPUT"
           echo "rc changelog base: ${notes_from:-<none>}"
-
   fan-out:
     name: Dispatch image builds at the rc tag
     needs: rc-tag
@@ -138,9 +138,8 @@ jobs:
             gh workflow run "$wf" --ref "$VERSION" \
               -f release_version="$VERSION" -f secondary_tag=staging
           done
-
   publish-rc-bundle:
-    name: Refresh rolling staging prerelease (+ rc notes)
+    name: Publish rc release + refresh rolling staging
     needs: rc-tag
     uses: ./.github/workflows/create-release.yml
     with:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,10 +5,12 @@
 # Builds the self-contained deployment bundle for a version and publishes it as
 # a GitHub Release, in one of two modes:
 #
-#   channel = nightly  -> ROLLING prerelease.
-#     One release at the moving `nightly` pointer tag, updated in place with a
-#     STABLE asset name (swissaihub-nightly.tar.gz). No changelog. This is the
-#     bundle host the nightly VM fetches (see aihub-playbook fetch.yml).
+#   channel = nightly  -> ROLLING prerelease (manual dispatch only).
+#     One release at the moving `nightly` pointer tag, STABLE asset name
+#     (swissaihub-nightly.tar.gz), no changelog. NOT published automatically:
+#     the trunk nightly flow (add-tag.yml) publishes no GitHub Release — it only
+#     cuts the nightly git tag and builds the :nightly images. Kept as a manual
+#     escape hatch for anyone who needs a nightly bundle on demand.
 #
 #   channel = staging  -> ROLLING prerelease + immutable per-rc release.
 #     1) Refreshes the rolling `staging` release (stable tag + stable asset

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,12 +5,19 @@
 # Builds the self-contained deployment bundle for a version and publishes it as
 # a GitHub Release, in one of two modes:
 #
-#   channel = nightly | staging  -> ROLLING prerelease.
-#     One release per channel, at the moving pointer tag (`nightly`/`staging`),
-#     updated in place with a STABLE asset name (swissaihub-<channel>.tar.gz).
-#     Nightly carries no changelog; staging (rc) carries the rc release notes.
-#     This is the bundle host the staging/nightly VMs fetch (see aihub-playbook
-#     fetch.yml). The Releases list never fills with per-build entries.
+#   channel = nightly  -> ROLLING prerelease.
+#     One release at the moving `nightly` pointer tag, updated in place with a
+#     STABLE asset name (swissaihub-nightly.tar.gz). No changelog. This is the
+#     bundle host the nightly VM fetches (see aihub-playbook fetch.yml).
+#
+#   channel = staging  -> ROLLING prerelease + immutable per-rc release.
+#     1) Refreshes the rolling `staging` release (stable tag + stable asset
+#        swissaihub-staging.tar.gz) that the QC staging VM fetches — unchanged
+#        deploy contract.
+#     2) Also publishes an immutable, PRESERVED release at the rc tag
+#        vX.Y.Z-rc.N titled "Swiss AI Hub vX.Y.Z-rc.N" (prerelease, not latest,
+#        version-named asset). Both carry the rc release notes (rc.1 = since the
+#        last stable = full; rc.N = since rc.(N-1) = delta).
 #
 #   channel = latest -> VERSIONED release.
 #     A real Release at the flat tag vX.Y.Z, marked Latest, asset
@@ -34,7 +41,7 @@ on:
         required: true
         type: string
       channel:
-        description: 'nightly | staging | latest'
+        description: nightly | staging | latest
         required: true
         type: string
       notes_from:
@@ -48,7 +55,7 @@ on:
         description: Full version, e.g. v0.317.0, v0.317.0-rc.2, v0.317.0-nightly.891
         required: true
       channel:
-        description: 'nightly | staging | latest | backport'
+        description: nightly | staging | latest | backport
         required: true
         type: choice
         options: [nightly, staging, latest, backport]
@@ -83,23 +90,21 @@ jobs:
             echo "::error::release_version '$VERSION' is not a valid version tag."
             exit 1
           fi
+          # `asset` = stable rolling asset name for nightly/staging, version-named
+          # for latest/backport. Release target tag, prerelease and latest flags are
+          # derived per channel in the publish step.
           case "$CHANNEL" in
-            nightly)  target="nightly";  asset="nightly";  prerelease=true;  latest=false; notes=false ;;
-            staging)  target="staging";  asset="staging";  prerelease=true;  latest=false; notes=true ;;
-            latest)   target="$VERSION"; asset="$VERSION"; prerelease=false; latest=true;  notes=true ;;
-            # Backport: a full versioned release for an older line, published but
-            # NOT marked Latest (latest must not move backwards).
-            backport) target="$VERSION"; asset="$VERSION"; prerelease=false; latest=false; notes=true ;;
+            nightly)  asset="nightly";  notes=false ;;
+            staging)  asset="staging";  notes=true ;;
+            latest)   asset="$VERSION"; notes=true ;;
+            backport) asset="$VERSION"; notes=true ;;
             *) echo "::error::channel must be nightly, staging, latest, or backport (got '$CHANNEL')."; exit 1 ;;
           esac
           # Nightly never carries notes; others only when a base ref is given.
           if [ "$notes" = "true" ] && [ -z "$NOTES_FROM" ]; then notes=false; fi
           {
             echo "version=$VERSION"
-            echo "target=$target"
             echo "asset=$asset"
-            echo "prerelease=$prerelease"
-            echo "latest=$latest"
             echo "notes=$notes"
           } >> "$GITHUB_OUTPUT"
       - name: Checkout at the version tag (full history for notes)
@@ -130,16 +135,23 @@ jobs:
             test -f "${DEST}/setup-env.sh"
             find "${DEST}" \( -name '*.yml' -o -name '*.yaml' \) -exec uv run yamlfix {} +
           done
-      - name: Create tar.gz archives with the target asset name
+      - name: Create tar.gz archives (version-named, plus stable rolling name)
         run: |
           set -euo pipefail
           VERSION="${{ steps.in.outputs.version }}"
           ASSET="${{ steps.in.outputs.asset }}"
-          # Asset name is stable per channel for rolling releases (swissaihub-nightly.tar.gz),
-          # or version-named for latest. The inner directory keeps the version; the deploy
-          # extracts with --strip-components=1 so the inner name does not matter.
-          tar -czf "swissaihub-${ASSET}.tar.gz"     -C "dist/release" "swissaihub-${VERSION}"
-          tar -czf "swissaihub-${ASSET}-gpu.tar.gz" -C "dist/release" "swissaihub-${VERSION}-gpu"
+          # Always produce version-named archives — used by latest/backport and by
+          # the immutable per-rc staging release. The inner directory keeps the
+          # version; the deploy extracts with --strip-components=1 so the inner name
+          # does not matter.
+          tar -czf "swissaihub-${VERSION}.tar.gz"     -C "dist/release" "swissaihub-${VERSION}"
+          tar -czf "swissaihub-${VERSION}-gpu.tar.gz" -C "dist/release" "swissaihub-${VERSION}-gpu"
+          # Rolling channels (nightly/staging) also need the stable per-channel asset
+          # name for the moving-pointer release the deploy VMs fetch.
+          if [ "$ASSET" != "$VERSION" ]; then
+            cp "swissaihub-${VERSION}.tar.gz"     "swissaihub-${ASSET}.tar.gz"
+            cp "swissaihub-${VERSION}-gpu.tar.gz" "swissaihub-${ASSET}-gpu.tar.gz"
+          fi
       - name: Generate release notes (rc / latest)
         if: steps.in.outputs.notes == 'true'
         env:
@@ -160,29 +172,20 @@ jobs:
           chmod +x infra/release/generate-release-notes.sh
           infra/release/generate-release-notes.sh "$NOTES_FROM" "$VERSION" > release-notes.md
           echo "Generated release notes:"; cat release-notes.md
-      - name: Publish or update the GitHub Release
+      - name: Publish or update the GitHub Release(s)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           VERSION: ${{ steps.in.outputs.version }}
-          TARGET: ${{ steps.in.outputs.target }}
           ASSET: ${{ steps.in.outputs.asset }}
-          PRERELEASE: ${{ steps.in.outputs.prerelease }}
-          LATEST: ${{ steps.in.outputs.latest }}
           NOTES: ${{ steps.in.outputs.notes }}
           CHANNEL: ${{ inputs.channel }}
         run: |-
           set -euo pipefail
-          A1="swissaihub-${ASSET}.tar.gz"
-          A2="swissaihub-${ASSET}-gpu.tar.gz"
-
-          case "$CHANNEL" in
-            nightly)  TITLE="Nightly (rolling) - ${VERSION}" ;;
-            staging)  TITLE="Staging (rolling) - ${VERSION}" ;;
-            latest)   TITLE="Swiss AI Hub ${VERSION}" ;;
-            backport) TITLE="Swiss AI Hub ${VERSION} (backport)" ;;
-          esac
-
+          VER_A1="swissaihub-${VERSION}.tar.gz"
+          VER_A2="swissaihub-${VERSION}-gpu.tar.gz"
+          ROLL_A1="swissaihub-${ASSET}.tar.gz"
+          ROLL_A2="swissaihub-${ASSET}-gpu.tar.gz"
           NOTES_ARGS=()
           if [ "$NOTES" = "true" ] && [ -f release-notes.md ]; then
             NOTES_ARGS=(--notes-file release-notes.md)
@@ -192,16 +195,42 @@ jobs:
             NOTES_ARGS=(--notes "Bundle for ${VERSION}.")
           fi
 
-          if gh release view "$TARGET" >/dev/null 2>&1; then
-            echo "Updating existing release $TARGET in place."
-            gh release edit "$TARGET" --title "$TITLE" \
-              --prerelease="$PRERELEASE" --latest="$LATEST" "${NOTES_ARGS[@]}"
-            gh release upload "$TARGET" "$A1" "$A2" --clobber
-          else
-            echo "Creating release $TARGET."
-            EXTRA=()
-            if [ "$PRERELEASE" = "true" ]; then EXTRA+=(--prerelease); fi
-            if [ "$LATEST" = "true" ]; then EXTRA+=(--latest); else EXTRA+=(--latest=false); fi
-            gh release create "$TARGET" --title "$TITLE" "${NOTES_ARGS[@]}" "${EXTRA[@]}" "$A1" "$A2"
-          fi
-          echo "Published $TARGET (channel=$CHANNEL, prerelease=$PRERELEASE, latest=$LATEST)."
+          # Publish (create) or refresh (edit in place) one release.
+          # args: <target-tag> <title> <prerelease true|false> <latest true|false> <asset...>
+          publish() {
+            local target="$1" title="$2" pre="$3" lat="$4"; shift 4
+            if gh release view "$target" >/dev/null 2>&1; then
+              echo "Updating existing release $target in place."
+              gh release edit "$target" --title "$title" \
+                --prerelease="$pre" --latest="$lat" "${NOTES_ARGS[@]}"
+              gh release upload "$target" "$@" --clobber
+            else
+              echo "Creating release $target."
+              local extra=()
+              if [ "$pre" = "true" ]; then extra+=(--prerelease); fi
+              if [ "$lat" = "true" ]; then extra+=(--latest); else extra+=(--latest=false); fi
+              gh release create "$target" --title "$title" "${NOTES_ARGS[@]}" "${extra[@]}" "$@"
+            fi
+          }
+          case "$CHANNEL" in
+            nightly)
+              publish "nightly" "Nightly (rolling) - ${VERSION}" true false "$ROLL_A1" "$ROLL_A2"
+              ;;
+            staging)
+              # 1) Rolling pointer release the QC staging VM fetches (stable tag + asset).
+              publish "staging" "Staging (rolling) - ${VERSION}" true false "$ROLL_A1" "$ROLL_A2"
+              # 2) Immutable, PRESERVED per-rc release for humans, version-named assets.
+              #    Only for real rc builds (build-rc.yml). promote-to-staging.yml
+              #    promotes a nightly to staging — that must not create a versioned entry.
+              if printf '%s' "$VERSION" | grep -Eq -- '-rc\.[0-9]+$'; then
+                publish "$VERSION" "Swiss AI Hub ${VERSION}" true false "$VER_A1" "$VER_A2"
+              fi
+              ;;
+            latest)
+              publish "$VERSION" "Swiss AI Hub ${VERSION}" false true "$VER_A1" "$VER_A2"
+              ;;
+            backport)
+              publish "$VERSION" "Swiss AI Hub ${VERSION} (backport)" false false "$VER_A1" "$VER_A2"
+              ;;
+          esac
+          echo "Published channel=$CHANNEL for ${VERSION}."

--- a/infra/release/generate-release-notes.sh
+++ b/infra/release/generate-release-notes.sh
@@ -38,27 +38,38 @@ EXCLUDE_PATTERNS=(
     ':(exclude)*.drawio'
 )
 
-diff_output="$(git diff "$FROM" "$TO" -- . "${EXCLUDE_PATTERNS[@]}" || true)"
+# Incremental rc (rc.2, rc.3, ...) — the FROM ref is itself an rc tag — gets a
+# compact list of the conventional-commit subjects added since the previous rc,
+# not the full grouped template. rc.1 (FROM = last stable) and latest (FROM =
+# previous stable) keep the full LLM-grouped notes below.
+if printf '%s' "$FROM" | grep -Eq -- '-rc\.[0-9]+$'; then
+    body="$(git log --format='- %s' "${FROM}..${TO}" 2>/dev/null \
+        | grep -E -- '^- (feat|fix|perf|refactor|docs?|test|build|ci|chore|style|revert)(\([^)]+\))?!?: ' \
+        || true)"
+    [ -n "$body" ] || body="_No changes since ${FROM}._"
+else
+    diff_output="$(git diff "$FROM" "$TO" -- . "${EXCLUDE_PATTERNS[@]}" || true)"
 
-# Guard the model's context window / cost on a big release: if the patch is very
-# large, summarise from the diffstat instead of the full patch.
-MAX_DIFF_LINES="${RELEASE_NOTES_MAX_DIFF_LINES:-6000}"
-diff_note=""
-if [ "$(printf '%s\n' "$diff_output" | wc -l)" -gt "$MAX_DIFF_LINES" ]; then
-    diff_output="$(git diff --stat "$FROM" "$TO" -- . "${EXCLUDE_PATTERNS[@]}" || true)"
-    diff_note=" (large release — summarised from the diffstat)"
-fi
+    # Guard the model's context window / cost on a big release: if the patch is very
+    # large, summarise from the diffstat instead of the full patch.
+    MAX_DIFF_LINES="${RELEASE_NOTES_MAX_DIFF_LINES:-6000}"
+    diff_note=""
+    if [ "$(printf '%s\n' "$diff_output" | wc -l)" -gt "$MAX_DIFF_LINES" ]; then
+        diff_output="$(git diff --stat "$FROM" "$TO" -- . "${EXCLUDE_PATTERNS[@]}" || true)"
+        diff_note=" (large release — summarised from the diffstat)"
+    fi
 
-# Natural-language, grouped body via the LLM: system prompt from the file, the
-# diff piped as the user turn. Degrades gracefully if `llm` is unavailable or
-# the call fails, so a release is never blocked on note prose.
-body=""
-if [ -n "$diff_output" ] && command -v llm >/dev/null 2>&1; then
-    body="$(printf 'Here is the git diff from %s to %s%s. Generate the grouped release notes.\n\n%s\n' \
-        "$FROM" "$TO" "$diff_note" "$diff_output" \
-        | llm --no-stream -m "$MODEL" --system "$(cat "$PROMPT_FILE")" 2>/dev/null || true)"
+    # Natural-language, grouped body via the LLM: system prompt from the file, the
+    # diff piped as the user turn. Degrades gracefully if `llm` is unavailable or
+    # the call fails, so a release is never blocked on note prose.
+    body=""
+    if [ -n "$diff_output" ] && command -v llm >/dev/null 2>&1; then
+        body="$(printf 'Here is the git diff from %s to %s%s. Generate the grouped release notes.\n\n%s\n' \
+            "$FROM" "$TO" "$diff_note" "$diff_output" \
+            | llm --no-stream -m "$MODEL" --system "$(cat "$PROMPT_FILE")" 2>/dev/null || true)"
+    fi
+    [ -n "$body" ] || body="_No summarised changes for this range._"
 fi
-[ -n "$body" ] || body="_No summarised changes for this range._"
 
 # References: PR numbers parsed from squash-merge commit subjects in (FROM, TO].
 # Squash merges carry "(#123)" in the subject, so this lists every PR in range.


### PR DESCRIPTION
## Summary

Rework how release candidates surface on the Releases page:

1. **Preserve every rc as its own release.** For each rc build, publish an immutable, preserved release at the rc tag `vX.Y.Z-rc.N`, titled **`Swiss AI Hub vX.Y.Z-rc.N`** (prerelease, not latest, version-named assets `swissaihub-vX.Y.Z-rc.N.tar.gz` + `-gpu`). The rolling `staging` release is still refreshed unchanged so the QC staging VM fetch keeps working.

2. **No more `Nightly (rolling)` release.** The trunk nightly flow (`add-tag.yml`) no longer publishes a GitHub Release — it still cuts the nightly git tag and builds the `:nightly` images, only the Release entry is dropped. The `nightly` channel in `create-release.yml` remains as a manual-dispatch escape hatch.

3. **Release-notes format per rc:**
   - **rc.1** — full templated changelog (LLM-grouped) of everything since the last stable, plus References.
   - **rc.2+** — a compact **semantic-commit list** of the delta since the previous rc (conventional-commit subjects), plus References. Implemented in `generate-release-notes.sh` by detecting a `FROM` ref that is itself an rc tag.

## Files

- `.github/workflows/create-release.yml` — staging channel publishes rolling `staging` + immutable per-rc release; bundle built once; `nightly` header noted as manual-only; per-rc guarded to real `-rc.N` versions (so `promote-to-staging` promoting a nightly doesn't create a versioned entry).
- `.github/workflows/build-rc.yml` — job/comment wording for the dual publish.
- `.github/workflows/add-tag.yml` — removed the `publish-nightly-bundle` job.
- `infra/release/generate-release-notes.sh` — semantic-list mode for rc.2+.

## Result on the Releases page

```
Swiss AI Hub v0.317.0-rc.1   (pre-release)  ← full templated notes (since last stable)
Swiss AI Hub v0.317.0-rc.2   (pre-release)  ← semantic list of rc.2 delta only
Staging (rolling) - …        (pre-release)  ← QC staging VM fetch pointer (unchanged)
(no Nightly (rolling) entry)
```

## Safety

- Staging rolling release + asset name preserved → QC staging VM deploy contract unchanged.
- Nightly: only the Release entry is removed; nightly tags + `:nightly` images still built. Assumes no VM fetches the nightly channel (confirmed with owner).
- `latest` / `backport` release behaviour unchanged.

## Rollout note

`build-rc.yml` runs from the workflow copy on the release branch, so this takes effect for release lines cut after merge. To apply to an in-flight line (e.g. `release/0.317`), forward-port this branch to that line (paired with #1656 so its PRs are scannable).
