### PR TITLE
fix(ui): Warn about the organization memory performance issue

### DIFF
--- a/packages/web/components/FormKit/DynamicConfiguration.vue
+++ b/packages/web/components/FormKit/DynamicConfiguration.vue
@@ -54,6 +54,13 @@ import type { FormKitSchemaDefinition } from '@formkit/core'
 
 const { t } = useI18n()
 
+// Fields with a known platform issue, keyed by the backend element id. Frontend-only on
+// purpose: the notice is temporary and carries no config semantics, so it stays out of the
+// agent's form schema. Drop the entry once the underlying issue is fixed.
+const FIELD_WARNING_KEYS: Record<string, string> = {
+  org_memory: 'form.warnings.org_memory_performance',
+}
+
 const props = defineProps<{
   form: FormkitElement[]
   initialData?: Record<string, unknown>
@@ -98,9 +105,15 @@ function replaceLabelVariables(label: string): string {
   })
 }
 
+function fieldWarning(element: FormElement): string | undefined {
+  const warningKey = FIELD_WARNING_KEYS[element.id as string]
+  return warningKey ? t(warningKey) : undefined
+}
+
 const schema = computed<FormKitSchemaDefinition>(() => {
   return buildFormKitSchema(props.form as FormElement[], {
     labelTransform: replaceLabelVariables,
+    fieldWarning,
   })
 })
 
