### PR TITLE
fix(deploy): Keep agent answers contiguous in the OpenWebUI pipeline

### DIFF
--- a/infra/configs/openwebui/functions/aihub_pipeline.py
+++ b/infra/configs/openwebui/functions/aihub_pipeline.py
@@ -124,13 +124,17 @@ class ThinkingBlock(ContentBlock):
 
     def to_html(self) -> Annotated[str, "HTML details element"]:
         """Convert to HTML details element for reasoning display"""
-        if self.closed and self.duration:
-            return (
-                f'\n<details type="reasoning" done="true" duration="{self.duration}">\n'
-                f"{self.content.strip()}\n"
-                f"</details>\n"
-            )
-        return f'\n<details type="reasoning" done="false">\n{self.content.strip()}</details>\n'
+        if not self.closed:
+            return f'\n<details type="reasoning" done="false">\n{self.content.strip()}</details>\n'
+        # A sub-second thought has a duration of 0. Keep it done="true" — gating done on a truthy
+        # duration made fast thoughts render as an unfinished "Thought" — and just drop the attribute,
+        # since OpenWebUI omits the "for N seconds" suffix when there is nothing to report.
+        duration_attribute = f' duration="{self.duration}"' if self.duration else ""
+        return (
+            f'\n<details type="reasoning" done="true"{duration_attribute}>\n'
+            f"{self.content.strip()}\n"
+            f"</details>\n"
+        )
 
     def is_complete(self) -> Annotated[bool, "Whether block has content"]:
         """Thinking blocks are complete when they have content"""
@@ -357,6 +361,9 @@ class StreamingStateManager:
     def __init__(self):
         self._content_blocks: Annotated[list[ContentBlock], "List of finalized content blocks"] = []
         self._current_block: Annotated[Optional[ContentBlock], "Currently active block being built"] = None
+        self._deferred_thinking: Annotated[
+            Optional[ThinkingBlock], "Thoughts that arrived while an answer was streaming"
+        ] = None
         self._block_factory = ContentBlockFactory()
 
     def start_text_block(self, content: Annotated[str, "Initial text content"] = "") -> None:
@@ -374,6 +381,15 @@ class StreamingStateManager:
 
     def start_thinking_block(self, content: Annotated[str, "Initial reasoning content"] = "") -> None:
         """Start or append to thinking block"""
+        # A thought arriving while an answer is streaming comes from a step running concurrently with
+        # it (title generation, follow-up questions), not from the answer itself — display events carry
+        # no step identity, so arrival order is all we have. Opening a block here would finalize the
+        # text block and cut the answer into two paragraphs with a "Thought" wedged between them, so
+        # redirect it to the run's existing reasoning block and keep the answer contiguous.
+        if isinstance(self._current_block, TextBlock):
+            self._defer_thought(content)
+            return
+
         # Close any open tool blocks
         self._close_tool_block_if_open()
 
@@ -395,6 +411,8 @@ class StreamingStateManager:
         # Close any open blocks
         self._close_open_blocks()
         self._finalize_current_block()
