### PR TITLE
fix(tracing): Make OpenWebUI OTEL metrics opt-in (default off)

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -315,6 +315,8 @@ DOMAIN='127.0.0.1.nip.io'
 # OpenTelemetry Configuration
 # -----------------------------------------------------------------------------
 OTEL_ENABLED='true'
+# OpenWebUI OTEL metrics are opt-in (high-cardinality HTTP metrics, see issue 1496); traces stay on.
+ENABLE_OTEL_METRICS='false'
 OTEL_EXPORTER_OTLP_PROTOCOL='grpc'
 OTEL_RESOURCE_SERVICE_NAME='swiss-ai-hub'
 OTEL_RESOURCE_SERVICE_VERSION='0.0.1'

--- a/.env.prod
+++ b/.env.prod
@@ -291,6 +291,8 @@ SLACK_SERVICE_URL='https://slack.botframework.com'
 # OpenTelemetry Configuration (Optional)
 # -----------------------------------------------------------------------------
 OTEL_ENABLED='true'
+# OpenWebUI OTEL metrics are opt-in (high-cardinality HTTP metrics, see issue 1496); traces stay on.
+ENABLE_OTEL_METRICS='false'
 
 # Cloud OTEL (optional - for external observability platforms)
 OTEL_CLOUD_ENDPOINT='placeholder:1234'

--- a/infra/deployment/templates/docker-compose.yml.j2
+++ b/infra/deployment/templates/docker-compose.yml.j2
@@ -2196,8 +2196,12 @@ services:
       GLOBAL_LOG_LEVEL: ${LOG_LEVEL}
 
       # --- Telemetry ---
+      # Traces always on. Metrics are opt-in: OpenWebUI emits very high-cardinality
+      # HTTP-server metrics that dominate SigNoz ingestion (see issue 1496), so they
+      # default off (ENABLE_OTEL_METRICS=false in .env.dev/.env.prod) and any deploy
+      # can turn them back on via its own env.
       ENABLE_OTEL: True
-      ENABLE_OTEL_METRICS: True
+      ENABLE_OTEL_METRICS: ${ENABLE_OTEL_METRICS}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://{{ 'localhost' if stage == 'dev' else 'otel-collector' }}:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_EXPORTER_OTLP_INSECURE: True

--- a/infra/docker-compose.build.gpu.yml
+++ b/infra/docker-compose.build.gpu.yml
@@ -1957,8 +1957,12 @@ services:
       GLOBAL_LOG_LEVEL: ${LOG_LEVEL}
 
       # --- Telemetry ---
+      # Traces always on. Metrics are opt-in: OpenWebUI emits very high-cardinality
+      # HTTP-server metrics that dominate SigNoz ingestion (see issue 1496), so they
+      # default off (ENABLE_OTEL_METRICS=false in .env.dev/.env.prod) and any deploy
+      # can turn them back on via its own env.
       ENABLE_OTEL: true
-      ENABLE_OTEL_METRICS: true
+      ENABLE_OTEL_METRICS: ${ENABLE_OTEL_METRICS}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_EXPORTER_OTLP_INSECURE: true

--- a/infra/docker-compose.build.yml
+++ b/infra/docker-compose.build.yml
@@ -1737,8 +1737,12 @@ services:
       GLOBAL_LOG_LEVEL: ${LOG_LEVEL}
 
       # --- Telemetry ---
+      # Traces always on. Metrics are opt-in: OpenWebUI emits very high-cardinality
+      # HTTP-server metrics that dominate SigNoz ingestion (see issue 1496), so they
+      # default off (ENABLE_OTEL_METRICS=false in .env.dev/.env.prod) and any deploy
+      # can turn them back on via its own env.
       ENABLE_OTEL: true
-      ENABLE_OTEL_METRICS: true
+      ENABLE_OTEL_METRICS: ${ENABLE_OTEL_METRICS}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_EXPORTER_OTLP_INSECURE: true

--- a/infra/docker-compose.dev.gpu.yml
+++ b/infra/docker-compose.dev.gpu.yml
@@ -1646,8 +1646,12 @@ services:
       GLOBAL_LOG_LEVEL: ${LOG_LEVEL}
 
       # --- Telemetry ---
