### PR TITLE
fix(rag): Strip summary child relationships before the Milvus insert

### DIFF
--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -465,6 +465,14 @@ role assignments), `ThreadEntity` (conversations), `PersistedAgentEventEntity` /
 storage), `AgentConfigEntity` / `ProcessConfigEntity` (configs), `UserDashboardEntity` (dashboard config),
 `NotificationEntity`, `LocaleStringEntity`.
 
+**Vector store — children are not persisted**: `PartitionAwareMilvusVectorStore.add` strips `NodeRelationship.CHILD`
+before serializing. LlamaIndex packs every relationship into `_node_content` inside Milvus' dynamic field, which is
+capped at 65536 bytes, and a hierarchical summary node carries one entry per descendant — so a wide summary tree fails
+the insert outright. The edge is recoverable because each child persists its own `PARENT`, which is that edge's exact
+inverse; read it that way rather than expecting `child_nodes`, which comes back `None`. `add` also verifies the dynamic
+field fits before writing any node, so a new metadata key that reintroduces the overflow fails with the offending
+document and node named instead of Milvus' `code=1100`.
+
 ## Infrastructure Settings
 
 ~20 Pydantic `BaseSettings` classes for external service connections. Environment variables are NOT auto-loaded — they

--- a/packages/core/swiss_ai_hub/core/persistence/rag/vectors/stores/partition_aware_milvus_vector_store.py
+++ b/packages/core/swiss_ai_hub/core/persistence/rag/vectors/stores/partition_aware_milvus_vector_store.py
@@ -1,6 +1,7 @@
+import json
 from typing import Any
 
-from llama_index.core.schema import BaseNode
+from llama_index.core.schema import BaseNode, NodeRelationship
 from llama_index.core.utils import iter_batch
 from llama_index.core.vector_stores import MetadataFilters
 from llama_index.core.vector_stores.types import VectorStoreQuery, VectorStoreQueryMode, VectorStoreQueryResult
@@ -9,7 +10,7 @@ from llama_index.vector_stores.milvus import MilvusVectorStore
 from llama_index.vector_stores.milvus.utils import BaseSparseEmbeddingFunction
 from pymilvus import MilvusClient
 
