### PR TITLE
fix(dagster): Make QueuedRunCoordinator max_concurrent_runs configurable via environment variable

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -216,8 +216,14 @@ MINERU_TABLE_ENABLE='true'
 # Invariant: 0.5 GB baseline + MINERU_API_MAX_CONCURRENT_REQUESTS x (MINERU_PAGE_BATCH_SIZE x ~30 MB)
 # must stay under the mineru-api container memory limit (4G). Raise only together with that limit.
 MINERU_API_MAX_CONCURRENT_REQUESTS='3'
-MINERU_PAGE_BATCH_SIZE='25'
-MINERU_MAX_CONCURRENT_BATCH_REQUESTS='2'
+MINERU_PAGE_BATCH_SIZE='20'
+MINERU_MAX_CONCURRENT_BATCH_REQUESTS='1'
+
+# Dagster Run Coordinator
+# Max pipeline runs executing in parallel (QueuedRunCoordinator). Sizing rule:
+# DAGSTER_MAX_CONCURRENT_RUNS x MINERU_MAX_CONCURRENT_BATCH_REQUESTS should not exceed
+# MINERU_API_MAX_CONCURRENT_REQUESTS, or bulk uploads exhaust the 503 retry budget.
+DAGSTER_MAX_CONCURRENT_RUNS='3'
 
 # Milvus Configuration
 MILVUS_DIMENSION='1024'

--- a/.env.prod
+++ b/.env.prod
@@ -196,8 +196,14 @@ MINERU_TABLE_ENABLE='true'
 # Invariant: 0.5 GB baseline + MINERU_API_MAX_CONCURRENT_REQUESTS x (MINERU_PAGE_BATCH_SIZE x ~30 MB)
 # must stay under the mineru-api container memory limit (4G). Raise only together with that limit.
 MINERU_API_MAX_CONCURRENT_REQUESTS='3'
-MINERU_PAGE_BATCH_SIZE='25'
-MINERU_MAX_CONCURRENT_BATCH_REQUESTS='2'
+MINERU_PAGE_BATCH_SIZE='20'
+MINERU_MAX_CONCURRENT_BATCH_REQUESTS='1'
+
+# Dagster Run Coordinator
+# Max pipeline runs executing in parallel (QueuedRunCoordinator). Sizing rule:
+# DAGSTER_MAX_CONCURRENT_RUNS x MINERU_MAX_CONCURRENT_BATCH_REQUESTS should not exceed
+# MINERU_API_MAX_CONCURRENT_REQUESTS, or bulk uploads exhaust the 503 retry budget.
+DAGSTER_MAX_CONCURRENT_RUNS='3'
 
 # Mem0
 MEM0_LLM_NAME='text-generation/gemma-4-31B-it'

