### PR TITLE
fix(ui): Move e2e make targets from packages/web to e2e

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,0 +1,11 @@
+e2e:
+	pnpm test:e2e
+
+e2e-headed:
+	pnpm test:e2e:headed
+
+e2e-ui:
+	pnpm test:e2e:ui
+
+e2e-install:
+	pnpm install && npx playwright install chromium

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -2,9 +2,9 @@
   "name": "swiss-ai-hub-e2e",
   "private": true,
   "scripts": {
-    "test": "playwright test",
-    "test:ui": "playwright test --ui",
-    "test:headed": "playwright test --headed"
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed"
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0"

--- a/packages/web/Makefile
+++ b/packages/web/Makefile
@@ -18,15 +18,3 @@ build:
 
 generate-sdk:
 	pnpm generate-sdk
-
-e2e:
-	pnpm test:e2e
-
-e2e-headed:
-	pnpm test:e2e:headed
-
-e2e-ui:
-	pnpm test:e2e:ui
-
-e2e-install:
-	pnpm install && npx playwright install chromium


### PR DESCRIPTION
Closes #1237

## Context

`packages/web/Makefile` defined four targets — `e2e`, `e2e-headed`, `e2e-ui`, `e2e-install` — that each invoked a `pnpm test:e2e*` script. No such script exists in `packages/web/swiss_ai_hub_web/package.json`, so every one of them errored out:

```
$ make -C packages/web e2e
pnpm test:e2e
ERR_PNPM_NO_SCRIPT  Missing script: test:e2e
```

The Playwright suite they were meant to drive lives in `e2e/`, which is its own pnpm workspace (`e2e/pnpm-workspace.yaml`) with `@playwright/test` as its only dependency. The targets were pointing at the wrong workspace, which is misleading for contributors reading the Makefile as the "how do I run tests" entry point.

## Change

- **New `e2e/Makefile`** — the four targets moved verbatim, now next to the suite they run.
- **`e2e/package.json`** — scripts renamed to the names the targets call: `test` → `test:e2e`, `test:ui` → `test:e2e:ui`, `test:headed` → `test:e2e:headed`.
- **`packages/web/Makefile`** — the four dead targets removed. Its remaining targets (`pr-ready`, `format`, `lint`, `test`, `dev`, `build`, `generate-sdk`) all map to scripts that exist.

## Verification

```
$ make -C e2e -n e2e e2e-headed e2e-ui e2e-install
pnpm test:e2e
pnpm test:e2e:headed
pnpm test:e2e:ui
pnpm install && npx playwright install chromium
```

All four resolve. No dangling callers left behind: `grep` across the root `Makefile`, `.github/workflows/`, and all Markdown found no other reference to the old `packages/web` e2e targets or to the old `test`/`test:ui`/`test:headed` script names.

Root `make test` does not invoke e2e — unchanged by this PR, since the suite needs a running stack.

## Acceptance criteria

- [x] No `make` target in `packages/web/Makefile` references a `pnpm` script that doesn't exist
- [x] Make commands for e2e tests moved to `/e2e`