### PR TITLE
fix(swiss-ai-hub): Prevent empty locale strings from crashing endpoint discovery

### DIFF
--- a/packages/api/playground/testing/tests/agent/test_agent_service_unit_tests.py
+++ b/packages/api/playground/testing/tests/agent/test_agent_service_unit_tests.py
@@ -15,9 +15,11 @@ from swiss_ai_hub.core.persistence.access.entities.tenant_metadata_entity import
 from swiss_ai_hub.core.persistence.access.entities.user_tenant_role_entity import UserTenantRoleEntity
 from swiss_ai_hub.core.persistence.agents import AgentClassEntity
 from swiss_ai_hub.core.persistence.agents.agent_config_entity_document import AgentConfigEntityDocument
+from swiss_ai_hub.core.persistence.i18n.locale_string_entity import LocaleStringEntity
 from swiss_ai_hub.core.persistence.messaging.entities.thread_entity import ThreadEntity
 
 from swiss_ai_hub.api.routes.agent.agent_service import AgentService
+from swiss_ai_hub.api.routes.agent.dto.agent_config_dto import AgentConfigDTO
 from swiss_ai_hub.api.routes.agent.dto.create_agent_instance_request import CreateAgentInstanceRequest
 from swiss_ai_hub.api.routes.agent.dto.full_agent_instance_dto import FullAgentInstanceDTO
 from swiss_ai_hub.api.routes.agent.dto.minimal_agent_instance_dto import MinimalAgentInstanceDTO
@@ -246,6 +248,27 @@ class TestAgentServiceUnit:
                     assert len(result) == 2
                     assert first_dto in result
                     assert second_dto in result
+
+    @pytest.mark.asyncio
+    async def test_get_all_agent_instances_skips_record_that_fails_to_build(
+        self, sample_agent_class_entity, sample_config_entity, mock_locale_handler
+    ):
+        """A single instance whose DTO cannot be built must be skipped, not abort the whole sweep."""
+        bad_config = Mock()
+        bad_config.agent_class = "TestAgent"
+        bad_config.agent_id = "bad_agent"
+
+        with patch.object(AgentClassEntity, "get_all", return_value=[sample_agent_class_entity]):
+            with patch.object(
+                AgentConfigEntityDocument, "find_for_class", return_value=[sample_config_entity, bad_config]
+            ):
+                with patch.object(FullAgentInstanceDTO, "from_class_and_config") as mock_from:
+                    good_dto = Mock(spec=FullAgentInstanceDTO)
+                    mock_from.side_effect = [good_dto, ValueError("could not build DTO")]
+
+                    result = await AgentService.get_all_agent_instances(mock_locale_handler)
+
+        assert result == [good_dto]
 
     @pytest.mark.asyncio
     async def test_send_event_success(self, mock_nats, mock_user_identity):
@@ -556,3 +579,26 @@ class TestUpdateAgentInstanceLocksAgentId:
         assert config_entity.config_data["agent_id"] == "intructed_agent_02"
         assert result["agent_id"] == "intructed_agent_02"
         config_entity.save.assert_called_once()
+
+
+class TestAgentConfigDTOEmptyLocale:
+    """Regression: an instance whose localized name/description is empty must build, not raise.
+
+    This is the read-side resilience the fix guarantees — empty localized fields are legitimate
+    data (LocaleStringEntity columns are all optional), so a required-str DTO field coerces to "".
+    """
+
+    def test_empty_locale_name_and_description_coerce_to_empty_string(self):
+        class_entity = Mock()
+        class_entity.form = None
+
+        config_entity = Mock()
+        config_entity.agent_id = "empty_locale_agent"
+        config_entity.name = LocaleStringEntity()
+        config_entity.description = LocaleStringEntity()
+        config_entity.icon = "mage:robot"
+
+        dto = AgentConfigDTO.from_class_and_config(class_entity, config_entity, LocaleHandler())
+
+        assert dto.name == ""
+        assert dto.description == ""

--- a/packages/api/playground/testing/tests/process/test_process_service_unit_tests.py
+++ b/packages/api/playground/testing/tests/process/test_process_service_unit_tests.py
@@ -163,6 +163,27 @@ class TestProcessServiceUnit:
             assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