-from swiss_ai_hub.core.persistence.rag.vectors.node_metadata import NAMESPACE
+from swiss_ai_hub.core.persistence.rag.vectors.node_metadata import DOCUMENT_ID, NAMESPACE
 from swiss_ai_hub.core.persistence.rag.vectors.stores.milvus_partition_manager import (
     MAX_PARTITIONS,
     get_partition_name_for_namespace,
@@ -22,6 +23,8 @@ except ImportError:
     AnnSearchRequest = None
     RRFRanker = None
     WeightedRanker = None
+
+MILVUS_DYNAMIC_FIELD_MAX_BYTES = 65536
 
 
 class PartitionAwareMilvusVectorStore(MilvusVectorStore):
@@ -65,6 +68,7 @@ class PartitionAwareMilvusVectorStore(MilvusVectorStore):
         self._milvusclient = client
 
         self._has_manual_partitions: bool | None = None
+        self._declared_fields: set[str] | None = None
 
     def _ensure_collection_loaded(self, partition_names: list[str] | None = None) -> None:
         """Lazily load partitions (or whole collection if none specified). Idempotent — blocks until ready.
@@ -91,9 +95,20 @@ class PartitionAwareMilvusVectorStore(MilvusVectorStore):
         return self._has_manual_partitions
 
     def add(self, nodes: list[BaseNode], **add_kwargs: Any) -> list[str]:
-        """Insert nodes into their hashed partitions (or fallback to base class if no manual partitions)."""
+        """
+        Insert nodes into their hashed partitions (or fallback to base class if no manual partitions).
+
+        Sanitize and verify every node before writing any of them: a batch spans namespaces and is inserted
+        one partition at a time, so validating at the insert site would leave earlier partitions written
+        behind a rejected one. Verifying here also covers the super().add() fallback, which builds its own
+        entries. Re-deriving the entry costs one node_to_metadata_dict per node, negligible against embedding.
+        """
         if not nodes:
             return []
+
+        nodes = [self._without_child_relationship(node) for node in nodes]
+        for node in nodes:
+            self._verify_entry_fits(node_to_metadata_dict(node, remove_text=True, text_field=self.text_key), node)
 
         if not self._check_has_manual_partitions():
             self._ensure_collection_loaded()
@@ -112,6 +127,70 @@ class PartitionAwareMilvusVectorStore(MilvusVectorStore):
             self.client.flush(self.collection_name)
 
         return all_ids
+
+    @staticmethod
+    def _without_child_relationship(node: BaseNode) -> BaseNode:
+        """
+        Drop parent -> children before serialization: node_to_metadata_dict packs relationships into the
+        dynamic field, which Milvus caps at 65536 bytes, and a hierarchical summary node carries one entry
+        per descendant — unbounded. The edge is not lost, since every child persists its own parent edge and
+        this is that edge's exact inverse; recovering it means scanning the document's nodes, as it is inside
+        the _node_content JSON string rather than a queryable key.
+
+        Returns a copy: the caller's nodes continue to downstream ops, so writing them must not change them.
+        """
+        if NodeRelationship.CHILD not in node.relationships:
+            return node
+
+        relationships = {
+            relationship: info
+            for relationship, info in node.relationships.items()
+            if relationship != NodeRelationship.CHILD
+        }
+        return node.model_copy(update={"relationships": relationships})
+
+    def _declared_field_names(self) -> set[str]:
+        """
+        Resolve declared columns from the live collection rather than restating the schema, which lives in
+        milvus_vector_store_factory and would drift. The store attributes alone are not enough either —
+        namespace is a declared column with no corresponding attribute.
+        """
+        if self._declared_fields is None:
+            description = self.client.describe_collection(collection_name=self.collection_name)
+            self._declared_fields = {field["name"] for field in description["fields"]}
+
+        return self._declared_fields
+
+    def _verify_entry_fits(self, entry: dict[str, Any], node: BaseNode) -> None:
+        """Split declared columns from the dynamic remainder exactly as pymilvus does before packing it."""
+        declared_fields = self._declared_field_names()
+        dynamic_field = {key: value for key, value in entry.items() if key not in declared_fields}
+        self._verify_dynamic_field_fits(dynamic_field, node)
+
+    @classmethod
+    def _verify_dynamic_field_fits(cls, dynamic_field: dict[str, Any], node: BaseNode) -> None:
+        """Fail with a diagnosable message instead of Milvus' code=1100, which names neither the document
+        nor the node."""
+        size = cls._json_size_in_bytes(dynamic_field)
+        if size <= MILVUS_DYNAMIC_FIELD_MAX_BYTES:
+            return
+
+        by_size = sorted(dynamic_field, key=lambda key: cls._json_size_in_bytes(dynamic_field[key]), reverse=True)
+        largest_keys = [f"{key}={cls._json_size_in_bytes(dynamic_field[key])}B" for key in by_size[:3]]
+        raise ValueError(
+            f"Node {node.node_id} of document {node.metadata.get(DOCUMENT_ID)} serializes to {size} bytes of "
+            f"Milvus dynamic field, over the {MILVUS_DYNAMIC_FIELD_MAX_BYTES} limit. "
+            f"Largest keys: {largest_keys}"
+        )
+
+    @staticmethod
+    def _json_size_in_bytes(value: Any) -> int:
+        """
+        Mirror how pymilvus packs the dynamic field: orjson.dumps, which emits compact separators and raw
+        UTF-8. Milvus then measures the result in bytes, which diverges from character count on the very
+        German documents most likely to breach the limit.
+        """
+        return len(json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode())
 
     @staticmethod
     def _group_nodes_by_namespace(nodes: list[BaseNode]) -> dict[str, list[BaseNode]]:

--- a/packages/core/swiss_ai_hub/core/persistence/rag/vectors/stores/tests/unit/test_partition_aware_milvus_vector_store.py
+++ b/packages/core/swiss_ai_hub/core/persistence/rag/vectors/stores/tests/unit/test_partition_aware_milvus_vector_store.py
@@ -255,9 +255,10 @@ def test_undeclared_keys_do_count_toward_the_dynamic_field() -> None:
 
 def test_declared_field_names_are_resolved_once_and_cached() -> None:
     store = _make_store_with_stub_client()
+    expected = {"id", DOCUMENT_ID, NAMESPACE, "embedding", "sparse_embedding", "text"}
 
-    assert store._declared_field_names() == {"id", DOCUMENT_ID, NAMESPACE, "embedding", "sparse_embedding", "text"}
-    assert store._declared_field_names() == store._declared_field_names()
+    assert store._declared_field_names() == expected
+    assert store._declared_field_names() == expected
     assert store.client.describe_calls == 1
 
 
@@ -275,8 +276,9 @@ def test_guard_measures_bytes_not_characters() -> None:
     store = _make_store()
     payload = "ü" * (MILVUS_DYNAMIC_FIELD_MAX_BYTES // 2)
     dynamic_field = {"_node_content": payload}
+    node = _make_summary_node(child_count=0)
 
     assert len(json.dumps(dynamic_field, ensure_ascii=False)) < MILVUS_DYNAMIC_FIELD_MAX_BYTES
 
     with pytest.raises(ValueError):
-        store._verify_dynamic_field_fits(dynamic_field, _make_summary_node(child_count=0))
+        store._verify_dynamic_field_fits(dynamic_field, node)

--- a/packages/core/swiss_ai_hub/core/persistence/rag/vectors/stores/tests/unit/test_partition_aware_milvus_vector_store.py
+++ b/packages/core/swiss_ai_hub/core/persistence/rag/vectors/stores/tests/unit/test_partition_aware_milvus_vector_store.py
@@ -1,8 +1,14 @@
+import json
+
+import pytest
+from llama_index.core.schema import NodeRelationship, RelatedNodeInfo, TextNode
 from llama_index.core.vector_stores import MetadataFilter, MetadataFilters
 from llama_index.core.vector_stores.types import FilterCondition, VectorStoreQuery
+from llama_index.core.vector_stores.utils import metadata_dict_to_node, node_to_metadata_dict
 
-from swiss_ai_hub.core.persistence.rag.vectors.node_metadata import NAMESPACE, TYPE
+from swiss_ai_hub.core.persistence.rag.vectors.node_metadata import DOCUMENT_ID, NAMESPACE, TYPE
 from swiss_ai_hub.core.persistence.rag.vectors.stores.partition_aware_milvus_vector_store import (
+    MILVUS_DYNAMIC_FIELD_MAX_BYTES,
     PartitionAwareMilvusVectorStore,
 )
 
@@ -10,6 +16,47 @@ from swiss_ai_hub.core.persistence.rag.vectors.stores.partition_aware_milvus_vec
 def _make_store() -> PartitionAwareMilvusVectorStore:
     """Bypass __init__ — these tests cover pure helpers that don't need a Milvus client."""
     return PartitionAwareMilvusVectorStore.__new__(PartitionAwareMilvusVectorStore)
+
+
+class _StubMilvusClient:
+    """Answers describe_collection with the schema from milvus_vector_store_factory."""
+
+    def __init__(self) -> None:
+        self.describe_calls = 0
+
+    def describe_collection(self, collection_name: str) -> dict[str, list[dict[str, str]]]:
+        self.describe_calls += 1
+        return {
+            "fields": [
+                {"name": name} for name in ("id", DOCUMENT_ID, NAMESPACE, "embedding", "sparse_embedding", "text")
+            ]
+        }
+
+
+def _make_store_with_stub_client() -> PartitionAwareMilvusVectorStore:
+    """__init__ needs a live Milvus; these tests only need collection_name and a describe_collection."""
+    store = _make_store()
+    object.__setattr__(store, "__dict__", {"collection_name": "defaultknowledge"})
+    store._milvusclient = _StubMilvusClient()
+    store._declared_fields = None
+    return store
+
+
+def _make_summary_node(child_count: int) -> TextNode:
+    """A summary node shaped like the one that broke ingestion: one CHILD entry per descendant."""
+    return TextNode(
+        text="summary",
+        metadata={DOCUMENT_ID: "6b5447776c2e3176da636a57", NAMESPACE: "embre-new"},
+        relationships={
+            NodeRelationship.SOURCE: RelatedNodeInfo(node_id="source-doc"),
+            NodeRelationship.PARENT: RelatedNodeInfo(node_id="root-summary"),
+            NodeRelationship.PREVIOUS: RelatedNodeInfo(node_id="previous-summary"),
+            NodeRelationship.NEXT: RelatedNodeInfo(node_id="next-summary"),
+            NodeRelationship.CHILD: [
+                RelatedNodeInfo(node_id=f"{index:08x}-4b1e-4f8a-9c2d-{index:012x}") for index in range(child_count)
+            ],
+        },
+    )
 
 
 def test_extract_namespaces_returns_empty_when_query_has_no_filters() -> None:
@@ -98,3 +145,138 @@ def test_extract_namespaces_from_metadata_filters_directly() -> None:
     )
 
     assert store._extract_namespaces_from_metadata_filters(filters) == ["alpha"]
