### PR TITLE
fix(rag): Declare reasoning before the answer in table analysis schemas

### DIFF
--- a/packages/core/swiss_ai_hub/core/generative_ai/document/refinement/models.py
+++ b/packages/core/swiss_ai_hub/core/generative_ai/document/refinement/models.py
@@ -13,18 +13,23 @@ class TableBoundary(BaseModel):
 class TableSplitAnalysis(BaseModel):
     """LLM analysis result for detecting merged tables."""
 
+    # reasoning is declared first on purpose. Under guided JSON decoding the field order is the generation
+    # order, and a model that emits the answer first has nothing left to say for a trailing required
+    # explanation - but the grammar forbids closing the object without it. Whitespace stays legal, so the
+    # model emits it until max_tokens. Measured on gemma-4-31B: answer-first deadlocks every call,
+    # reasoning-first returns valid JSON in ~1s.
+    reasoning: Annotated[str, Field(description="Brief explanation of why tables were split or kept together")]
     tables: Annotated[
         list[TableBoundary],
         Field(description="List of table boundaries. First table always starts at row 0."),
     ]
-    reasoning: Annotated[str, Field(description="Brief explanation of why tables were split or kept together")]
 
 
 class HeaderAnalysis(BaseModel):
     """LLM analysis result for detecting header rows."""
 
-    num_header_rows: Annotated[int, Field(description="Number of header rows (1-4)")]
     reasoning: Annotated[str, Field(description="Brief explanation of header structure detected")]
+    num_header_rows: Annotated[int, Field(description="Number of header rows (1-4)")]
 
 
 # Result Models

--- a/packages/core/swiss_ai_hub/core/generative_ai/document/refinement/tests/unit/test_table_refiner.py
+++ b/packages/core/swiss_ai_hub/core/generative_ai/document/refinement/tests/unit/test_table_refiner.py
@@ -622,3 +622,11 @@ class TestOversizedTableSkipsRefinement:
             result = refine_document_tables_with_metadata(self._large_markdown_table(5), mock_llm_config)
 
         assert result.metadata.tables_processed == 1
+
+
+class TestSchemaFieldOrder:
+    """Answer-before-explanation deadlocks guided decoding; see the comment in models.py."""
+
+    def test_reasoning_is_declared_before_the_answer(self) -> None:
+        for model in (TableSplitAnalysis, HeaderAnalysis):
+            assert next(iter(model.model_json_schema()["properties"])) == "reasoning"


### PR DESCRIPTION
## Problem

Since #1699 merged, document ingestion is much slower and table-heavy documents exceed the 7200s Dagster job limit.

#1699 added `HtmlTableConverter`, which restored the markdown contract MinerU broke — and in doing so made LLM table
refinement run for the first time on MinerU-parsed documents. Refinement had been effectively dead code since #899
(`parse_markdown_table` returned `None` for every MinerU `<tr><td>` table, so the refiner `continue`d past all of them
and issued zero LLM calls). Making it live exposed a latent defect in its response schemas.

## Root cause

Not MinerU, not `HtmlTableConverter`, and not the model — it is the **field order of the Pydantic response schema**.

`TableSplitAnalysis` declared `tables` and then a required `reasoning`. Under guided JSON decoding the declaration order
is the generation order. The model emits the answer, considers itself finished, and the grammar refuses to close the
object until `reasoning` appears. Whitespace is legal JSON everywhere, so the model emits whitespace until `max_tokens`
(8192), `ResilientOpenAILike` retries 3×, and `_refine_single_table` swallows the result into its `except` branch —
where it silently falls back to a single header row. Roughly 88s burned per table, for a worse result than not running
at all.

Isolated against a **hand-built** schema; `TableSplitAnalysis` itself was never involved, only the order varied:

