### PR TITLE
fix(rag): Unwrap MinerU page-batch TaskGroup errors

### DIFF
--- a/packages/core/swiss_ai_hub/core/generative_ai/document/loaders/mineru_loader.py
+++ b/packages/core/swiss_ai_hub/core/generative_ai/document/loaders/mineru_loader.py
@@ -239,10 +239,13 @@ class MineruLoader(BaseReader):
                 return await self._convert_batch(file_bytes, filename, include_images, start, end)
 
         async def convert_all() -> MineruFileResult:
-            async with asyncio.TaskGroup() as task_group:
-                tasks = []
-                for start, end in ranges:
-                    tasks.append(task_group.create_task(convert_range(start, end)))
+            tasks = []
+            try:
+                async with asyncio.TaskGroup() as task_group:
+                    for start, end in ranges:
+                        tasks.append(task_group.create_task(convert_range(start, end)))
+            except ExceptionGroup as exception_group:
+                raise self._unwrap_batch_failure(exception_group, filename)
             return self._merge_results([task.result() for task in tasks])
 
         return await self._with_deadline(convert_all(), num_batches=len(ranges), filename=filename)
@@ -254,6 +257,30 @@ class MineruLoader(BaseReader):
             return await asyncio.wait_for(awaitable, timeout=deadline)
         except TimeoutError:
             raise TimeoutError(f"MinerU conversion timed out after {deadline}s for {filename} ({num_batches} batches)")
+
+    @staticmethod
+    def _unwrap_batch_failure(exception_group: ExceptionGroup, filename: str) -> Exception:
+        """
+        Surface the batch failure itself instead of the TaskGroup wrapper.
+
+        Consumers such as Dagster render only the linear __cause__/__context__ chain, so an
+        ExceptionGroup reaches the UI as "1 sub-exception" with the actual error discarded.
+        """
+        leaves: list[Exception] = []
+        pending: list[Exception] = list(exception_group.exceptions)
+        while pending:
+            exception = pending.pop(0)
+            if isinstance(exception, ExceptionGroup):
+                pending[:0] = exception.exceptions
+            else:
+                leaves.append(exception)
+
+        if len(leaves) > 1:
+            logger.error(
+                f"[MineruLoader] {len(leaves)} page batches failed for {filename}, "
+                f"reporting the first: {[repr(leaf) for leaf in leaves]}"
+            )
+        return leaves[0]
 
     @staticmethod
     def _count_pdf_pages(file_bytes: bytes) -> int:

--- a/packages/core/swiss_ai_hub/core/generative_ai/document/loaders/tests/unit/test_mineru_loader.py
+++ b/packages/core/swiss_ai_hub/core/generative_ai/document/loaders/tests/unit/test_mineru_loader.py
@@ -247,9 +247,11 @@ class TestBatchFailurePropagation:
                 raise MineruRequestError("MinerU API rejected the request with status 400") from root_cause
             return make_response(f"pages{start_page_id}", end_page_id - start_page_id + 1)
 
+        pdf_bytes = make_pdf(5)
+
         with patch.object(loader, "_execute_conversion", AsyncMock(side_effect=failing_execute)):
             with pytest.raises(MineruRequestError, match="status 400") as error:
-                await loader.aload_data_from_bytes(make_pdf(5), FILENAME, embed_base64=True)
+                await loader.aload_data_from_bytes(pdf_bytes, FILENAME, embed_base64=True)
 
         assert error.value.__cause__ is root_cause
 

--- a/packages/core/swiss_ai_hub/core/generative_ai/document/loaders/tests/unit/test_mineru_loader.py
+++ b/packages/core/swiss_ai_hub/core/generative_ai/document/loaders/tests/unit/test_mineru_loader.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 from io import BytesIO
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -228,6 +229,53 @@ class TestBatching:
         assert mock.await_count == 1
         assert mock.await_args.args[3] is None
         assert documents[0].text == "content"
