### PR TITLE
fix(rag): Restore meta-question detection on weak instruction-followers

### DIFF
--- a/packages/agent/swiss_ai_hub/agent/self_awareness/meta_question_detector.py
+++ b/packages/agent/swiss_ai_hub/agent/self_awareness/meta_question_detector.py
@@ -27,17 +27,31 @@ REASONING_DISABLED_EXTRA_BODY = {"chat_template_kwargs": {"thinking": False, "en
 # Reasoning models on Infomaniak cannot reliably produce structured output (tool calls / JSON) but are
 # reliable at emitting a single free-text label, so detection classifies via a plain-text token. Tokens
 # are language-agnostic; the model reads the (any-language) user message and emits the English token.
-_CLASSIFICATION_PROMPT = """You decide whether a user's message is a "meta question" about the AI assistant \
-itself, or a NORMAL task/question to be answered from documents.
+#
+# Prompt shape decides whether a weak instruction-follower can use this at all. An earlier revision listed
+# NORMAL first with the longest elaboration and closed with "When in doubt, answer NORMAL." — on Apertus-70B
+# that collapsed to NORMAL for *every* meta question, including the prompt's own verbatim examples, so the
+# self-awareness branch became unreachable. Hence three properties worth preserving: META_ labels lead,
+# the "do you know X?" lookalike carve-outs live inside NORMAL's own definition rather than as a closing
+# tie-breaker, and each label carries non-English anchors (without them "Was kannst du?" reads as NORMAL).
+_CLASSIFICATION_PROMPT = """You classify a user's message to an AI assistant. Decide what the message is \
+*about*: the assistant itself, or the world.
+
+The message may be in any language; always reply with the English token.
 
 Reply with EXACTLY ONE token on the final line, and nothing else:
-- NORMAL — a task, or a question about a topic, place, person, entity, or field of knowledge — even when \
-phrased "do you know X?", "what do you know about X?", or "what can I do with this document?".
-- META_IDENTITY — who or what the assistant is (e.g. "who are you?", "what is your name?").
-- META_CAPABILITIES — what the assistant can do in general (e.g. "what can you do?", "can you help me?").
-- META_BEHAVIOR — why the assistant did something, or how it works (e.g. "why did you answer that way?").
+- META_IDENTITY — who or what the assistant is. "who are you?", "what is your name?", "are you a human?", \
+"Wer bist du?", "Qui es-tu ?", "Chi sei?"
+- META_CAPABILITIES — what the assistant can or cannot do, or what to use it for. "what can you do?", \
+"can you help me?", "what are your limits?", "Was kannst du?", "Que peux-tu faire ?", "Cosa sai fare?"
+- META_BEHAVIOR — why the assistant did something, or how it works internally. "why did you answer that \
+way?", "how do you work?", "where did you get that from?", "Wie funktionierst du?", "Comment fonctionnes-tu ?"
+- NORMAL — everything else: a task to perform, or a question about a topic, place, person, organization, \
+document, or field of knowledge — even when phrased "do you know X?", "what do you know about X?", or \
+"what can I do with this document?".
 
-When in doubt, answer NORMAL.
+Decide by the subject of the message: if the subject is the assistant, pick the matching META_ label; if it \
+is anything else, pick NORMAL.
 
 User message: "{user_query}"
 Answer:"""
@@ -67,7 +81,9 @@ async def detect_meta_question(llm: LLM, t: LocaleHandler, user_query: str) -> M
             response = await llm.achat([message], extra_body=REASONING_DISABLED_EXTRA_BODY)
         except BadRequestError:
             response = await llm.achat([message])
-        label = _parse_label(str(response.message.content))
+        raw_answer = str(response.message.content)
+        label = _parse_label(raw_answer)
+        degraded_reason = None if label is not None else f"unrecognized classification {raw_answer.strip()[:80]!r}"
     except (APIError, ValueError, TypeError) as detection_failure:
         # Detection gates every chat message, so a transient gateway error (timeout, connection,
         # rate-limit, 5xx — all openai.APIError) or an unparseable response must degrade to the normal
@@ -76,6 +92,7 @@ async def detect_meta_question(llm: LLM, t: LocaleHandler, user_query: str) -> M
             "Meta-question detection failed (%s); treating as a normal question.", type(detection_failure).__name__
         )
         label = None
+        degraded_reason = f"detection call failed ({type(detection_failure).__name__})"
 
     category = _LABEL_TO_CATEGORY.get(label or "")
     if category is not None:
@@ -83,6 +100,14 @@ async def detect_meta_question(llm: LLM, t: LocaleHandler, user_query: str) -> M
             is_meta_question=True,
             category=category,
             reasoning="Classified as a meta question about the assistant.",
+        )
+    # Spell out *why* the normal pipeline was chosen: a genuine NORMAL verdict and a degraded fallback used to
+    # emit the same reasoning, which made a silently-failing classifier indistinguishable from a working one
+    # in the persisted event log.
+    if degraded_reason is not None:
+        return MetaQuestionClassification(
+            is_meta_question=False,
+            reasoning=f"Defaulted to a normal task for the assistant: {degraded_reason}.",
         )
     return MetaQuestionClassification(
         is_meta_question=False,

--- a/packages/agent/swiss_ai_hub/agent/self_awareness/tests/test_do_detect_meta_question.py
+++ b/packages/agent/swiss_ai_hub/agent/self_awareness/tests/test_do_detect_meta_question.py
@@ -102,6 +102,7 @@ async def test_unrecognized_label_falls_back_to_gate(displayer, locale_handler):
     )
 
     assert isinstance(result, NotAMetaQuestionEvent)
+    assert "unrecognized classification" in result.reasoning
 
 
 @pytest.mark.asyncio
@@ -119,3 +120,44 @@ async def test_transport_error_falls_back_to_gate(displayer, locale_handler):
     )
 
     assert isinstance(result, NotAMetaQuestionEvent)
+    assert "detection call failed" in result.reasoning
+
+
+@pytest.mark.asyncio
+async def test_degraded_fallback_is_distinguishable_from_a_genuine_normal_verdict(displayer, locale_handler):
+    """A silently-failing classifier used to be indistinguishable from a working one in the event log."""
+    verdict = await do_detect_meta_question(
+        user_query="What is the vacation policy?",
+        llm_config=_llm_config(_llm_returning("NORMAL")),
+        displayer=displayer,
+        t=locale_handler,
+    )
+    degraded = await do_detect_meta_question(
+        user_query="What is the vacation policy?",
+        llm_config=_llm_config(_llm_returning("no idea")),
+        displayer=displayer,
+        t=locale_handler,
+    )
+
+    assert verdict.reasoning != degraded.reasoning
+
+
+@pytest.mark.parametrize(
+    ("label", "category"),
+    [
+        ("META_IDENTITY", "identity"),
+        ("META_CAPABILITIES", "capabilities"),
+        ("META_BEHAVIOR", "behavior"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_every_meta_label_maps_to_its_category(label, category, displayer, locale_handler):
+    result = await do_detect_meta_question(
+        user_query="who are you?",
+        llm_config=_llm_config(_llm_returning(label)),
+        displayer=displayer,
+        t=locale_handler,
+    )
+
+    assert isinstance(result, MetaQuestionDetectedEvent)
+    assert result.category == category


### PR DESCRIPTION
## Problem

Asking the RAG Agent a meta question (`who are you?`, `what can you do?`) ran the **normal retrieval pipeline** instead of the self-awareness branch.

The routing was never at fault. The classifier had **collapsed to a single output class**: on `Apertus-70B-Instruct-2509` it returned `NORMAL` for every message, including the classification prompt's own verbatim examples. `NORMAL` maps to no category, so detection always emitted `NotAMetaQuestionEvent` — which is precisely the gate-opening event:

```
label = "NORMAL"  →  _LABEL_TO_CATEGORY.get("NORMAL") is None  →  NotAMetaQuestionEvent  →  gate opens
```

The score shape distinguished a collapsed classifier from a merely inaccurate one: **3/8, and those three were exactly the three `NORMAL` cases** — 100% of negatives, 0% of positives.

## Root cause

Two properties of the prompt text, both pushing the same direction on a weak instruction-follower:

1. **`NORMAL` was listed first and defined at the greatest length**, including the "even when phrased *do you know X?*" carve-outs. Position plus mass made it read as the dominant class rather than one of four.
2. **The prompt closed with `When in doubt, answer NORMAL.`** — the last instruction before the user message. Intended as a tie-breaker; read as a standing default.

Not sampling noise: identical results at T=0.2 and T=0.0.

## Fix

Reshape the prompt, preserving the single-token mechanism from ADR `2026_06_29_resilience_for_reasoning_models_on_infomaniak`:

- META_ labels lead; `NORMAL` becomes "everything else"
- Closing tie-breaker replaced with a subject test — *if the subject is the assistant → META_, else NORMAL*
- Lookalike carve-outs kept, but inside `NORMAL`'s own definition rather than as a global default
- Native-language anchors per label for de/fr/it — the English examples did not transfer on their own (`Was kannst du?` still read as `NORMAL`)

Ablation on Apertus-70B: dropping the closing clause alone → 6/8; also reordering META first → 7/8; adding native anchors → **25/26 with zero false positives**.

Secondarily: a **degraded fallback** (gateway error, unparseable label) and a **genuine `NORMAL` verdict** emitted *identical* `reasoning` strings, so a silently-failing classifier was indistinguishable from a working one in the persisted `agent_events` log. That is what made this bug present as a gateway error. They are now distinguishable.

## Verification

Measured against the live gateway using the profile's own model and temperature (Apertus-70B @ T=0.2), driving the real `detect_meta_question`:

| | before | after |
|---|---|---|
| Meta questions routed to the self-awareness branch | 0 / 5 | **8 / 8** |
| Normal questions correctly left alone | 6 / 6 | **6 / 6** |

- `test_test_ragagent_answers_a_meta_question_about_itself_without_retrieval` (real end-to-end BDD) **failed on a clean tree and passes with this change**.
- Self-awareness unit tests: 35 passed, 3 skipped.
- No false positives introduced: `What is AI?` / `Was ist AI?` / `Qu'est-ce que l'IA?` returned `NORMAL` on 16/16 calls — checked specifically because the RAG multilanguage tests use those queries.

New test coverage: every META_ label maps to its category; the degraded fallback is asserted to be distinguishable from a genuine `NORMAL` verdict.

## Pre-existing failures, not from this change

`make test` in `packages/agent` reports 7 failures / 319 passed. All 7 are `self_hosted` tests that depend on live LLM calls, and all were verified independent of this change:

- `test_rag_agent.py::...multilanguage_system_prompt[en|de|fr]` — fail identically on a clean tree (`StopIteration: No event of class LLMEvent`), i.e. gateway latency
- `test_followup_affirmation`, `test_rag_agent_meta_routing.py` (both), `test_user_memory_agent.py::test_verify_stored_memory_content` — pre-existing; the meta-routing ones stub detection out entirely and so cannot be affected by a prompt change

These are excluded from lean CI. Worth noting they fail *open* under gateway latency: a timeout hits the graceful-degradation path, yielding `NotAMetaQuestionEvent` — which the new `reasoning` string now makes visible in the event log.

## Follow-up (not in this PR)

`task_llm` is `null` on the `shared-knowledge-rag` profile, so detection inherits the main answer model and its temperature. Detection quality therefore moves with whatever is set as the answer model. Setting `task_llm` explicitly would decouple the two — that is what the field exists for.