### PR TITLE
fix(ui): Show promoted release version instead of the -rc build suffix

### DIFF
--- a/packages/web/composables/app/useAppVersion.ts
+++ b/packages/web/composables/app/useAppVersion.ts
@@ -5,15 +5,23 @@ import { minutesToMilliseconds } from 'date-fns'
 // into the static bundle at build time (runtimeConfig.public.appVersion); the API
 // version is read from the health endpoint. When both match a single number is
 // shown, otherwise both are shown as `UI / API`.
+//
+// A release is promoted by retagging the exact `-rc.N` build that was tested, so
+// the baked version keeps its release-candidate suffix (e.g. `v0.317.0-rc.3`)
+// even though the artifact IS the final release. Strip that suffix so a promoted
+// build shows its release version (`v0.317.0`). Rolling-channel builds
+// (`-nightly.N` / `-staging.N`) keep their suffix so they stay identifiable.
+const toReleaseVersion = (version: string): string => version.replace(/-rc\.\d+$/, '')
+
 export const useAppVersion = defineQuery(() => {
-  const uiVersion = useRuntimeConfig().public.appVersion as string
+  const uiVersion = toReleaseVersion(useRuntimeConfig().public.appVersion as string)
 
   const { data: apiVersion } = useQuery<string>({
     key: () => ['app-version', 'api'],
     staleTime: minutesToMilliseconds(60),
     query: async () => {
       const health = await getHealth({ composable: '$fetch' })
-      return health.version
+      return toReleaseVersion(health.version)
     },
   })
 

--- a/packages/web/composables/app/useAppVersion.ts
+++ b/packages/web/composables/app/useAppVersion.ts
@@ -3,32 +3,39 @@ import { minutesToMilliseconds } from 'date-fns'
 
 // Surfaces the running version of both services. The UI service version is baked
 // into the static bundle at build time (runtimeConfig.public.appVersion); the API
-// version is read from the health endpoint. When both match a single number is
+// version is read from the health endpoint, which reports the channel tag (e.g.
+// `latest`) the running image was pulled as. When both match a single number is
 // shown, otherwise both are shown as `UI / API`.
 //
-// A release is promoted by retagging the exact `-rc.N` build that was tested, so
-// the baked version keeps its release-candidate suffix (e.g. `v0.317.0-rc.3`)
-// even though the artifact IS the final release. Strip that suffix so a promoted
-// build shows its release version (`v0.317.0`). Rolling-channel builds
-// (`-nightly.N` / `-staging.N`) keep their suffix so they stay identifiable.
+// A release is promoted onto the `latest` channel by retagging the exact `-rc.N`
+// build that was tested, so the baked version keeps its release-candidate suffix
+// (e.g. `v0.317.0-rc.3`) even though the artifact IS the final release. Strip that
+// suffix only on the `latest` channel, so a promoted build shows its release
+// version (`v0.317.0`). On any other channel the build is genuinely a candidate or
+// rolling build, so keep the suffix to stay identifiable.
+const RELEASE_CHANNEL = 'latest'
 const toReleaseVersion = (version: string): string => version.replace(/-rc\.\d+$/, '')
 
 export const useAppVersion = defineQuery(() => {
-  const uiVersion = toReleaseVersion(useRuntimeConfig().public.appVersion as string)
+  const bakedUiVersion = useRuntimeConfig().public.appVersion as string
 
   const { data: apiVersion } = useQuery<string>({
     key: () => ['app-version', 'api'],
     staleTime: minutesToMilliseconds(60),
     query: async () => {
       const health = await getHealth({ composable: '$fetch' })
-      return toReleaseVersion(health.version)
+      return health.version
     },
   })
 
+  const uiVersion = computed(() =>
+    apiVersion.value === RELEASE_CHANNEL ? toReleaseVersion(bakedUiVersion) : bakedUiVersion,
+  )
+
   const versionDisplay = computed(() => {
     const api = apiVersion.value
-    if (!api || api === uiVersion) return uiVersion
-    return `${uiVersion} / ${api}`
+    if (!api || api === uiVersion.value) return uiVersion.value
+    return `${uiVersion.value} / ${api}`
   })
 
   return { uiVersion, apiVersion, versionDisplay }


### PR DESCRIPTION
## Problem

The version shown in the UI (Settings popover) displays the release-candidate build suffix — e.g. `v0.317.0-rc.3 / latest` — instead of the promoted release version `v0.317.0`.

## Root cause

Releases are promoted by **retagging the exact `-rc.N` image that was tested** (`set-latest.yml` pulls `:vX.Y.Z-rc.N` and pushes `:latest` — no rebuild). The web frontend bakes its version into the static bundle **at build time** via the `VERSION` build-arg (`packages/web/Dockerfile` → `APP_VERSION` → `runtimeConfig.public.appVersion`). Because the artifact is not rebuilt on promotion, the baked version keeps its `-rc.N` suffix even though the code is byte-identical to the final release.

## Fix

Normalize the displayed version in `useAppVersion` by stripping the `-rc.N` suffix — a promoted build *is* its release, so it should surface the release version. Rolling-channel builds (`-nightly.N` / `-staging.N`) keep their suffix so development builds stay identifiable.

Result: **`v0.317.0 / latest`** instead of `v0.317.0-rc.3 / latest`.

## Notes

- Preserves the "ship exactly what was tested" property of retag-based promotion (no rebuild required).
- Frontend-only; no change to the release/promote pipeline.
- Follow-up (separate): the API `health.version` reports the channel tag (`latest`) rather than the resolved release version, which is why the UI still shows two values (`version / channel`). Reporting the concrete version there would collapse it to a single `v0.317.0`.