### PR TITLE
fix(swiss-ai-hub): Prevent empty locale strings from crashing endpoint discovery

### DIFF
--- a/packages/api/playground/testing/tests/agent/test_agent_service_unit_tests.py
+++ b/packages/api/playground/testing/tests/agent/test_agent_service_unit_tests.py
@@ -15,9 +15,11 @@ from swiss_ai_hub.core.persistence.access.entities.tenant_metadata_entity import
 from swiss_ai_hub.core.persistence.access.entities.user_tenant_role_entity import UserTenantRoleEntity
 from swiss_ai_hub.core.persistence.agents import AgentClassEntity
 from swiss_ai_hub.core.persistence.agents.agent_config_entity_document import AgentConfigEntityDocument
+from swiss_ai_hub.core.persistence.i18n.locale_string_entity import LocaleStringEntity
 from swiss_ai_hub.core.persistence.messaging.entities.thread_entity import ThreadEntity
 
 from swiss_ai_hub.api.routes.agent.agent_service import AgentService
+from swiss_ai_hub.api.routes.agent.dto.agent_config_dto import AgentConfigDTO
 from swiss_ai_hub.api.routes.agent.dto.create_agent_instance_request import CreateAgentInstanceRequest
 from swiss_ai_hub.api.routes.agent.dto.full_agent_instance_dto import FullAgentInstanceDTO
 from swiss_ai_hub.api.routes.agent.dto.minimal_agent_instance_dto import MinimalAgentInstanceDTO
@@ -246,6 +248,27 @@ class TestAgentServiceUnit:
                     assert len(result) == 2
                     assert first_dto in result
                     assert second_dto in result
+
+    @pytest.mark.asyncio
+    async def test_get_all_agent_instances_skips_record_that_fails_to_build(
+        self, sample_agent_class_entity, sample_config_entity, mock_locale_handler
+    ):
+        """A single instance whose DTO cannot be built must be skipped, not abort the whole sweep."""
+        bad_config = Mock()
+        bad_config.agent_class = "TestAgent"
+        bad_config.agent_id = "bad_agent"
+
+        with patch.object(AgentClassEntity, "get_all", return_value=[sample_agent_class_entity]):
+            with patch.object(
+                AgentConfigEntityDocument, "find_for_class", return_value=[sample_config_entity, bad_config]
+            ):
+                with patch.object(FullAgentInstanceDTO, "from_class_and_config") as mock_from:
+                    good_dto = Mock(spec=FullAgentInstanceDTO)
+                    mock_from.side_effect = [good_dto, ValueError("could not build DTO")]
+
+                    result = await AgentService.get_all_agent_instances(mock_locale_handler)
+
+        assert result == [good_dto]
 
     @pytest.mark.asyncio
     async def test_send_event_success(self, mock_nats, mock_user_identity):
@@ -556,3 +579,26 @@ class TestUpdateAgentInstanceLocksAgentId:
         assert config_entity.config_data["agent_id"] == "intructed_agent_02"
         assert result["agent_id"] == "intructed_agent_02"
         config_entity.save.assert_called_once()
+
+
+class TestAgentConfigDTOEmptyLocale:
+    """Regression: an instance whose localized name/description is empty must build, not raise.
+
+    This is the read-side resilience the fix guarantees — empty localized fields are legitimate
+    data (LocaleStringEntity columns are all optional), so a required-str DTO field coerces to "".
+    """
+
+    def test_empty_locale_name_and_description_coerce_to_empty_string(self):
+        class_entity = Mock()
+        class_entity.form = None
+
+        config_entity = Mock()
+        config_entity.agent_id = "empty_locale_agent"
+        config_entity.name = LocaleStringEntity()
+        config_entity.description = LocaleStringEntity()
+        config_entity.icon = "mage:robot"
+
+        dto = AgentConfigDTO.from_class_and_config(class_entity, config_entity, LocaleHandler())
+
+        assert dto.name == ""
+        assert dto.description == ""

--- a/packages/api/playground/testing/tests/process/test_process_service_unit_tests.py
+++ b/packages/api/playground/testing/tests/process/test_process_service_unit_tests.py
@@ -163,6 +163,27 @@ class TestProcessServiceUnit:
             assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
