### PR TITLE
doc(swiss-ai-hub): Add Email Agent documentation

### DIFF
--- a/docs/docs/2_platform/5_agents/11_email_agent/index.de.md
+++ b/docs/docs/2_platform/5_agents/11_email_agent/index.de.md
@@ -1,7 +1,7 @@
 ---
 title: E-Mail-Agent
 description: Ein Postfach-Agent, der ungelesene E-Mails aus einem IMAP-Posteingang liest, sie ablegt und Antworten zur Prüfung durch einen Menschen entwirft — versendet wird nie.
-source_sha: 9bea49d9fefcea8b3f5e29c0aaa98679259cdcb27ee500b450c066c9246e721d
+source_sha: fd9620f92f3f3cbfa6230c9c03c900e2adca9a34506f781c55471a10286d57fb
 ---
 
 # E-Mail-Agent
@@ -82,6 +82,14 @@ Verschieben verlagert eine Nachricht; gelöscht wird nie.
 3. **Speichern und markieren.** Jeder Entwurf wird an den Entwürfe-Ordner angehängt, und erst danach wird die
    Quellnachricht als entworfen markiert. Die Quellnachricht bleibt **ungelesen** — ein Mensch sieht sie weiterhin als
    neue Post, die Aufmerksamkeit braucht.
+
+::: details Welches Flag eine Nachricht als entworfen markiert
+Der Agent bevorzugt ein privates Keyword (`$AiHubDrafted`), das nur er selbst versteht, damit eine Nachricht mit einem
+ungesendeten Entwurf nicht nach etwas aussieht, das sie nicht ist. Nicht jeder Mailserver unterstützt jedoch
+benutzerdefinierte Keywords. Auf einem Server ohne diese Unterstützung weicht der Agent auf das Standard-Flag
+`\Answered` aus — solche Nachrichten erscheinen in Ihrem Mail-Client dann als **beantwortet**, obwohl noch nichts
+gesendet wurde. Falls Ihr Postfach unerwartete „beantwortet"-Markierungen zeigt, ist das der Grund.
+:::
 
 ::: details Warum die Quellnachricht ungelesen bleibt
 Das Entwerfen ist ein Vorbereitungsschritt, keine Erledigung. Der Sinn ist, dass ein Mensch das Postfach öffnet, die

