### PR TITLE
fix(swiss-ai-hub): Correct local development config for Dagster and the likec4 MCP

### DIFF
--- a/.claude/mcp/mcp-likec4.sh
+++ b/.claude/mcp/mcp-likec4.sh
@@ -12,5 +12,10 @@ set -e
 #
 # Pinned to the v1 line for reproducible agent behaviour (matches the `likec4`
 # CLI pin in docs/package.json). Bump deliberately when upgrading the model tooling.
-cd "$(dirname "$0")/../.."
+#
+# The workspace is the current directory (or $LIKEC4_WORKSPACE) — so we cd into
+# docs/likec4, not the repo root. The server's only default exclude is
+# `**/node_modules/**`, so a repo-root workspace would scan and file-watch .venv/,
+# .git/ and infra/.docker-volumes/, and would miss a docs/likec4/likec4.config.json.
+cd "$(dirname "$0")/../../docs/likec4"
 exec npx -y "@likec4/mcp@1"

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ down-dev:
 # Requires `make up-dev` first. UI at http://localhost:3000.
 playground:
 	@echo "Starting Dagster playground at http://localhost:3000 ..."
-	cd packages/pipeline && uv run dagster dev -m playground
+	@$(MAKE) -C packages/pipeline playground
 
 up-dev-gpu:
 	@echo "Starting development GPU environment with Docker Compose..."

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -190,6 +190,10 @@ The `likec4` MCP server (`.claude/mcp/mcp-likec4.sh`) exposes the model for runt
 `read-project-summary`, `read-view`, `query-graph`, `find-relationship-paths`. Useful for sanity-checking the model
 without re-reading the `.c4` files.
 
+The server's workspace is its working directory, so the wrapper script `cd`s into `docs/likec4`. Keep it that way: from
+the repo root it would file-watch the entire monorepo (its only default exclude is `**/node_modules/**`, so `.venv/`,
+`.git/` and `infra/.docker-volumes/` are all in scope) and would not find a `docs/likec4/likec4.config.json`.
+
 ## ADRs
 
 - Location: `arc42/decisions/`

--- a/packages/pipeline/CLAUDE.md
+++ b/packages/pipeline/CLAUDE.md
@@ -298,6 +298,29 @@ failure alerts without per-asset wiring.
 
 Start: `make playground` or `uv run dagster dev -m playground` Access: http://localhost:3000 (Dagster UI)
 
+## Local Dagster Instance
+
+`make playground`, `make quickstart`, and `make rag-pipelines` each depend on the `dagster-home` target, which installs
+`dagster.local.yaml` into `$(DAGSTER_HOME)` as `dagster.yaml` (copy-if-absent), and source the repo-root `.env` for the
+dev-stack connection settings. Two failure modes this prevents: an unset `DAGSTER_HOME` makes `dagster dev` create a
+throwaway `.tmp_dagster_home_*` instance per start, and a missing instance config leaves `DefaultRunCoordinator` in
+place, which fans out runs with no cap and storms MinerU. `dagster.local.yaml` uses the same `QueuedRunCoordinator` as
+`infra/configs/dagster/dagster-config.<stage>.yml`, but with `max_concurrent_runs` as a literal instead of
+`env: DAGSTER_MAX_CONCURRENT_RUNS`. Keep it literal: the file is installed into `$DAGSTER_HOME`, so an unresolvable env
+var would raise `PostProcessingError` in every Dagster process on the machine, including ones started without the repo
+`.env` loaded.
+
+`DAGSTER_HOME ?= $(HOME)/.dagster_home` is defined in the Makefile and exported over whatever `.env` says — same
+directory, but already absolute, so the recipes can `mkdir`/`cp` with it. `.env` keeps the tilde form for the manual
+`set -a && source .env && set +a` flow, where Dagster's own `expanduser` resolves it.
+
+Do NOT use the `-include ../../.env` + `export` pattern from `packages/api/Makefile` here. Make keeps the quotes from
+`.env`, so every value arrives wrapped in literal apostrophes — `DAGSTER_HOME='~/.dagster_home'` reaches Dagster with
+the quotes attached and is rejected as a non-absolute path. Source the file in the recipe instead.
+
+`dagster.local.yaml` is local-only: Dagster reads no filename but `dagster.yaml`, so the copy in this directory is inert
+where it sits, including inside the pipeline images that `COPY packages/pipeline`.
+
 ## Templates
 
 `templates/sources/` — 7 pre-configured source templates. Each contains `.env.template` (required configuration),