+      # Traces always on. Metrics are opt-in: OpenWebUI emits very high-cardinality
+      # HTTP-server metrics that dominate SigNoz ingestion (see issue 1496), so they
+      # default off (ENABLE_OTEL_METRICS=false in .env.dev/.env.prod) and any deploy
+      # can turn them back on via its own env.
       ENABLE_OTEL: true
-      ENABLE_OTEL_METRICS: true
+      ENABLE_OTEL_METRICS: ${ENABLE_OTEL_METRICS}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://localhost:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_EXPORTER_OTLP_INSECURE: true

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -1426,8 +1426,12 @@ services:
       GLOBAL_LOG_LEVEL: ${LOG_LEVEL}
 
       # --- Telemetry ---
+      # Traces always on. Metrics are opt-in: OpenWebUI emits very high-cardinality
+      # HTTP-server metrics that dominate SigNoz ingestion (see issue 1496), so they
+      # default off (ENABLE_OTEL_METRICS=false in .env.dev/.env.prod) and any deploy
+      # can turn them back on via its own env.
       ENABLE_OTEL: true
-      ENABLE_OTEL_METRICS: true
+      ENABLE_OTEL_METRICS: ${ENABLE_OTEL_METRICS}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://localhost:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_EXPORTER_OTLP_INSECURE: true

--- a/infra/docker-compose.latest.gpu.yml
+++ b/infra/docker-compose.latest.gpu.yml
@@ -1913,8 +1913,12 @@ services:
       GLOBAL_LOG_LEVEL: ${LOG_LEVEL}
 
       # --- Telemetry ---
+      # Traces always on. Metrics are opt-in: OpenWebUI emits very high-cardinality
+      # HTTP-server metrics that dominate SigNoz ingestion (see issue 1496), so they
+      # default off (ENABLE_OTEL_METRICS=false in .env.dev/.env.prod) and any deploy
+      # can turn them back on via its own env.
       ENABLE_OTEL: true
-      ENABLE_OTEL_METRICS: true
+      ENABLE_OTEL_METRICS: ${ENABLE_OTEL_METRICS}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_EXPORTER_OTLP_INSECURE: true

--- a/infra/docker-compose.latest.yml
+++ b/infra/docker-compose.latest.yml
@@ -1699,8 +1699,12 @@ services:
       GLOBAL_LOG_LEVEL: ${LOG_LEVEL}
 
       # --- Telemetry ---
+      # Traces always on. Metrics are opt-in: OpenWebUI emits very high-cardinality
+      # HTTP-server metrics that dominate SigNoz ingestion (see issue 1496), so they
+      # default off (ENABLE_OTEL_METRICS=false in .env.dev/.env.prod) and any deploy
+      # can turn them back on via its own env.
       ENABLE_OTEL: true
-      ENABLE_OTEL_METRICS: true
+      ENABLE_OTEL_METRICS: ${ENABLE_OTEL_METRICS}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_EXPORTER_OTLP_INSECURE: true

--- a/infra/docker-compose.local.gpu.yml
+++ b/infra/docker-compose.local.gpu.yml
@@ -1950,8 +1950,12 @@ services:
       GLOBAL_LOG_LEVEL: ${LOG_LEVEL}
 
       # --- Telemetry ---
+      # Traces always on. Metrics are opt-in: OpenWebUI emits very high-cardinality
+      # HTTP-server metrics that dominate SigNoz ingestion (see issue 1496), so they
+      # default off (ENABLE_OTEL_METRICS=false in .env.dev/.env.prod) and any deploy
+      # can turn them back on via its own env.
       ENABLE_OTEL: true
-      ENABLE_OTEL_METRICS: true
+      ENABLE_OTEL_METRICS: ${ENABLE_OTEL_METRICS}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_EXPORTER_OTLP_INSECURE: true

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -1730,8 +1730,12 @@ services:
       GLOBAL_LOG_LEVEL: ${LOG_LEVEL}
 
       # --- Telemetry ---
