### PR TITLE
feat(swiss-ai-hub): Validate required localized config fields on instance create/update

### DIFF
--- a/packages/api/playground/testing/tests/agent/test_instance_config_helper.py
+++ b/packages/api/playground/testing/tests/agent/test_instance_config_helper.py
@@ -1,0 +1,99 @@
+import pytest
+from fastapi import HTTPException
+from swiss_ai_hub.core.i18n import LocaleString
+
+from swiss_ai_hub.api.util.instance_config_helper import InstanceConfigHelper
+
+LOCALE_STRING_DEF = {
+    "type": "object",
+    "properties": {
+        "de": {"type": "string"},
+        "en": {"type": "string"},
+        "fr": {"type": "string"},
+        "it": {"type": "string"},
+    },
+}
+
+
+def _schema(required: list[str]) -> dict:
+    """A config schema with localized name/description/system_prompt and a plain agent_id."""
+    return {
+        "$defs": {"LocaleString": LOCALE_STRING_DEF},
+        "properties": {
+            "agent_id": {"type": "string"},
+            "name": {"$ref": "#/$defs/LocaleString"},
+            "description": {"$ref": "#/$defs/LocaleString"},
+            "system_prompt": {"$ref": "#/$defs/LocaleString"},
+        },
+        "required": required,
+    }
+
+
+def test_localized_field_names_detects_ref_allof_and_anyof():
+    schema = {
+        "$defs": {"LocaleString": LOCALE_STRING_DEF},
+        "properties": {
+            "agent_id": {"type": "string"},
+            "name": {"$ref": "#/$defs/LocaleString"},
+            "description": {"allOf": [{"$ref": "#/$defs/LocaleString"}]},
+            "system_prompt": {"anyOf": [{"$ref": "#/$defs/LocaleString"}, {"type": "null"}]},
+        },
+    }
+    assert InstanceConfigHelper._localized_field_names(schema) == {"name", "description", "system_prompt"}
+
+
+def test_validate_required_locale_fields_rejects_every_empty_required_field():
+    config = {"agent_id": "x", "name": None, "description": None, "system_prompt": None}
+    with pytest.raises(HTTPException) as exc:
+        InstanceConfigHelper.validate_required_locale_fields(
+            config, _schema(["agent_id", "name", "description", "system_prompt"])
+        )
+    assert exc.value.status_code == 400
+    assert "description, name, system_prompt" in exc.value.detail
+
+
+def test_validate_required_locale_fields_passes_when_all_required_have_content():
+    config = {"agent_id": "x", "name": {"en": "Hi"}, "description": {"de": "Bot"}, "system_prompt": {"en": "sys"}}
+    InstanceConfigHelper.validate_required_locale_fields(
+        config, _schema(["agent_id", "name", "description", "system_prompt"])
+    )
+
+
+def test_validate_required_locale_fields_ignores_optional_localized_field():
+    config = {"agent_id": "x", "name": {"en": "Hi"}, "description": {"en": "Bot"}, "system_prompt": None}
+    InstanceConfigHelper.validate_required_locale_fields(config, _schema(["name", "description"]))
+
+
+def test_validate_required_locale_fields_ignores_non_localized_required_field():
+    config = {"agent_id": None, "name": {"en": "Hi"}, "description": {"en": "Bot"}}
+    InstanceConfigHelper.validate_required_locale_fields(config, _schema(["agent_id", "name", "description"]))
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, False),
+        ({}, False),
+        ({"de": "", "en": "", "fr": "", "it": ""}, False),
+        ({"en": "Hello"}, True),
+        (LocaleString(), False),
+        (LocaleString(fr="Bonjour"), True),
+    ],
+)
+def test_locale_value_has_content(value, expected):
+    assert InstanceConfigHelper._locale_value_has_content(value) is expected
+
+
+def test_build_locale_entities_stores_empty_entity_for_missing_description():
+    entities = InstanceConfigHelper.build_locale_entities(None, None, "RAGAgent", "mage:robot")
+    assert entities.description.to_locale_string().has_content() is False
+    assert entities.description.de is None and entities.description.en is None
+    # Name still falls back to a populated default so it never persists blank.
+    assert entities.name.to_locale_string().has_content() is True
+
+
+def test_build_locale_entities_uses_provided_description():
+    entities = InstanceConfigHelper.build_locale_entities(
+        LocaleString(en="Name"), LocaleString(en="Desc"), "RAGAgent", "mage:robot"
+    )
+    assert entities.description.en == "Desc"

