### PR TITLE
fix(ci-cd): Restore rolling nightly bundle publish and rename rolling titles

### DIFF
--- a/.github/workflows/add-tag.yml
+++ b/.github/workflows/add-tag.yml
@@ -3,10 +3,11 @@
 # Nightly Tag & Build
 # =============================================================================
 # On every push to main (each merged PR), cut an immutable nightly tag and move
-# the rolling `nightly` pointer, then dispatch the image builds and docs.
+# the rolling `nightly` pointer, dispatch the image builds and docs, and refresh
+# the single rolling `nightly` prerelease (the bundle the nightly VM fetches via
+# aihub-playbook roles/aihub_application/tasks/fetch.yml).
 # Lightweight trunk path: no version bump, no changelog, no versioned Release,
-# no npm/PyPI. No GitHub Release is published for nightly — only the nightly git
-# tag and the :nightly images (ghcr) are produced.
+# no npm/PyPI. create-release runs here in `nightly` (rolling) mode only.
 #
 # Triggered on `push` (not `pull_request`) on purpose: push events run the
 # workflow file from the pushed commit, so merging THIS change activates the new
@@ -95,7 +96,7 @@ jobs:
       # (repository_dispatch: [release-ready]) builds the nightly images with
       # secondary_tag=nightly, and deploy-docs.yml publishes the docs. Only
       # create-release.yml stopped listening (it is now workflow_call only).
-      # No GitHub Release is published for the nightly channel.
+      # The rolling nightly bundle is handled by the publish-nightly-bundle job.
       - name: Dispatch release-ready (nightly image builds + docs)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -104,3 +105,14 @@ jobs:
           gh api "repos/${{ github.repository }}/dispatches" \
             -F event_type=release-ready \
             -F "client_payload[release_version]=$VERSION"
+
+  publish-nightly-bundle:
+    name: Refresh rolling nightly prerelease
+    needs: nightly-tag
+    # Skip when the tag already existed (re-run): the pointer/bundle are current.
+    if: needs.nightly-tag.outputs.created == 'true'
+    uses: ./.github/workflows/create-release.yml
+    with:
+      release_version: ${{ needs.nightly-tag.outputs.version }}
+      channel: nightly
+    secrets: inherit

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -216,11 +216,11 @@ jobs:
           }
           case "$CHANNEL" in
             nightly)
-              publish "nightly" "Nightly (rolling) - ${VERSION}" true false "$ROLL_A1" "$ROLL_A2"
+              publish "nightly" "Swiss AI Hub Nightly ${VERSION}" true false "$ROLL_A1" "$ROLL_A2"
               ;;
             staging)
               # 1) Rolling pointer release the QC staging VM fetches (stable tag + asset).
-              publish "staging" "Staging (rolling) - ${VERSION}" true false "$ROLL_A1" "$ROLL_A2"
+              publish "staging" "Swiss AI Hub Staging ${VERSION}" true false "$ROLL_A1" "$ROLL_A2"
               # 2) Immutable, PRESERVED per-rc release for humans, version-named assets.
               #    Only for real rc builds (build-rc.yml). promote-to-staging.yml
               #    promotes a nightly to staging — that must not create a versioned entry.


### PR DESCRIPTION
## Problem

PR #1655 dropped the rolling `nightly` GitHub Release on the assumption that no VM fetches the nightly channel. That assumption is incorrect: the Ansible deploy (`aihub-playbook` → `roles/aihub_application/tasks/fetch.yml`) downloads the nightly bundle from `GET /releases/tags/nightly` (stable asset `swissaihub-nightly.tar.gz`).

With that Release no longer refreshed (and since deleted), the nightly VM is stuck on a stale bundle (`v0.318.0-nightly.897`) — every deploy silently re-uses it, and on the next cache-miss the fetch will `404` and the deploy will fail outright.

## Fix

1. **Restore the `publish-nightly-bundle` job** in `add-tag.yml` (an exact revert of the part #1655 removed), so every merge to `main` refreshes the rolling `nightly` prerelease and its `swissaihub-nightly.tar.gz` asset — the bundle the deploy contract depends on. Also corrects the header/inline comments that #1655 left inaccurate.
2. **Rename the rolling release titles** in `create-release.yml` for consistency with the versioned releases (`Swiss AI Hub <version>`):
   - `Nightly (rolling) - <version>` -> `Swiss AI Hub Nightly <version>`
   - `Staging (rolling) - <version>` -> `Swiss AI Hub Staging <version>`

## Why this is safe and self-healing

`add-tag.yml` runs on `push` using the workflow file from the pushed commit, so merging this PR re-activates nightly bundle publishing on that very merge -> the nightly VM self-heals on its next `infra-pull` (~15 min). The title change is display-only (`gh release edit/create --title`) with no functional effect.

## Notes

- Trade-off: the rolling nightly entry reappears on the Releases page. This rolling Release is a deploy contract, not clutter — it should not be removed again without first changing the playbook fetch mechanism.
- Follow-up (separate issue): the rolling `nightly` git tag currently lags (`.899`) behind the latest per-version nightly tags (`.902`); worth watching the next nightly run.