+    async def test_get_all_process_instances_skips_record_that_fails_to_build(self, mock_locale_handler):
+        """A single instance whose DTO cannot be built must be skipped, not abort the whole sweep."""
+        mock_class_entity = Mock(spec=ProcessClassEntity)
+        mock_class_entity.is_online = True
+        mock_class_entity.process_class = "TestProcess"
+        good_config = Mock(spec=ProcessConfigEntityDocument)
+        good_config.process_id = "good"
+        bad_config = Mock(spec=ProcessConfigEntityDocument)
+        bad_config.process_id = "bad"
+
+        with patch.object(ProcessClassEntity, "get_all", return_value=[mock_class_entity]):
+            with patch.object(ProcessConfigEntityDocument, "find_for_class", return_value=[good_config, bad_config]):
+                with patch.object(FullProcessInstanceDTO, "from_class_and_config") as mock_from:
+                    good_dto = Mock(spec=FullProcessInstanceDTO)
+                    mock_from.side_effect = [good_dto, ValueError("could not build DTO")]
+
+                    result = await ProcessService.get_all_process_instances(mock_locale_handler)
+
+        assert result == [good_dto]
+
+    @pytest.mark.asyncio
     async def test_send_event_success(self, mock_user_identity):
         """Test send_event successfully sends event to process."""
         event = HumanStartEvent(

--- a/packages/api/swiss_ai_hub/api/routes/agent/agent_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/agent/agent_service.py
@@ -43,6 +43,7 @@ from swiss_ai_hub.api.routes.thread.thread_service import ThreadService
 from swiss_ai_hub.api.services.model_creation_service import ModelCreationService
 from swiss_ai_hub.api.util.config_authorization_service import ConfigAuthorizationService
 from swiss_ai_hub.api.util.instance_config_helper import InstanceConfigHelper
+from swiss_ai_hub.api.util.instance_dto_builder import InstanceDtoBuilder
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +108,15 @@ class AgentService:
 
             configs = AgentConfigEntityDocument.find_for_name(agent_class=class_entity.agent_class, name=search)
             for config_entity in configs:
-                agents.append(FullAgentInstanceDTO.from_class_and_config(class_entity, config_entity, t))
+                dto = InstanceDtoBuilder.build_or_skip(
+                    lambda class_entity=class_entity, config_entity=config_entity: (
+                        FullAgentInstanceDTO.from_class_and_config(class_entity, config_entity, t)
+                    ),
+                    kind="agent instance",
+                    key=f"{class_entity.agent_class}/{getattr(config_entity, 'agent_id', '?')}",
+                )
+                if dto is not None:
+                    agents.append(dto)
         return agents
 
     @staticmethod

--- a/packages/api/swiss_ai_hub/api/routes/agent/dto/agent_config_dto.py
+++ b/packages/api/swiss_ai_hub/api/routes/agent/dto/agent_config_dto.py
@@ -51,8 +51,8 @@ class AgentConfigDTO(BaseModel):
         """
         form = [form_element.in_locale(t) for form_element in class_entity.form_elements] if class_entity.form else None
 
-        name = t.extract(config_entity.name.to_locale_string())
-        description = t.extract(config_entity.description.to_locale_string())
+        name = t.extract_required(config_entity.name.to_locale_string(), field_name="agent.name")
+        description = t.extract_required(config_entity.description.to_locale_string(), field_name="agent.description")
 
         icon = config_entity.icon
 

--- a/packages/api/swiss_ai_hub/api/routes/process/dto/full_process_instance_dto.py
+++ b/packages/api/swiss_ai_hub/api/routes/process/dto/full_process_instance_dto.py
@@ -69,7 +69,9 @@ class FullProcessInstanceDTO(MinimalProcessInstanceDTO):
         process_config_dto = ProcessConfigDTO(
             process_id=config_entity.process_id,
             name=t.extract_required(config_entity.name.to_locale_string(), field_name="process.name"),
-            description=t.extract_required(config_entity.description.to_locale_string(), field_name="process.description"),
+            description=t.extract_required(
+                config_entity.description.to_locale_string(), field_name="process.description"
+            ),
             icon=config_entity.icon,
         )
 

--- a/packages/api/swiss_ai_hub/api/routes/process/dto/full_process_instance_dto.py
+++ b/packages/api/swiss_ai_hub/api/routes/process/dto/full_process_instance_dto.py
@@ -68,8 +68,8 @@ class FullProcessInstanceDTO(MinimalProcessInstanceDTO):
         """
         process_config_dto = ProcessConfigDTO(
             process_id=config_entity.process_id,
-            name=t.extract(config_entity.name.to_locale_string()),
-            description=t.extract(config_entity.description.to_locale_string()),
+            name=t.extract_required(config_entity.name.to_locale_string(), field_name="process.name"),
+            description=t.extract_required(config_entity.description.to_locale_string(), field_name="process.description"),
             icon=config_entity.icon,
         )
 

--- a/packages/api/swiss_ai_hub/api/routes/process/dto/in_specs/human_in_dto.py
+++ b/packages/api/swiss_ai_hub/api/routes/process/dto/in_specs/human_in_dto.py
@@ -22,8 +22,8 @@ class HumanInDTO(BaseModel):
     @classmethod
     def from_human_in_specs(cls, human_in_specs: HumanInSpecs, t: LocaleHandler) -> Self:
         human_in_dto = cls(
-            name=t.extract(human_in_specs.name),
-            description=t.extract(human_in_specs.description),
+            name=t.extract_required(human_in_specs.name, field_name="human_input.name"),
+            description=t.extract_required(human_in_specs.description, field_name="human_input.description"),
             route=human_in_specs.route,
             method=human_in_specs.method,
             is_process_start=human_in_specs.is_process_start,
@@ -36,8 +36,10 @@ class HumanInDTO(BaseModel):
     @classmethod
     def from_entity_specs(cls, human_in_specs_entity: HumanInSpecsEntity, t: LocaleHandler) -> Self:
         human_in_dto = cls(
-            name=t.extract(human_in_specs_entity.name.to_locale_string()),
-            description=t.extract(human_in_specs_entity.description.to_locale_string()),
+            name=t.extract_required(human_in_specs_entity.name.to_locale_string(), field_name="human_input.name"),
+            description=t.extract_required(
+                human_in_specs_entity.description.to_locale_string(), field_name="human_input.description"
+            ),
             route=human_in_specs_entity.route,
             method=human_in_specs_entity.method,
             is_process_start=human_in_specs_entity.is_process_start,

--- a/packages/api/swiss_ai_hub/api/routes/process/dto/minimal_process_instance_dto.py
+++ b/packages/api/swiss_ai_hub/api/routes/process/dto/minimal_process_instance_dto.py
@@ -43,7 +43,9 @@ class MinimalProcessInstanceDTO(BaseModel):
         process_config_dto = ProcessConfigDTO(
             process_id=config_entity.process_id,
             name=t.extract_required(config_entity.name.to_locale_string(), field_name="process.name"),
-            description=t.extract_required(config_entity.description.to_locale_string(), field_name="process.description"),
+            description=t.extract_required(
+                config_entity.description.to_locale_string(), field_name="process.description"
+            ),
             icon=config_entity.icon,
         )
         return cls(

--- a/packages/api/swiss_ai_hub/api/routes/process/dto/minimal_process_instance_dto.py
+++ b/packages/api/swiss_ai_hub/api/routes/process/dto/minimal_process_instance_dto.py
@@ -42,8 +42,8 @@ class MinimalProcessInstanceDTO(BaseModel):
         """
         process_config_dto = ProcessConfigDTO(
             process_id=config_entity.process_id,
-            name=t.extract(config_entity.name.to_locale_string()),
-            description=t.extract(config_entity.description.to_locale_string()),
+            name=t.extract_required(config_entity.name.to_locale_string(), field_name="process.name"),
+            description=t.extract_required(config_entity.description.to_locale_string(), field_name="process.description"),
             icon=config_entity.icon,
         )
         return cls(

--- a/packages/api/swiss_ai_hub/api/routes/process/dto/process_config_dto.py
+++ b/packages/api/swiss_ai_hub/api/routes/process/dto/process_config_dto.py
@@ -17,7 +17,7 @@ class ProcessConfigDTO(BaseModel):
     def from_process_config(cls, process_config: ProcessConfig, t: LocaleHandler) -> Self:
         return cls(
             process_id=process_config.process_id,
-            name=t.extract(process_config.name),
-            description=t.extract(process_config.description),
+            name=t.extract_required(process_config.name, field_name="process.name"),
+            description=t.extract_required(process_config.description, field_name="process.description"),
             icon=process_config.icon,
         )

--- a/packages/api/swiss_ai_hub/api/routes/process/process_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/process/process_service.py
@@ -290,8 +290,8 @@ class ProcessService:
         configs = ProcessConfigEntityDocument.find_for_class(process_class)
         for config_entity in configs:
             dto = InstanceDtoBuilder.build_or_skip(
-                lambda config_entity=config_entity: (
-                    FullProcessInstanceDTO.from_class_and_config(class_entity, config_entity, t)
+                lambda config_entity=config_entity: FullProcessInstanceDTO.from_class_and_config(
+                    class_entity, config_entity, t
                 ),
                 kind="process instance",
                 key=f"{process_class}/{getattr(config_entity, 'process_id', '?')}",

--- a/packages/api/swiss_ai_hub/api/routes/process/process_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/process/process_service.py
@@ -28,6 +28,7 @@ from swiss_ai_hub.api.routes.process.dto.submitted_form_dto import SubmittedForm
 from swiss_ai_hub.api.services.model_creation_service import ModelCreationService
 from swiss_ai_hub.api.util.config_authorization_service import ConfigAuthorizationService
 from swiss_ai_hub.api.util.instance_config_helper import InstanceConfigHelper
+from swiss_ai_hub.api.util.instance_dto_builder import InstanceDtoBuilder
 
 
 class ProcessService:
@@ -95,8 +96,8 @@ class ProcessService:
                         )
 
                 process_human_input_dto = HumanInDTO(
-                    name=t.extract(human_in_specs.name),
-                    description=t.extract(human_in_specs.description),
+                    name=t.extract_required(human_in_specs.name, field_name="human_input.name"),
+                    description=t.extract_required(human_in_specs.description, field_name="human_input.description"),
                     route=human_in_specs.route,
                     method=human_in_specs.method,
                     form=work_form_elements,
@@ -288,7 +289,15 @@ class ProcessService:
         instances = []
         configs = ProcessConfigEntityDocument.find_for_class(process_class)
         for config_entity in configs:
-            instances.append(FullProcessInstanceDTO.from_class_and_config(class_entity, config_entity, t))
+            dto = InstanceDtoBuilder.build_or_skip(
+                lambda config_entity=config_entity: (
+                    FullProcessInstanceDTO.from_class_and_config(class_entity, config_entity, t)
+                ),
+                kind="process instance",
+                key=f"{process_class}/{getattr(config_entity, 'process_id', '?')}",
+            )
+            if dto is not None:
+                instances.append(dto)
         return instances
 
     @staticmethod
@@ -442,7 +451,15 @@ class ProcessService:
 
             configs = ProcessConfigEntityDocument.find_for_class(class_entity.process_class)
             for config_entity in configs:
-                instances.append(FullProcessInstanceDTO.from_class_and_config(class_entity, config_entity, t))
+                dto = InstanceDtoBuilder.build_or_skip(
+                    lambda class_entity=class_entity, config_entity=config_entity: (
+                        FullProcessInstanceDTO.from_class_and_config(class_entity, config_entity, t)
+                    ),
+                    kind="process instance",
+                    key=f"{class_entity.process_class}/{getattr(config_entity, 'process_id', '?')}",
+                )
+                if dto is not None:
+                    instances.append(dto)
         return instances
 
     # ==================== Walkthrough Methods ====================

--- a/packages/api/swiss_ai_hub/api/util/instance_dto_builder.py
+++ b/packages/api/swiss_ai_hub/api/util/instance_dto_builder.py
@@ -1,0 +1,32 @@
+import logging
+from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+
+class InstanceDtoBuilder:
+    """Isolates a single corrupt record when building instance DTOs for an aggregate read.
+
+    Endpoint-discovery sweeps and list endpoints iterate every persisted instance in one loop.
+    A single record that fails to serialize (missing field, decode error, or any other
+    unforeseen failure) must not abort the whole batch — historically one bad record took the
+    60s discovery sweep down and left the platform with no registered endpoints. The known
+    empty-locale case is already handled upstream by `LocaleHandler.extract_required`; this is
+    the net for everything else.
+
+    This deliberately deviates from the repo's fail-fast convention. The catch is intentionally
+    broad: the whole point of the resilience boundary is that *any* unexpected failure in one
+    record is contained, so narrowing to a fixed exception list would let a new error type
+    re-crash the sweep. Genuine bugs are not hidden — `logger.exception` records the full
+    traceback at ERROR level, so they remain visible in logs and monitoring; they simply no
+    longer take the aggregate read down with them.
+    """
+
+    @staticmethod
+    def build_or_skip[T](builder: Callable[[], T], *, kind: str, key: str) -> T | None:
+        """Run `builder`, returning its DTO, or `None` (logged) if it raises."""
+        try:
+            return builder()
+        except Exception:
+            logger.exception("Skipping %s %s: could not build its DTO.", kind, key)
+            return None

--- a/packages/core/swiss_ai_hub/core/i18n/locale_handler.py
+++ b/packages/core/swiss_ai_hub/core/i18n/locale_handler.py
@@ -78,7 +78,7 @@ class LocaleHandler:
         available_locales = list(locale_data.keys())
         if available_locales:
             return locale_data[available_locales[0]]
-        raise ValueError("No language keys available")
+        return None
 
     def extract_multi_locale(self, locale_data: dict[str, Any] | LocaleString, locale: str | None = None) -> Any:
         locale = self.get_locale(locale)
@@ -91,7 +91,21 @@ class LocaleHandler:
         available_locales = [field for field in self.LOCALE_WHITE_LIST if getattr(locale_data, field, None)]
         if available_locales:
             return getattr(locale_data, available_locales[0])
-        raise ValueError("No language keys available")
+        return None
+
+    def extract_required(self, locale_data: dict[str, Any] | LocaleString, field_name: str | None = None) -> str:
+        """Extract a localized value for a required string field, coercing an unset value to `""`.
+
+        Required DTO fields must render even when a record has no populated locale (legitimate,
+        since the storage columns are optional). Returning `""` instead of `None` keeps a single
+        empty record from aborting an aggregate read such as the endpoint-discovery sweep, and the
+        warning keeps that malformed record discoverable.
+        """
+        value = self.extract(locale_data)
+        if value:
+            return value
+        logger.warning("Localized field %r is empty in every locale; coercing to empty string.", field_name or "?")
+        return ""
 
     def t_object(self, key: str, locale: str | None = None) -> Any:
         locale = self.get_locale(locale)

--- a/packages/core/swiss_ai_hub/core/i18n/locale_string.py
+++ b/packages/core/swiss_ai_hub/core/i18n/locale_string.py
@@ -58,8 +58,8 @@ class LocaleString(BaseModel):
         """Extract the string for a locale, falling back to other locales if it is unset.
 
         With `fallback` (the default), mirrors `LocaleHandler.extract_multi_locale`:
-        requested locale → default locale → first populated locale in the whitelist;
-        unlike that method it returns None instead of raising when every locale is empty.
+        requested locale → default locale → first populated locale in the whitelist,
+        returning None when every locale is empty.
 
         Pass `fallback=False` to read exactly the requested locale (no substitution) — for
         callers that need the requested language verbatim or want their own fallback order.

--- a/packages/core/swiss_ai_hub/core/i18n/tests/unit/test_locale_handler.py
+++ b/packages/core/swiss_ai_hub/core/i18n/tests/unit/test_locale_handler.py
@@ -91,6 +91,27 @@ def test_extract_from_multi_locale_with_missing_locale_returns_first_available()
     assert LocaleHandler().extract(partial_locale_data, "de") == "Agente di ricerca"
 
 
+def test_extract_from_empty_multi_locale_returns_none():
+    assert LocaleHandler().extract(LocaleString(), "de") is None
+
+
+def test_extract_from_dict_with_only_none_values_returns_none():
+    assert LocaleHandler().extract({"de": None}, "de") is None
+
+
+def test_extract_dict_with_no_locales_returns_none():
+    # Reached only by calling extract_dict directly: extract() short-circuits an empty dict to None.
+    assert LocaleHandler().extract_dict({}, "de") is None
+
+
+def test_extract_required_coerces_empty_locale_to_empty_string():
+    assert LocaleHandler().extract_required(LocaleString()) == ""
+
+
+def test_extract_required_returns_value_when_populated():
+    assert LocaleHandler().extract_required(LocaleString(en="Search-Agent")) == "Search-Agent"
+
+
 def test_t_object_with_nonexistent_file_raises_file_not_found_error():
     with pytest.raises(FileNotFoundError):
         LocaleHandler().t_object("nonexistent.folder.name", "de")


### PR DESCRIPTION
## Forward-port of #1668 (release/0.317 → main)

Cherry-picks the empty-locale endpoint-discovery fix (merged to `release/0.317` as the `v0.317.1` hotfix) onto `main`, so the next release line (`0.318`) keeps the fix instead of regressing it.

- Cherry-picked commit: `81d066db` (squash-merge of #1668).
- Clean cherry-pick, no conflicts (13 files, +183/-21).
- **Only the fix commit is forward-ported** — the `chore: Bump version to 0.317.1` commit stays on the release line.

### What the fix does (recap)
`AgentService.get_all_agent_instances` (and the process equivalent) crashed the whole 60s endpoint-discovery sweep when a single instance had an all-empty localized `description` (`ValueError: No language keys available`). This hardens the read side:
- `LocaleHandler.extract_multi_locale` / `extract_dict` return `None` instead of raising; `extract_required` coerces required DTO fields to `""` (logged).
- `InstanceDtoBuilder.build_or_skip` isolates a corrupt record per-item so one bad instance can't abort the aggregate read.
- Unit tests for the empty-locale path (core i18n + api agent/process service).

See #1668 for full context.