--- a/packages/api/swiss_ai_hub/api/routes/agent/agent_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/agent/agent_service.py
@@ -362,6 +362,10 @@ class AgentService:
 
         configuration = InstanceConfigHelper.normalize_form_configuration(configuration)
 
+        InstanceConfigHelper.validate_required_locale_fields(
+            configuration, class_entity.agent_config_specs.agent_config_schema
+        )
+
         config_model = ModelCreationService.create_agent_config_model(
             AgentConfigSpecs(
                 agent_class=class_entity.agent_config_specs.agent_class,
@@ -452,6 +456,8 @@ class AgentService:
             )
 
         config = InstanceConfigHelper.normalize_form_configuration(request.configuration)
+
+        InstanceConfigHelper.validate_required_locale_fields(config, class_entity.agent_config_specs.agent_config_schema)
 
         config_model = ModelCreationService.create_agent_config_model(
             AgentConfigSpecs(

--- a/packages/api/swiss_ai_hub/api/routes/process/process_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/process/process_service.py
@@ -333,6 +333,11 @@ class ProcessService:
 
         config = InstanceConfigHelper.normalize_form_configuration(request.configuration)
 
+        process_config_schema = (
+            class_entity.process_config_specs.process_config_schema if class_entity.process_config_specs else {}
+        )
+        InstanceConfigHelper.validate_required_locale_fields(config, process_config_schema)
+
         config_model = ModelCreationService.create_process_config_model(
             ProcessConfigSpecs(
                 process_class=(
@@ -340,9 +345,7 @@ class ProcessService:
                     if class_entity.process_config_specs
                     else process_class
                 ),
-                process_config_schema=(
-                    class_entity.process_config_specs.process_config_schema if class_entity.process_config_specs else {}
-                ),
+                process_config_schema=process_config_schema,
             )
         )
         config_instance = InstanceConfigHelper.validate_config_for_create(config, config_model)
@@ -393,6 +396,11 @@ class ProcessService:
 
         configuration = InstanceConfigHelper.normalize_form_configuration(configuration)
 
+        process_config_schema = (
+            class_entity.process_config_specs.process_config_schema if class_entity.process_config_specs else {}
+        )
+        InstanceConfigHelper.validate_required_locale_fields(configuration, process_config_schema)
+
         config_model = ModelCreationService.create_process_config_model(
             ProcessConfigSpecs(
                 process_class=(
@@ -400,9 +408,7 @@ class ProcessService:
                     if class_entity.process_config_specs
                     else process_class
                 ),
-                process_config_schema=(
-                    class_entity.process_config_specs.process_config_schema if class_entity.process_config_specs else {}
-                ),
+                process_config_schema=process_config_schema,
             )
         )
         config_instance = InstanceConfigHelper.validate_config_for_update(configuration, config_model)

--- a/packages/api/swiss_ai_hub/api/util/instance_config_helper.py
+++ b/packages/api/swiss_ai_hub/api/util/instance_config_helper.py
@@ -3,7 +3,10 @@ from typing import Any, NamedTuple, TypeVar
 from fastapi import HTTPException
 from pydantic import BaseModel, ValidationError
 from swiss_ai_hub.core.form import normalize_empty_locale_strings, normalize_empty_objects_to_none
+from swiss_ai_hub.core.i18n import LocaleString
 from swiss_ai_hub.core.persistence.i18n.locale_string_entity import LocaleStringEntity
+
+_LOCALE_KEYS = frozenset({"de", "en", "fr", "it"})
 
 
 class ConfigMetadata(NamedTuple):
@@ -35,6 +38,55 @@ class InstanceConfigHelper:
         config = normalize_empty_objects_to_none(config)
         config = normalize_empty_locale_strings(config)
         return config
+
+    @staticmethod
+    def validate_required_locale_fields(config: dict[str, Any], schema: dict[str, Any]) -> None:
+        """Reject a create/update whose required localized field carries no populated locale.
+
+        Localized fields (LocaleString: de/en/fr/it) are optional-per-locale, so an all-empty
+        value normalizes to None and would either persist a blank record or surface the schema
+        model's opaque "not a valid dictionary" error. This raises a clear, field-named 400 for
+        every required localized field — name, description, system_prompt, and any future one —
+        driven by the schema rather than a hardcoded list.
+        """
+        required = set(schema.get("required", []))
+        empty_fields = sorted(
+            field
+            for field in required & InstanceConfigHelper._localized_field_names(schema)
+            if not InstanceConfigHelper._locale_value_has_content(config.get(field))
+        )
+        if empty_fields:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "The following field(s) require at least one language with content: "
+                    f"{', '.join(empty_fields)}."
+                ),
+            )
+
+    @staticmethod
+    def _localized_field_names(schema: dict[str, Any]) -> set[str]:
+        """Field names whose schema type resolves to a LocaleString (de/en/fr/it object)."""
+        defs = schema.get("$defs", {})
+        localized: set[str] = set()
+        for field_name, prop in schema.get("properties", {}).items():
+            candidates = [prop, *prop.get("allOf", []), *prop.get("anyOf", [])]
+            for candidate in candidates:
+                ref = candidate.get("$ref") if isinstance(candidate, dict) else None
+                target = defs.get(ref.split("/")[-1], {}) if ref else candidate
+                properties = target.get("properties") if isinstance(target, dict) else None
+                if properties and set(properties).issubset(_LOCALE_KEYS):
+                    localized.add(field_name)
+                    break
+        return localized
+
+    @staticmethod
+    def _locale_value_has_content(value: Any) -> bool:
+        if isinstance(value, LocaleString):
+            return value.has_content()
+        if isinstance(value, dict):
+            return any(value.get(locale) not in (None, "") for locale in _LOCALE_KEYS)
+        return False
 
     @staticmethod
     def validate_config_for_create(config: dict[str, Any], config_model: type[BaseModel]) -> BaseModel:
@@ -82,9 +134,7 @@ class InstanceConfigHelper:
             )
         )
         description_entity = (
-            LocaleStringEntity.from_locale_string(description)
-            if description
-            else LocaleStringEntity(de="", en="", fr="", it="")
+            LocaleStringEntity.from_locale_string(description) if description else LocaleStringEntity()
         )
         return LocaleEntities(name=name_entity, description=description_entity, icon=icon)
 