+        # A tool call ends the current phase, so deferred thoughts belong before it, not after the run.
+        self._flush_deferred_thoughts()
 
         self._current_block = self._block_factory.create_tool_block(
             tool_id=tool_id, tool_name=tool_name, tool_params=tool_params
@@ -417,6 +435,41 @@ class StreamingStateManager:
         """Finalize all blocks when stream ends"""
         self._close_open_blocks()
         self._finalize_current_block()
+        self._flush_deferred_thoughts()
+
+    def _defer_thought(self, content: Annotated[str, "Reasoning content to defer"]) -> None:
+        """Route a thought that arrived mid-answer out of the answer's way.
+
+        Preferred target is the reasoning block the run already opened, so one message carries one
+        collapsible and the answer stays last on screen. Its recorded duration is left untouched:
+        the block measures the pre-answer thinking, and stretching it across the answer this thought
+        arrived during would report a wait the user never had.
+        """
+        merge_index = self._last_thinking_block_index()
+        if merge_index is not None:
+            self._content_blocks[merge_index] = self._content_blocks[merge_index].with_content(content)
+            return
+
+        # Nothing to merge into (the run streamed an answer without thinking first), so hold the
+        # thought for a trailing block rather than splitting the answer to place it.
+        block = self._deferred_thinking or self._block_factory.create_thinking_block()
+        self._deferred_thinking = block.with_content(content).with_closure()
+
+    def _last_thinking_block_index(self) -> Annotated[Optional[int], "Index of the newest finalized thinking block"]:
+        """Locate the run's existing reasoning block, if it has one"""
+        for index in reversed(range(len(self._content_blocks))):
+            if isinstance(self._content_blocks[index], ThinkingBlock):
+                return index
+        return None
+
+    def _flush_deferred_thoughts(self) -> None:
+        """Move deferred thoughts behind the content they were held back for"""
+        if not self._deferred_thinking:
+            return
+
+        self._finalize_current_block()
+        self._content_blocks.append(self._deferred_thinking)
+        self._deferred_thinking = None
 
     def _close_open_blocks(self) -> None:
         """Close any blocks that need closing (tool or thinking)"""
@@ -450,6 +503,11 @@ class StreamingStateManager:
         # Render current block if exists
         if self._current_block:
             html_parts.append(self._current_block.to_html())
+
+        # Deferred thoughts render live at the tail so reasoning stays visible while it happens; the
+        # answer above them keeps growing, and flushing later lands them in this same position.
+        if self._deferred_thinking:
+            html_parts.append(self._deferred_thinking.to_html())
 
         return "".join(html_parts)
 

--- a/infra/deployment/CLAUDE.md
+++ b/infra/deployment/CLAUDE.md
@@ -67,6 +67,30 @@ make generate-compose  →  uv run python deployment/generate_compose.py
 **After ANY change to templates or `compose-config.yml`**: run `make generate-compose` and commit BOTH the template
 changes AND the regenerated output files.
 
+Note that `make generate-compose` also runs `make format-yaml`, which is repo-wide: if any YAML outside `infra/` is not
+yamlfix-clean on `main`, it gets reformatted into your working tree. Revert that churn before committing so the diff
+stays reviewable.
+
+### Applying an OpenWebUI function change to a running stack
+
+`configs/openwebui/functions/*.py` is **not** what OpenWebUI executes. The one-shot `openwebui-init` container reads
+those files and upserts each one into the `function` table of the `openwebui` PostgreSQL database (`init-openwebui.sh`,
+`ON CONFLICT DO UPDATE`); OpenWebUI runs the row, and `open-webui` does not even mount the functions directory. So
+editing a function — or regenerating it — changes nothing about the running pipe, and neither does restarting
+`open-webui` on its own, because the stale content is in the database. Re-register, then reload:
+
+```bash
+cd infra && docker compose -f docker-compose.dev.yml --env-file ../.env up openwebui-init
+docker restart open-webui   # re-imports the function module
+```
+
+Verify what is actually live rather than trusting the file:
+
+```bash
+docker exec postgres psql -U admin -d openwebui \
+  -tAc "select id, updated_at, length(content) from function where id='aihub-pipeline';"
+```
+
 ## The Stage x Hardware Matrix
 
 | Stage     | Traefik | SSL                | Domain               | 1st-party services | Local inference | Use case                 |

--- a/infra/deployment/templates/openwebui_functions/aihub_pipeline.py
+++ b/infra/deployment/templates/openwebui_functions/aihub_pipeline.py
@@ -124,13 +124,17 @@ class ThinkingBlock(ContentBlock):
 
     def to_html(self) -> Annotated[str, "HTML details element"]:
         """Convert to HTML details element for reasoning display"""
-        if self.closed and self.duration:
-            return (
-                f'\n<details type="reasoning" done="true" duration="{self.duration}">\n'
-                f"{self.content.strip()}\n"
-                f"</details>\n"
-            )
-        return f'\n<details type="reasoning" done="false">\n{self.content.strip()}</details>\n'
+        if not self.closed:
+            return f'\n<details type="reasoning" done="false">\n{self.content.strip()}</details>\n'
+        # A sub-second thought has a duration of 0. Keep it done="true" — gating done on a truthy
+        # duration made fast thoughts render as an unfinished "Thought" — and just drop the attribute,
+        # since OpenWebUI omits the "for N seconds" suffix when there is nothing to report.
+        duration_attribute = f' duration="{self.duration}"' if self.duration else ""
+        return (
+            f'\n<details type="reasoning" done="true"{duration_attribute}>\n'
+            f"{self.content.strip()}\n"
+            f"</details>\n"
+        )
 
     def is_complete(self) -> Annotated[bool, "Whether block has content"]:
         """Thinking blocks are complete when they have content"""
@@ -357,6 +361,9 @@ class StreamingStateManager:
     def __init__(self):
         self._content_blocks: Annotated[list[ContentBlock], "List of finalized content blocks"] = []
         self._current_block: Annotated[Optional[ContentBlock], "Currently active block being built"] = None
+        self._deferred_thinking: Annotated[
+            Optional[ThinkingBlock], "Thoughts that arrived while an answer was streaming"
+        ] = None
         self._block_factory = ContentBlockFactory()
 
     def start_text_block(self, content: Annotated[str, "Initial text content"] = "") -> None:
@@ -374,6 +381,15 @@ class StreamingStateManager:
 
     def start_thinking_block(self, content: Annotated[str, "Initial reasoning content"] = "") -> None:
         """Start or append to thinking block"""
+        # A thought arriving while an answer is streaming comes from a step running concurrently with
+        # it (title generation, follow-up questions), not from the answer itself — display events carry
+        # no step identity, so arrival order is all we have. Opening a block here would finalize the
+        # text block and cut the answer into two paragraphs with a "Thought" wedged between them, so
+        # redirect it to the run's existing reasoning block and keep the answer contiguous.
+        if isinstance(self._current_block, TextBlock):
+            self._defer_thought(content)
+            return
+
         # Close any open tool blocks
         self._close_tool_block_if_open()
 
@@ -395,6 +411,8 @@ class StreamingStateManager:
         # Close any open blocks
         self._close_open_blocks()
         self._finalize_current_block()
+        # A tool call ends the current phase, so deferred thoughts belong before it, not after the run.
+        self._flush_deferred_thoughts()
 
         self._current_block = self._block_factory.create_tool_block(
             tool_id=tool_id, tool_name=tool_name, tool_params=tool_params
@@ -417,6 +435,41 @@ class StreamingStateManager:
         """Finalize all blocks when stream ends"""
         self._close_open_blocks()
         self._finalize_current_block()
+        self._flush_deferred_thoughts()
+
+    def _defer_thought(self, content: Annotated[str, "Reasoning content to defer"]) -> None:
+        """Route a thought that arrived mid-answer out of the answer's way.
+
+        Preferred target is the reasoning block the run already opened, so one message carries one
+        collapsible and the answer stays last on screen. Its recorded duration is left untouched:
+        the block measures the pre-answer thinking, and stretching it across the answer this thought
+        arrived during would report a wait the user never had.
+        """
+        merge_index = self._last_thinking_block_index()
+        if merge_index is not None:
+            self._content_blocks[merge_index] = self._content_blocks[merge_index].with_content(content)
+            return
+
+        # Nothing to merge into (the run streamed an answer without thinking first), so hold the
+        # thought for a trailing block rather than splitting the answer to place it.
+        block = self._deferred_thinking or self._block_factory.create_thinking_block()
+        self._deferred_thinking = block.with_content(content).with_closure()
+
+    def _last_thinking_block_index(self) -> Annotated[Optional[int], "Index of the newest finalized thinking block"]:
+        """Locate the run's existing reasoning block, if it has one"""
+        for index in reversed(range(len(self._content_blocks))):
+            if isinstance(self._content_blocks[index], ThinkingBlock):
+                return index
+        return None
+
+    def _flush_deferred_thoughts(self) -> None:
+        """Move deferred thoughts behind the content they were held back for"""
+        if not self._deferred_thinking:
+            return
+
+        self._finalize_current_block()
+        self._content_blocks.append(self._deferred_thinking)
+        self._deferred_thinking = None
 
     def _close_open_blocks(self) -> None:
         """Close any blocks that need closing (tool or thinking)"""
@@ -450,6 +503,11 @@ class StreamingStateManager:
         # Render current block if exists
         if self._current_block:
             html_parts.append(self._current_block.to_html())
+
+        # Deferred thoughts render live at the tail so reasoning stays visible while it happens; the
+        # answer above them keeps growing, and flushing later lands them in this same position.
+        if self._deferred_thinking:
+            html_parts.append(self._deferred_thinking.to_html())
 
         return "".join(html_parts)
 


### PR DESCRIPTION
## Summary

A meta question answered by a self-aware agent renders in OpenWebUI as two paragraphs with a collapsed `Thought`
wedged between them, plus trailing `Thought` blocks that look unfinished. The answer is intact — the pipe's block
machine is driven purely by display-event arrival order, so a `ThoughtEvent` landing mid-stream finalizes the open text
block and opens a new reasoning block.

Those mid-stream thoughts are not the answer's own reasoning: title generation and follow-up questions run as steps
concurrent with the answer step (deliberately, per ADR `2026_06_18`), so their thoughts interleave with the answer's
chunks. Every self-aware blueprint is affected — `FewShotAgent`, `LLMWrappingAgent`, `RAGAgent` and `ExpertRAGAgent` all
fan the title step out in parallel; on `RAGAgent`/`ExpertRAGAgent` the normal (non-meta) path races too, since
`generate_conversation_title_step` is anchored on the early `LimitChatHistoryEvent`.

Rendered from a real captured run, before → after:

```
BEFORE: Thought(1s) → text → Thought → text → Thought
AFTER:  Thought(1s, all four lines) → the whole answer
```

## Changes

- `StreamingStateManager.start_thinking_block` redirects a thought that arrives while a text block is open into the
  reasoning block the run already opened, so one message carries one collapsible and the answer stays last on screen.
  The block's recorded duration is deliberately **not** extended — it measures the pre-answer thinking, and stretching
  it across the answer the late thought arrived during would report a wait the user never had.
- Falls back to a trailing block when the run streamed an answer with no thinking first (nothing to merge into), which
  keeps the answer contiguous rather than splitting it to place the thought. That fallback is flushed before a tool
  block, since a tool call is a genuine phase boundary.
- `ThinkingBlock.to_html` emits `done="true"` for any closed block and attaches `duration` only when non-zero. Gating
  `done` on a truthy duration made every sub-second thought render as an unfinished `Thought` — this is why the trailing
  blocks in the screenshots have no duration.
- Documents in `infra/deployment/CLAUDE.md` how a function change actually reaches a running stack: OpenWebUI executes
  the row in the `openwebui.function` table, not `configs/openwebui/functions/*.py`, so editing or regenerating a
  function does nothing until `openwebui-init` re-registers it and `open-webui` reloads the module — and a plain
  `docker restart open-webui` does not help, because the stale content is in the database. Also notes that
  `make generate-compose` runs a repo-wide `format-yaml` that pulls unrelated YAML churn into the working tree.

No agent, core or API code changes — agent logic, NATS events, the Admin UI event timeline and the bot channels are
untouched. Only OpenWebUI rendering changes.

## Test plan

There is no automated coverage for the OpenWebUI pipe functions (no test home for `infra/`, and the module imports
`open_webui.*`), so this was verified behaviorally rather than with new unit tests:

- **Replay against real data.** Pulled the display-event sequence of an actual meta-question run from
  `aihub.agent_events` and replayed it through both the `main` and patched modules. Asserted that the rendered answer is
  byte-identical to the concatenation of all `ChunkEvent` contents, sits in a single block, retains all four thoughts,
  and leaves nothing `done="false"` after finalize.
- **Other paths diffed before/after:** pre-answer-thoughts-only (the normal RAG shape), tool call mid-answer, HITL chat
  question, exception mid-answer, thought-only run, and the no-leading-thought fallback. The only behavioral deltas
  beyond the intended fix: a HITL question and an error message now continue the answer block instead of being pushed
  below a `Thought`. Tool block rendering is unchanged.
- **Live in the dev stack.** Re-registered via `openwebui-init`, restarted `open-webui`, and confirmed with the Support
  Ticket Classifier that a meta question renders as one reasoning block followed by the whole answer. Verified the live
  Postgres row matches the committed file (its only differences are the init script's dollar-quoted heredoc newlines and
  OpenWebUI's own `replace_imports` rewriting a comment on load).

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>` (see
  [CONTRIBUTING.md](https://github.com/bbvch-ai/aihub-core/blob/main/CONTRIBUTING.md))
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [x] CLA signed
- [ ] Tests added or updated where relevant — none added; see Test plan for why the pipe has no test harness and how
  this was verified instead
