### PR TITLE
fix(rag): Keep chunked SeaweedFS ETags as DataLakeFile hash

### DIFF
--- a/docs/arc42/decisions/2026_07_23_upgrade_seaweedfs_to_4_01_for_content_disposition.md
+++ b/docs/arc42/decisions/2026_07_23_upgrade_seaweedfs_to_4_01_for_content_disposition.md
@@ -43,8 +43,8 @@ Upgrade SeaweedFS **3.97 → 4.01** and use the now-honored override to force do
 2. **Opt-in disposition, defaulting to current behavior.** `S3AnonymousFileAccessService.generate_sas_url` gains an
    optional `response_content_disposition: str | None = None`; when set, it is passed as `ResponseContentDisposition`
    into the presigned `get_object`. Default `None` preserves inline behavior, so the other callers of this shared method
-   (RAG figure signing per ADR `2026_07_10_inline_rag_figures_as_base64`, and the generic file controller) are
-   untouched — no new abstraction.
+   (RAG figure signing per ADR `2026_07_10_inline_rag_figures_as_base64`, and the generic file controller) are untouched
+   — no new abstraction.
 
 3. **Download vs preview split at the endpoint.** The knowledge document-URL endpoint gains a `download: bool = False`
    query param, threaded to `KnowledgeService.get_document_url(..., as_attachment=)`, which builds