--- a/packages/core/swiss_ai_hub/core/agents/agent_config.py
+++ b/packages/core/swiss_ai_hub/core/agents/agent_config.py
@@ -16,11 +16,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _locale_string_has_content(value: LocaleString) -> bool:
-    """Check if a LocaleString has at least one non-empty locale value."""
-    return any(getattr(value, locale, None) not in (None, "") for locale in ("de", "en", "fr", "it"))
-
-
 class StepConfig(Form):
     """
     A base configuration class for workflow steps, allowing future extensions
@@ -91,9 +86,9 @@ class AgentConfig(Form):
     def validate_locale_strings_have_content(self) -> Self:
         """Validate that name and description LocaleStrings have at least one non-empty value."""
         # Skip validation for form mode (when fields are LocaleInput elements)
-        if isinstance(self.name, LocaleString) and not _locale_string_has_content(self.name):
+        if isinstance(self.name, LocaleString) and not self.name.has_content():
             raise ValueError("name must have at least one language with content")
-        if isinstance(self.description, LocaleString) and not _locale_string_has_content(self.description):
+        if isinstance(self.description, LocaleString) and not self.description.has_content():
             raise ValueError("description must have at least one language with content")
         return self
 

--- a/packages/core/swiss_ai_hub/core/i18n/locale_string.py
+++ b/packages/core/swiss_ai_hub/core/i18n/locale_string.py
@@ -54,6 +54,15 @@ class LocaleString(BaseModel):
     fr: Annotated[str | None, Field(description="French")] = None
     it: Annotated[str | None, Field(description="Italian")] = None
 
+    def has_content(self) -> bool:
+        """Whether at least one locale holds a non-empty value.
+
+        The single source of truth for "is this localized string populated" — a required
+        localized field with no content should be rejected on write, and an empty one yields
+        None on read (`in_locale`).
+        """
+        return any(getattr(self, locale, None) not in (None, "") for locale in ("de", "en", "fr", "it"))
+
     def in_locale(self, locale: str, fallback: bool = True) -> str | None:
         """Extract the string for a locale, falling back to other locales if it is unset.
 

--- a/packages/core/swiss_ai_hub/core/i18n/tests/unit/test_locale_string.py
+++ b/packages/core/swiss_ai_hub/core/i18n/tests/unit/test_locale_string.py
@@ -39,3 +39,15 @@ def test_in_locale_strict_returns_none_without_falling_back():
     locale_string = LocaleString(de="Hallo")
     assert locale_string.in_locale("en", fallback=False) is None
     assert locale_string.in_locale("es", fallback=False) is None