--- a/packages/pipeline/Makefile
+++ b/packages/pipeline/Makefile
@@ -1,4 +1,18 @@
-.PHONY: lint format typecheck pr-ready test-cov test playground quickstart rag-pipelines
+.PHONY: lint format typecheck pr-ready test-cov test playground quickstart rag-pipelines \
+	check-dotenv dagster-home
+
+DOTENV := ../../.env
+
+# Same location as DAGSTER_HOME in .env, but pre-expanded so mkdir and cp can
+# use it directly (.env spells it "~/.dagster_home" for the manual
+# `source .env` flow, where Dagster's own expanduser resolves the tilde).
+DAGSTER_HOME ?= $(HOME)/.dagster_home
+
+# Source the repo-root .env into the recipe shell for the dev-stack connection
+# settings. `-include ../../.env` (the pattern in packages/api and
+# packages/agent) is deliberately NOT used: Make keeps the quotes from the file,
+# so every value arrives wrapped in literal apostrophes.
+LOAD_ENV := set -a && . $(DOTENV) && set +a && export DAGSTER_HOME=$(DAGSTER_HOME)
 
 lint:
 	@echo "Running linter for pipelines..."
@@ -27,13 +41,30 @@ test:
 	@echo "Running tests in swiss_ai_hub.pipeline..."
 	uv run pytest || echo "No tests found. Skipping..."
 
-playground:
+check-dotenv:
+	@test -f $(DOTENV) || { echo "Missing $(DOTENV) — run 'make setup' from the workspace root."; exit 1; }
+
+# Without DAGSTER_HOME, `dagster dev` builds a throwaway instance in a
+# .tmp_dagster_home_* dir under the cwd on every start: run history is lost and
+# the unconfigured DefaultRunCoordinator fans out without a concurrency cap.
+# Install the instance config copy-if-absent so local tuning survives.
+dagster-home:
+	@mkdir -p $(DAGSTER_HOME)
+	@if [ -f $(DAGSTER_HOME)/dagster.yaml ]; then \
+		echo "Using existing Dagster instance config at $(DAGSTER_HOME)/dagster.yaml"; \
+	else \
+		cp dagster.local.yaml $(DAGSTER_HOME)/dagster.yaml; \
+		echo "Installed dagster.local.yaml -> $(DAGSTER_HOME)/dagster.yaml"; \
+	fi
+
+playground: check-dotenv dagster-home
 	@echo "Running playground..."
-	OTEL_ENABLED=false uv run dagster dev -m playground --use-legacy-code-server-behavior
+	@$(LOAD_ENV) && OTEL_ENABLED=false uv run dagster dev -m playground --use-legacy-code-server-behavior
 
-quickstart:
+quickstart: check-dotenv dagster-home
 	@echo "Running quickstart..."
-	OTEL_ENABLED=false uv run dagster dev -f playground/quick_start/simple_pipeline.py -f playground/quick_start/my_document_pipeline.py
+	@$(LOAD_ENV) && OTEL_ENABLED=false uv run dagster dev -f playground/quick_start/simple_pipeline.py -f playground/quick_start/my_document_pipeline.py
 
-rag-pipelines:
-	OTEL_ENABLED=false uv run dagster dev -m app.default_rag_pipeline -m app.shared_rag_pipeline
+rag-pipelines: check-dotenv dagster-home
+	@echo "Running RAG pipelines..."
+	@$(LOAD_ENV) && OTEL_ENABLED=false uv run dagster dev -m app.default_rag_pipeline -m app.shared_rag_pipeline