+
+
+def test_stripping_children_keeps_summary_node_under_the_dynamic_field_limit() -> None:
+    """
+    Regression for #155: a summary node over a flat document accumulates one CHILD entry per section,
+    and the serialized node exceeds Milvus' dynamic field cap long before the tree gets deep.
+    """
+    store = _make_store()
+    node = _make_summary_node(child_count=500)
+
+    assert store._json_size_in_bytes(node_to_metadata_dict(node, remove_text=True)) > MILVUS_DYNAMIC_FIELD_MAX_BYTES
+
+    sanitized = store._without_child_relationship(node)
+    entry = node_to_metadata_dict(sanitized, remove_text=True)
+
+    assert store._json_size_in_bytes(entry) <= MILVUS_DYNAMIC_FIELD_MAX_BYTES
+
+
+def test_stripping_children_preserves_every_other_relationship() -> None:
+    store = _make_store()
+
+    sanitized = store._without_child_relationship(_make_summary_node(child_count=10))
+
+    assert set(sanitized.relationships) == {
+        NodeRelationship.SOURCE,
+        NodeRelationship.PARENT,
+        NodeRelationship.PREVIOUS,
+        NodeRelationship.NEXT,
+    }
+    assert sanitized.relationships[NodeRelationship.PARENT].node_id == "root-summary"
+
+
+def test_stripping_children_does_not_mutate_the_callers_node() -> None:
+    """add() receives nodes that stay in use downstream — persistence must not edit them in place."""
+    store = _make_store()
+    node = _make_summary_node(child_count=10)
+
+    store._without_child_relationship(node)
+
+    assert len(node.relationships[NodeRelationship.CHILD]) == 10
+
+
+def test_node_without_children_is_returned_unchanged() -> None:
+    store = _make_store()
+    node = TextNode(text="content", relationships={NodeRelationship.SOURCE: RelatedNodeInfo(node_id="source-doc")})
+
+    assert store._without_child_relationship(node) is node
+
+
+def test_children_are_not_restored_on_read() -> None:
+    """
+    Pins the trade-off: the stored node has no child list, so nothing can silently reintroduce the
+    overflow by round-tripping it. Consumers walk PARENT upward instead.
+    """
+    store = _make_store()
+    entry = node_to_metadata_dict(store._without_child_relationship(_make_summary_node(child_count=10)))
+
+    restored = metadata_dict_to_node(entry)
+
+    assert restored.child_nodes is None
+    assert restored.parent_node.node_id == "root-summary"
+
+
+def test_guard_names_the_document_and_node_when_the_dynamic_field_overflows() -> None:
+    store = _make_store()
+    node = _make_summary_node(child_count=500)
+    dynamic_field = node_to_metadata_dict(node, remove_text=True)
+
+    with pytest.raises(ValueError) as exception_info:
+        store._verify_dynamic_field_fits(dynamic_field, node)
+
+    message = str(exception_info.value)
+    assert node.node_id in message
+    assert "6b5447776c2e3176da636a57" in message
+    assert "_node_content" in message
+
+
+def test_declared_columns_do_not_count_toward_the_dynamic_field() -> None:
+    """
+    The split must mirror pymilvus' own (`k not in fields_data`, prepare.py). Counting declared columns
+    would reject entries Milvus accepts — text alone is allowed a full 65535 bytes of its own.
+    """
+    store = _make_store_with_stub_client()
+    node = _make_summary_node(child_count=0)
+    entry = node_to_metadata_dict(node, remove_text=True)
+    entry.update(
+        {
+            "id": node.node_id,
+            "text": "x" * MILVUS_DYNAMIC_FIELD_MAX_BYTES,
+            "embedding": [0.123456789] * 4096,
+            "sparse_embedding": {1: 0.5},
+        }
+    )
+
+    store._verify_entry_fits(entry, node)
+
+
+def test_undeclared_keys_do_count_toward_the_dynamic_field() -> None:
+    """The mirror of the above: missing a key that Milvus packs would make the guard decorative."""
+    store = _make_store_with_stub_client()
+    node = _make_summary_node(child_count=0)
+    entry = node_to_metadata_dict(node, remove_text=True)
+    entry["table_refinement"] = "x" * MILVUS_DYNAMIC_FIELD_MAX_BYTES
+
+    with pytest.raises(ValueError):
+        store._verify_entry_fits(entry, node)
+
+
+def test_declared_field_names_are_resolved_once_and_cached() -> None:
+    store = _make_store_with_stub_client()
+
+    assert store._declared_field_names() == {"id", DOCUMENT_ID, NAMESPACE, "embedding", "sparse_embedding", "text"}
+    assert store._declared_field_names() == store._declared_field_names()
+    assert store.client.describe_calls == 1
+
+
+def test_size_matches_how_pymilvus_serializes_the_dynamic_field() -> None:
+    """pymilvus packs the dynamic field with orjson, which emits compact separators and raw UTF-8."""
+    orjson = pytest.importorskip("orjson")
+    store = _make_store()
+    dynamic_field = node_to_metadata_dict(_make_summary_node(child_count=20), remove_text=True)
+
+    assert store._json_size_in_bytes(dynamic_field) == len(orjson.dumps(dynamic_field))
+
+
+def test_guard_measures_bytes_not_characters() -> None:
+    """Milvus rejects on UTF-8 byte length; a two-byte-per-character payload fits by count and not by size."""
+    store = _make_store()
+    payload = "ü" * (MILVUS_DYNAMIC_FIELD_MAX_BYTES // 2)
+    dynamic_field = {"_node_content": payload}
+
+    assert len(json.dumps(dynamic_field, ensure_ascii=False)) < MILVUS_DYNAMIC_FIELD_MAX_BYTES
+
+    with pytest.raises(ValueError):
+        store._verify_dynamic_field_fits(dynamic_field, _make_summary_node(child_count=0))


### PR DESCRIPTION
Fixes bbvch-ai/aihub-core-private#155

## Problem

Documents with a wide summary tree fail the vector-store insert with Milvus `code=1100` and never reach RAG. The
document ingests its content nodes, then the `summary_nodes` asset dies, so the document is silently half-indexed.

On the dev stack today, `OR-01012026-DE.pdf` has **2179 content nodes and 0 summary nodes**.

## Root cause

`RecursiveNodeSummarizer._set_parent_child` appends one `RelatedNodeInfo` to the parent's `CHILD` list per descendant.
`node_to_metadata_dict` serializes every relationship into `_node_content`, which lands in Milvus' dynamic field. That
field is capped at **65536 UTF-8 bytes** and each child entry costs ~149 B, so the insert breaks somewhere between
**420 and 430 children** (bisected).

| Document             | Children on root summary | Dynamic field             |
| -------------------- | ------------------------ | ------------------------- |
| `OR-01012026-DE.pdf` | 2051                     | **308 358 B** — 4.7× over |
| `WBB 21.pdf`         | 415                      | 64 511 B — 98.4% of limit |

The upstream driver is that MinerU's VLM backend emits a flat H1-only structure, so every content node lands at level
1, level 0 has no nodes of its own, and `_summarize_summaries` builds a single root over *all* level-1 summaries. See
"Not in scope".

## The fix

**1. Strip `CHILD` at the persistence boundary** (`PartitionAwareMilvusVectorStore.add`).

The edge is not lost: every child persists its own `PARENT`, which is this edge's exact inverse. Nothing in the
codebase reads `child_nodes` — `ParentSummaryPostProcessor` walks `PARENT` upward, `VectorPrevNextPostProcessor` uses
`prev_node`/`next_node`, and the frontend has zero references. The only readers are the summary parser's own unit
tests, which work in memory before persistence.

Returns a copy rather than mutating, since the caller's nodes stay in use downstream.

**2. Verify the dynamic field fits before writing any node.**

This is a diagnosability fix, not a resilience one. Milvus' `code=1100` names neither the document nor the node, which
is most of why this took an investigation to pin down. The guard raises with both, plus the three largest keys and
their sizes:

```
Node f947bd71-… of document 6b544777… serializes to 160654 bytes of Milvus dynamic field,
over the 65536 limit. Largest keys: ['_node_content=80554B', 'table_refinement=80002B', '_node_type=10B']
```

It runs in `add()` before either write path, so a batch spanning namespaces is all-or-nothing — `add()` inserts one
partition at a time, and validating at the insert site would leave earlier partitions written behind a rejected one.
`vector_store_io_manager` flattens `list[list[TextNode]]` across documents into one `add()`, so multi-namespace batches
are real.

Size accounting mirrors pymilvus exactly: it packs the dynamic field with `orjson.dumps`, so the guard uses compact
separators and raw UTF-8 and measures **bytes, not characters** — the two diverge on precisely the German documents
most likely to breach the cap.

## Evidence

**Unit** — 17 tests in `test_partition_aware_milvus_vector_store.py`, including that declared columns are excluded from
the measurement, that the size matches `orjson.dumps` byte-for-byte, and that the child list is *not* restored on read
so nothing can silently reintroduce the overflow.

**Integration, live Milvus** — a root summary with 2051 children inserts; the caller's nodes keep their child list;
`PARENT`/`PREVIOUS`/`NEXT`/`SOURCE` survive; `metadata_dict_to_node` reconstructs cleanly; `ParentSummaryPostProcessor`
still resolves the parent; the non-partitioned fallback still ingests; a cross-namespace batch with one oversized node
writes **0 rows**.

**End-to-end, real pipeline** — the same 7 documents through the real `default_definitions()` asset graph on both
branches. `FamZWL.23.pdf` succeeds either way, but the peak dynamic field drops from **38 548 B (59% of the limit) on
main to 3 507 B (5%)** — the ~146 B/child cost of a 240-child root, matching the 149 B/child measured in the
investigation. Note MinerU's VLM backend is non-deterministic: the same PDF parsed twice gave 287 vs 290 content nodes,
so cross-run counts are approximate.

## Not in scope

- **The summary tree is degenerate.** With H1-only input it is two levels: N leaf summaries plus one root over all N.
  Once this lands, OR ingests a root summarising ~2000 sections that `ParentSummaryPostProcessor` (`max_levels=3`) will
  pull into context on nearly every query in that namespace. This fix exposes that rather than causing it.
- **MinerU emits flat headings by design.** `get_title_level` reads `block.get('level', 1)` and the `vlm-http-client`
  backend never sets `level`. Hierarchy is opt-in via `llm_aided.title_aided` + `mineru[core]`, and
  `get_llm_aided_config()` returns `None` in our container. The classifier also produces false-positive titles (margin
  numbers, mid-sentence fragments), each adding a section and therefore a child.
- **Summarisation is sequential.** `RecursiveNodeSummarizer` issues one LLM call at a time; OR's summary step ran ~6.7
  calls/min, several hours for one document. No batching or concurrency.
- **Rejected alternatives.** Stripping in the parser (it legitimately needs the list in memory); a dedicated VARCHAR
  field (caps at 65535 bytes, and OR's `_node_content` alone is 278 670); a queryable `parent_id` key (no consumer, and
  `excluded_embed_metadata_keys` is empty so a raw UUID would enter the embedded text).

## Review notes

Two review findings were consciously not actioned: `_declared_fields` is never invalidated (matches the
`_has_manual_partitions` precedent directly above it; invalidating would mean a `describe_collection` per insert), and
the coupling direction of `_without_child_relationship` living in generic persistence infra (deliberate — the 65536 cap
is a Milvus fact and this class is the only thing that knows it).