| schema | outcome |
| --- | --- |
| `{tables, reasoning}` both required | 400 tokens of whitespace, `finish_reason=length` |
| **`{reasoning, tables}` both required** | **valid JSON, 1.2s, real reasoning retained** |
| `{tables, reasoning?}` optional | valid JSON, 0.6s |
| no `response_format` at all | valid answer, 0.6s |

A hand-written 3-row table that never touched MinerU or the converter fails byte-identically to a real one, so the input
is irrelevant. The one table in ten that succeeded had a genuine page-break split — the model had something to say for
`reasoning`, so it closed the object normally.

`GuardResult` already declares `reasoning` first and every guard inherits it. The refinement models were the outliers;
this brings them in line with the existing convention.

## Change

Two moved lines. `reasoning` is declared first in `TableSplitAnalysis` and `HeaderAnalysis`, with a comment recording
why — the ordering looks arbitrary, and a future tidy-up that "groups the important fields first" would silently
reintroduce a multi-thousand-second regression. Plus a pure-introspection regression test asserting the order.

Source-compatible: every construction site uses keyword arguments.

## Verification

Cold LiteLLM cache, MinerU output frozen per document so the comparison isolates the schema change.

| document | pages | tables | refined | refine | LLM calls | nodes | embed | malformed |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: |
| Beitragstabellen SE und NE 12 | 34 | 7 | 7/7 | 85.8s | 22 | 110 | ok | 0 |
| Bundessteuergesetz DBG | 112 | 4 | 4/4 | 12.2s | 8 | 475 | ok | 0 |
| FamZWL.23 | 164 | 10 | 10/10 | 37.5s | 21 | 291 | ok | 0 |
| OR-01012026-DE | 556 | 25 | 25/25 | 92.7s | 58 | 2196 | ok | 0 |
| WBB 21 | 227 | 106 | 106/106 | 371.2s | 226 | 637 | ok | 0 |
| **total** | **1093** | **152** | **152/152** | **599s** | **335** | **3709** | **0 failures** | **0** |

The 335 calls are exactly 152 `detect_splits` + 183 `detect_headers` — **no retries anywhere**, the direct signal the
deadlock is gone. Zero unparseable, zero oversized, zero embedding failures.

Before/after on the one document measured cold on both sides (FamZWL, 10 tables): refinement **~800s → 37.5s**, 30 calls
(27 of them retries) → 21 calls, 27 malformed-output warnings → 0, tables genuinely refined **1/10 → 10/10**. Node output
is byte-identical either way (291 nodes, 36 975 table chars) — the reorder changes how the refiner reaches its verdict,
not the verdict.

**WBB 21 is the document that was failing.** At the measured pre-fix rate (~88s per deadlocked table, ~90% deadlock
rate) its 106 tables project to ~8400s, past the 7200s limit; it now completes refinement in 371s and the whole document
in 495s wall clock. That projection calibrates against FamZWL (predicted 792s, measured ~800s) and is the one number
here that is projected rather than observed — WBB was not re-measured pre-fix, as that is ~2.3h of shared GPU time.

Re-confirmed on this branch with a fresh cold run of the control document: refine 32.1s, 21 calls, 10/10 tables refined,
291 nodes, 0 malformed. `packages/core` suite passes (1113 tests).

## Follow-ups (filed separately, not fixed here)

1. The refiner pads tables 2.64× via `df.to_markdown(index=False)` — 14 016 chars in, 36 975 out on FamZWL, all embedded.
2. `HtmlTableConverter` expands `rowspan="2"` into both rows, so header merging concatenates a value with itself
   (`Kategorie - Kategorie`).
3. `split_dataframe_into_chunks` costs one `token_counter` HTTP round trip per table row, each building a fresh
   `httpx.Client` — 1093 calls / 24.3s on one document.
4. `max_tokens` is uncapped on the structured path (8192 for answers of ~30 tokens), which is what made each deadlocked
   attempt 29s instead of 2s.
5. `RouteSelectionModel` and `NamespaceDecision` share the same shape and are at risk by construction, but were never
   observed failing — verify each against the live model before reordering.