--- a/packages/pipeline/README.md
+++ b/packages/pipeline/README.md
@@ -130,6 +130,23 @@ and in CI.
 > **Settings are not auto-loaded from the environment.** The SDK reads connection settings only when constructed, so
 > make sure the variables above are exported in the process that runs Dagster (`set -a && source .env && set +a`).
 
+### Make targets
+
+`make playground`, `make quickstart`, and `make rag-pipelines` wrap the three steps above: they source the repo-root
+`.env` and install `dagster.local.yaml` into `$DAGSTER_HOME` (`~/.dagster_home` unless you export something else) as
+`dagster.yaml` if no config is there yet.
+
+Both parts matter. Without `DAGSTER_HOME`, `dagster dev` builds a throwaway instance in a `.tmp_dagster_home_*` folder
+under the working directory on every start — run history is lost between sessions. And without an instance config,
+Dagster falls back to `DefaultRunCoordinator`, which launches runs with no concurrency cap and overwhelms MinerU. The
+local config uses `QueuedRunCoordinator`, the same coordinator the deployed stages use, with `max_concurrent_runs` as a
+literal `2` — deployed stages read that number from `DAGSTER_MAX_CONCURRENT_RUNS`, but a `$DAGSTER_HOME` config has no
+guarantee the variable is set, and an unresolvable one breaks every Dagster process on the machine. Edit the installed
+copy to tune it.
+
+The copy is skipped when `$DAGSTER_HOME/dagster.yaml` already exists, so local tuning is never overwritten. Delete that
+file to pick the repo version back up.
+
 ## Production
 
 In production a pipeline runs as a **Dagster code location**: a gRPC server in a container that the platform's Dagster

--- a/packages/pipeline/dagster.local.yaml
+++ b/packages/pipeline/dagster.local.yaml
@@ -1,0 +1,32 @@
+---
+# ===================================================================
+# Dagster instance config for LOCAL `dagster dev` runs only.
+# ===================================================================
+# Installed into $DAGSTER_HOME by the `dagster-home` target in this
+# directory's Makefile (copy-if-absent — your local edits are never
+# overwritten). Dagster only ever reads a file named `dagster.yaml`, so
+# this file is inert where it sits.
+#
+# Containerized Dagster uses infra/configs/dagster/dagster-config.<stage>.yml
+# (Postgres-backed, generated from a Jinja2 template) — not this file.
+#
+# Storage is left at the default (SQLite under $DAGSTER_HOME) so local runs
+# never touch the dev stack's Postgres.
+# ===================================================================
+run_coordinator:
+  module: dagster.core.run_coordinator
+  class: QueuedRunCoordinator
+  config:
+    # Without this, local runs fall back to DefaultRunCoordinator and fan out
+    # unbounded, storming MinerU into HTTP 503 rejections.
+    #
+    # Deliberately a literal, not `env: DAGSTER_MAX_CONCURRENT_RUNS` as the
+    # deployed stages use: this file is installed into $DAGSTER_HOME, so an
+    # unresolvable env var would break every Dagster process on the machine —
+    # including ones started without the repo .env loaded. Tune it in place.
+    max_concurrent_runs: 2
+telemetry:
+  enabled: false
+python_logs:
+  python_log_level: INFO
+  managed_python_loggers: [swiss_ai_hub]


### PR DESCRIPTION
## Summary

Two local-development configuration bugs. `make rag-pipelines` never loaded the repo-root `.env`, so `dagster dev` built a throwaway instance on every start and launched runs with no concurrency cap; and the `likec4` MCP wrapper took the whole monorepo as its workspace instead of `docs/likec4`. Local-only — no deployed stage, compose template, or CI workflow is affected.

## Changes

**Dagster local instance** (`packages/pipeline/`)