--- a/docs/docs/2_platform/5_agents/11_email_agent/index.de.md
+++ b/docs/docs/2_platform/5_agents/11_email_agent/index.de.md
@@ -1,0 +1,215 @@
+---
+title: E-Mail-Agent
+description: Ein Postfach-Agent, der ungelesene E-Mails aus einem IMAP-Posteingang liest, sie ablegt und Antworten zur Prüfung durch einen Menschen entwirft — versendet wird nie.
+source_sha: 9bea49d9fefcea8b3f5e29c0aaa98679259cdcb27ee500b450c066c9246e721d
+---
+
+# E-Mail-Agent
+
+Der **E-Mail-Agent** (der IMAP-Agent) verbindet sich über IMAP mit einem Postfach und arbeitet es für Sie ab. Er listet
+die ungelesenen E-Mails eines Posteingangs auf, ruft eine Nachricht samt Anhängen ab, legt diese Nachricht optional in
+einem anderen Ordner ab und entwirft — als separater, unabhängig geplanter Job — Antworten für einen Stapel von
+Nachrichten und hinterlegt sie in Ihrem Entwürfe-Ordner.
+
+Anders als die chatbasierten Assistenten hat dieser Agent **keine Chat-Oberfläche**. Sie sprechen nicht mit ihm. Er wird
+einmalig im Admin UI konfiguriert und danach programmatisch ausgelöst — durch einen Scheduler, durch einen anderen
+Workflow oder über die API. Darin verhält er sich wie der [Retrieval Agent](../6_retrieval_agent/): Er ist ein Baustein
+für Automatisierung und kein Gesprächspartner.
+
+::: tip Wann Sie zu diesem Agent greifen sollten
+Setzen Sie den E-Mail-Agent ein, wenn Arbeit per E-Mail eintrifft und Sie den Routineanteil automatisch erledigt haben
+möchten — die Triage eines gemeinsam genutzten Postfachs, das Ablegen verarbeiteter E-Mails aus dem Posteingang oder das
+nächtliche Vorbereiten von Antwort-Entwürfen, sodass ein Mensch nur noch prüfen und senden muss. Wenn Sie einen
+Assistenten zum Chatten möchten, verwenden Sie stattdessen den [Instructed Assistant](../3_instructed_assistant/) oder
+den [Document Intelligence Assistant](../5_document_intelligence_assistant/).
+:::
+
+::: warning Er versendet niemals E-Mails
+Der Agent spricht ausschliesslich IMAP — es gibt nirgends SMTP. Er kann lesen, verschieben und *einen Entwurf
+speichern*, aber er kann niemals eine Nachricht tatsächlich versenden. Immer öffnet ein Mensch den Entwurf, prüft ihn
+und sendet ihn. Das ist eine bewusste Design-Grenze und keine Voreinstellung, die Sie abschalten können.
+:::
+
+## Was er tut
+
+Der Agent hat **zwei unabhängige Fähigkeiten**, jede mit einem eigenen Trigger. Sie hängen nicht voneinander ab, und Sie
+können sie getrennt einplanen — zum Beispiel Lesen/Verschieben alle fünf Minuten und das Entwerfen einmal pro Stunde.
+
+```mermaid
+flowchart TD
+    subgraph read [Lesen und ablegen]
+        A[Lese-Trigger] --> B[Ungelesene E-Mails auflisten]
+        B --> C{Ungelesene<br/>Nachrichten?}
+        C -- Nein --> D[Stopp]
+        C -- Ja --> E[Erste Nachricht abrufen<br/>+ Anhänge]
+        E --> F{Verschieben<br/>aktiviert?}
+        F -- Nein --> G[Im Posteingang lassen, Stopp]
+        F -- Ja --> H[In Verarbeitet-Ordner verschieben]
+    end
+
+    subgraph draft [Antworten entwerfen]
+        I[Entwurfs-Trigger] --> J{Entwerfen<br/>aktiviert?}
+        J -- Nein --> K[Stopp]
+        J -- Ja --> L[Stapel noch nicht entworfener<br/>Nachrichten lesen]
+        L --> M[Antwort mit dem<br/>LLM entwerfen]
+        M --> N[An Entwürfe anhängen,<br/>Quelle markieren]
+    end
+```
+
+### Lesen und ablegen
+
+1. **Ungelesene E-Mails auflisten.** Der Agent öffnet den konfigurierten Posteingang-Ordner und liefert eine
+   Zusammenfassung jeder ungelesenen Nachricht, begrenzt durch **Max. ungelesene E-Mails**.
+2. **Eine Nachricht abrufen.** Die erste ungelesene Nachricht wird vollständig abgerufen — Absender, Betreff, Datum,
+   Text und Anhänge. Enthält der Posteingang keine ungelesene Post, endet der Lauf hier einfach. Die Anhangsdaten werden
+   in den Dateispeicher der Plattform geschrieben, und das Nachrichten-Event trägt lediglich *Referenzen* darauf, damit
+   Audit-Trail und Event-Stream klein bleiben.
+3. **Ablegen.** Ist **Abgerufene E-Mail verschieben** aktiviert, wird die Nachricht in den Verarbeitet-Ordner
+   verschoben. Ist die Option deaktiviert, bleibt die Nachricht, wo sie ist, und der Lauf endet.
+
+Der gesamte Lesepfad ist **auf Protokollebene read-only**: Das Postfach wird mit einem read-only Select geöffnet und
+Nachrichtentexte werden mit `BODY.PEEK` abgerufen, sodass die Nachricht nie unbemerkt als gelesen markiert wird.
+Verschieben verlagert eine Nachricht; gelöscht wird nie.
+
+### Antworten entwerfen
+
+1. **Kandidaten finden.** Der Entwurfsdienst liest bis zu **Entwurfs-Stapelgröße** Nachrichten aus seinem eigenen
+   Quellordner, für die noch kein Entwurf existiert. Bereits entworfene Nachrichten erkennt er an einem IMAP-Flag, das
+   der Agent setzt — ein erneuter Lauf erzeugt daher keine doppelten Entwürfe.
+2. **Jede Antwort entwerfen.** Für jede Nachricht erhält das konfigurierte Chat-Modell Ihren **Entwurfs-Prompt** und die
+   Originalnachricht und schreibt einen Antworttext. Das Ergebnis wird in einen korrekt verketteten Antwort-Umschlag
+   verpackt, sodass der Entwurf in Ihrem Mail-Client in der richtigen Konversation erscheint.
+3. **Speichern und markieren.** Jeder Entwurf wird an den Entwürfe-Ordner angehängt, und erst danach wird die
+   Quellnachricht als entworfen markiert. Die Quellnachricht bleibt **ungelesen** — ein Mensch sieht sie weiterhin als
+   neue Post, die Aufmerksamkeit braucht.
+
+::: details Warum die Quellnachricht ungelesen bleibt
+Das Entwerfen ist ein Vorbereitungsschritt, keine Erledigung. Der Sinn ist, dass ein Mensch das Postfach öffnet, die
+Nachricht als ungelesen und unbearbeitet sieht, einen bereits wartenden Antwort-Entwurf vorfindet und entscheidet, was
+zu tun ist. Die Post als gelesen zu markieren würde Arbeit verbergen, die tatsächlich noch nicht getan ist.
+:::
+
+::: details Was passiert, wenn ein Lauf abbricht
+Der Entwurf wird an den Entwürfe-Ordner angehängt, *bevor* die Quellnachricht markiert wird. Stirbt der Lauf zwischen
+diesen beiden Operationen, ist der schlimmste Fall ein doppelter Entwurf beim nächsten Lauf — niemals eine Nachricht,
+die stillschweigend als erledigt markiert ist, ohne dass ein Entwurf existiert. Arbeit zu verlieren gilt als schlimmer,
+als ein wenig davon doppelt zu tun.
+:::
+
+## Was er *nicht* tut
+
+- **Er versendet nie.** Kein SMTP, keine ausgehende Zustellung, kein „senden, wenn sicher genug"-Modus.
+- **Er löscht nie.** Verschieben verlagert eine Nachricht; nichts wird dauerhaft aus dem Postfach entfernt.
+- **Er hat keine Chat-Oberfläche.** Er erscheint nicht im Chat UI und kann nicht befragt werden.
+- **Er hat keine Wissensbasis.** Entwürfe entstehen aus der Originalnachricht plus Ihrem Prompt — der Agent durchsucht
+  Ihre Dokumente nicht. Für fundierte, mit Quellen belegte Antworten verwenden Sie den
+  [Document Intelligence Assistant](../5_document_intelligence_assistant/).
+- **Er liest eine Nachricht pro Lese-Lauf.** Die Lesen/Verschieben-Kette listet alle ungelesenen E-Mails auf, ruft und
+  legt aber nur die erste Nachricht ab. Planen Sie sie häufiger ein, um einen Rückstand abzuarbeiten; die Entwurfs-Kette
+  ist diejenige, die einen Stapel verarbeitet.
+
+## Konfiguration
+
+Erstellen Sie im Admin UI ein Profil aus dem Blueprint **IMAP Agent**. Das Formular hat zwei Abschnitte: die
+Postfach-Verbindung und die Entwurfs-Einstellungen.
+
+### Postfach-Verbindung
+
+| Feld                              | Typ      | Standard    | Beschreibung                                                                                                                          |
+| --------------------------------- | -------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| **IMAP-Host**                     | Text     | —           | Hostname des IMAP-Servers, z. B. `imap.example.com`. Erforderlich.                                                                    |
+| **IMAP-Port**                     | Zahl     | `993`       | Port des Servers. `993` ist der Standard für implizites TLS. Bereich 1–65535.                                                         |
+| **Benutzername**                  | Text     | —           | Postfach-Login, üblicherweise die vollständige E-Mail-Adresse. Erforderlich.                                                          |
+| **Passwort**                      | Passwort | *(leer)*    | Postfach-Passwort oder besser ein anwendungsspezifisches Token. Wird beim Agent-Profil gespeichert.                                   |
+| **TLS verwenden**                 | Schalter | An          | Verbindung über implizites TLS. Nur für einen Klartext-Testserver deaktivieren.                                                       |
+| **Posteingang-Ordner**            | Text     | `INBOX`     | Der Ordner, aus dem eingehende E-Mails gelesen werden.                                                                                |
+| **Max. ungelesene E-Mails**       | Zahl     | `50`        | Wie viele ungelesene Zusammenfassungen ein einzelner Lauf auflistet. Hält den Lauf klein, wenn der Posteingang überquillt. 1–500.     |
+| **Abgerufene E-Mail verschieben** | Schalter | Aus         | Wenn aktiviert, wird die abgerufene Nachricht in den Verarbeitet-Ordner verschoben. Wenn deaktiviert, entfällt der Verschiebeschritt. |
+| **Verarbeitet-Ordner**            | Text     | `Processed` | Wohin eine verarbeitete Nachricht abgelegt wird. Nur sichtbar — und erforderlich —, wenn **Abgerufene E-Mail verschieben** aktiv ist. |
+
+### Entwurfs-Einstellungen
+
+Alles in diesem Abschnitt bleibt verborgen, bis **Antwort entwerfen** eingeschaltet ist.
+
+| Feld                        | Typ            | Standard                     | Beschreibung                                                                                                                                                                                         |
+| --------------------------- | -------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Antwort entwerfen**       | Schalter       | Aus                          | Hauptschalter für die Entwurfs-Fähigkeit. Wenn aus, endet ein Entwurfs-Lauf sofort, ohne etwas zu tun.                                                                                               |
+| **Quellordner für Entwurf** | Text           | `INBOX`                      | Wo der Entwurfsdienst nach Kandidatennachrichten sucht. Verweisen Sie auf Ihren Verarbeitet-Ordner, um Antworten auf dort abgelegte E-Mails zu entwerfen.                                            |
+| **Entwurfs-Stapelgröße**    | Zahl           | `5`                          | Wie viele Nachrichten pro Lauf entworfen werden. Mindestens 1.                                                                                                                                       |
+| **Entwürfe-Ordner**         | Text           | `Drafts`                     | Wo Entwürfe gespeichert werden. Hat der Server keinen Ordner dieses Namens, wird sein Standard-Ordner `\Drafts` verwendet.                                                                           |
+| **LLM-Modell**              | Modell-Auswahl | *(leer)*                     | Das Chat-Modell, das den Antworttext schreibt. Die Optionen stammen aus Ihrer LiteLLM-Konfiguration.                                                                                                 |
+| **Entwurfs-Prompt**         | Langtext       | *(sinnvolle Voreinstellung)* | Anweisungen zu Ton, Sprache und Form der Antwort. Die Voreinstellung verlangt eine knappe, höfliche Antwort in der Sprache des Absenders, ohne erfundene Fakten und ohne Betreffzeile oder Signatur. |
+
+::: details Deployment-fixe Limits, die Sie im Formular nicht sehen
+Drei Grössenlimits werden vom Betreiber der Plattform festgelegt und sind nicht als Formularfelder verfügbar, weil sie
+die Plattform schützen und nicht das Verhalten des Agents formen:
+
+| Limit                  | Standard | Was es schützt                                                                                                                                                           |
+| ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Max. Nachrichtengrösse | 50 MB    | Die Rohgrösse einer Nachricht wird geprüft, *bevor* der Text heruntergeladen wird, sodass übergrosse oder bösartige Post abgewiesen statt in den Speicher geladen wird.  |
+| Max. Textgrösse        | 1 MB     | Begrenzt den Nachrichtentext in einem Event; längere Texte werden gekürzt, damit das gespeicherte und gestreamte Event innerhalb der Grössenlimits der Plattform bleibt. |
+| Max. Anhangsgrösse     | 10 MB    | Begrenzt einen einzelnen gespeicherten Anhang; grössere Anhänge werden übersprungen, damit eine Nachricht den Anhangsspeicher nicht überlasten kann.                     |
+
+Fragen Sie Ihre Plattform-Administration, falls eine legitime Arbeitslast an eines dieser Limits stösst.
+:::
+
+::: details Wie die Einstellungen zur Laufzeit zusammenspielen
+Ein **Lese**-Trigger verbindet sich mit den Postfach-Einstellungen, listet bis zu **Max. ungelesene E-Mails** aus dem
+**Posteingang-Ordner** auf, ruft die erste ab und verschiebt sie — wenn **Abgerufene E-Mail verschieben** aktiv ist — in
+den **Verarbeitet-Ordner**.
+
+Ein **Entwurfs**-Trigger ist davon unabhängig. Ist **Antwort entwerfen** aktiv, liest er bis zu **Entwurfs-Stapelgröße**
+noch nicht entworfene Nachrichten aus dem **Quellordner für Entwurf**, ruft das gewählte **LLM-Modell** einmal pro
+Nachricht mit Ihrem **Entwurfs-Prompt** auf, hängt jedes Ergebnis an den **Entwürfe-Ordner** an und markiert die Quelle.
+Die Mail-Verbindung wird nur für die IMAP-Arbeit geöffnet und wieder geschlossen, während das Modell schreibt — so
+bleibt keine untätige Verbindung offen, die der Server abbrechen könnte.
+:::
+
+## Beispiel-Workflows
+
+**Triage eines gemeinsam genutzten Postfachs.** Aktivieren Sie **Abgerufene E-Mail verschieben** mit einem
+`Processed`-Ordner und planen Sie den Lese-Trigger im Minutentakt ein. Jeder Lauf nimmt die älteste ungelesene Nachricht
+aus dem Posteingang und legt sie ab, wobei die vollständige Nachricht samt Anhängen im Audit-Trail der Plattform
+festgehalten wird. Der Posteingang wird zu einer Queue, die sich selbst leert.
+
+**Antwort-Entwürfe über Nacht vorbereiten.** Lassen Sie das Verschieben aus, aktivieren Sie **Antwort entwerfen** mit
+**Quellordner für Entwurf** = `INBOX` und planen Sie den Entwurfs-Trigger ausserhalb der Geschäftszeiten mit einer
+Stapelgrösse, die zu Ihrem Tagesvolumen passt. Am Morgen öffnet das Team das Postfach und findet unter jeder neuen
+Nachricht einen wartenden Entwurf — prüfen, anpassen, senden.
+
+**Beides nacheinander.** Richten Sie den Lese-Trigger mit aktivem Verschieben auf `INBOX` und setzen Sie **Quellordner
+für Entwurf** auf denselben `Processed`-Ordner. Post wird abgelegt, sobald sie eintrifft, und der Entwurfsdienst
+arbeitet die abgelegten Nachrichten nach seinem eigenen Zeitplan ab. Die beiden Jobs konkurrieren nie um dieselbe
+Nachricht.
+
+## Best Practices
+
+**Verwenden Sie ein anwendungsspezifisches Passwort.** Die meisten Anbieter (Gmail, Microsoft 365 und andere) stellen
+Anmeldedaten pro Anwendung aus, die sich einzeln widerrufen lassen. Nutzen Sie eines davon statt des echten
+Konto-Passworts, und geben Sie dem Agent ein Postfach, das nur enthält, was er sehen muss.
+
+**Starten Sie mit deaktiviertem Verschieben und Entwerfen.** Beides ist aus gutem Grund standardmässig aus. Lassen Sie
+den Agent zuerst nur lesend laufen, prüfen Sie in der Event-Timeline, dass er sich verbindet und die richtigen
+Nachrichten aufgreift, und schalten Sie dann eine Fähigkeit nach der anderen ein.
+
+**Setzen Sie den Verarbeitet-Ordner, bevor Sie das Verschieben aktivieren.** **Abgerufene E-Mail verschieben** mit einem
+leeren **Verarbeitet-Ordner** lässt den Lauf fehlschlagen. Legen Sie den Ordner zuerst auf dem Mailserver an — der Agent
+legt dort ab, er erstellt ihn nicht.
+
+**Halten Sie die Stapelgrösse anfangs klein.** Jede Nachricht in einem Stapel kostet einen Modellaufruf. Beginnen Sie
+mit drei bis fünf, beobachten Sie Kosten und Qualität in den Traces, und erhöhen Sie erst, wenn Sie dem Ergebnis
+vertrauen.
+
+**Schreiben Sie den Entwurfs-Prompt für eine prüfende Person, nicht für die Empfängerin oder den Empfänger.** Die besten
+Entwürfe sind die, die ein Mensch in Sekunden freigeben kann. Verlangen Sie eine kurze Antwort, eine ausdrückliche
+Aussage, wenn Informationen fehlen, und keine erfundenen Fakten — ein Entwurf, der höflich sagt „Ich muss X noch
+prüfen", ist nützlicher als eine selbstbewusst falsche Antwort.
+
+**Stimmen Sie Quellordner und Zeitplan aufeinander ab.** Wenn derselbe Ordner sowohl den Verschiebeschritt als auch den
+Entwurfsdienst speist, achten Sie darauf, dass der Lese-Trigger oft genug läuft, um den Entwurfsdienst zu versorgen —
+und dass dessen Stapelgrösse nicht so gross ist, dass er wiederholt nichts zu tun findet.
+
+**Denken Sie daran, dass eingehende Post nicht vertrauenswürdig ist.** Jede und jeder kann Ihrem Postfach beliebige
+Inhalte schicken, und der Text dieser Nachricht geht in den Prompt des Modells ein. Der PII-Guard der Plattform
+anonymisiert personenbezogene Daten am LLM-Gateway, dennoch sollten Sie Entwürfe als Vorschläge aus einer nicht
+vertrauenswürdigen Quelle behandeln — genau deshalb prüft ein Mensch jeden einzelnen, bevor er gesendet wird.

