### PR TITLE
fix(ci-cd): Bump claude-code-action to v1.0.183

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@86eb26bf0139bdd75acd15ea5f00f45ee0a284c2  # v1.0.122
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b  # v1.0.183
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@86eb26bf0139bdd75acd15ea5f00f45ee0a284c2  # v1.0.122
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b  # v1.0.183
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Context

The Claude Code Review workflow has failed on every PR since 2026-07-29 10:29 UTC. Runs die ~1.5s after Claude launches, before any API call or tool use.

The `CLAUDE_CODE_OAUTH_TOKEN` secret was renewed on 2026-07-30 03:09 UTC and the next run (30509903858, 03:23 UTC) failed identically, so the token is not the cause. Verified directly against the API: an invalid token returns `401 authentication_error`, while the current secret authenticates and resolves to a real organization.

## Cause

Both workflows pinned `claude-code-action@86eb26bf` = v1.0.122, released 2026-05-13 — 61 releases behind. Pinning by SHA also freezes the toolchain the action installs:

| Pin | Bundled |
|---|---|
| v1.0.122 (old) | Claude Code CLI 2.1.141, Agent SDK **0.2.141** |
| v1.0.183 (new) | Claude Code CLI 2.1.220, Agent SDK **0.3.220** |

## Change

Bump both workflows to v1.0.183 (`be7b93b1`, the dereferenced commit for the annotated tag).

Also picks up the removal of `--tsconfig-override`, which triggers a Bun bug (oven-sh/bun#25730) — visible in current logs as `Internal error: directory mismatch for directory .../tsconfig.json` and reported upstream as anthropics/claude-code-action#1568.

## Checked before bumping

anthropics/claude-code-action#1547 reports every Bash call failing on CLI 2.1.216+ — which would matter here, since this workflow does nothing but Bash (`gh pr comment`, `gh pr diff`), and the job would go **green** while posting nothing. It does not apply: that bug requires `allowed_non_write_users`, which enables bubblewrap sandboxing. Neither workflow sets it, and the run logs confirm both gates are empty (`ALLOWED_NON_WRITE_USERS:`, `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB:`).

Verified against `action.yml` at the new SHA that all inputs still exist (`claude_code_oauth_token`, `prompt`, `claude_args`, `additional_permissions`) and no new inputs are required.

## Verification

This PR tests itself. `pull_request` events run the workflow file from the head ref, so opening it executes the bumped pin. A posted review confirms the fix; another 1.5s crash means the cause lies elsewhere.