### PR TITLE
fix(ui): Pre-select the routed tenant in the tenant form field

### DIFF
--- a/packages/web/components/FormKit/TenantSelect.vue
+++ b/packages/web/components/FormKit/TenantSelect.vue
@@ -36,11 +36,11 @@ const props = defineProps<TenantSelectProps>()
 const { t } = useI18n()
 
 const { tenants, tenantsAreLoading } = useTenantMemberships()
-const { activeTenant, activeTenantIsLoading } = useActiveTenantQuery()
+const { tenantId } = useTenant()
 
 const placeholder = computed(() => props.context.placeholder)
 const filter = computed(() => props.context.filter ?? true)
-const isLoading = computed(() => tenantsAreLoading.value || activeTenantIsLoading.value)
+const isLoading = computed(() => tenantsAreLoading.value)
 
 const selectedTenant = computed({
   get: () => props.context.value ?? null,
@@ -52,10 +52,10 @@ const selectedTenant = computed({
 // Pre-select the user's active tenant on a fresh field, while leaving an
 // already-configured value (editing an existing instance) untouched.
 watch(
-  [activeTenant, () => props.context.value],
+  [tenantId, () => props.context.value],
   ([active, current]) => {
-    if (!current && active?.id) {
-      props.context.node.input(active.id)
+    if (!current && active) {
+      props.context.node.input(active)
     }
   },
   { immediate: true },


### PR DESCRIPTION
## Summary

The tenant dropdown in agent config forms pre-selected the *server-persisted* active tenant
(`getMyActiveTenant`) instead of the tenant the user is actually browsing. On first open of an
organization-memory config the field therefore showed the wrong tenant name, as reported in
https://github.com/bbvch-ai/aihub-core/issues/1541#issuecomment-5090467042. `TenantSelect` now
derives the default from `useTenant()`, the route-based single source of truth for tenant context.

Follow-up to #1541.

https://github.com/user-attachments/assets/a1ea45ca-373c-4f1c-8209-6ae8346317d7


## Changes

- `packages/web/components/FormKit/TenantSelect.vue`: replaced `useActiveTenantQuery()` with
  `useTenant()`, so the pre-selection watcher keys off the route's `tenant` param rather than the
  persisted active tenant.
- Dropped `activeTenantIsLoading` from the field's loading state — the route param is available
  synchronously, so only the tenant-membership list can still be pending. This also removes the
  window in which the field rendered empty while the active-tenant query was in flight.

Unchanged: the field is still populated from `useTenantMemberships()`, an already-configured value
(editing an existing agent instance) is still left untouched, and the user can still switch to any
other tenant they are a member of.

## Test plan

- [x] Open an org-memory agent config from `/[tenant]/service/...` for the first time — the tenant
      field shows the tenant from the URL, matching the video in the linked comment.
- [x] Switch tenants, then open the config again — the newly routed tenant is pre-selected without a
      reload.
- [x] Edit an existing agent instance whose config already has a tenant — the stored value is kept,
      not overwritten by the routed tenant.
- [x] Change the dropdown to another tenant you are a member of and save — the selection persists.