--- a/docs/docs/2_platform/5_agents/11_email_agent/index.en.md
+++ b/docs/docs/2_platform/5_agents/11_email_agent/index.en.md
@@ -1,0 +1,201 @@
+---
+title: Email Agent
+description: A mailbox agent that reads unread mail from an IMAP inbox, files it away, and drafts replies for a human to review — it never sends.
+---
+
+# Email Agent
+
+The **Email Agent** (the IMAP agent) connects to a mailbox over IMAP and works through it on your behalf. It lists the
+unread mail in an inbox, fetches a message with its attachments, optionally files that message into another folder, and
+— as a separate, independently scheduled job — drafts replies to a batch of messages and leaves them in your Drafts
+folder.
+
+Unlike the chat-based assistants, this agent has **no chat interface**. You do not talk to it. It is configured once in
+the Admin UI and then triggered programmatically — by a scheduler, by another workflow, or via the API. In this respect
+it behaves like the [Retrieval Agent](../6_retrieval_agent/): it is a building block for automation rather than a
+conversational partner.
+
+::: tip When to reach for this agent
+Use the Email Agent when work arrives by email and you want the routine part handled automatically — triaging a shared
+mailbox, filing processed mail out of the inbox, or preparing reply drafts overnight so a person only has to review and
+click send. If you want a colleague-style assistant to chat with, use the
+[Instructed Assistant](../3_instructed_assistant/) or the
+[Document Intelligence Assistant](../5_document_intelligence_assistant/) instead.
+:::
+
+::: warning It never sends email
+The agent speaks IMAP only — there is no SMTP anywhere in it. It can read, move, and *save a draft*, but it can never
+put a message on the wire. A human always opens the draft, reviews it, and sends it. This is a deliberate design
+boundary, not a configuration default you can turn off.
+:::
+
+## What it does
+
+The agent has **two independent capabilities**, each started by its own trigger. They do not depend on each other, and
+you can schedule them separately — for example, read/move every five minutes and drafting once an hour.
+
+```mermaid
+flowchart TD
+    subgraph read [Read and file]
+        A[Read trigger] --> B[List unread mail]
+        B --> C{Any unread<br/>messages?}
+        C -- No --> D[Stop]
+        C -- Yes --> E[Fetch first message<br/>+ attachments]
+        E --> F{Move enabled?}
+        F -- No --> G[Leave in inbox, stop]
+        F -- Yes --> H[Move to processed folder]
+    end
+
+    subgraph draft [Draft replies]
+        I[Draft trigger] --> J{Drafting<br/>enabled?}
+        J -- No --> K[Stop]
+        J -- Yes --> L[Read batch of<br/>not-yet-drafted mail]
+        L --> M[Draft a reply<br/>with the LLM]
+        M --> N[Append to Drafts,<br/>mark source as drafted]
+    end
+```
+
+### Reading and filing
+
+1. **List unread mail.** The agent opens the configured inbox folder and returns a summary of every unread message, up
+   to the **Max Unread Messages** cap.
+2. **Fetch a message.** The first unread message is fetched in full — sender, subject, date, body, and attachments. If
+   the inbox has no unread mail, the run simply stops here. Attachment bytes are written to the platform's file storage
+   and the message event carries only *references* to them, so the audit trail and the event stream stay small.
+3. **File it away.** If **Move Fetched Mail** is enabled, the message is moved into the processed folder. If it is
+   disabled, the message stays where it is and the run ends.
+
+The whole read path is **read-only at the protocol level**: the mailbox is opened with a read-only select and bodies are
+fetched with `BODY.PEEK`, so the message is never marked as read behind your back. Moving relocates a message; it never
+deletes one.
+
+### Drafting replies
+
+1. **Find candidates.** The drafter reads up to **Draft Batch Size** messages from its own source folder that have not
+   been drafted yet. Already-drafted messages are recognised by an IMAP flag the agent sets, so re-running the job does
+   not produce duplicate drafts.
+2. **Draft each reply.** For every message, the configured chat model is given your **Draft Prompt** and the original
+   message, and writes a reply body. The result is wrapped in a properly threaded reply envelope, so the draft shows up
+   in the right conversation in your mail client.
+3. **Save and mark.** Each draft is appended to the drafts folder, and only then is the source message flagged as
+   drafted. The source message stays **unread** — a person still sees it as new mail waiting for attention.
+
+::: details Why the source message stays unread
+Drafting is a preparation step, not a resolution. The point is that a human opens the mailbox, sees the message as
+unread and unhandled, finds a draft reply already waiting, and decides what to do. Marking mail as read would hide work
+that has not actually been done.
+:::
+
+::: details What happens if a run is interrupted
+The draft is appended to the drafts folder *before* the source message is flagged. If the run dies between those two
+operations, the worst case is a duplicate draft on the next run — never a message that is silently marked as handled
+without a draft existing. Losing work is treated as worse than doing a little of it twice.
+:::
+
+## What it does *not* do
+
+- **It never sends.** No SMTP, no outbound delivery, no "send if confident" mode.
+- **It never deletes.** Moving a message relocates it; nothing is permanently removed from the mailbox.
+- **It has no chat interface.** It does not appear in the chat UI and cannot be asked questions.
+- **It has no knowledge base.** Drafts are written from the original message plus your prompt — the agent does not
+  search your documents. For grounded, cited answers, use the
+  [Document Intelligence Assistant](../5_document_intelligence_assistant/).
+- **It reads one message per read run.** The read/move chain lists all unread mail but fetches and files the first
+  message only. Schedule it more frequently to work through a backlog; the drafting chain is the one that processes a
+  batch.
+
+## Configuration
+
+Create a profile from the **IMAP Agent** blueprint in the Admin UI. The form has two sections: the mailbox connection
+and the drafting settings.
+
+### Mailbox connection
+
+| Field                   | Type     | Default     | Description                                                                                             |
+| ----------------------- | -------- | ----------- | ------------------------------------------------------------------------------------------------------- |
+| **IMAP Host**           | Text     | —           | Hostname of the IMAP server, e.g. `imap.example.com`. Required.                                         |
+| **IMAP Port**           | Number   | `993`       | Server port. `993` is the standard for implicit TLS. Range 1–65535.                                     |
+| **Username**            | Text     | —           | Mailbox login, usually the full email address. Required.                                                |
+| **Password**            | Password | *(empty)*   | Mailbox password or, preferably, an app-specific token. Stored with the agent profile.                  |
+| **Use TLS**             | Toggle   | On          | Connect over implicit TLS. Turn off only for a plaintext test server.                                   |
+| **Inbox Folder**        | Text     | `INBOX`     | The folder incoming mail is read from.                                                                  |
+| **Max Unread Messages** | Number   | `50`        | How many unread summaries a single run lists. Keeps the run small when the inbox is overflowing. 1–500. |
+| **Move Fetched Mail**   | Toggle   | Off         | When on, the fetched message is moved to the processed folder. When off, the move step is skipped.      |
+| **Processed Folder**    | Text     | `Processed` | Where a processed message is filed. Only shown — and required — when **Move Fetched Mail** is on.       |
+
+### Draft email settings
+
+Everything in this section is hidden until **Draft Reply** is switched on.
+
+| Field                   | Type         | Default                | Description                                                                                                                                                                                    |
+| ----------------------- | ------------ | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Draft Reply**         | Toggle       | Off                    | Master switch for the drafting capability. When off, a draft run stops immediately without doing anything.                                                                                     |
+| **Draft Source Folder** | Text         | `INBOX`                | Where the drafter looks for candidate messages. Point it at your processed folder to draft replies to mail the move step filed.                                                                |
+| **Draft Batch Size**    | Number       | `5`                    | How many messages are drafted per run. Must be at least 1.                                                                                                                                     |
+| **Drafts Folder**       | Text         | `Drafts`               | Where drafts are saved. If the server does not have a folder by this name, its standard `\Drafts` folder is used instead.                                                                      |
+| **LLM Model**           | Model picker | *(empty)*              | The chat model that writes the reply body. Options come from your LiteLLM configuration.                                                                                                       |
+| **Draft Prompt**        | Long text    | *(a sensible default)* | Instructions steering tone, language, and format of the reply. The default asks for a concise, polite reply in the sender's language, with no invented facts and no subject line or signature. |
+
+::: details Deployment-fixed limits you will not see in the form
+Three size caps are fixed by whoever operates the platform and are not exposed as form fields, because they protect the
+platform rather than shape the agent's behaviour:
+
+| Limit               | Default | What it protects                                                                                                                                   |
+| ------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Max message size    | 50 MB   | The raw size of a message is checked *before* the body is downloaded, so an oversized or hostile mail is refused rather than pulled into memory.   |
+| Max body size       | 1 MB    | Caps the message body carried in an event; longer bodies are truncated so the stored and streamed event stays within platform message-size limits. |
+| Max attachment size | 10 MB   | Caps a single stored attachment; larger attachments are skipped so one message cannot overload the attachment store.                               |
+
+Ask your platform administrator if a legitimate workload runs into one of these.
+:::
+
+::: details How the settings combine at runtime
+A **read** trigger connects with the mailbox settings, lists up to **Max Unread Messages** from **Inbox Folder**,
+fetches the first one, and — if **Move Fetched Mail** is on — moves it to **Processed Folder**.
+
+A **draft** trigger is independent. If **Draft Reply** is on, it reads up to **Draft Batch Size** not-yet-drafted
+messages from **Draft Source Folder**, calls the selected **LLM Model** once per message with your **Draft Prompt**,
+appends each result to **Drafts Folder**, and flags the source. The mail connection is opened only for the IMAP work and
+closed again while the model is writing, so a slow model does not leave an idle connection for the server to drop.
+:::
+
+## Example workflows
+
+**Triage a shared mailbox.** Enable **Move Fetched Mail** with a `Processed` folder and schedule the read trigger every
+few minutes. Each run takes the oldest unread message out of the inbox and files it, with the full message and its
+attachments recorded in the platform's audit trail. The inbox becomes a queue that drains itself.
+
+**Prepare overnight reply drafts.** Leave moving off, enable **Draft Reply** with **Draft Source Folder** set to
+`INBOX`, and schedule the draft trigger to run outside business hours with a batch size that matches your daily volume.
+In the morning the team opens the mailbox and finds a draft waiting under each new message — review, adjust, send.
+
+**Both, in sequence.** Point the read trigger at `INBOX` with moving on, and set **Draft Source Folder** to the same
+`Processed` folder. Mail is filed as it arrives, and the drafter works through the filed messages on its own schedule.
+The two jobs never contend for the same message.
+
+## Best practices
+
+**Use an app-specific password.** Most providers (Gmail, Microsoft 365, and others) issue per-application credentials
+that can be revoked on their own. Use one instead of the account's real password, and give the agent a mailbox that
+holds only what it needs to see.
+
+**Start with moving and drafting off.** Both are off by default for a reason. Run the agent read-only first, confirm in
+the event timeline that it connects and picks up the right messages, then switch on one capability at a time.
+
+**Set the processed folder before enabling the move.** Turning on **Move Fetched Mail** with an empty **Processed
+Folder** fails the run. Create the folder on the mail server first — the agent files into it, it does not create it.
+
+**Keep the batch size small at first.** Every message in a batch costs one model call. Start at three to five, watch the
+cost and quality in the traces, and raise it once you trust the output.
+
+**Write the draft prompt for a reviewer, not for a recipient.** The best drafts are the ones a person can approve in
+seconds. Ask for a short reply, an explicit statement when information is missing, and no invented facts — a draft that
+politely says "I need to check X" is more useful than a confident wrong answer.
+
+**Match the source folder to your schedule.** If the same folder feeds both the move step and the drafter, make sure the
+read trigger runs often enough to keep the drafter supplied — and that the drafter's batch size is not so large it
+repeatedly finds nothing to do.
+
+**Remember that inbound mail is untrusted.** Anyone can send your mailbox anything, and the body of that message goes
+into the model's prompt. The platform's PII guard anonymises personal data at the LLM gateway, but you should still
+treat drafts as suggestions from an untrusted input — which is exactly why a human reviews every one before it is sent.