+
+
+class TestBatchFailurePropagation:
+    @pytest.mark.asyncio
+    async def test_batch_failure_replaces_exception_group(self, loader: MineruLoader):
+        root_cause = httpx.ConnectError("connection refused")
+
+        async def failing_execute(
+            file_bytes: bytes,
+            filename: str,
+            include_images: bool,
+            start_page_id: int | None = None,
+            end_page_id: int | None = None,
+        ) -> MineruParseResponse:
+            if start_page_id == 2:
+                raise MineruRequestError("MinerU API rejected the request with status 400") from root_cause
+            return make_response(f"pages{start_page_id}", end_page_id - start_page_id + 1)
+
+        with patch.object(loader, "_execute_conversion", AsyncMock(side_effect=failing_execute)):
+            with pytest.raises(MineruRequestError, match="status 400") as error:
+                await loader.aload_data_from_bytes(make_pdf(5), FILENAME, embed_base64=True)
+
+        assert error.value.__cause__ is root_cause
+
+    def test_unwraps_arbitrarily_nested_groups_and_reports_first_leaf(self, caplog: pytest.LogCaptureFixture):
+        first = MineruRequestError("first batch")
+        second = MineruTransientError("second batch")
+        third = MineruTransientError("third batch")
+        group = ExceptionGroup(
+            "unhandled errors in a TaskGroup",
+            [ExceptionGroup("outer", [ExceptionGroup("inner", [first, ExceptionGroup("deepest", [second])])]), third],
+        )
+
+        with caplog.at_level(logging.ERROR):
+            assert MineruLoader._unwrap_batch_failure(group, FILENAME) is first
+
+        assert f"3 page batches failed for {FILENAME}" in caplog.text
+        assert "second batch" in caplog.text
+        assert "third batch" in caplog.text
+
+    def test_single_failure_is_not_logged(self, caplog: pytest.LogCaptureFixture):
+        only = MineruTransientError("only batch")
+
+        with caplog.at_level(logging.ERROR):
+            assert MineruLoader._unwrap_batch_failure(ExceptionGroup("group", [only]), FILENAME) is only
+
+        assert caplog.text == ""
 
 
 class TestSettingsValidation:


### PR DESCRIPTION
## Summary

When a MinerU page batch fails, `asyncio.TaskGroup` wraps the real error in an `ExceptionGroup`, and Dagster renders only the linear `__cause__`/`__context__` chain — so the step failure reached the UI as `ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)` with the actual `MineruTransientError` / `MineruRequestError` discarded, after 3 op retries × 4 tenacity attempts. This unwraps the group so the message thrown inside the batch task is what surfaces.

## Changes

- `MineruLoader._convert_batched` catches the `ExceptionGroup` from the page-batch `TaskGroup` and raises the underlying batch failure instead.
- New `MineruLoader._unwrap_batch_failure` flattens the group depth-first (arbitrary nesting) and returns the first leaf, re-raised without `from None` so its own `__cause__` (e.g. the underlying `httpx` error) still renders.
- When more than one batch failed, the remaining failures are logged with `repr`, since only one exception can be raised.
- Catches `ExceptionGroup` rather than `BaseExceptionGroup`: every member of the group this TaskGroup can raise is an `Exception`, so the narrow clause is sufficient and will not intercept a group carrying an exotic `BaseException`. The deadline path is unaffected either way — `wait_for` cancellation propagates as a **bare** `CancelledError` (`asyncio/taskgroups.py:152-159`), never a group, so `TimeoutError: MinerU conversion timed out after Ns` still surfaces.

Diagnostics only — no behavioural change to parsing, batching, retry policy, or configuration.

## Verification

Measured on the real op (real resources, real `RetryPolicy`) by reading the `STEP_FAILURE` event Dagster renders:

| Scenario | Error chain in the Dagster failure |
| --- | --- |
| Before | `Exceeded max_retries` → `ExceptionGroup: unhandled errors in a TaskGroup (3 sub-exceptions)` — no message |
| After, batch error with a cause | → `MineruTransientError: HTTP error: ReadTimeout: mineru vlm backend stopped responding` → `httpx.ReadTimeout: ...` |
| After, batch error with no cause | → `ValueError: No result found for document.pdf in MinerU response` |

Sibling failures reach the op log stream in the same run:

```
ERROR - [MineruLoader] 3 page batches failed for document.pdf, reporting the first: ["MineruTransientError('HTTP error: ReadTimeout: ...')", ...]
```

## Known limitations

- **Deadline path still names no cause.** If `_with_deadline` fires while batches are inside tenacity retries, all tasks are cancelled and no error is registered with the TaskGroup, so the failure is `TimeoutError: MinerU conversion timed out after Ns for <file> (N batches)`; the batch errors appear only as `MinerU conversion failed (attempt N)` warnings in the compute log. A batch whose retries are already exhausted is unaffected — errors take priority over cancellation.
- **Only the first of N simultaneous failures is in the structured error**; the rest are log-only.

## Test plan

- 3 tests added in `TestBatchFailurePropagation` (`test_mineru_loader.py`):
  - end-to-end through `aload_data_from_bytes` asserting the concrete error escapes the TaskGroup with `__cause__` intact — verified to fail without the fix, since `pytest.raises(MineruRequestError)` does not match `ExceptionGroup[MineruRequestError]`;
  - four-level nested group with leaves at three depths → first leaf returned, others logged;
  - single failure produces no log noise.
- Pre-existing `TestConversionDeadline` tests still pass, confirming the cancellation/timeout path is unaffected.
- `packages/core`: 1037 passed. `packages/pipeline`: 55 passed (direct consumer of `MineruLoader`).
- `ruff check` / `ruff format --check` clean.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>`
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [x] CLA signed
- [x] Tests added or updated where relevant
