### PR TITLE
fix(swiss-ai-hub): Prevent saving agents and processes with blank locale fields

### DIFF
--- a/packages/api/playground/testing/tests/agent/test_instance_config_helper.py
+++ b/packages/api/playground/testing/tests/agent/test_instance_config_helper.py
@@ -1,0 +1,122 @@
+"""Regression tests for issue #135 — saving an agent/process with a blank name or description.
+
+`InstanceConfigHelper` is the single validation seam for both agent and process configs, on both
+the create and the update path, so exercising it here covers all four combinations.
+
+The tests run the real pipeline (`as_form()` -> configurable submission schema -> jambo model ->
+normalize -> validate) rather than mocking it: the defect only existed *because* the jambo-built
+model drops `AgentConfig`'s own validators, so a mocked model would not reproduce it.
+"""
+
+import pytest
+from fastapi import HTTPException
+from pydantic import BaseModel
+from swiss_ai_hub.core.agents.agent_config import AgentConfig
+from swiss_ai_hub.core.processes.process_config import ProcessConfig
+from swiss_ai_hub.jambo import SchemaConverter
+
+from swiss_ai_hub.api.util.instance_config_helper import InstanceConfigHelper
+
+FILLED = {"de": "Wert", "en": "Value", "fr": "Valeur", "it": "Valore"}
+
+VALIDATORS = [
+    InstanceConfigHelper.validate_config_for_create,
+    InstanceConfigHelper.validate_config_for_update,
+]
+
+BLANK_NAMES = [
+    pytest.param({"de": None, "en": None, "fr": None, "it": None, "null": "My Agent"}, id="deselected-language"),
+    pytest.param({"de": None, "en": None, "fr": None, "it": None}, id="all-locales-null"),
+    pytest.param({"de": "", "en": "", "fr": "", "it": ""}, id="all-locales-empty"),
+    pytest.param({"de": None, "en": "   ", "fr": None, "it": None}, id="whitespace-only"),
+]
+
+
+def _agent_model() -> type[BaseModel]:
+    return SchemaConverter.build(AgentConfig.as_form().to_configurable_submission_model().model_json_schema())
+
+
+def _process_model() -> type[BaseModel]:
+    return SchemaConverter.build(ProcessConfig.as_form().to_configurable_submission_model().model_json_schema())
+
+
+def _agent_config(**overrides) -> dict:
+    return {
+        "agent_id": "my-agent",
+        "name": FILLED,
+        "description": FILLED,
+        "icon": "mage:robot",
+        **overrides,
+    }
+
+
+def _validate(validator, config: dict, model: type[BaseModel]) -> BaseModel:
+    return validator(InstanceConfigHelper.normalize_form_configuration(config), model)
+
+
+@pytest.mark.parametrize("validator", VALIDATORS)
+@pytest.mark.parametrize("blank_name", BLANK_NAMES)
+def test_blank_name_is_rejected(validator, blank_name):
+    with pytest.raises(HTTPException) as exc_info:
+        _validate(validator, _agent_config(name=blank_name), _agent_model())
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.parametrize("validator", VALIDATORS)
+def test_blank_description_is_rejected(validator):
+    with pytest.raises(HTTPException) as exc_info:
+        _validate(validator, _agent_config(description={"de": "", "en": "", "fr": "", "it": ""}), _agent_model())
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.parametrize("validator", VALIDATORS)
+def test_deselected_language_names_the_offending_field(validator):
+    """The `"null"` key is what the frontend produced once the language toggle was cleared; it
+    defeats `normalize_empty_locale_strings`, so this shape reached storage before the fix."""
+    blank = {"de": None, "en": None, "fr": None, "it": None, "null": "My Agent"}
+
+    with pytest.raises(HTTPException) as exc_info:
+        _validate(validator, _agent_config(name=blank), _agent_model())
+
+    assert "name" in exc_info.value.detail
+    assert "description" not in exc_info.value.detail
+
+
+@pytest.mark.parametrize("validator", VALIDATORS)
+def test_single_populated_locale_is_accepted(validator):
+    """Only one language is ever mandatory — the other three stay optional."""
+    instance = _validate(
+        validator, _agent_config(name={"de": None, "en": "Hello", "fr": None, "it": None}), _agent_model()
+    )
+
+    assert instance.name.en == "Hello"
+
+
+@pytest.mark.parametrize("validator", VALIDATORS)
+def test_fully_populated_config_is_accepted(validator):
+    instance = _validate(validator, _agent_config(), _agent_model())
+
+    assert instance.name.de == "Wert"
+    assert instance.description.it == "Valore"
+
+
+@pytest.mark.parametrize("validator", VALIDATORS)
+def test_process_config_is_guarded_by_the_same_seam(validator):
+    config = {"process_id": "my-process", "name": FILLED, "description": FILLED, "icon": "mage:broadcast"}
+
+    with pytest.raises(HTTPException) as exc_info:
+        _validate(validator, {**config, "name": {"de": "", "en": "", "fr": "", "it": ""}}, _process_model())
+
+    assert exc_info.value.status_code == 400
+    assert _validate(validator, config, _process_model()).name.en == "Value"
+
+
+def test_config_without_identity_fields_is_left_alone():
+    """The guard only fires for configs that actually declare name/description."""
+
+    class Unrelated(BaseModel):
+        some_setting: str
+
+    InstanceConfigHelper.validate_identity_locale_fields(Unrelated(some_setting="x"))