@@ -60,11 +60,12 @@ The 4.x line is a genuine architectural shift, not just the disposition fix:
   volume reads/writes require **JWT** (3.99 #7376, 4.01 #7514). All four SeaweedFS services share
   `WEED_JWT_SIGNING_KEY`, so internal auth continues to work.
 - **Non-root container user** (4.00 #7399) + **`/data` ownership/permission fix** (4.01 #7451) — the primary upgrade
-  risk on existing deployments. In our dev volumes the data files are already owned by the host user, so no
-  permission break occurred; **production upgrades must verify (and if needed `chown`) the mounted volume ownership.**
-- **Bucket-policy enforcement** (4.01 #7471), **auto-create bucket** (4.01 #7549), path/virtual-style addressing
-  changes (3.99 #7357), and S3 error-code changes (3.98: 400 vs 500) — none affected our path-style, explicit-identity
+  risk on existing deployments. In our dev volumes the data files are already owned by the host user, so no permission
+  break occurred; **production upgrades must verify (and if needed `chown`) the mounted volume ownership.**
+- **Bucket-policy enforcement** (4.01 #7471), **auto-create bucket** (4.01 #7549), path/virtual-style addressing changes
+  (3.99 #7357), and S3 error-code changes (3.98: 400 vs 500) — none affected our path-style, explicit-identity
   configuration.
+- **Chunked ETags above 8 MiB** — discovered after the fact, see the Trade-offs entry below.
 
 ## Consequences
 
@@ -84,6 +85,21 @@ The 4.x line is a genuine architectural shift, not just the disposition fix:
   than 3.97; upstream 4.x regressions could surface in future point releases.
 - **Production rollout needs the two operational steps** the dev upgrade could skip: mirror 4.01 to GHCR first, and
   verify/adjust volume-mount ownership for the non-root container user before starting.
+- **ETag format changed above 8 MiB — this broke ingestion (#121).** 4.01 chunks objects larger than 8 MiB server-side
+  and returns a multipart-style ETag `<md5hex>-<n>`, where 3.97 returned a plain MD5 at any size. A boundary sweep
+  confirms it: on 4.01, 8.0 MB yields a plain MD5 while 8.5 MB yields `…-2`; on 3.97, 5/9/15/20 MB are all plain MD5. It
+  is server-side, not client-side — presigned PUT, chunked transfer-encoding, `put_object`, and `upload_fileobj` all
+  produce the same ETag. `S3DataLakeClient._create_data_lake_file_from_s3_object` only handled the plain-MD5 shape and
+  left `hash = None` otherwise, failing `DataLakeFile` validation. Because `get_all_files()` enumerates the whole bucket
+  inside one observable source asset, a single oversized object aborted observation and **halted ingestion for the
+  entire bucket**, not just that file. Fixed by keeping the chunked ETag verbatim as the content-version token; the ≤8
+  MiB base64-MD5 output is deliberately frozen, since `hash` feeds the persisted `DataVersion` and changing it would
+  force a full re-parse and re-embed of every corpus.
+- **Verification gap to close on the next storage bump.** The "whole S3 blast radius re-verified" claim above used only
+  small files, so the 8 MiB threshold went unnoticed. Any future major object-store upgrade must include a >8 MiB
+  document in its checklist. Raising the filer's `-maxMB` above the largest expected document would also avoid chunking
+  without code changes, but was rejected: it pushes very large single chunks at the volume server and merely moves the
+  threshold instead of removing the assumption.
 - **Filename header is not RFC 6266-encoded** — the attachment filename is the S3 key basename interpolated directly;
   unusual characters (embedded quotes, non-ASCII, control chars) are not escaped. Acceptable because keys derive from
   constrained upload filenames, but a future hardening could add `filename*=UTF-8''<encoded>`.

--- a/packages/pipeline/swiss_ai_hub/pipeline/resources/data_lake/s3/s3_data_lake_client.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/resources/data_lake/s3/s3_data_lake_client.py
@@ -156,16 +156,15 @@ class S3DataLakeClient(AbstractDataLakeClient):
 
         md5_hash_str: str | None = None
         if etag:
-            try:
-                # Only convert if ETag looks like a hex string (standard MD5)
-                if len(etag) == 32 and all(c in "0123456789abcdef" for c in etag.lower()):
-                    md5_hash_str = base64.b64encode(bytes.fromhex(etag)).decode("utf-8")
-                else:
-                    # For multipart uploads or other ETag formats, keep as-is
-                    logger.debug(f"Non-standard ETag format for {key}: {etag}")
-            except (ValueError, TypeError) as e:
-                logger.warning(f"Failed to convert ETag to MD5 hash for {key}: {e}")
-                md5_hash_str = None
+            if len(etag) == 32 and all(c in "0123456789abcdef" for c in etag.lower()):
+                # Frozen format: persisted as content_hash and embedded in the DataVersion.
+                # Changing it forces a full re-parse and re-embed of every existing corpus.
+                md5_hash_str = base64.b64encode(bytes.fromhex(etag)).decode("utf-8")
+            else:
+                # SeaweedFS >=4.01 chunks objects above 8 MiB and returns "<md5hex>-<chunks>".
+                # Kept verbatim: deterministic and content-derived, so it still works as a
+                # change-detection token. Do NOT unify with the base64 branch above.
+                md5_hash_str = etag
 
         last_modified_timestamp = int(last_modified.timestamp()) if last_modified else int(datetime.now().timestamp())
 

--- a/packages/pipeline/swiss_ai_hub/pipeline/resources/data_lake/s3/tests/test_s3_data_lake_client.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/resources/data_lake/s3/tests/test_s3_data_lake_client.py
@@ -1,0 +1,84 @@
+import base64
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+from swiss_ai_hub.pipeline.resources.data_lake.s3.s3_data_lake_client import S3DataLakeClient
+
+PLAIN_MD5_ETAG = "33d0c38d07a0671842cffe80c9973b8c"
+CHUNKED_ETAG = "33d0c38d07a0671842cffe80c9973b8c-2"
+
+NAMESPACE_PATCH_TARGET = (
+    "swiss_ai_hub.pipeline.resources.data_lake.s3.s3_data_lake_client.get_or_create_namespace_for_directory"
+)
+
+
+def _make_s3_client(etag: str) -> MagicMock:
+    mock = MagicMock()
+    mock.head_object.return_value = {
+        "ContentType": "application/pdf",
+        "ETag": f'"{etag}"',
+        "Metadata": {},
+        "LastModified": datetime(2026, 7, 24, tzinfo=UTC),
+        "ContentLength": 9_000_000,
+    }
+    return mock
+
+
+def _make_s3_object(key: str, etag: str) -> dict:
+    return {
+        "Key": key,
+        "Size": 9_000_000,
+        "LastModified": datetime(2026, 7, 24, tzinfo=UTC),
+        "ETag": f'"{etag}"',
+    }
+
+
+class TestCreateDataLakeFileFromS3Object:
+    @patch(NAMESPACE_PATCH_TARGET, return_value="docs")
+    def test_chunked_etag_is_kept_verbatim(self, _namespace: MagicMock) -> None:
+        client = S3DataLakeClient(container_name="bucket", s3_client=_make_s3_client(CHUNKED_ETAG))
+
+        data_lake_file = client._create_data_lake_file_from_s3_object(
+            "s3://bucket/docs/large.pdf", _make_s3_object("docs/large.pdf", CHUNKED_ETAG), "docs/large.pdf"
+        )
+
+        assert data_lake_file.hash == CHUNKED_ETAG
+
+    @patch(NAMESPACE_PATCH_TARGET, return_value="docs")
+    def test_plain_md5_etag_stays_base64_encoded(self, _namespace: MagicMock) -> None:
+        client = S3DataLakeClient(container_name="bucket", s3_client=_make_s3_client(PLAIN_MD5_ETAG))
+
+        data_lake_file = client._create_data_lake_file_from_s3_object(
+            "s3://bucket/docs/small.pdf", _make_s3_object("docs/small.pdf", PLAIN_MD5_ETAG), "docs/small.pdf"
+        )
+
+        assert data_lake_file.hash == base64.b64encode(bytes.fromhex(PLAIN_MD5_ETAG)).decode("utf-8")
+
+
+class TestGetAllFiles:
+    @patch(NAMESPACE_PATCH_TARGET, return_value="docs")
+    def test_mixed_etag_formats_all_enumerate(self, _namespace: MagicMock) -> None:
+        s3_client = _make_s3_client(PLAIN_MD5_ETAG)
+        s3_client.get_paginator.return_value.paginate.return_value = [
+            {
+                "Contents": [
+                    _make_s3_object("docs/small.pdf", PLAIN_MD5_ETAG),
+                    _make_s3_object("docs/large.pdf", CHUNKED_ETAG),
+                ]
+            }
+        ]
+        s3_client.head_object.side_effect = lambda Bucket, Key: {  # noqa: N803
+            "ContentType": "application/pdf",
+            "ETag": f'"{CHUNKED_ETAG if "large" in Key else PLAIN_MD5_ETAG}"',
+            "Metadata": {},
+            "LastModified": datetime(2026, 7, 24, tzinfo=UTC),
+        }
+
+        client = S3DataLakeClient(container_name="bucket", s3_client=s3_client)
+
+        files = client.get_all_files()
+
+        assert [file.hash for file in files] == [
+            base64.b64encode(bytes.fromhex(PLAIN_MD5_ETAG)).decode("utf-8"),
+            CHUNKED_ETAG,
+        ]

--- a/packages/pipeline/swiss_ai_hub/pipeline/types/data_lake_file.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/types/data_lake_file.py
@@ -22,7 +22,14 @@ class DataLakeFile(BaseModel):
     size: Annotated[int, Field(description="The size of the file in bytes.")]
     content_type: Annotated[str, Field(description="The MIME type of the file content.")]
     owner: Annotated[str, Field(description="The owner of the file.")]
-    hash: Annotated[str, Field(description="The MD5 hash of the file content, base64-encoded.")]
+    hash: Annotated[
+        str,
+        Field(
+            description="Opaque content-version token. Base64-encoded MD5 for locally produced content and for "
+            "plain-MD5 S3 ETags, but a verbatim chunked ETag ('<md5hex>-<n>') for objects the store chunked. "
+            "Only assume base64-MD5 where the file came from from_content() — see AzureDataLakeIOManager."
+        ),
+    ]
 
     created: Annotated[int, Field(description="The UNIX timestamp when the file was created.")]
     updated: Annotated[int, Field(description="The UNIX timestamp when the file was last updated.")]


### PR DESCRIPTION
## Problem

Uploading any document larger than **8 MiB** through the Knowledge Base halts ingestion for the **entire knowledge base**, not just that file.

SeaweedFS chunks objects above 8 MiB server-side and returns a multipart-style ETag `<md5hex>-<n>`. `_create_data_lake_file_from_s3_object` only converted the plain-MD5 shape and left `md5_hash_str = None` otherwise, but `DataLakeFile.hash` is a required `str`:

```
pydantic_core.ValidationError: 1 validation error for DataLakeFile
hash
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
```

`get_all_files()` enumerates the whole bucket in one op inside a single `observable_source_asset`, so one bad object aborts observation — no partitions register or update, and nothing in that bucket ingests.

This is a **regression** from #1647 (`f6adbabd`), which bumped SeaweedFS 3.97 → 4.01 for `Content-Disposition` support. 3.97 returned a plain MD5 at any size.

Related: bbvch-ai/aihub-core-private#121, bbvch-ai/aihub-core-private#117

## Fix

Keep the chunked ETag verbatim as the content-version token. It is deterministic and content-derived, so `DataVersion = "{updated}-{hash}"` change detection keeps working.

The ≤8 MiB base64-MD5 output is **deliberately frozen**. `hash` is persisted as `content_hash` and embedded in the DataVersion, so changing that format would force a full MinerU re-parse and re-embed of every corpus. A regression test pins it.

The rejected alternative — `hash: str | None` — is worse: `None` interpolates into the DataVersion as the literal `"None"`, so every large file shares one version and content changes stop triggering re-ingestion. A loud crash becomes silent staleness.

## Evidence

Measured against the dev stack (SeaweedFS 4.01):

| Upload method | Size | ETag |
| --- | --- | --- |
| `put_object` | 8.0 MB | plain MD5 |
| `put_object` | **8.5 MB** | `8ef49112…**-2**` |
| `put_object` | 17 MB | `9f8afaec…**-3**` |
| presigned PUT (the KB path) | 8.5 MB | `acf5c84a…**-2**` |

Server-side, not client-side: `put_object` is a single PUT with no multipart, and all upload methods agree.

**The real user path triggers it.** `KnowledgeService.initiate_document_upload` → `S3AnonymousFileAccessService.generate_upload_url` mints a presigned `put_object` URL against the S3 gateway; the browser PUTs there directly. Running that exact chain with a 9 MiB PDF:

```
KB presigned PUT -> HTTP 200   size=9.0 MiB
ETag = 44117fc4299e1115ac2eacb18fa785b7-2     CHUNKED = True
DataLakeFile.hash = 44117fc4299e1115ac2eacb18fa785b7-2
get_all_files() -> 22 files, no ValidationError
```

**Blast radius confirmed** by running the pre-fix code (loaded from `git HEAD`) against a bucket with one 9 MiB upload added:

```
BEFORE the oversized upload:   pre-fix  -> 21 files enumerated
AFTER  the oversized upload:   pre-fix  -> RAISED ValidationError
                               post-fix -> 22 files enumerated
```

21 healthy files → zero. Not 20-of-21.

**No re-ingestion of existing corpora.** Stored objects keep the ETag they were written with — the 16 MB and 20.66 MB files already in `defaultknowledge` still return plain MD5 — so no DataVersion churn and no re-parse.

## Changes

- `s3_data_lake_client.py` — fall back to the raw ETag; drop the dead `try/except` (`bytes.fromhex` cannot raise once the hex check gates it)
- `data_lake_file.py` — `hash` documented as an opaque content-version token, noting the one caller that still assumes MD5 (`AzureDataLakeIOManager`, unreachable from this path)
- `test_s3_data_lake_client.py` — chunked ETag, frozen-format regression guard, mixed-page `get_all_files()`
- ADR `2026_07_23_upgrade_seaweedfs_to_4_01…` — records the ETag breaking change and the verification gap (the original blast-radius check used only small files)

## Test plan

- [x] `make test` in `packages/pipeline` — 53 passed
- [x] Chunked ETag reproduced end to end via the Knowledge Base upload path
- [x] Blast radius reproduced with pre-fix code, cleared with post-fix code
- [x] ≤8 MiB base64-MD5 output byte-identical (regression test)
- [ ] Full `documents` → `nodes` → Milvus run on a >8 MiB PDF — blocked locally by an unrelated MinerU OOM (`BrokenProcessPool` in `load_images_from_pdf` against the 4 GiB cap)

## Out of scope

- **MinerU OOM on large PDFs** — separate issue; blocks the last e2e step above
- **Azure data lake client** — same latent `hash=None` bug plus four more, but `azure_data_lake_resources` has zero callers
- **Per-file `try/except` in `get_all_files()`** — would contain the blast radius, but silently skipping files contradicts the fail-fast convention; making the hash always derivable removes the failure mode instead