--- a/docs/docs/2_platform/5_agents/11_email_agent/index.en.md
+++ b/docs/docs/2_platform/5_agents/11_email_agent/index.en.md
@@ -80,6 +80,13 @@ deletes one.
 3. **Save and mark.** Each draft is appended to the drafts folder, and only then is the source message flagged as
    drafted. The source message stays **unread** — a person still sees it as new mail waiting for attention.
 
+::: details Which flag marks a message as drafted
+The agent prefers a private keyword (`$AiHubDrafted`) that only it understands, so a message with an unsent draft is not
+made to look like something it is not. Not every mail server supports custom keywords, though. On a server that does
+not, the agent falls back to the standard `\Answered` flag — and those messages will show up as **replied** in your mail
+client even though nothing has been sent yet. If your mailbox shows unexpected "replied" markers, this is why.
+:::
+
 ::: details Why the source message stays unread
 Drafting is a preparation step, not a resolution. The point is that a human opens the mailbox, sees the message as
 unread and unhandled, finds a draft reply already waiting, and decides what to do. Marking mail as read would hide work


### PR DESCRIPTION
## Summary

Adds a user-facing documentation page for the **Email Agent** (the `ImapAgent` blueprint) under the Agents section, following the structure and style of the existing Teachable Assistant page.