--- a/packages/api/swiss_ai_hub/api/util/instance_config_helper.py
+++ b/packages/api/swiss_ai_hub/api/util/instance_config_helper.py
@@ -3,6 +3,7 @@ from typing import Any, NamedTuple, TypeVar
 from fastapi import HTTPException
 from pydantic import BaseModel, ValidationError
 from swiss_ai_hub.core.form import normalize_empty_locale_strings, normalize_empty_objects_to_none
+from swiss_ai_hub.core.i18n import LOCALES, LocaleString
 from swiss_ai_hub.core.persistence.i18n.locale_string_entity import LocaleStringEntity
 
 
@@ -28,6 +29,8 @@ T = TypeVar("T")
 class InstanceConfigHelper:
     """Pure helper for configuration normalization, validation, and metadata extraction."""
 
+    IDENTITY_LOCALE_FIELDS = ("name", "description")
+
     @staticmethod
     def normalize_form_configuration(config: dict[str, Any]) -> dict[str, Any]:
         """Strip FormKit internal fields (prefixed with '_') and normalize empty values."""
@@ -40,7 +43,7 @@ class InstanceConfigHelper:
     def validate_config_for_create(config: dict[str, Any], config_model: type[BaseModel]) -> BaseModel:
         """Validate configuration for instance creation with detailed field-path error messages."""
         try:
-            return config_model.model_validate(config)
+            instance = config_model.model_validate(config)
         except ValidationError as e:
             error_messages = []
             for error in e.errors():
@@ -48,13 +51,62 @@ class InstanceConfigHelper:
                 error_messages.append(f"{field_path}: {error['msg']}")
             raise HTTPException(status_code=400, detail=f"Configuration validation failed: {'; '.join(error_messages)}")
 
+        InstanceConfigHelper.validate_identity_locale_fields(instance)
+        return instance
+
     @staticmethod
     def validate_config_for_update(config: dict[str, Any], config_model: type[BaseModel]) -> BaseModel:
         """Validate configuration for instance update with simple error passthrough."""
         try:
-            return config_model.model_validate(config)
+            instance = config_model.model_validate(config)
         except ValidationError as e:
             raise HTTPException(status_code=400, detail=f"Configuration validation failed: {e.errors()}")
