### PR TITLE
fix(ci-cd): Fix promote hotfix dispatch (GH_REPO) and downstream move-latest skip

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -306,7 +306,14 @@ jobs:
   # rc: retag images :CLEAN only, so set-latest.yml moves git+docker :latest.
   move-latest-rc:
     name: Move latest (rc)
-    if: ${{ github.event.inputs.source_tag != '' && needs.resolve.outputs.is_backport != 'true' }}
+    # always() + explicit result checks: build-release uses if: always(), so a
+    # plain if here would be skipped as a downstream of a conditional job.
+    if: >-
+      always()
+      && needs.resolve.result == 'success'
+      && needs.build-release.result == 'success'
+      && github.event.inputs.source_tag != ''
+      && needs.resolve.outputs.is_backport != 'true'
     runs-on: ubuntu-slim
     timeout-minutes: 5
     needs: [resolve, build-release]
@@ -327,7 +334,12 @@ jobs:
   # docker retag against the async hotfix image builds.
   move-latest-hotfix:
     name: Move latest (hotfix)
-    if: ${{ github.event.inputs.hotfix_branch != '' && needs.resolve.outputs.is_backport != 'true' }}
+    if: >-
+      always()
+      && needs.resolve.result == 'success'
+      && needs.build-release.result == 'success'
+      && github.event.inputs.hotfix_branch != ''
+      && needs.resolve.outputs.is_backport != 'true'
     runs-on: ubuntu-slim
     timeout-minutes: 5
     needs: [resolve, build-release]
@@ -353,7 +365,11 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 5
     needs: [resolve, build-release]
-    if: needs.resolve.outputs.is_backport == 'true'
+    if: >-
+      always()
+      && needs.resolve.result == 'success'
+      && needs.build-release.result == 'success'
+      && needs.resolve.outputs.is_backport == 'true'
     steps:
       - name: Log backport outcome
         env:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -252,6 +252,7 @@ jobs:
       - name: Dispatch build workflows at the clean tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           VERSION: ${{ needs.resolve.outputs.clean }}
           SECONDARY: ${{ needs.resolve.outputs.secondary_tag }}
         run: |-
@@ -313,6 +314,7 @@ jobs:
       - name: Dispatch set-latest for the clean version
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           CLEAN: ${{ needs.resolve.outputs.clean }}
         run: |-
           set -euo pipefail


### PR DESCRIPTION
## Problem

The `build-hotfix-images` and `move-latest-rc` jobs in `promote.yml` run `gh workflow run` **without checking out the repo and without `GH_REPO`**, so `gh` falls back to shelling out to git to infer the repo and dies:

```
Dispatching build-agents.yml @ v0.317.1 (secondary_tag='latest')
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

Hit live promoting the `v0.317.1` hotfix: resolve/bump/tag/npm/PyPI all succeeded, but the hotfix image fan-out failed, so no `v0.317.1` images were built. (Same latent gap existed in the old `hotfix-promote.yml` fan-out — never exercised. `move-latest-rc` has it too, which would break the rc path's `latest` move.)

## Fix

Add `GH_REPO: ${{ github.repository }}` to both dispatch jobs' env, so `gh` resolves the repo from the env instead of git. No checkout needed.

## Note (v0.317.1 remediation)

The `v0.317.1` image builds were dispatched manually as a one-off to unblock that release; this fixes the workflow so it never needs the manual step again.