+
+
+def test_has_content_true_when_any_locale_is_populated():
+    assert LocaleString(fr="Bonjour").has_content() is True
+
+
+def test_has_content_false_when_all_locales_are_none():
+    assert LocaleString().has_content() is False
+
+
+def test_has_content_false_when_all_locales_are_empty_strings():
+    assert LocaleString(de="", en="", fr="", it="").has_content() is False

--- a/packages/core/swiss_ai_hub/core/processes/process_config.py
+++ b/packages/core/swiss_ai_hub/core/processes/process_config.py
@@ -16,11 +16,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _locale_string_has_content(value: LocaleString) -> bool:
-    """Check if a LocaleString has at least one non-empty locale value."""
-    return any(getattr(value, locale, None) not in (None, "") for locale in ("de", "en", "fr", "it"))
-
-
 class ProcessConfig(Form):
     """
     Each process instance can be configured with its own parameters.
@@ -54,9 +49,9 @@ class ProcessConfig(Form):
     @model_validator(mode="after")
     def validate_locale_strings_have_content(self) -> Self:
         """Validate that name and description LocaleStrings have at least one non-empty value."""
-        if isinstance(self.name, LocaleString) and not _locale_string_has_content(self.name):
+        if isinstance(self.name, LocaleString) and not self.name.has_content():
             raise ValueError("name must have at least one language with content")
-        if isinstance(self.description, LocaleString) and not _locale_string_has_content(self.description):
+        if isinstance(self.description, LocaleString) and not self.description.has_content():
             raise ValueError("description must have at least one language with content")
         return self
 


### PR DESCRIPTION
## Context

Follow-up to the discovery-loop hotfix (empty localized `description` crashing `AgentService.get_all_agent_instances`). That fix made the **read** path resilient. This PR is the complementary **write-side** hardening: stop empty localized values for **required** fields from entering the DB, and re-evaluate *which* localized fields need validation (not just name/description).

## What I found (re-evaluation)

- **Required localized fields are already enforced at write time** — the jambo config-model (`validate_config_for_create/update`) rejects an all-blank `name`, `description`, **and `system_prompt`**: normalization collapses an all-empty locale dict to `None`, and these are `required` non-nullable in the schema. Optional ones (`rag_agent.system_prompt: … | None`) are correctly not required.
- Two real gaps remained:
  1. **Opaque errors** — jambo rejects an empty `system_prompt` with `"Input should be a valid dictionary or instance of LocaleString"`, never naming the field.
  2. **`InstanceConfigHelper.build_locale_entities` fabricated `LocaleStringEntity(de="", en="", fr="", it="")`** for a missing description — the exact all-blank record that crashed discovery (reachable via seeders / non-configurable fields, bypassing schema validation).

## Changes

- **`InstanceConfigHelper.validate_required_locale_fields(config, schema)`** — a shared, **schema-driven** guard run before model validation in agent + process **create and update**. For every field that is `required` **and** resolves to a `LocaleString` (de/en/fr/it), it requires at least one populated locale, else a clear field-named **400**. Covers `name`, `description`, `system_prompt`, and any future localized field — no hardcoded list. Detects the type via `$ref`/`allOf`/`anyOf` to the LocaleString def.
- **`build_locale_entities`** no longer persists blank strings for a missing description — stores a truly-empty `LocaleStringEntity()` instead.
- **`LocaleString.has_content()`** — public helper; the single source of truth for "is this localized string populated". De-duplicated the two copies of `_locale_string_has_content` in `AgentConfig`/`ProcessConfig` onto it.
- The guard is a **no-op on an empty (`{}`) schema**, so it does not disturb mocked service unit tests.

## Scope note

`name`/`description`/`system_prompt` were already rejected when empty by the schema model, so valid clients see **no behavior change** — this adds clear errors, closes the seeder/edge blank-record path, and makes the rule schema-driven. The read-side resilience from the hotfix stays in place (defense in depth for existing/imported records); it reaches `main` via the hotfix's forward-port.

## Tests

- `packages/core` — `LocaleString.has_content()` cases + full i18n/agents/processes suites (31 passed).
- `packages/api` — new `test_instance_config_helper.py` (13 passed): schema detection (`$ref`/`allOf`/`anyOf`), rejects each empty required localized field, passes when populated, ignores optional/non-localized fields, and `build_locale_entities` no longer stores blanks. Agent + process service unit tests still pass (24 + 24).