- `Makefile` never loaded `../../.env`, unlike `packages/api` and `packages/agent`, and Dagster's own dotenv injection reads the cwd (`packages/pipeline/`), not the repo root. `DAGSTER_HOME` was therefore unset, so `get_possibly_temporary_instance_for_cli` fell through to `_get_temporary_instance` and created a `.tmp_dagster_home_*` directory per start — 9 had accumulated locally. Run history was lost between sessions.
- With no `$DAGSTER_HOME/dagster.yaml`, the instance also fell back to `DefaultRunCoordinator`, which launches runs with no cap and overwhelms MinerU. Deployed stages get `QueuedRunCoordinator` from `infra/configs/dagster/dagster-config.<stage>.yml`; local runs got nothing.
- `playground`, `quickstart`, and `rag-pipelines` now depend on a `dagster-home` target that installs the new `dagster.local.yaml` into `$DAGSTER_HOME` as `dagster.yaml` (copy-if-absent, so local tuning survives), and source `.env` in the recipe shell for the dev-stack connection settings.
- Sourcing rather than `-include ../../.env` is deliberate: Make does not strip the quotes from the file, so `DAGSTER_HOME` would arrive as `"'~/.dagster_home'"` and Dagster rejects it as a non-absolute path (`factory.py:86`). `DAGSTER_HOME ?= $(HOME)/.dagster_home` is defined in the Makefile so recipes have an already-absolute path for `mkdir`/`cp`.
- `max_concurrent_runs` is a literal `2`, not the deployed `env: DAGSTER_MAX_CONCURRENT_RUNS`. The file lands in `$DAGSTER_HOME`, a user-global location, so an unresolvable env var would raise `PostProcessingError` in *every* Dagster process on the machine — including ones started without the repo `.env` loaded. This was caught in review and verified both ways.
- Root `make playground` now delegates to the package target instead of inlining the command, so it picks up the same fix. Side effect: it inherits `--use-legacy-code-server-behavior`, which the package target already used and the root one did not.

**LikeC4 MCP** (`.claude/mcp/mcp-likec4.sh`)

- The script `cd`'d to the repo root, and the server's workspace is its working directory. `list-projects` reported `folder: <repo root>` instead of `docs/likec4`. Its only default exclude is `**/node_modules/**`, so it scanned and file-watched `.venv/`, `.git/` and `infra/.docker-volumes/`, and a future `docs/likec4/likec4.config.json` would never have been found. Now `cd`s into `docs/likec4`.

**Docs**: local-run sections in `packages/pipeline/README.md` and `packages/pipeline/CLAUDE.md`, and the MCP note in `docs/CLAUDE.md`.

## Test plan

Dagster, via `make rag-pipelines` against the dev stack:

- `QueuedRunCoordinatorDaemon` present in the daemon list — absent before the change
- Zero `"Using temporary directory ... for storage"` log lines, zero new `.tmp_dagster_home_*` directories during the run, after it, and after `pytest`
- Instance resolves to `/home/<user>/.dagster_home` with `QueuedRunCoordinator` and `max_concurrent_runs = 2`
- Loads with `DAGSTER_MAX_CONCURRENT_RUNS` unset (this raised `PostProcessingError` before the literal fix)
- `make dagster-home` twice → second run reports "Using existing", confirming it does not clobber; `DAGSTER_HOME=<path>` override honoured
- `make test` in `packages/pipeline`: 55 passed

LikeC4, by driving the server over a stdio JSON-RPC handshake:

- `folder` went from `<repo root>/` to `<repo root>/docs/likec4/`; all six `.c4` sources still resolve

CI safety, running what the workflows run:

- `make generate-compose` → `infra/docker-compose.*.yml` byte-identical
- `make check-env` (strict) → exit 0
- `ruff format --check` / `ruff check` → findings only in `infra/deployment/templates/*.py`; this diff contains zero `.py` files, and `lint_backend` reports through `reviewdog -reporter=github-pr-review`, which annotates diff lines only
- No workflow invokes `playground`, `quickstart`, or `rag-pipelines`; `.env.dev`, `.env.prod`, compose templates, and `infra/configs/dagster/*` are untouched
- `dagster.local.yaml` ships inside the pipeline images (`COPY packages/pipeline`) but is inert: Dagster reads no filename but `dagster.yaml`, and the containers set `DAGSTER_HOME=/dagster_home`

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>`
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [ ] CLA signed
- [x] Tests added or updated where relevant — no production code changed; existing `packages/pipeline` suite re-run (55 passed)