@@ -136,6 +149,10 @@ async function submitHandler() {
 
 .content :deep(.formkit-outer) {
   @apply pt-3 pb-1;
+}
+
+.content :deep(.formkit-field-warning) {
+  @apply flex items-start gap-1.5 pb-1 text-xs text-amber-600 dark:text-amber-400;
 }
 
 .content :deep(.formkit-group-fieldset) {

--- a/packages/web/composables/form/useFormKitTransform.ts
+++ b/packages/web/composables/form/useFormKitTransform.ts
@@ -132,6 +132,43 @@ export interface TransformOptions {
   locale?: string
   labelTransform?: (label: string) => string
   optionsResolver?: (element: FormElement) => unknown[] | undefined
+  // Resolves a frontend-only warning for an element. The backend form schema carries no
+  // warning of its own, so notices about known platform issues are attached here.
+  fieldWarning?: (element: FormElement) => string | undefined
+}
+
+/**
+ * Warning notice rendered next to a field, styled like a `Message severity="warn"
+ * variant="simple"` (see `.formkit-field-warning` in FormKit/DynamicConfiguration.vue).
+ * A plain `$el` node rather than `$cmp: 'Message'`: PrimeVue components are auto-imported
+ * per component, so FormKitSchema cannot resolve them by name.
+ */
+function buildFieldWarningNode(element: FormElement, text: string): FormKitSchemaNode {
+  const base = (element.id as string | undefined) ?? (element.name as string)
+  return {
+    $el: 'div',
+    key: `${base}__warning`,
+    attrs: { class: 'formkit-field-warning' },
+    children: [
+      { $el: 'i', attrs: { class: 'pi pi-exclamation-triangle' } },
+      { $el: 'span', children: text },
+    ],
+  } as unknown as FormKitSchemaNode
+}
+
+/**
+ * Places the warning directly under the "Enable X" toggle for a nullable element — the
+ * toggle stays mounted when the section is switched off, so the warning remains readable
+ * before the user opts in. Non-nullable elements get it above their own node.
+ */
+function withFieldWarning(
+  nodes: FormKitSchemaNode | FormKitSchemaNode[],
+  warning: FormKitSchemaNode | undefined,
+  afterToggle: boolean,
+): FormKitSchemaNode | FormKitSchemaNode[] {
+  if (!warning) return nodes
+  const nodeArray = Array.isArray(nodes) ? nodes : [nodes]
+  return afterToggle ? [nodeArray[0], warning, ...nodeArray.slice(1)] : [warning, ...nodeArray]
 }
 
 function createGroupNode(
@@ -362,7 +399,7 @@ export function transformElementToSchema(
   const formkitType = getFormkitType(element)
   if (formkitType === 'repeater') return []
 
-  const { locale = 'en', labelTransform, optionsResolver } = options
+  const { locale = 'en', labelTransform, optionsResolver, fieldWarning } = options
 
   const children = (element.children as FormElement[] || []).flatMap(
     child => transformElementToSchema(child, options),
@@ -376,21 +413,26 @@ export function transformElementToSchema(
   const isNullable = element.nullable === true
   const toggleCondition = isNullable ? `$get(${nullableToggleId(element)}).value` : undefined
 
+  const warningText = fieldWarning?.(element)
+  const warningNode = warningText ? buildFieldWarningNode(element, warningText) : undefined
+
   if (formkitType === 'group') {
     const gatedElement = isNullable ? gateElement(element, toggleCondition!) : element
     const groupNode = createGroupNode(gatedElement, children, label)
-    if (!isNullable) return groupNode
-    return applyNullableToggle(element, groupNode, label, getLocalizedString(element.help, locale))
+    if (!isNullable) return withFieldWarning(groupNode, warningNode, false)
+    const toggledNodes = applyNullableToggle(element, groupNode, label, getLocalizedString(element.help, locale))
+    return withFieldWarning(toggledNodes, warningNode, true)
   }
 
   const cleanNode = buildNodeProperties(element, formkitType, label, locale, optionsResolver)
   if (children.length > 0) cleanNode.children = children
   if (isNullable) {
     cleanNode.if = combineConditions(toggleCondition!, element.if as string | undefined)
-    return applyNullableToggle(element, cleanNode as FormKitSchemaNode, label)
+    const toggledNodes = applyNullableToggle(element, cleanNode as FormKitSchemaNode, label)
+    return withFieldWarning(toggledNodes, warningNode, true)
   }
 
-  return cleanNode as FormKitSchemaNode
+  return withFieldWarning(cleanNode as FormKitSchemaNode, warningNode, false)
 }
 
 function buildLeafNodeForRepeater(

--- a/packages/web/i18n/locales/de.yaml
+++ b/packages/web/i18n/locales/de.yaml
@@ -790,6 +790,10 @@ process:
 form:
   locale_input:
     translate_tooltip: In alle Sprachen übersetzen
+  warnings:
+    org_memory_performance: Diese Funktion funktioniert in manchen Fällen möglicherweise
+      nicht wie erwartet. Um unerwartetes Verhalten zu vermeiden, deaktivieren Sie
+      sie bitte vorübergehend, bis eine Korrektur veröffentlicht wird.
 lib:
   vectorStore:
     label: Vektorspeicher

--- a/packages/web/i18n/locales/en.yaml
+++ b/packages/web/i18n/locales/en.yaml
@@ -778,6 +778,9 @@ process:
 form:
   locale_input:
     translate_tooltip: Translate to all languages
+  warnings:
+    org_memory_performance: This feature may not work as expected in some cases. To
+      avoid unexpected behavior, please temporarily disable it until a fix is released.
 lib:
   vectorStore:
     label: Vector Store

--- a/packages/web/i18n/locales/fr.yaml
+++ b/packages/web/i18n/locales/fr.yaml
@@ -790,6 +790,10 @@ process:
 form:
   locale_input:
     translate_tooltip: Traduire dans toutes les langues
+  warnings:
+    org_memory_performance: Cette fonctionnalité peut ne pas fonctionner comme prévu
+      dans certains cas. Pour éviter tout comportement inattendu, veuillez la désactiver
+      temporairement jusqu'à la publication d'un correctif.
 lib:
   vectorStore:
     label: Stockage vectoriel

--- a/packages/web/i18n/locales/it.yaml
+++ b/packages/web/i18n/locales/it.yaml
@@ -786,6 +786,10 @@ process:
 form:
   locale_input:
     translate_tooltip: Traduci in tutte le lingue
+  warnings:
+    org_memory_performance: Questa funzionalità potrebbe non funzionare come previsto
+      in alcuni casi. Per evitare comportamenti inattesi, disattivala temporaneamente
+      fino al rilascio di una correzione.
 lib:
   vectorStore:
     label: Archivio vettoriale


### PR DESCRIPTION
## Summary

Ports #1694 (merged into `release/0.318`) to `main`, so the warning is not lost on the next release branch. Cherry-pick of `be075cc` — applied cleanly, no conflicts, identical diff.

Organization memory may not behave as expected in some cases. This surfaces a warning next to the **Enable Organization Memory** toggle in the agent configuration form, telling users to temporarily disable the feature until a fix is released — so they see it before switching it on. Frontend-only and temporary: no change to any agent's form schema.

Message shown: *"This feature may not work as expected in some cases. To avoid unexpected behavior, please temporarily disable it until a fix is released."* (localized in en/de/fr/it.)

## Changes

- `useFormKitTransform`: new `fieldWarning` option on `TransformOptions`, plus `buildFieldWarningNode` / `withFieldWarning`. For a nullable field the warning node is inserted **after the "Enable X" toggle and outside the gated fieldset**, so it stays readable while the section is switched off.
- `FormKit/DynamicConfiguration.vue`: `FIELD_WARNING_KEYS` map (`org_memory` → i18n key), passes the resolver into `buildFormKitSchema`, and adds the `.formkit-field-warning` style — amber text with `pi-exclamation-triangle`, matching the `Message severity="warn" variant="simple"` pattern used elsewhere.
- `i18n/locales/{en,de,fr,it}.yaml`: new `form.warnings.org_memory_performance` key.

Notes:

- Keying on the backend element id `org_memory` means every form carrying that field gets the warning — `RAGAgent`, `ExpertRAGAgent` and `ExpertAskingAgent` (whose group is non-nullable, so the warning sits directly above the fieldset).
- A plain `$el` div rather than `$cmp: 'Message'`: PrimeVue components are auto-imported per component here, so `FormKitSchema` cannot resolve them by name.
- Removing the warning once the underlying issue is fixed is a one-line deletion in `FIELD_WARNING_KEYS` plus the locale keys.

## Test plan

Re-verified on the `main` base after the cherry-pick (not just carried over from #1694):

- Ran `buildFormKitSchema` directly against representative elements and asserted node ordering:
  - nullable group + warning → `[enable toggle, warning, gated fieldset]`, group children untouched
  - non-nullable group + warning → `[warning, fieldset]`
  - leaf + warning → `[warning, input]`
  - no matching warning → output identical to before (both with no resolver and with a resolver that matches nothing)
- All four locale files parse and the new key resolves in each.
- `eslint` clean on both changed files; `vue-tsc --noEmit` reported no errors in them on #1694's base and the files are unchanged here.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>` (see
  [CONTRIBUTING.md](https://github.com/bbvch-ai/aihub-core/blob/main/CONTRIBUTING.md))
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [ ] CLA signed — post this exact comment on the PR if the bot hasn't prompted you yet:
  `I have read the CONTRIBUTOR_AGREEMENT and I hereby sign the CLA`
  ([read the agreement](https://github.com/bbvch-ai/aihub-core/blob/main/CONTRIBUTOR_AGREEMENT.md))
- [ ] Tests added or updated where relevant — no frontend test setup exists in `packages/web` (`make test` is a no-op there); verified via the direct schema checks above