+      # Traces always on. Metrics are opt-in: OpenWebUI emits very high-cardinality
+      # HTTP-server metrics that dominate SigNoz ingestion (see issue 1496), so they
+      # default off (ENABLE_OTEL_METRICS=false in .env.dev/.env.prod) and any deploy
+      # can turn them back on via its own env.
       ENABLE_OTEL: true
-      ENABLE_OTEL_METRICS: true
+      ENABLE_OTEL_METRICS: ${ENABLE_OTEL_METRICS}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_EXPORTER_OTLP_INSECURE: true

--- a/infra/docker-compose.nightly.gpu.yml
+++ b/infra/docker-compose.nightly.gpu.yml
@@ -1913,8 +1913,12 @@ services:
       GLOBAL_LOG_LEVEL: ${LOG_LEVEL}
 
       # --- Telemetry ---
+      # Traces always on. Metrics are opt-in: OpenWebUI emits very high-cardinality
+      # HTTP-server metrics that dominate SigNoz ingestion (see issue 1496), so they
+      # default off (ENABLE_OTEL_METRICS=false in .env.dev/.env.prod) and any deploy
+      # can turn them back on via its own env.
       ENABLE_OTEL: true
-      ENABLE_OTEL_METRICS: true
+      ENABLE_OTEL_METRICS: ${ENABLE_OTEL_METRICS}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_EXPORTER_OTLP_INSECURE: true

--- a/infra/docker-compose.nightly.yml
+++ b/infra/docker-compose.nightly.yml
@@ -1699,8 +1699,12 @@ services:
       GLOBAL_LOG_LEVEL: ${LOG_LEVEL}
 
       # --- Telemetry ---
+      # Traces always on. Metrics are opt-in: OpenWebUI emits very high-cardinality
+      # HTTP-server metrics that dominate SigNoz ingestion (see issue 1496), so they
+      # default off (ENABLE_OTEL_METRICS=false in .env.dev/.env.prod) and any deploy
+      # can turn them back on via its own env.
       ENABLE_OTEL: true
-      ENABLE_OTEL_METRICS: true
+      ENABLE_OTEL_METRICS: ${ENABLE_OTEL_METRICS}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_EXPORTER_OTLP_INSECURE: true


### PR DESCRIPTION
## Problem

OpenWebUI is the #1 metrics producer hitting SigNoz Cloud — measured **~35M datapoints/hour (~700-850M/day, ~10k/s)** on the nightly workspace. Its high-cardinality HTTP-server metrics dominate ingestion cost. The existing `filter/metrics_cardinality` backstop (issue #1496) only drops 7 named `http.server.*` metrics, which does not catch OpenWebUI's full volume.

The value was a hardcoded literal (`ENABLE_OTEL_METRICS: True`) baked into every generated compose file, so no deploy could turn it off without editing the aihub-core template.

## Fix

Make OpenWebUI OTEL metrics **opt-in**:
- Template: `ENABLE_OTEL_METRICS: ${ENABLE_OTEL_METRICS}` (traces stay on via `ENABLE_OTEL: True`).
- Default **off** via the env templates (`ENABLE_OTEL_METRICS=false`).
- Any deploy can turn it back on through its own env (e.g. a playbook `docker_env` override) without touching this repo.

Regenerated all 10 compose variants via `make generate-compose`.

## Draft — one manual step remaining

The env-template default lines are **not yet added** (sensitive files, could not be edited by the tooling). `make check-env` currently fails:

```
ERROR: ENABLE_OTEL_METRICS  required by docker-compose interpolation -> add to env
```

Add `ENABLE_OTEL_METRICS=false` to **both** env templates (dev + prod), then `make check-env` passes and this can be marked ready.

## Impact

- Traces unaffected.
- Metrics off by default in all stages (they are noise everywhere, consistent with #1496). OpenWebUI's own default for unset/empty is also `False`, so behaviour is safe even before a deploy sets the var.
- Expected effect: metrics ingestion drops sharply once deployed; re-measure and set SigNoz limits afterward.
