### PR TITLE
fix(tracing): Serialize agent step inputs for JSON safety

### DIFF
--- a/packages/agent/playground/testing/tests/test_agent_run_tracer.py
+++ b/packages/agent/playground/testing/tests/test_agent_run_tracer.py
@@ -1,5 +1,6 @@
 """Tests for AgentRunTracer — OTEL + Langfuse span enrichment for agent runs."""
 
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -7,6 +8,7 @@ from bson import ObjectId
 from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes
 from opentelemetry import trace
 from opentelemetry.trace import NonRecordingSpan, SpanContext, StatusCode, TraceFlags
+from pydantic import BaseModel
 from swiss_ai_hub.core.dispatcher import TraceStore
 from swiss_ai_hub.core.events.agent import StartEvent
 from swiss_ai_hub.core.topics import AgentInstanceTopic
@@ -14,6 +16,16 @@ from swiss_ai_hub.core.topics import AgentInstanceTopic
 from swiss_ai_hub.agent.tracing.agent_run_tracer import AgentRunTracer
 
 _FAKE_TRACEPARENT = {"traceparent": "00-0000000000000000000000000000dead-000000000000beef-01"}
+
+
+class _DatedItem(BaseModel):
+    """Stand-in for a nested payload holding a datetime, e.g. UnreadMailSummary with its Date header."""
+
+    date: datetime | None = None
+
+
+class _DatedEvent(StartEvent):
+    items: list[_DatedItem] = []
 
 
 @pytest.fixture
@@ -160,6 +172,34 @@ class TestTraceStepStart:
 
             mock_ctx.detach.assert_called_once_with("token")
             mock_span.end.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_serializes_event_carrying_nested_datetime(
+        self, tracer: AgentRunTracer, topic: AgentInstanceTopic
+    ) -> None:
+        """A step input holding a datetime must not break span creation — real mail servers always set Date,
+        so the IMAP agent died here while GreenMail fixtures (no parseable Date) kept it hidden."""
+        mock_span = MagicMock()
+        mock_tracer = MagicMock()
+        mock_tracer.start_span.return_value = mock_span
+        tracer.tracer = mock_tracer
+
+        async def dummy_step():
+            pass
+
+        event = _DatedEvent(items=[_DatedItem(date=datetime(2022, 11, 28, 11, 51, 27, tzinfo=UTC))])
+
+        with (
+            patch("swiss_ai_hub.agent.tracing.agent_run_tracer.set_span_in_context"),
+            patch("swiss_ai_hub.agent.tracing.agent_run_tracer.context") as mock_ctx,
+        ):
+            mock_ctx.attach.return_value = "token"
+
+            async with tracer.trace_step_start(topic, dummy_step, {"event": event}) as span:
+                assert span is mock_span
+
+        attributes = mock_tracer.start_span.call_args.kwargs["attributes"]
+        assert "2022-11-28 11:51:27" in attributes[SpanAttributes.INPUT_VALUE]
 
 
 class TestTraceStepStop:

--- a/packages/agent/swiss_ai_hub/agent/tracing/agent_run_tracer.py
+++ b/packages/agent/swiss_ai_hub/agent/tracing/agent_run_tracer.py
@@ -111,7 +111,9 @@ class AgentRunTracer:
         attributes = {
             SpanAttributes.OPENINFERENCE_SPAN_KIND: OpenInferenceSpanKindValues.CHAIN.value,
             SpanAttributes.SESSION_ID: topic.thread_id,
-            SpanAttributes.INPUT_VALUE: json.dumps(input_values),
+            # default=str mirrors the output path below: step inputs carry types Python-mode model_dump leaves
+            # as objects (nested datetimes, most commonly a mail Date header), which plain json.dumps refuses.
+            SpanAttributes.INPUT_VALUE: json.dumps(input_values, default=str),
             SpanAttributes.INPUT_MIME_TYPE: OpenInferenceMimeTypeValues.JSON.value,
             SpanAttributes.TAG_TAGS: [topic.thread_id, topic.display_id, topic.run_id],
         }


### PR DESCRIPTION
## Problem

`AgentRunTracer.trace_step_start` built its `INPUT_VALUE` span attribute with a bare `json.dumps`, while
`trace_step_end` already passed `default=str` for `OUTPUT_VALUE`. Any step input carrying a value that
Python-mode `model_dump` leaves as an object therefore raised:

```
TypeError: Object of type datetime is not JSON serializable
```

`BaseEvent` arguments are serialized via `to_trace_dict`, which spreads `self.model_dump()` without
`mode="json"`, so nested datetimes survive into the dump.

## Impact

This crashed `ImapAgent.fetch_mail_step` against **any real IMAP server**, whose messages always carry a
parseable `Date` header. GreenMail fixtures have none, so `date` stayed `None` and the whole chain looked
JSON-clean — which is why #1508 passed its acceptance criteria while the feature could not complete a move
against a real mailbox.

Reproduced end-to-end against Gmail: the run reached `list_unread_step`, then produced no `MailFetchedEvent`,
no `MailMovedEvent` and no `StopEvent`.

## Fix

Pass `default=str` at the `json.dumps` call site rather than changing `to_trace_dict`. This:

- covers all four serialization branches (`BaseEvent`, `BaseContext`, `ListOfSize`, `BaseModel`), not just the
  one that happened to fail;
- mirrors the existing output path, removing the input/output asymmetry that caused the bug;
- stays out of `packages/core`, whose `to_trace_dict` has exactly two consumers, both in this file.

## Test

`TestTraceStepStart::test_serializes_event_carrying_nested_datetime` uses a `StartEvent` subclass holding a
nested model with a `datetime`, matching `UnreadMailSummary.date` and exercising the same `to_trace_dict` path.
Verified in both directions: it fails with the production `TypeError` when the fix is reverted.

A GreenMail-only test cannot catch this, which is how it shipped.

## Notes for the reviewer

- Datetimes now serialize as `str()` (`2022-11-28 11:51:27+00:00`), consistent with the output path. Using
  `mode="json"` in `to_trace_dict` would give ISO-8601, which is nicer to query in Langfuse — a deliberate
  follow-up, not required here.
- **Pre-existing, unrelated:** 4 of 8 tests in `imap_agent/tests/test_imap_agent.py` fail locally with a
  different subset each run. Confirmed identical on unmodified `main` (`5f5f5215`), so not introduced here.
  They are not marked `flaky`, so CI runs them; likely contention on shared NATS consumer state. Worth a
  separate issue.
- **Related bug, not fixed here:** because this failure occurs in the tracer's context-manager entry rather
  than the step body, it bypasses `stop_on_error` and emits no `ExceptionEvent` — so API callers hang
  indefinitely instead of receiving an error. This commit removes the trigger; the hang-on-setup-failure class
  of bug remains.

Refs #1508