Closes #1644

## What's included

- **`docs/docs/2_platform/5_agents/11_email_agent/index.en.md`** — the source page
- **`docs/docs/2_platform/5_agents/11_email_agent/index.de.md`** — German version

Page structure mirrors [4_teachable_assistant](https://docs.ai-hub.bbv.ch/docs/2_platform/5_agents/4_teachable_assistant/):

- Intro + "when to reach for this agent" tip, and a prominent warning that the agent **never sends email**
- A mermaid diagram of the two independent chains (read/move and drafting), plus a step-by-step walkthrough of each
- "What it does *not* do" — no sending, no deleting, no chat UI, no knowledge base
- Full configuration reference for both form sections (mailbox connection, draft settings), including the three deployment-fixed size caps that have no form control
- Collapsible details on why the source message stays unread, the append-before-flag ordering, and which flag marks a message as drafted
- Three example workflows and a best-practices section

## Notes for reviewers

- The blueprint appears in the Admin UI as **"IMAP Agent"**; the page title uses the friendlier **"Email Agent"** to match the ticket and the section's naming convention (`4_teachable_assistant` likewise documents the `FewShotAgent`). The blueprint name is called out in the Configuration section so it stays findable.
- Field names, defaults, and ranges were taken from `ImapClientConfig` and `DraftEmailSettings`; the German form labels are the actual `imap.de.yml` UI strings rather than re-translations.
- The second commit documents a user-visible behaviour found while cross-checking the code: on servers without custom-keyword support the dedup flag falls back to `\Answered`, so mail with an *unsent* draft shows as **replied** in the user's client.
- The German page was hand-produced (the `llm` CLI that `docs:translate` requires is not available locally) with a matching `source_sha`, so the translation pipeline treats it as up to date. Re-run `pnpm run docs:translate` after any future edit to the English source.
- No screenshots — the ticket lists them as optional and the mermaid diagram carries the flow. Happy to add an Admin UI screenshot of the config form if reviewers want one.

## Test plan

- [x] `vitepress build` passes with no errors and no dead links
- [x] Both `/docs/2_platform/5_agents/11_email_agent/` and `/de/docs/2_platform/5_agents/11_email_agent/` render
- [x] Page appears in the auto-generated sidebar (sibling pages link to it)
- [x] Mermaid diagram is handled identically to the reference page
- [x] `source_sha` in `index.de.md` matches the SHA-256 of `index.en.md`
- [x] All configuration values verified against `ImapClientConfig` / `DraftEmailSettings`
- [x] All cross-page link texts verified against the target pages' `title` frontmatter
- [ ] Reviewer sanity-check of the German wording