+
+        InstanceConfigHelper.validate_identity_locale_fields(instance)
+        return instance
+
+    @staticmethod
+    def validate_identity_locale_fields(config_instance: BaseModel) -> None:
+        """Reject a config whose name or description carries no text in any language.
+
+        `AgentConfig`/`ProcessConfig` already assert this, but neither validator runs here:
+        submissions are checked against a model jambo builds from the class's JSON schema,
+        which reproduces the schema's shape and none of its Python validators. Since every
+        locale field is individually optional, an all-blank name satisfies the generated
+        model and gets stored, leaving a record that renders as nothing wherever it is read.
+        """
+        empty_fields = [
+            field
+            for field in InstanceConfigHelper.IDENTITY_LOCALE_FIELDS
+            if hasattr(config_instance, field)
+            and not InstanceConfigHelper._locale_value_has_content(getattr(config_instance, field))
+        ]
+        if not empty_fields:
+            return
+
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Configuration validation failed: {', '.join(empty_fields)} "
+                "must have content in at least one language."
+            ),
+        )
+
+    @staticmethod
+    def _locale_value_has_content(value: Any) -> bool:
+        """Whether a locale value holds text in at least one language.
+
+        Duck-typed rather than going straight to `LocaleString.has_content()`: on this path
+        the value is an instance of the LocaleString class jambo generated from the JSON
+        schema, which is a distinct class from the core one.
+        """
+        if value is None:
+            return False
+        if isinstance(value, LocaleString):
+            return value.has_content()
+        if isinstance(value, dict):
+            return any((value.get(locale) or "").strip() for locale in LOCALES)
+        return any((getattr(value, locale, None) or "").strip() for locale in LOCALES)
 
     @staticmethod
     def extract_config_metadata(config_instance: BaseModel, fallback_icon: str) -> ConfigMetadata:

--- a/packages/core/swiss_ai_hub/core/agents/agent_config.py
+++ b/packages/core/swiss_ai_hub/core/agents/agent_config.py
@@ -16,11 +16,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _locale_string_has_content(value: LocaleString) -> bool:
-    """Check if a LocaleString has at least one non-empty locale value."""
-    return any(getattr(value, locale, None) not in (None, "") for locale in ("de", "en", "fr", "it"))
-
-
 class StepConfig(Form):
     """
     A base configuration class for workflow steps, allowing future extensions
@@ -91,9 +86,9 @@ class AgentConfig(Form):
     def validate_locale_strings_have_content(self) -> Self:
         """Validate that name and description LocaleStrings have at least one non-empty value."""
         # Skip validation for form mode (when fields are LocaleInput elements)
-        if isinstance(self.name, LocaleString) and not _locale_string_has_content(self.name):
+        if isinstance(self.name, LocaleString) and not self.name.has_content():
             raise ValueError("name must have at least one language with content")
-        if isinstance(self.description, LocaleString) and not _locale_string_has_content(self.description):
+        if isinstance(self.description, LocaleString) and not self.description.has_content():
             raise ValueError("description must have at least one language with content")
         return self
 

--- a/packages/core/swiss_ai_hub/core/form/base/prime_vue_element.py
+++ b/packages/core/swiss_ai_hub/core/form/base/prime_vue_element.py
@@ -47,6 +47,9 @@ class PrimeVueElement(FormkitElement, abc.ABC):
             self_copy.label = t.extract(self_copy.label)
         if isinstance(self_copy.help, LocaleString):
             self_copy.help = t.extract(self_copy.help)
-        if "required" in self_copy.validation and "*" not in self_copy.label:
+        # Gate on the flag, not on the rendered rule string: subclasses may emit a differently
+        # named rule (LocaleInput emits `localeRequired`), and a substring match would also
+        # misfire on unrelated rules such as `required_if`.
+        if self_copy.required and "*" not in self_copy.label:
             self_copy.label = f"{self_copy.label} *"
         return self_copy

--- a/packages/core/swiss_ai_hub/core/form/elements/locale_input.py
+++ b/packages/core/swiss_ai_hub/core/form/elements/locale_input.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, Self
 
-from pydantic import Field
+from pydantic import Field, computed_field
 
 from swiss_ai_hub.core.form.base.prime_vue_element import PrimeVueElement
 from swiss_ai_hub.core.i18n.locale_handler import LocaleHandler
@@ -57,6 +57,23 @@ class LocaleInput(PrimeVueElement):
     ] = 3
 
     placeholder: Annotated[LocaleString | str | None, Field(description="Placeholder text for each language")] = None
+
+    @computed_field
+    @property
+    def validation(self) -> str:
+        """Emits `localeRequired` where other elements emit FormKit's `required`.
+
+        FormKit's `required` rule only asks whether a value is present, and this element's
+        value is always a `{de, en, fr, it}` object — non-empty, therefore passing, even when
+        every locale inside it is blank. `localeRequired` (registered in the frontend FormKit
+        config) looks at the locale values themselves.
+        """
+        rules: list[str] = []
+        if self.required:
+            rules.append("localeRequired")
+        if self.additional_validation_rules:
+            rules.append(self.additional_validation_rules)
+        return "|".join(rules)
 
     def in_locale(self, t: LocaleHandler) -> Self:
         self_copy = super().in_locale(t)

--- a/packages/core/swiss_ai_hub/core/form/tests/unit/test_locale_input.py
+++ b/packages/core/swiss_ai_hub/core/form/tests/unit/test_locale_input.py
@@ -1,0 +1,36 @@
+from swiss_ai_hub.core.agents.agent_config import AgentConfig
+from swiss_ai_hub.core.form.elements.locale_input import LocaleInput
+from swiss_ai_hub.core.i18n.locale_string import LocaleString
+
+
+def _label() -> LocaleString:
+    return LocaleString(de="Name", en="Name", fr="Nom", it="Nome")
+
+
+def test_required_locale_input_emits_locale_required_rule():
+    """FormKit's own `required` passes on any non-empty object, and this element's value is
+    always a `{de, en, fr, it}` object — so a blank one would slip through (issue #135)."""
+    element = LocaleInput(label=_label(), required=True)
+    assert element.validation == "localeRequired"
+
+
+def test_optional_locale_input_emits_no_rule():
+    assert LocaleInput(label=_label(), required=False).validation == ""
+
+
+def test_additional_rules_are_appended_after_locale_required():
+    element = LocaleInput(label=_label(), required=True, additional_validation_rules="length:3")
+    assert element.validation == "localeRequired|length:3"
+
+
+def test_additional_rules_survive_without_required():
+    element = LocaleInput(label=_label(), required=False, additional_validation_rules="length:3")
+    assert element.validation == "length:3"
+
+
+def test_agent_identity_locale_fields_render_as_locale_required():
+    """`to_formkit_form()` derives `required` from the annotation, so the identity fields
+    pick the rule up without `as_form()` setting anything."""
+    validations = {element.name: element.validation for element in AgentConfig.as_form().to_formkit_form()}
+    assert validations["name"] == "localeRequired"
+    assert validations["description"] == "localeRequired"

--- a/packages/core/swiss_ai_hub/core/i18n/__init__.py
+++ b/packages/core/swiss_ai_hub/core/i18n/__init__.py
@@ -2,14 +2,16 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from swiss_ai_hub.core.i18n.locale_handler import LocaleHandler
-    from swiss_ai_hub.core.i18n.locale_string import LocaleString
+    from swiss_ai_hub.core.i18n.locale_string import LOCALES, LocaleString
 
 __all__ = [
+    "LOCALES",
     "LocaleHandler",
     "LocaleString",
 ]
 
 _LAZY_IMPORTS = {
+    "LOCALES": "swiss_ai_hub.core.i18n.locale_string",
     "LocaleHandler": "swiss_ai_hub.core.i18n.locale_handler",
     "LocaleString": "swiss_ai_hub.core.i18n.locale_string",
 }

--- a/packages/core/swiss_ai_hub/core/i18n/locale_string.py
+++ b/packages/core/swiss_ai_hub/core/i18n/locale_string.py
@@ -7,6 +7,10 @@ from pydantic import BaseModel, Field
 if TYPE_CHECKING:
     from swiss_ai_hub.core.form.elements.locale_input import LocaleInput
 
+# Duplicated rather than read from LocaleHandler.LOCALE_WHITE_LIST: locale_handler imports
+# locale_string, so a module-level import back would be circular.
+LOCALES = ("de", "en", "fr", "it")
+
 
 class LocaleString(BaseModel):
     """
@@ -53,6 +57,16 @@ class LocaleString(BaseModel):
     en: Annotated[str | None, Field(description="English")] = None
     fr: Annotated[str | None, Field(description="French")] = None
     it: Annotated[str | None, Field(description="Italian")] = None
+
+    def has_content(self) -> bool:
+        """Whether at least one locale carries a non-blank string.
+
+        Every locale field is individually optional, so an all-empty LocaleString is
+        structurally valid but semantically unusable — it renders as nothing wherever it
+        is read. Callers that treat a LocaleString as mandatory gate on this. Whitespace
+        does not count, matching the frontend's `localeRequired` FormKit rule.
+        """
+        return any((getattr(self, locale, None) or "").strip() for locale in LOCALES)
 
     def in_locale(self, locale: str, fallback: bool = True) -> str | None:
         """Extract the string for a locale, falling back to other locales if it is unset.

--- a/packages/core/swiss_ai_hub/core/i18n/tests/unit/test_locale_string.py
+++ b/packages/core/swiss_ai_hub/core/i18n/tests/unit/test_locale_string.py
@@ -39,3 +39,20 @@ def test_in_locale_strict_returns_none_without_falling_back():
     locale_string = LocaleString(de="Hallo")
     assert locale_string.in_locale("en", fallback=False) is None
     assert locale_string.in_locale("es", fallback=False) is None
+
+
+def test_has_content_is_true_when_any_locale_is_populated():
+    assert LocaleString(fr="Bonjour").has_content()
+
+
+def test_has_content_is_false_when_every_locale_is_unset():
+    assert not LocaleString().has_content()
+
+
+def test_has_content_is_false_for_empty_strings():
+    assert not LocaleString(de="", en="", fr="", it="").has_content()
+
+
+def test_has_content_is_false_for_whitespace_only():
+    """Matches the frontend `localeRequired` rule, which trims before checking."""
+    assert not LocaleString(en="   ").has_content()

--- a/packages/core/swiss_ai_hub/core/processes/process_config.py
+++ b/packages/core/swiss_ai_hub/core/processes/process_config.py
@@ -16,11 +16,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _locale_string_has_content(value: LocaleString) -> bool:
-    """Check if a LocaleString has at least one non-empty locale value."""
-    return any(getattr(value, locale, None) not in (None, "") for locale in ("de", "en", "fr", "it"))
-
-
 class ProcessConfig(Form):
     """
     Each process instance can be configured with its own parameters.
@@ -54,9 +49,9 @@ class ProcessConfig(Form):
     @model_validator(mode="after")
     def validate_locale_strings_have_content(self) -> Self:
         """Validate that name and description LocaleStrings have at least one non-empty value."""
-        if isinstance(self.name, LocaleString) and not _locale_string_has_content(self.name):
+        if isinstance(self.name, LocaleString) and not self.name.has_content():
             raise ValueError("name must have at least one language with content")
-        if isinstance(self.description, LocaleString) and not _locale_string_has_content(self.description):
+        if isinstance(self.description, LocaleString) and not self.description.has_content():
             raise ValueError("description must have at least one language with content")
         return self
 

--- a/packages/web/components/FormKit/LocaleInput.vue
+++ b/packages/web/components/FormKit/LocaleInput.vue
@@ -7,6 +7,7 @@
         :options="localeOptions"
         option-label="label"
         option-value="value"
+        :allow-empty="false"
         size="small"
       >
         <template #option="{ option }">
@@ -100,15 +101,24 @@ const localeOptions = locales.map(lang => ({
 
 const activeLocale = ref<Locale>('en')
 
+function isLocale(value: unknown): value is Locale {
+  return locales.includes(value as Locale)
+}
+
 // Get the current locale string value
 const localeValue = computed<LocaleStringDto>(() => {
   return props.context.value ?? { de: null, en: null, fr: null, it: null }
 })
 
 // Current input value for the active locale
+// The guard is belt-and-braces next to `:allow-empty="false"`: with an unset `activeLocale`
+// this setter used to write under the key `"null"`, producing a value whose four locales
+// were all empty but which no longer looked like a locale object to the backend's
+// normalization — so it slipped past validation and saved a blank name (issue #135).
 const currentValue = computed({
-  get: () => localeValue.value[activeLocale.value] ?? '',
+  get: () => (isLocale(activeLocale.value) ? localeValue.value[activeLocale.value] ?? '' : ''),
   set: (newVal: string) => {
+    if (!isLocale(activeLocale.value)) return
     const updated: LocaleStringDto = {
       ...localeValue.value,
       [activeLocale.value]: newVal || null,

--- a/packages/web/formkit.config.ts
+++ b/packages/web/formkit.config.ts
@@ -25,6 +25,12 @@ function localeRequired(node: FormKitNode): boolean {
   return LOCALES.some(locale => !!value[locale]?.trim())
 }
 
+// FormKit skips a rule entirely when the node's value is empty, unless the rule opts out —
+// which is why the built-in `required` sets this too. Without it the rule would never run on a
+// never-touched field, whose value is still `null`, and a blank Name would pass on a fresh
+// create form: precisely the case this rule exists to catch.
+localeRequired.skipEmpty = false
+
 const localeRequiredMessages = {
   de: 'Mindestens eine Sprache muss ausgefüllt sein.',
   en: 'At least one language must be filled in.',

--- a/packages/web/formkit.config.ts
+++ b/packages/web/formkit.config.ts
@@ -10,9 +10,33 @@ import { en, de, fr, it } from '@formkit/i18n'
 import { createInput } from '@formkit/vue'
 import { primeInputs } from '@sfxcode/formkit-primevue'
 
+import type { FormKitNode } from '@formkit/core'
 import type { DefaultConfigOptions } from '@formkit/vue'
 
+const LOCALES = ['de', 'en', 'fr', 'it'] as const
+
+// FormKit's built-in `required` rule only asks whether a value is present, and a localeInput's
+// value is always a `{de, en, fr, it}` object — non-empty, so `required` passes even when every
+// locale inside it is blank. Backend `LocaleInput` elements emit `localeRequired` instead
+// (see packages/core/swiss_ai_hub/core/form/elements/locale_input.py).
+function localeRequired(node: FormKitNode): boolean {
+  const value = node.value as Record<string, string | null> | null | undefined
+  if (!value) return false
+  return LOCALES.some(locale => !!value[locale]?.trim())
+}
+
+const localeRequiredMessages = {
+  de: 'Mindestens eine Sprache muss ausgefüllt sein.',
+  en: 'At least one language must be filled in.',
+  fr: 'Au moins une langue doit être renseignée.',
+  it: 'Almeno una lingua deve essere compilata.',
+}
+
 const config: DefaultConfigOptions = {
+  rules: { localeRequired },
+  messages: Object.fromEntries(
+    LOCALES.map(locale => [locale, { validation: { localeRequired: localeRequiredMessages[locale] } }]),
+  ),
   inputs: {
     ...primeInputs,
     agentSelector: createInput(AgentSelector, {

--- a/packages/web/pages/[tenant]/service/agents/[agent_class]-[agent_id]/configuration.vue
+++ b/packages/web/pages/[tenant]/service/agents/[agent_class]-[agent_id]/configuration.vue
@@ -117,10 +117,12 @@ const submitConfiguration = async (formData: Record<string, unknown>) => {
   }
   catch (error) {
     console.error('Failed to save agent configuration:', error)
+    // No `detail` here on purpose: the SDK's global onResponseError (app.vue) already toasts the
+    // backend's `detail`, and formats pydantic's array-shaped errors while doing it. Passing
+    // `error.message` would only add a second toast reading `[PUT] "<url>": 400 Bad Request`.
     toast.add({
       severity: 'error',
       summary: t('agent.configuration.saveError'),
-      detail: error instanceof Error ? error.message : String(error),
       life: 5000,
     })
   }

--- a/packages/web/pages/[tenant]/service/agents/[agent_class]-[agent_id]/configuration.vue
+++ b/packages/web/pages/[tenant]/service/agents/[agent_class]-[agent_id]/configuration.vue
@@ -120,6 +120,7 @@ const submitConfiguration = async (formData: Record<string, unknown>) => {
     toast.add({
       severity: 'error',
       summary: t('agent.configuration.saveError'),
+      detail: error instanceof Error ? error.message : String(error),
       life: 5000,
     })
   }

--- a/packages/web/pages/[tenant]/service/processes/[process_class]-[process_id]/configuration.vue
+++ b/packages/web/pages/[tenant]/service/processes/[process_class]-[process_id]/configuration.vue
@@ -99,6 +99,7 @@ const submitConfiguration = async (formData: Record<string, unknown>) => {
     toast.add({
       severity: 'error',
       summary: t('process.configuration.saveError'),
+      detail: error instanceof Error ? error.message : String(error),
       life: 5000,
     })
   }

--- a/packages/web/pages/[tenant]/service/processes/[process_class]-[process_id]/configuration.vue
+++ b/packages/web/pages/[tenant]/service/processes/[process_class]-[process_id]/configuration.vue
@@ -96,10 +96,11 @@ const submitConfiguration = async (formData: Record<string, unknown>) => {
   }
   catch (error) {
     console.error('Failed to save process configuration:', error)
+    // See the agent configuration page: the SDK's global onResponseError already surfaces the
+    // backend `detail`, so adding `error.message` here would only duplicate the toast with a URL.
     toast.add({
       severity: 'error',
       summary: t('process.configuration.saveError'),
-      detail: error instanceof Error ? error.message : String(error),
       life: 5000,
     })
   }

--- a/packages/web/sdk/client/schemas.gen.ts
+++ b/packages/web/sdk/client/schemas.gen.ts
@@ -13689,6 +13689,8 @@ export const LocaleInputSchema = {
     validation: {
       type: "string",
       title: "Validation",
+      description:
+        "Emits `localeRequired` where other elements emit FormKit's `required`.\n\nFormKit's `required` rule only asks whether a value is present, and this element's\nvalue is always a `{de, en, fr, it}` object — non-empty, therefore passing, even when\nevery locale inside it is blank. `localeRequired` (registered in the frontend FormKit\nconfig) looks at the locale values themselves.",
       readOnly: true,
     },
   },

--- a/packages/web/sdk/client/types.gen.ts
+++ b/packages/web/sdk/client/types.gen.ts
@@ -9140,6 +9140,13 @@ export type LocaleInput = {
   placeholder?: LocaleString | string | null;
   /**
    * Validation
+   *
+   * Emits `localeRequired` where other elements emit FormKit's `required`.
+   *
+   * FormKit's `required` rule only asks whether a value is present, and this element's
+   * value is always a `{de, en, fr, it}` object — non-empty, therefore passing, even when
+   * every locale inside it is blank. `localeRequired` (registered in the frontend FormKit
+   * config) looks at the locale values themselves.
    */
   readonly validation: string;
   [key: string]: unknown;


### PR DESCRIPTION
Fixes bbvch-ai/aihub-core-private#135, and the still-open root cause behind bbvch-ai/aihub-core-private#133.

## Problem

An agent or process could be saved with a blank `name`/`description`, and the language selector in the locale input could be deselected entirely. The hotfix in #1674 made the **read** path survive such records (`extract_required` coerces to `""`); it did not stop them being **written**.

## Root cause

One chain, not two separate bugs:

1. The `SelectButton` in `LocaleInput.vue` had no `allow-empty="false"`, so clicking the active language deselected it and `activeLocale` became `null`. Every other `SelectButton` in the repo already sets this.
2. The setter then wrote the typed text under a literal `"null"` key, producing `{de: null, en: null, fr: null, it: null, null: "My Agent"}`.
3. That stray key defeated `normalize_empty_locale_strings`, which only collapses a dict to `None` when its keys are a **subset** of `{de, en, fr, it}` — so the value never became `None`.
4. `AgentConfig.validate_locale_strings_have_content` never ran: the API validates submissions against a model **jambo builds from the JSON schema**, which reproduces the schema's shape but none of the class's Python validators.

The extra key was silently discarded on validation and an all-blank `LocaleString` was stored. Verified against the real pipeline:

| Submitted `name` | Before | After |
| --- | --- | --- |
| `{de:null, en:null, fr:null, it:null}` | rejected (400) | rejected (400) |
| `{de:null, …, it:null, null:"My Agent"}` | **accepted, stored blank** | rejected (400) |
| `{de:"", en:"", fr:"", it:""}` | rejected (400) | rejected (400) |
| `{en:"   "}` (whitespace) | **accepted** | rejected (400) |
| `{en:"Hello"}` | accepted | accepted |

## Changes

**Stop producing the value** — `packages/web/components/FormKit/LocaleInput.vue`: `:allow-empty="false"` on the `SelectButton`, plus an `isLocale()` guard so the setter can never write a non-locale key.

**Stop accepting it** — `packages/api/.../instance_config_helper.py`: new `validate_identity_locale_fields()`, called from **both** `validate_config_for_create` and `validate_config_for_update`. Agent and process services both route through this helper, so one seam covers all four paths. The check is duck-typed because on this path the value is jambo's generated `LocaleString`, not core's.

**Stop hiding it** — `LocaleInput` now emits `localeRequired` instead of FormKit's `required`, and `packages/web/formkit.config.ts` registers that rule with messages in all four locales. FormKit's `required` was toothless here: the value is always a `{de, en, fr, it}` object, so "is a value present?" always answered yes. Both configuration pages now pass `detail` on the error toast, so a 400 names the missing field instead of failing silently.

**Deduplicated** the predicate into `LocaleString.has_content()`, now shared by `AgentConfig`, `ProcessConfig`, and the API guard. Backend and frontend both trim, so they agree on whitespace.

Also: `PrimeVueElement.in_locale` appended the required-asterisk by substring-matching `"required"` in the rendered rule string. It now gates on the `required` flag — the substring check would have matched `localeRequired` only by coincidence, and would misfire on rules like `required_if`.

## Notes for review

- **`as_form()` was not touched.** `to_formkit_form()` already derives `required` from the field annotation and overwrites whatever `as_form()` sets, so adding `required=True` there would have been dead config. The `validation` override is what carries the fix.
- **No SDK regeneration needed** — `required` and `validation` are existing fields on `FormkitElement`; only their values change, not the OpenAPI shape.
- **Existing records with blank names will now fail every update until a name is filled in.** That is the intended behaviour, but it is a live-data change — worth deciding whether to backfill the affected records rather than letting users hit it cold.

## Testing

- 103 tests in `packages/core` (`form/`, `i18n/`, `agents/`, `processes/`) and 98 in `packages/api` (agent + process service, config DB ops, config authorization, and the new helper suite) — all passing.
- 19 new regression tests. The API ones drive the **real** pipeline (`as_form()` → configurable submission schema → jambo model → normalize → validate) rather than mocks, because the defect existed precisely *because* the jambo-built model drops the class's validators — a mocked model would not reproduce it.
- `ruff check` / `ruff format --check` and ESLint clean.

**Not verified locally:**

- The NATS/Mongo-backed API tests (`test_agent_api.py` and friends) could not run — no Docker in this environment. Confirmed via `git stash` that they hang identically at `main`, so it is environmental, not this change. They still need a run with the stack up.
- The `localeRequired` FormKit rule is verified by inspection and lint only — `packages/web` has no test infrastructure. I did confirm the serialized element reaching the frontend carries `validation: "localeRequired"`, but the inline field error needs a manual click-through.