+    async def test_get_all_process_instances_skips_record_that_fails_to_build(self, mock_locale_handler):
+        """A single instance whose DTO cannot be built must be skipped, not abort the whole sweep."""
+        mock_class_entity = Mock(spec=ProcessClassEntity)
+        mock_class_entity.is_online = True
+        mock_class_entity.process_class = "TestProcess"
+        good_config = Mock(spec=ProcessConfigEntityDocument)
+        good_config.process_id = "good"
+        bad_config = Mock(spec=ProcessConfigEntityDocument)
+        bad_config.process_id = "bad"
+
+        with patch.object(ProcessClassEntity, "get_all", return_value=[mock_class_entity]):
+            with patch.object(ProcessConfigEntityDocument, "find_for_class", return_value=[good_config, bad_config]):
+                with patch.object(FullProcessInstanceDTO, "from_class_and_config") as mock_from:
+                    good_dto = Mock(spec=FullProcessInstanceDTO)
+                    mock_from.side_effect = [good_dto, ValueError("could not build DTO")]
+
+                    result = await ProcessService.get_all_process_instances(mock_locale_handler)
+
+        assert result == [good_dto]
+
+    @pytest.mark.asyncio
     async def test_send_event_success(self, mock_user_identity):
         """Test send_event successfully sends event to process."""
         event = HumanStartEvent(

--- a/packages/api/swiss_ai_hub/api/routes/agent/agent_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/agent/agent_service.py
@@ -107,7 +107,14 @@ class AgentService:
 
             configs = AgentConfigEntityDocument.find_for_name(agent_class=class_entity.agent_class, name=search)
             for config_entity in configs:
-                agents.append(FullAgentInstanceDTO.from_class_and_config(class_entity, config_entity, t))
+                try:
+                    agents.append(FullAgentInstanceDTO.from_class_and_config(class_entity, config_entity, t))
+                except Exception:
+                    logger.exception(
+                        "Skipping agent instance %s/%s: could not build its DTO.",
+                        class_entity.agent_class,
+                        getattr(config_entity, "agent_id", "?"),
+                    )
         return agents
 
     @staticmethod

--- a/packages/api/swiss_ai_hub/api/routes/agent/agent_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/agent/agent_service.py
@@ -43,6 +43,7 @@ from swiss_ai_hub.api.routes.thread.thread_service import ThreadService
 from swiss_ai_hub.api.services.model_creation_service import ModelCreationService
 from swiss_ai_hub.api.util.config_authorization_service import ConfigAuthorizationService
 from swiss_ai_hub.api.util.instance_config_helper import InstanceConfigHelper
+from swiss_ai_hub.api.util.instance_dto_builder import InstanceDtoBuilder
 
 logger = logging.getLogger(__name__)
 
@@ -107,14 +108,15 @@ class AgentService:
 
             configs = AgentConfigEntityDocument.find_for_name(agent_class=class_entity.agent_class, name=search)
             for config_entity in configs:
-                try:
-                    agents.append(FullAgentInstanceDTO.from_class_and_config(class_entity, config_entity, t))
-                except Exception:
-                    logger.exception(
-                        "Skipping agent instance %s/%s: could not build its DTO.",
-                        class_entity.agent_class,
-                        getattr(config_entity, "agent_id", "?"),
-                    )
+                dto = InstanceDtoBuilder.build_or_skip(
+                    lambda class_entity=class_entity, config_entity=config_entity: (
+                        FullAgentInstanceDTO.from_class_and_config(class_entity, config_entity, t)
+                    ),
+                    kind="agent instance",
+                    key=f"{class_entity.agent_class}/{getattr(config_entity, 'agent_id', '?')}",
+                )
+                if dto is not None:
+                    agents.append(dto)
         return agents
 
     @staticmethod

--- a/packages/api/swiss_ai_hub/api/routes/agent/dto/agent_config_dto.py
+++ b/packages/api/swiss_ai_hub/api/routes/agent/dto/agent_config_dto.py
@@ -51,8 +51,8 @@ class AgentConfigDTO(BaseModel):
         """
         form = [form_element.in_locale(t) for form_element in class_entity.form_elements] if class_entity.form else None
 
-        name = t.extract(config_entity.name.to_locale_string())
-        description = t.extract(config_entity.description.to_locale_string())
+        name = t.extract(config_entity.name.to_locale_string()) or ""
+        description = t.extract(config_entity.description.to_locale_string()) or ""
 
         icon = config_entity.icon
 

--- a/packages/api/swiss_ai_hub/api/routes/agent/dto/agent_config_dto.py
+++ b/packages/api/swiss_ai_hub/api/routes/agent/dto/agent_config_dto.py
@@ -51,8 +51,8 @@ class AgentConfigDTO(BaseModel):
         """
         form = [form_element.in_locale(t) for form_element in class_entity.form_elements] if class_entity.form else None
 
-        name = t.extract(config_entity.name.to_locale_string()) or ""
-        description = t.extract(config_entity.description.to_locale_string()) or ""
+        name = t.extract_required(config_entity.name.to_locale_string(), field_name="agent.name")
+        description = t.extract_required(config_entity.description.to_locale_string(), field_name="agent.description")
 
         icon = config_entity.icon
 

--- a/packages/api/swiss_ai_hub/api/routes/process/dto/full_process_instance_dto.py
+++ b/packages/api/swiss_ai_hub/api/routes/process/dto/full_process_instance_dto.py
@@ -68,8 +68,8 @@ class FullProcessInstanceDTO(MinimalProcessInstanceDTO):
         """
         process_config_dto = ProcessConfigDTO(
             process_id=config_entity.process_id,
-            name=t.extract(config_entity.name.to_locale_string()),
-            description=t.extract(config_entity.description.to_locale_string()),
+            name=t.extract(config_entity.name.to_locale_string()) or "",
+            description=t.extract(config_entity.description.to_locale_string()) or "",
             icon=config_entity.icon,
         )
 

--- a/packages/api/swiss_ai_hub/api/routes/process/dto/full_process_instance_dto.py
+++ b/packages/api/swiss_ai_hub/api/routes/process/dto/full_process_instance_dto.py
@@ -68,8 +68,8 @@ class FullProcessInstanceDTO(MinimalProcessInstanceDTO):
         """
         process_config_dto = ProcessConfigDTO(
             process_id=config_entity.process_id,
-            name=t.extract(config_entity.name.to_locale_string()) or "",
-            description=t.extract(config_entity.description.to_locale_string()) or "",
+            name=t.extract_required(config_entity.name.to_locale_string(), field_name="process.name"),
+            description=t.extract_required(config_entity.description.to_locale_string(), field_name="process.description"),
             icon=config_entity.icon,
         )
 

--- a/packages/api/swiss_ai_hub/api/routes/process/dto/in_specs/human_in_dto.py
+++ b/packages/api/swiss_ai_hub/api/routes/process/dto/in_specs/human_in_dto.py
@@ -22,8 +22,8 @@ class HumanInDTO(BaseModel):
     @classmethod
     def from_human_in_specs(cls, human_in_specs: HumanInSpecs, t: LocaleHandler) -> Self:
         human_in_dto = cls(
-            name=t.extract(human_in_specs.name),
-            description=t.extract(human_in_specs.description),
+            name=t.extract_required(human_in_specs.name, field_name="human_input.name"),
+            description=t.extract_required(human_in_specs.description, field_name="human_input.description"),
             route=human_in_specs.route,
             method=human_in_specs.method,
             is_process_start=human_in_specs.is_process_start,
@@ -36,8 +36,10 @@ class HumanInDTO(BaseModel):
     @classmethod
     def from_entity_specs(cls, human_in_specs_entity: HumanInSpecsEntity, t: LocaleHandler) -> Self:
         human_in_dto = cls(
-            name=t.extract(human_in_specs_entity.name.to_locale_string()),
-            description=t.extract(human_in_specs_entity.description.to_locale_string()),
+            name=t.extract_required(human_in_specs_entity.name.to_locale_string(), field_name="human_input.name"),
+            description=t.extract_required(
+                human_in_specs_entity.description.to_locale_string(), field_name="human_input.description"
+            ),
             route=human_in_specs_entity.route,
             method=human_in_specs_entity.method,
             is_process_start=human_in_specs_entity.is_process_start,

--- a/packages/api/swiss_ai_hub/api/routes/process/dto/minimal_process_instance_dto.py
+++ b/packages/api/swiss_ai_hub/api/routes/process/dto/minimal_process_instance_dto.py
@@ -42,8 +42,8 @@ class MinimalProcessInstanceDTO(BaseModel):
         """
         process_config_dto = ProcessConfigDTO(
             process_id=config_entity.process_id,
-            name=t.extract(config_entity.name.to_locale_string()) or "",
-            description=t.extract(config_entity.description.to_locale_string()) or "",
+            name=t.extract_required(config_entity.name.to_locale_string(), field_name="process.name"),
+            description=t.extract_required(config_entity.description.to_locale_string(), field_name="process.description"),
             icon=config_entity.icon,
         )
         return cls(

--- a/packages/api/swiss_ai_hub/api/routes/process/dto/minimal_process_instance_dto.py
+++ b/packages/api/swiss_ai_hub/api/routes/process/dto/minimal_process_instance_dto.py
@@ -42,8 +42,8 @@ class MinimalProcessInstanceDTO(BaseModel):
         """
         process_config_dto = ProcessConfigDTO(
             process_id=config_entity.process_id,
-            name=t.extract(config_entity.name.to_locale_string()),
-            description=t.extract(config_entity.description.to_locale_string()),
+            name=t.extract(config_entity.name.to_locale_string()) or "",
+            description=t.extract(config_entity.description.to_locale_string()) or "",
             icon=config_entity.icon,
         )
         return cls(

--- a/packages/api/swiss_ai_hub/api/routes/process/dto/process_config_dto.py
+++ b/packages/api/swiss_ai_hub/api/routes/process/dto/process_config_dto.py
@@ -17,7 +17,7 @@ class ProcessConfigDTO(BaseModel):
     def from_process_config(cls, process_config: ProcessConfig, t: LocaleHandler) -> Self:
         return cls(
             process_id=process_config.process_id,
-            name=t.extract(process_config.name),
-            description=t.extract(process_config.description),
+            name=t.extract_required(process_config.name, field_name="process.name"),
+            description=t.extract_required(process_config.description, field_name="process.description"),
             icon=process_config.icon,
         )

--- a/packages/api/swiss_ai_hub/api/routes/process/process_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/process/process_service.py
@@ -1,4 +1,3 @@
-import logging
 import time
 from typing import Any
 
@@ -29,8 +28,7 @@ from swiss_ai_hub.api.routes.process.dto.submitted_form_dto import SubmittedForm
 from swiss_ai_hub.api.services.model_creation_service import ModelCreationService
 from swiss_ai_hub.api.util.config_authorization_service import ConfigAuthorizationService
 from swiss_ai_hub.api.util.instance_config_helper import InstanceConfigHelper
-
-logger = logging.getLogger(__name__)
+from swiss_ai_hub.api.util.instance_dto_builder import InstanceDtoBuilder
 
 
 class ProcessService:
@@ -291,14 +289,15 @@ class ProcessService:
         instances = []
         configs = ProcessConfigEntityDocument.find_for_class(process_class)
         for config_entity in configs:
-            try:
-                instances.append(FullProcessInstanceDTO.from_class_and_config(class_entity, config_entity, t))
-            except Exception:
-                logger.exception(
-                    "Skipping process instance %s/%s: could not build its DTO.",
-                    process_class,
-                    getattr(config_entity, "process_id", "?"),
-                )
+            dto = InstanceDtoBuilder.build_or_skip(
+                lambda config_entity=config_entity: (
+                    FullProcessInstanceDTO.from_class_and_config(class_entity, config_entity, t)
+                ),
+                kind="process instance",
+                key=f"{process_class}/{getattr(config_entity, 'process_id', '?')}",
+            )
+            if dto is not None:
+                instances.append(dto)
         return instances
 
     @staticmethod
@@ -452,14 +451,15 @@ class ProcessService:
 
             configs = ProcessConfigEntityDocument.find_for_class(class_entity.process_class)
             for config_entity in configs:
-                try:
-                    instances.append(FullProcessInstanceDTO.from_class_and_config(class_entity, config_entity, t))
-                except Exception:
-                    logger.exception(
-                        "Skipping process instance %s/%s: could not build its DTO.",
-                        class_entity.process_class,
-                        getattr(config_entity, "process_id", "?"),
-                    )
+                dto = InstanceDtoBuilder.build_or_skip(
+                    lambda class_entity=class_entity, config_entity=config_entity: (
+                        FullProcessInstanceDTO.from_class_and_config(class_entity, config_entity, t)
+                    ),
+                    kind="process instance",
+                    key=f"{class_entity.process_class}/{getattr(config_entity, 'process_id', '?')}",
+                )
+                if dto is not None:
+                    instances.append(dto)
         return instances
 
     # ==================== Walkthrough Methods ====================

--- a/packages/api/swiss_ai_hub/api/routes/process/process_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/process/process_service.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from typing import Any
 
@@ -28,6 +29,8 @@ from swiss_ai_hub.api.routes.process.dto.submitted_form_dto import SubmittedForm
 from swiss_ai_hub.api.services.model_creation_service import ModelCreationService
 from swiss_ai_hub.api.util.config_authorization_service import ConfigAuthorizationService
 from swiss_ai_hub.api.util.instance_config_helper import InstanceConfigHelper
+
+logger = logging.getLogger(__name__)
 
 
 class ProcessService:
@@ -95,8 +98,8 @@ class ProcessService:
                         )
 
                 process_human_input_dto = HumanInDTO(
-                    name=t.extract(human_in_specs.name),
-                    description=t.extract(human_in_specs.description),
+                    name=t.extract_required(human_in_specs.name, field_name="human_input.name"),
+                    description=t.extract_required(human_in_specs.description, field_name="human_input.description"),
                     route=human_in_specs.route,
                     method=human_in_specs.method,
                     form=work_form_elements,
@@ -288,7 +291,14 @@ class ProcessService:
         instances = []
         configs = ProcessConfigEntityDocument.find_for_class(process_class)
         for config_entity in configs:
-            instances.append(FullProcessInstanceDTO.from_class_and_config(class_entity, config_entity, t))
+            try:
+                instances.append(FullProcessInstanceDTO.from_class_and_config(class_entity, config_entity, t))
+            except Exception:
+                logger.exception(
+                    "Skipping process instance %s/%s: could not build its DTO.",
+                    process_class,
+                    getattr(config_entity, "process_id", "?"),
+                )
         return instances
 
     @staticmethod
@@ -442,7 +452,14 @@ class ProcessService:
 
             configs = ProcessConfigEntityDocument.find_for_class(class_entity.process_class)
             for config_entity in configs:
-                instances.append(FullProcessInstanceDTO.from_class_and_config(class_entity, config_entity, t))
+                try:
+                    instances.append(FullProcessInstanceDTO.from_class_and_config(class_entity, config_entity, t))
+                except Exception:
+                    logger.exception(
+                        "Skipping process instance %s/%s: could not build its DTO.",
+                        class_entity.process_class,
+                        getattr(config_entity, "process_id", "?"),
+                    )
         return instances
 
     # ==================== Walkthrough Methods ====================

--- a/packages/api/swiss_ai_hub/api/util/instance_dto_builder.py
+++ b/packages/api/swiss_ai_hub/api/util/instance_dto_builder.py
@@ -8,9 +8,11 @@ class InstanceDtoBuilder:
     """Isolates a single corrupt record when building instance DTOs for an aggregate read.
 
     Endpoint-discovery sweeps and list endpoints iterate every persisted instance in one loop.
-    A single record that fails to serialize (empty required locale, missing field, decode error)
-    must not abort the whole batch — historically one bad record took the 60s discovery sweep
-    down and left the platform with no registered endpoints.
+    A single record that fails to serialize (missing field, decode error, or any other
+    unforeseen failure) must not abort the whole batch — historically one bad record took the
+    60s discovery sweep down and left the platform with no registered endpoints. The known
+    empty-locale case is already handled upstream by `LocaleHandler.extract_required`; this is
+    the net for everything else.
 
     This deliberately deviates from the repo's fail-fast convention. The catch is intentionally
     broad: the whole point of the resilience boundary is that *any* unexpected failure in one

--- a/packages/api/swiss_ai_hub/api/util/instance_dto_builder.py
+++ b/packages/api/swiss_ai_hub/api/util/instance_dto_builder.py
@@ -1,0 +1,30 @@
+import logging
+from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+
+class InstanceDtoBuilder:
+    """Isolates a single corrupt record when building instance DTOs for an aggregate read.
+
+    Endpoint-discovery sweeps and list endpoints iterate every persisted instance in one loop.
+    A single record that fails to serialize (empty required locale, missing field, decode error)
+    must not abort the whole batch — historically one bad record took the 60s discovery sweep
+    down and left the platform with no registered endpoints.
+
+    This deliberately deviates from the repo's fail-fast convention. The catch is intentionally
+    broad: the whole point of the resilience boundary is that *any* unexpected failure in one
+    record is contained, so narrowing to a fixed exception list would let a new error type
+    re-crash the sweep. Genuine bugs are not hidden — `logger.exception` records the full
+    traceback at ERROR level, so they remain visible in logs and monitoring; they simply no
+    longer take the aggregate read down with them.
+    """
+
+    @staticmethod
+    def build_or_skip[T](builder: Callable[[], T], *, kind: str, key: str) -> T | None:
+        """Run `builder`, returning its DTO, or `None` (logged) if it raises."""
+        try:
+            return builder()
+        except Exception:
+            logger.exception("Skipping %s %s: could not build its DTO.", kind, key)
+            return None

--- a/packages/core/swiss_ai_hub/core/i18n/locale_handler.py
+++ b/packages/core/swiss_ai_hub/core/i18n/locale_handler.py
@@ -78,7 +78,7 @@ class LocaleHandler:
         available_locales = list(locale_data.keys())
         if available_locales:
             return locale_data[available_locales[0]]
-        raise ValueError("No language keys available")
+        return None
 
     def extract_multi_locale(self, locale_data: dict[str, Any] | LocaleString, locale: str | None = None) -> Any:
         locale = self.get_locale(locale)
@@ -91,7 +91,7 @@ class LocaleHandler:
         available_locales = [field for field in self.LOCALE_WHITE_LIST if getattr(locale_data, field, None)]
         if available_locales:
             return getattr(locale_data, available_locales[0])
-        raise ValueError("No language keys available")
+        return None
 
     def t_object(self, key: str, locale: str | None = None) -> Any:
         locale = self.get_locale(locale)

--- a/packages/core/swiss_ai_hub/core/i18n/locale_handler.py
+++ b/packages/core/swiss_ai_hub/core/i18n/locale_handler.py
@@ -93,6 +93,20 @@ class LocaleHandler:
             return getattr(locale_data, available_locales[0])
         return None
 
+    def extract_required(self, locale_data: dict[str, Any] | LocaleString, field_name: str | None = None) -> str:
+        """Extract a localized value for a required string field, coercing an unset value to `""`.
+
+        Required DTO fields must render even when a record has no populated locale (legitimate,
+        since the storage columns are optional). Returning `""` instead of `None` keeps a single
+        empty record from aborting an aggregate read such as the endpoint-discovery sweep, and the
+        warning keeps that malformed record discoverable.
+        """
+        value = self.extract(locale_data)
+        if value:
+            return value
+        logger.warning("Localized field %r is empty in every locale; coercing to empty string.", field_name or "?")
+        return ""
+
     def t_object(self, key: str, locale: str | None = None) -> Any:
         locale = self.get_locale(locale)
         folder, filename, *path = key.split(".")

--- a/packages/core/swiss_ai_hub/core/i18n/locale_string.py
+++ b/packages/core/swiss_ai_hub/core/i18n/locale_string.py
@@ -58,8 +58,8 @@ class LocaleString(BaseModel):
         """Extract the string for a locale, falling back to other locales if it is unset.
 
         With `fallback` (the default), mirrors `LocaleHandler.extract_multi_locale`:
-        requested locale → default locale → first populated locale in the whitelist;
-        unlike that method it returns None instead of raising when every locale is empty.
+        requested locale → default locale → first populated locale in the whitelist,
+        returning None when every locale is empty.
 
         Pass `fallback=False` to read exactly the requested locale (no substitution) — for
         callers that need the requested language verbatim or want their own fallback order.

--- a/packages/core/swiss_ai_hub/core/i18n/tests/unit/test_locale_handler.py
+++ b/packages/core/swiss_ai_hub/core/i18n/tests/unit/test_locale_handler.py
@@ -91,6 +91,14 @@ def test_extract_from_multi_locale_with_missing_locale_returns_first_available()
     assert LocaleHandler().extract(partial_locale_data, "de") == "Agente di ricerca"
 
 
+def test_extract_from_empty_multi_locale_returns_none():
+    assert LocaleHandler().extract(LocaleString(), "de") is None
+
+
+def test_extract_from_all_empty_dict_returns_none():
+    assert LocaleHandler().extract({"de": None}, "de") is None
+
+
 def test_t_object_with_nonexistent_file_raises_file_not_found_error():
     with pytest.raises(FileNotFoundError):
         LocaleHandler().t_object("nonexistent.folder.name", "de")

--- a/packages/core/swiss_ai_hub/core/i18n/tests/unit/test_locale_handler.py
+++ b/packages/core/swiss_ai_hub/core/i18n/tests/unit/test_locale_handler.py
@@ -95,8 +95,21 @@ def test_extract_from_empty_multi_locale_returns_none():
     assert LocaleHandler().extract(LocaleString(), "de") is None
 
 
-def test_extract_from_all_empty_dict_returns_none():
+def test_extract_from_dict_with_only_none_values_returns_none():
     assert LocaleHandler().extract({"de": None}, "de") is None
+
+
+def test_extract_dict_with_no_locales_returns_none():
+    # Reached only by calling extract_dict directly: extract() short-circuits an empty dict to None.
+    assert LocaleHandler().extract_dict({}, "de") is None
+
+
+def test_extract_required_coerces_empty_locale_to_empty_string():
+    assert LocaleHandler().extract_required(LocaleString()) == ""
+
+
+def test_extract_required_returns_value_when_populated():
+    assert LocaleHandler().extract_required(LocaleString(en="Search-Agent")) == "Search-Agent"
 
 
 def test_t_object_with_nonexistent_file_raises_file_not_found_error():


### PR DESCRIPTION
## Problem

Endpoint discovery was crashing the **entire** agent (and process) registration sweep whenever a **single** instance had a fully-empty localized `description`.

```
ValueError: No language keys available
  at locale_handler.py:94 in extract_multi_locale
  ← agent_config_dto.py:55  t.extract(config_entity.description.to_locale_string())
  ← agent_service.py:110    get_all_agent_instances  (loops over ALL instances)
  ← agent_endpoints_discovery_service.py  _discovery_loop (runs every 60s)
```

`AgentService.get_all_agent_instances` builds a DTO for every instance in one loop with no per-item error handling. One record whose `LocaleStringEntity` has `de/en/fr/it` all empty makes `LocaleHandler.extract_multi_locale` raise, aborting the whole loop → **no agent gets its endpoints registered** → platform effectively down. The process discovery loop shares the identical latent crash via `full/minimal_process_instance_dto`.

## Root cause

`LocaleHandler.extract_multi_locale` / `extract_dict` **raise** `ValueError` when every locale is empty, while the sibling `LocaleString.in_locale` intentionally **returns `None`** for the same case (its docstring even called out the inconsistency). An empty `description` is legitimate data (the field is optional at the storage layer — `LocaleStringEntity` has all locales `required=False, null=True`), so raising here is wrong.

## Fix

1. **Root cause** — `extract_multi_locale` / `extract_dict` now return `None` instead of raising when no locale is populated, making them consistent with `LocaleString.in_locale`. This removes the `ValueError` everywhere it could fire.
2. **Call sites** — the required-`str` DTOs that run inside the discovery loops (`AgentConfigDTO`, `FullProcessInstanceDTO`, `MinimalProcessInstanceDTO`) coerce `t.extract(...) or ""`, so an empty description renders as an empty string instead of a relocated validation error.
3. Updated the `LocaleString.in_locale` docstring and added unit tests for the empty-locale path.

This is read-side resilience (one bad record must never take down the aggregate). A **follow-up** should add write-side validation on agent/process create/update so empty required localized fields can't enter the DB in the first place — but that is a separate, behavior-changing change and does not belong in a hotfix. The read-side resilience is still required regardless, for existing/imported records.

## Tests

- `packages/core` i18n unit tests pass (10 passed), including two new cases:
  - `test_extract_from_empty_multi_locale_returns_none`
  - `test_extract_from_all_empty_dict_returns_none`
- API DTO change is a pure `or ""` coercion (syntax-verified; full API integration suite requires the Docker dev stack).