### PR TITLE
chore(ci-cd): Document automated PR review trigger behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,8 +352,8 @@ await runner.run_forever()
 
 On startup the agent registers itself: it appears in the chat UI, gets a configuration form in the admin panel, and
 receives full distributed tracing through Langfuse. The runtime routes `ContextSufficientAcceptEvent` to `respond` and
-`ContextInsufficientRejectEvent` to `escalate`; steps never call each other. `BotInTheLoop` sends the question to a configured
-Teams or Slack expert channel and pauses the workflow; when the expert responds, the dispatcher resumes at
+`ContextInsufficientRejectEvent` to `escalate`; steps never call each other. `BotInTheLoop` sends the question to a
+configured Teams or Slack expert channel and pauses the workflow; when the expert responds, the dispatcher resumes at
 `relay_expert`.
 
 ### Data pipelines
@@ -451,6 +451,9 @@ Swiss AI-Hub is developed by [bbv Software Services](https://www.bbv.ch) and ope
 | [Join the Discord](https://discord.gg/wArT8zDB)                | Ask questions, share what you have built, get help           |
 | [Open an issue](https://github.com/bbvch-ai/aihub-core/issues) | Report bugs and request features                             |
 | [Read the ADRs](https://bbvch-ai.github.io/aihub-core/arc42/)  | Understand key decisions before proposing structural changes |
+
+Pull requests opened by repository members receive an automated Claude Code review. It runs once when the PR is opened
+and again if a draft is marked ready for review, so pushing further commits does not re-trigger it.
 
 ## License
 


### PR DESCRIPTION
Adds one sentence to the contributing section noting that the automated Claude review fires on `opened` and `ready_for_review` only — pushing further commits to an open PR does not re-trigger it.

Also includes an mdformat rewrap of an adjacent paragraph, applied automatically by the repo's formatter.

## Secondary purpose

This PR doubles as the verification run for #1669, which bumped `claude-code-action` from v1.0.122 to v1.0.183. That bump could not be verified on its own PR: the action refuses to run when the workflow file on the head differs from `main`, so it skipped and concluded green without launching Claude.

This PR is branched from updated `main` and touches no workflow file, so it exercises the new pin on the normal path. If a review comment appears below, the bump fixed the crash.

Safe to close without merging if the sentence isn't wanted — the verification value is in the run, not the diff.