### PR TITLE
Minor: OTEL - Stamp deployment.environment and host.name on app telemetry

### DIFF
--- a/infra/deployment/templates/configs/otel-config.yml.j2
+++ b/infra/deployment/templates/configs/otel-config.yml.j2
@@ -36,6 +36,20 @@ processors:
     timeout: 15s
 {%- endif %}
 
+  # Stamp environment + host on ALL telemetry so every span/metric/log clearly
+  # shows which environment (deployment.environment, e.g. staging/nightly/latest)
+  # and which host it came from — alongside the service.name the app already
+  # sets. Values are injected per-VM by the deployment (aihub-playbook env.j2);
+  # the compose supplies a stage-name fallback so dev/local still render.
+  resource/deployment:
+    attributes:
+      - key: deployment.environment
+        value: "${OTEL_DEPLOYMENT_ENVIRONMENT}"
+        action: upsert
+      - key: host.name
+        value: "${OTEL_HOST_NAME}"
+        action: upsert
+
   filter/noise:
     error_mode: ignore
     traces:
@@ -116,37 +130,37 @@ service:
     # Send OpenInference traces to the stack-local Langfuse instance
     traces/langfuse:
       receivers: [ otlp ]
-      processors: [ filter/noise, filter/langfuse, batch ]
+      processors: [ filter/noise, filter/langfuse, resource/deployment, batch ]
       exporters: [ otlphttp/langfuse ]
 
     {%- if stage == 'dev' %}
     # Accept logs but use debug exporter (Langfuse doesn't support logs via OTEL)
     logs:
       receivers: [otlp]
-      processors: [batch]
+      processors: [resource/deployment, batch]
       exporters: [debug]
 
     # Accept metrics but use debug exporter (Langfuse doesn't support metrics via OTEL)
     metrics:
       receivers: [otlp]
-      processors: [filter/metrics_cardinality, batch]
+      processors: [filter/metrics_cardinality, resource/deployment, batch]
       exporters: [debug]
     {%- else %}
     # Send traces to cloud backend
     traces/cloud:
       receivers: [otlp]
-      processors: [filter/noise, batch]
+      processors: [filter/noise, resource/deployment, batch]
       exporters: [otlp/cloud]
 
     # Send metrics to cloud backend
     metrics:
       receivers: [otlp]
-      processors: [filter/metrics_cardinality, batch]
+      processors: [filter/metrics_cardinality, resource/deployment, batch]
       exporters: [otlp/cloud]
 
     # Send logs to cloud backend
     logs:
       receivers: [otlp]
-      processors: [batch]
+      processors: [resource/deployment, batch]
       exporters: [otlp/cloud]
     {%- endif %}

--- a/infra/deployment/templates/docker-compose.yml.j2
+++ b/infra/deployment/templates/docker-compose.yml.j2
@@ -2117,6 +2117,11 @@ services:
     environment:
       - OTEL_CLOUD_ENDPOINT=${OTEL_CLOUD_ENDPOINT}
       - OTEL_CLOUD_HEADERS=${OTEL_CLOUD_HEADERS}
+      # Environment + host tags stamped onto all app telemetry (see otel-config
+      # resource/deployment). Provided per-VM by aihub-playbook's .env; fall back
+      # to the stage name / "unknown" so dev/local and un-templated runs render.
+      - OTEL_DEPLOYMENT_ENVIRONMENT=${OTEL_DEPLOYMENT_ENVIRONMENT:-{{ stage }}}
+      - OTEL_HOST_NAME=${OTEL_HOST_NAME:-{{ stage }}}
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY}
       - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY}
     volumes:


### PR DESCRIPTION
## Why
App traces/metrics/logs flow: app OTEL SDK → aihub-core `otel-collector` → SigNoz cloud. The app `Resource.create()` only sets `service.name/version/namespace`, and the collector added no `deployment.environment` or `host.name`. Result in SigNoz: **app error logs show empty environment and empty host**, so you can't tell "an `api` error in `staging`" apart from other environments.

## What
Add a `resource/deployment` processor to the collector that upserts `deployment.environment` + `host.name` onto **every** pipeline (traces/cloud, traces/langfuse, metrics, logs, and dev variants). Values come from env vars injected per-VM by the deployment; the compose supplies a `:-{{ stage }}` fallback so dev/local still render.

- `infra/deployment/templates/configs/otel-config.yml.j2` — new `resource/deployment` processor, wired into all pipelines.
- `infra/deployment/templates/docker-compose.yml.j2` — `otel-collector` now receives `OTEL_DEPLOYMENT_ENVIRONMENT` / `OTEL_HOST_NAME` (fallback to stage).

Values are supplied by the aihub-playbook side (the generated app env file, `= customer_id` / VM hostname) — see companion PR in aihub-playbook.

## Notes
- **Templates only.** Generated `infra/configs/otel/*.yml` + `docker-compose.*.yml` are produced at release time by `generate_compose.py --release`; I did **not** commit regenerated artifacts (running the generator rewrites ~118 files with unrelated whitespace drift). Verified locally that regeneration produces the intended output.
- Takes effect after a new aihub-core release is cut and VMs pull that tag.

## Verify after deploy
In SigNoz: `deployment.environment = staging AND service.name = api AND severity_text = ERROR`.