--- a/docs/docs/2_platform/3_deployment_guide/9_environment_variables/index.en.md
+++ b/docs/docs/2_platform/3_deployment_guide/9_environment_variables/index.en.md
@@ -47,6 +47,7 @@ These variables are referenced as `${VAR}` (without a `${VAR:-default}` fallback
 | `DAGSTER_DB` |  | `backup-code` |  |
 | `DAGSTER_DEBUG_LOG_RETENTION_DAYS` |  | `backup-code` |  |
 | `DAGSTER_INFO_LOG_RETENTION_DAYS` |  | `backup-code` |  |
+| `DAGSTER_MAX_CONCURRENT_RUNS` |  | `dagster-daemon`, `dagster-webserver` |  |
 | `DAGSTER_UNIMPORTANT_EVENT_RETENTION_DAYS` |  | `backup-code` |  |
 | `DAGSTER_WARNING_LOG_RETENTION_DAYS` |  | `backup-code` |  |
 | `DOMAIN` | `30-clients.json`, `realm-settings.json` | `api`, `bot`, `default_rag_pipeline`, `expert_asking_agent`, `expert_rag_agent`, `few_shot_agent`, `imap_agent`, `keycloak`, `keycloak-config`, `langfuse-web`, `litellm`, `llm_wrapping_agent`, `memory_writer_agent`, `namespace_selection_agent`, `oauth2proxy-attu`, `oauth2proxy-backup`, `oauth2proxy-dagster`, `oauth2proxy-seaweed`, `open-webui`, `rag_agent`, `retrieval_agent`, `seaweedfs-s3`, `shared_rag_pipeline`, `sysadmin-api`, `sysadmin-web`, `traefik`, `web` |  |
@@ -255,6 +256,7 @@ These variables have sensible defaults (or are supplied to containers by docker-
 | `NOTIFICATION_MIN_INTERVAL_SECONDS` | `NotificationSettings.MIN_INTERVAL_SECONDS` | `30` | `default_rag_pipeline`, `shared_rag_pipeline` | Minimum interval between sensor ticks in seconds. |
 | `NOTIFICATION_TITLE_PREFIX` | `NotificationSettings.TITLE_PREFIX` | `'Swiss AI Hub Pipeline'` | `default_rag_pipeline`, `shared_rag_pipeline` | Prefix prepended to the notification title. |
 | `OPENWEBUI_BASE_URL` | `OpenWebuiSettings.BASE_URL` | _(supplied by compose)_ | `api`, `sysadmin-api` | OpenWebUI server base URL |
+| `OPENWEBUI_CONVERSATION_METADATA_MODEL` | `OpenWebuiSettings.CONVERSATION_METADATA_MODEL` | `'text-generation/gemma-4-31B-it'` | `api` | LiteLLM name (``capability/name``) of the model generating conversation metadata — chat titles and follow-up questions — for chats that have no agent behind them. OpenWebUI runs it under the end user's identity, so a role without access to this model loses both features silently; the access catalog flags the model for that reason. Same model as the OpenWebUI ``TASK_MODEL`` env var but in LiteLLM form, since that one names the workspace model wrapping it. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `OpenTelemetrySettings.EXPORTER_OTLP_ENDPOINT` | `None` | `api`, `expert_asking_agent`, `expert_rag_agent`, `few_shot_agent`, `imap_agent`, `litellm`, `llm_wrapping_agent`, `memory_writer_agent`, `namespace_selection_agent`, `open-webui`, `rag_agent`, `retrieval_agent`, `sysadmin-api` | OTLP exporter endpoint URL |
 | `OTEL_EXPORTER_OTLP_INSECURE` | `OpenTelemetrySettings.EXPORTER_OTLP_INSECURE` | `True` | `open-webui` | Use insecure connection (no TLS) for gRPC |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | `OpenTelemetrySettings.EXPORTER_OTLP_PROTOCOL` | `'grpc'` | `api`, `expert_asking_agent`, `expert_rag_agent`, `few_shot_agent`, `imap_agent`, `litellm`, `llm_wrapping_agent`, `memory_writer_agent`, `namespace_selection_agent`, `open-webui`, `rag_agent`, `retrieval_agent`, `sysadmin-api` | OTLP protocol |

--- a/infra/configs/dagster/dagster-config.build.gpu.yml
+++ b/infra/configs/dagster/dagster-config.build.gpu.yml
@@ -51,7 +51,8 @@ run_coordinator:
   module: dagster.core.run_coordinator
   class: QueuedRunCoordinator
   config:
-    max_concurrent_runs: 2
+    max_concurrent_runs:
+      env: DAGSTER_MAX_CONCURRENT_RUNS
 python_logs:
   python_log_level: INFO
   managed_python_loggers: [swiss_ai_hub]

--- a/infra/configs/dagster/dagster-config.build.yml
+++ b/infra/configs/dagster/dagster-config.build.yml
@@ -51,7 +51,8 @@ run_coordinator:
   module: dagster.core.run_coordinator
   class: QueuedRunCoordinator
   config:
-    max_concurrent_runs: 2
+    max_concurrent_runs:
+      env: DAGSTER_MAX_CONCURRENT_RUNS
 python_logs:
   python_log_level: INFO
   managed_python_loggers: [swiss_ai_hub]

--- a/infra/configs/dagster/dagster-config.dev.gpu.yml
+++ b/infra/configs/dagster/dagster-config.dev.gpu.yml
@@ -51,7 +51,8 @@ run_coordinator:
   module: dagster.core.run_coordinator
   class: QueuedRunCoordinator
   config:
-    max_concurrent_runs: 2
+    max_concurrent_runs:
+      env: DAGSTER_MAX_CONCURRENT_RUNS
 python_logs:
   python_log_level: INFO
   managed_python_loggers: [swiss_ai_hub]

--- a/infra/configs/dagster/dagster-config.dev.yml
+++ b/infra/configs/dagster/dagster-config.dev.yml
@@ -51,7 +51,8 @@ run_coordinator:
   module: dagster.core.run_coordinator
   class: QueuedRunCoordinator
   config:
-    max_concurrent_runs: 2
+    max_concurrent_runs:
+      env: DAGSTER_MAX_CONCURRENT_RUNS
 python_logs:
   python_log_level: INFO
   managed_python_loggers: [swiss_ai_hub]

--- a/infra/configs/dagster/dagster-config.latest.gpu.yml
+++ b/infra/configs/dagster/dagster-config.latest.gpu.yml
@@ -51,7 +51,8 @@ run_coordinator:
   module: dagster.core.run_coordinator
   class: QueuedRunCoordinator
   config:
-    max_concurrent_runs: 5
+    max_concurrent_runs:
+      env: DAGSTER_MAX_CONCURRENT_RUNS
 python_logs:
   python_log_level: INFO
   managed_python_loggers: [swiss_ai_hub]

--- a/infra/configs/dagster/dagster-config.latest.yml
+++ b/infra/configs/dagster/dagster-config.latest.yml
@@ -51,7 +51,8 @@ run_coordinator:
   module: dagster.core.run_coordinator
   class: QueuedRunCoordinator
   config:
-    max_concurrent_runs: 5
+    max_concurrent_runs:
+      env: DAGSTER_MAX_CONCURRENT_RUNS
 python_logs:
   python_log_level: INFO
   managed_python_loggers: [swiss_ai_hub]

--- a/infra/configs/dagster/dagster-config.local.gpu.yml
+++ b/infra/configs/dagster/dagster-config.local.gpu.yml
@@ -51,7 +51,8 @@ run_coordinator:
   module: dagster.core.run_coordinator
   class: QueuedRunCoordinator
   config:
-    max_concurrent_runs: 2
+    max_concurrent_runs:
+      env: DAGSTER_MAX_CONCURRENT_RUNS
 python_logs:
   python_log_level: INFO
   managed_python_loggers: [swiss_ai_hub]

--- a/infra/configs/dagster/dagster-config.local.yml
+++ b/infra/configs/dagster/dagster-config.local.yml
@@ -51,7 +51,8 @@ run_coordinator:
   module: dagster.core.run_coordinator
   class: QueuedRunCoordinator
   config:
-    max_concurrent_runs: 2
+    max_concurrent_runs:
+      env: DAGSTER_MAX_CONCURRENT_RUNS
 python_logs:
   python_log_level: INFO
   managed_python_loggers: [swiss_ai_hub]

--- a/infra/configs/dagster/dagster-config.nightly.gpu.yml
+++ b/infra/configs/dagster/dagster-config.nightly.gpu.yml
@@ -51,7 +51,8 @@ run_coordinator:
   module: dagster.core.run_coordinator
   class: QueuedRunCoordinator
   config:
-    max_concurrent_runs: 3
+    max_concurrent_runs:
+      env: DAGSTER_MAX_CONCURRENT_RUNS
 python_logs:
   python_log_level: INFO
   managed_python_loggers: [swiss_ai_hub]

--- a/infra/configs/dagster/dagster-config.nightly.yml
+++ b/infra/configs/dagster/dagster-config.nightly.yml
@@ -51,7 +51,8 @@ run_coordinator:
   module: dagster.core.run_coordinator
   class: QueuedRunCoordinator
   config:
-    max_concurrent_runs: 3
+    max_concurrent_runs:
+      env: DAGSTER_MAX_CONCURRENT_RUNS
 python_logs:
   python_log_level: INFO
   managed_python_loggers: [swiss_ai_hub]

--- a/infra/deployment/templates/configs/dagster-config.yml.j2
+++ b/infra/deployment/templates/configs/dagster-config.yml.j2
@@ -84,15 +84,8 @@ run_coordinator:
   module: dagster.core.run_coordinator
   class: QueuedRunCoordinator
   config:
-{%- if stage == "local" %}
-    max_concurrent_runs: 2
-{%- elif stage == "nightly" %}
-    max_concurrent_runs: 3
-{%- elif stage == "latest" %}
-    max_concurrent_runs: 5
-{%- else %}
-    max_concurrent_runs: 2
-{%- endif %}
+    max_concurrent_runs:
+      env: DAGSTER_MAX_CONCURRENT_RUNS
 
 python_logs:
   python_log_level: INFO

--- a/infra/deployment/templates/docker-compose.yml.j2
+++ b/infra/deployment/templates/docker-compose.yml.j2
@@ -2592,6 +2592,7 @@ services:
       DAGSTER_HOME: /dagster_home
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
       LOG_LEVEL: ${LOG_LEVEL}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/server_info"]
@@ -2633,6 +2634,7 @@ services:
       DAGSTER_HOME: /dagster_home
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
       LOG_LEVEL: ${LOG_LEVEL}
     healthcheck:
       test: ["CMD", "dagster-daemon", "liveness-check"]

--- a/infra/docker-compose.build.gpu.yml
+++ b/infra/docker-compose.build.gpu.yml
@@ -2305,6 +2305,7 @@ services:
       DAGSTER_HOME: /dagster_home
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
       LOG_LEVEL: ${LOG_LEVEL}
     healthcheck:
       test: [CMD, curl, -f, http://localhost:3000/server_info]
@@ -2340,6 +2341,7 @@ services:
       DAGSTER_HOME: /dagster_home
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
       LOG_LEVEL: ${LOG_LEVEL}
     healthcheck:
       test: [CMD, dagster-daemon, liveness-check]

--- a/infra/docker-compose.build.yml
+++ b/infra/docker-compose.build.yml
@@ -2093,6 +2093,7 @@ services:
       DAGSTER_HOME: /dagster_home
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
       LOG_LEVEL: ${LOG_LEVEL}
     healthcheck:
       test: [CMD, curl, -f, http://localhost:3000/server_info]
@@ -2128,6 +2129,7 @@ services:
       DAGSTER_HOME: /dagster_home
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
       LOG_LEVEL: ${LOG_LEVEL}
     healthcheck:
       test: [CMD, dagster-daemon, liveness-check]

--- a/infra/docker-compose.latest.gpu.yml
+++ b/infra/docker-compose.latest.gpu.yml
@@ -2258,6 +2258,7 @@ services:
       DAGSTER_HOME: /dagster_home
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
       LOG_LEVEL: ${LOG_LEVEL}
     healthcheck:
       test: [CMD, curl, -f, http://localhost:3000/server_info]
@@ -2291,6 +2292,7 @@ services:
       DAGSTER_HOME: /dagster_home
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
       LOG_LEVEL: ${LOG_LEVEL}
     healthcheck:
       test: [CMD, dagster-daemon, liveness-check]

--- a/infra/docker-compose.latest.yml
+++ b/infra/docker-compose.latest.yml
@@ -2052,6 +2052,7 @@ services:
       DAGSTER_HOME: /dagster_home
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
       LOG_LEVEL: ${LOG_LEVEL}
     healthcheck:
       test: [CMD, curl, -f, http://localhost:3000/server_info]
@@ -2085,6 +2086,7 @@ services:
       DAGSTER_HOME: /dagster_home
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
       LOG_LEVEL: ${LOG_LEVEL}
     healthcheck:
       test: [CMD, dagster-daemon, liveness-check]

--- a/infra/docker-compose.local.gpu.yml
+++ b/infra/docker-compose.local.gpu.yml
@@ -2296,6 +2296,7 @@ services:
       DAGSTER_HOME: /dagster_home
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
       LOG_LEVEL: ${LOG_LEVEL}
     healthcheck:
       test: [CMD, curl, -f, http://localhost:3000/server_info]
@@ -2329,6 +2330,7 @@ services:
       DAGSTER_HOME: /dagster_home
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
       LOG_LEVEL: ${LOG_LEVEL}
     healthcheck:
       test: [CMD, dagster-daemon, liveness-check]

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -2084,6 +2084,7 @@ services:
       DAGSTER_HOME: /dagster_home
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
       LOG_LEVEL: ${LOG_LEVEL}
     healthcheck:
       test: [CMD, curl, -f, http://localhost:3000/server_info]
@@ -2117,6 +2118,7 @@ services:
       DAGSTER_HOME: /dagster_home
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
       LOG_LEVEL: ${LOG_LEVEL}
     healthcheck:
       test: [CMD, dagster-daemon, liveness-check]

--- a/infra/docker-compose.nightly.gpu.yml
+++ b/infra/docker-compose.nightly.gpu.yml
@@ -2258,6 +2258,7 @@ services:
       DAGSTER_HOME: /dagster_home
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
       LOG_LEVEL: ${LOG_LEVEL}
     healthcheck:
       test: [CMD, curl, -f, http://localhost:3000/server_info]
@@ -2291,6 +2292,7 @@ services:
       DAGSTER_HOME: /dagster_home
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
       LOG_LEVEL: ${LOG_LEVEL}
     healthcheck:
       test: [CMD, dagster-daemon, liveness-check]

--- a/infra/docker-compose.nightly.yml
+++ b/infra/docker-compose.nightly.yml
@@ -2052,6 +2052,7 @@ services:
       DAGSTER_HOME: /dagster_home
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
       LOG_LEVEL: ${LOG_LEVEL}
     healthcheck:
       test: [CMD, curl, -f, http://localhost:3000/server_info]
@@ -2085,6 +2086,7 @@ services:
       DAGSTER_HOME: /dagster_home
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
       LOG_LEVEL: ${LOG_LEVEL}
     healthcheck:
       test: [CMD, dagster-daemon, liveness-check]


### PR DESCRIPTION
## Summary

Replaces the per-stage hardcoded `max_concurrent_runs` in `dagster-config.yml.j2` (local: 2, nightly: 3, latest: 5) with `DAGSTER_MAX_CONCURRENT_RUNS` env indirection — the same `env:` pattern the config already uses for the Postgres credentials (`max_concurrent_runs` is a Dagster `IntSource`). The variable is passed to both `dagster-webserver` and `dagster-daemon`, so deployments can tune pipeline parallelism without a template change and redeploy of compose files.

Also retunes the ingestion-concurrency defaults after the nightly bulk-upload incident (follow-up to #1685): uploading 9 PDFs at once with `max_concurrent_runs=5` produced 10 concurrent MinerU batch requests against a server cap of 3, exhausting the 503 retry budget and failing one document.

## Changes

- `infra/deployment/templates/configs/dagster-config.yml.j2`: `max_concurrent_runs` → `env: DAGSTER_MAX_CONCURRENT_RUNS`
- `infra/deployment/templates/docker-compose.yml.j2`: pass the variable to `dagster-webserver` and `dagster-daemon`
- `.env.dev` / `.env.prod`: `DAGSTER_MAX_CONCURRENT_RUNS='3'`, `MINERU_PAGE_BATCH_SIZE='20'`, `MINERU_MAX_CONCURRENT_BATCH_REQUESTS='1'`, with the sizing rule documented in place
- Regenerated: 10 compose files, 10 dagster-config variants, env-var docs page

## Sizing rationale

With the new defaults, batch demand exactly matches the MinerU server cap and memory stays well inside the container limit:

| Constraint | Value |
| --- | --- |
| Batch demand: `DAGSTER_MAX_CONCURRENT_RUNS` × `MINERU_MAX_CONCURRENT_BATCH_REQUESTS` | 3 × 1 = 3 |
| MinerU server cap (`MINERU_API_MAX_CONCURRENT_REQUESTS`) | 3 |
| Memory: 0.5 GB baseline + 3 slots × (20 pages × ~30 MB) | ≈ 2.3 GB vs 4G limit |

Trade-off: with per-document batch concurrency 1, a single large PDF parses its batches sequentially (roughly 2× slower alone), but three documents still parse in parallel and the VLM backend remains the aggregate bottleneck, so bulk-upload wall clock is nearly unchanged — and bulk uploads no longer starve any document.

## Migration note (operators)

Existing deployments must add `DAGSTER_MAX_CONCURRENT_RUNS` to their `.env` **before** deploying this compose version — the Dagster containers fail at startup if the env source resolves to empty. Note this lowers the effective `latest` default from 5 to 3, deliberately, per the sizing rule above.

## Test plan

- [x] `make pr-ready` clean (format, lint, license, env docs)
- [x] `make generate-compose` output committed; diff contains only the intended env indirection + passthrough lines
- [ ] Nightly: re-upload the issue-117 PDF set after deploy and confirm no 503 retry exhaustion