### PR TITLE
fix(rag): Bound recursive summary parser prompts to the LLM input limit

### DIFF
--- a/infra/configs/litellm/litellm-config.build.yml
+++ b/infra/configs/litellm/litellm-config.build.yml
@@ -38,7 +38,10 @@ model_list:
       drop_params: true
     model_info:
       mode: chat
-      max_input_tokens: 131072
+      # Infomaniak's GET /1/ai/models declares max_token_input: 100000 for this model, not the model's own
+      # 256K architecture limit. Their OpenAI-compatible /v1/models carries no context field to verify this
+      # against, so it must be checked manually against their native API if this model's serving changes.
+      max_input_tokens: 100000
       max_output_tokens: 8192
       supports_function_calling: true
       supports_response_schema: true
@@ -66,7 +69,9 @@ model_list:
       drop_params: true
     model_info:
       mode: chat
-      max_input_tokens: 131072
+      # Infomaniak's GET /1/ai/models declares max_token_input: 100000 for this model; see the note on
+      # gemma-4-31B-it above.
+      max_input_tokens: 100000
       max_output_tokens: 8192
       supports_function_calling: true
       supports_response_schema: true

--- a/infra/configs/litellm/litellm-config.dev.yml
+++ b/infra/configs/litellm/litellm-config.dev.yml
@@ -38,7 +38,10 @@ model_list:
       drop_params: true
     model_info:
       mode: chat
-      max_input_tokens: 131072
+      # Infomaniak's GET /1/ai/models declares max_token_input: 100000 for this model, not the model's own
+      # 256K architecture limit. Their OpenAI-compatible /v1/models carries no context field to verify this
+      # against, so it must be checked manually against their native API if this model's serving changes.
+      max_input_tokens: 100000
       max_output_tokens: 8192
       supports_function_calling: true
       supports_response_schema: true
@@ -66,7 +69,9 @@ model_list:
       drop_params: true
     model_info:
       mode: chat
-      max_input_tokens: 131072
+      # Infomaniak's GET /1/ai/models declares max_token_input: 100000 for this model; see the note on
+      # gemma-4-31B-it above.
+      max_input_tokens: 100000
       max_output_tokens: 8192
       supports_function_calling: true
       supports_response_schema: true

--- a/infra/configs/litellm/litellm-config.latest.yml
+++ b/infra/configs/litellm/litellm-config.latest.yml
@@ -38,7 +38,10 @@ model_list:
       drop_params: true
     model_info:
       mode: chat
-      max_input_tokens: 131072
+      # Infomaniak's GET /1/ai/models declares max_token_input: 100000 for this model, not the model's own
+      # 256K architecture limit. Their OpenAI-compatible /v1/models carries no context field to verify this
+      # against, so it must be checked manually against their native API if this model's serving changes.
+      max_input_tokens: 100000
       max_output_tokens: 8192
       supports_function_calling: true
       supports_response_schema: true
@@ -66,7 +69,9 @@ model_list:
       drop_params: true
     model_info:
       mode: chat
-      max_input_tokens: 131072
+      # Infomaniak's GET /1/ai/models declares max_token_input: 100000 for this model; see the note on
+      # gemma-4-31B-it above.
+      max_input_tokens: 100000
       max_output_tokens: 8192
       supports_function_calling: true
       supports_response_schema: true

--- a/infra/configs/litellm/litellm-config.local.yml
+++ b/infra/configs/litellm/litellm-config.local.yml
@@ -38,7 +38,10 @@ model_list:
       drop_params: true
     model_info:
       mode: chat
-      max_input_tokens: 131072
+      # Infomaniak's GET /1/ai/models declares max_token_input: 100000 for this model, not the model's own
+      # 256K architecture limit. Their OpenAI-compatible /v1/models carries no context field to verify this
+      # against, so it must be checked manually against their native API if this model's serving changes.
+      max_input_tokens: 100000
       max_output_tokens: 8192
       supports_function_calling: true
       supports_response_schema: true
@@ -66,7 +69,9 @@ model_list:
       drop_params: true
     model_info:
       mode: chat
-      max_input_tokens: 131072
+      # Infomaniak's GET /1/ai/models declares max_token_input: 100000 for this model; see the note on
+      # gemma-4-31B-it above.
+      max_input_tokens: 100000
       max_output_tokens: 8192
       supports_function_calling: true
       supports_response_schema: true

--- a/infra/configs/litellm/litellm-config.nightly.yml
+++ b/infra/configs/litellm/litellm-config.nightly.yml
@@ -38,7 +38,10 @@ model_list:
       drop_params: true
     model_info:
       mode: chat
-      max_input_tokens: 131072
+      # Infomaniak's GET /1/ai/models declares max_token_input: 100000 for this model, not the model's own
+      # 256K architecture limit. Their OpenAI-compatible /v1/models carries no context field to verify this
+      # against, so it must be checked manually against their native API if this model's serving changes.
+      max_input_tokens: 100000
       max_output_tokens: 8192
       supports_function_calling: true
       supports_response_schema: true
@@ -66,7 +69,9 @@ model_list:
       drop_params: true
     model_info:
       mode: chat
-      max_input_tokens: 131072
+      # Infomaniak's GET /1/ai/models declares max_token_input: 100000 for this model; see the note on
+      # gemma-4-31B-it above.
+      max_input_tokens: 100000
       max_output_tokens: 8192
       supports_function_calling: true
       supports_response_schema: true

--- a/infra/deployment/templates/configs/litellm-config.yml.j2
+++ b/infra/deployment/templates/configs/litellm-config.yml.j2
@@ -68,7 +68,10 @@ model_list:
       drop_params: true
     model_info:
       mode: chat
-      max_input_tokens: 131072
+      # Infomaniak's GET /1/ai/models declares max_token_input: 100000 for this model, not the model's own
+      # 256K architecture limit. Their OpenAI-compatible /v1/models carries no context field to verify this
+      # against, so it must be checked manually against their native API if this model's serving changes.
+      max_input_tokens: 100000
       max_output_tokens: 8192
       supports_function_calling: true
       supports_response_schema: true
@@ -98,7 +101,9 @@ model_list:
       drop_params: true
     model_info:
       mode: chat
-      max_input_tokens: 131072
+      # Infomaniak's GET /1/ai/models declares max_token_input: 100000 for this model; see the note on
+      # gemma-4-31B-it above.
+      max_input_tokens: 100000
       max_output_tokens: 8192
       supports_function_calling: true
       supports_response_schema: true

--- a/packages/core/swiss_ai_hub/core/generative_ai/document/parsers/recursive_summary_parser.py
+++ b/packages/core/swiss_ai_hub/core/generative_ai/document/parsers/recursive_summary_parser.py
@@ -1,8 +1,12 @@
+import logging
+from collections.abc import Callable
 from typing import Any
 
 from llama_index.core import PromptTemplate
 from llama_index.core.llms import LLM
+from llama_index.core.node_parser import SentenceSplitter
 from llama_index.core.schema import NodeRelationship, RelatedNodeInfo, TextNode
+from openai import BadRequestError
 
 from swiss_ai_hub.core.i18n.locale_handler import LocaleHandler
 from swiss_ai_hub.core.infrastructure.opentelemetry.tracing.decorators.trace_fn import trace_fn
@@ -18,16 +22,120 @@ from swiss_ai_hub.core.persistence.rag.vectors.node_metadata import (
     TYPE,
 )
 
+logger = logging.getLogger(__name__)
+
+DEFAULT_SUMMARIZATION_MAX_INPUT_TOKENS = 32768  # conservative default; Infomaniak serves gemma-4-31B-it at 100000
+
+# Absorbs the prompt-template overhead the budget check cannot measure until render time and the tokenizer
+# mismatch between our counter and the model actually enforcing the limit.
+SUMMARIZATION_BUDGET_SAFETY_FACTOR = 0.85
+
+# Worst-case tokens per character assumed by `_fits`'s accept short-circuit. Deployments process Latin-script
+# EU-language content (German, English, and other EU languages) -- even a multi-byte accented character
+# under byte-level BPE fallback costs at most ~2 tokens, well short of CJK's worst case of ~3. Raise this back
+# toward 3 if this pipeline ever needs to process CJK content.
+SHORT_CIRCUIT_MAX_TOKENS_PER_CHARACTER = 2
+
+MAX_REDUCE_ROUNDS = 4
+
+
+class SummaryDidNotConvergeError(Exception):
+    """A section still exceeds the token budget after MAX_REDUCE_ROUNDS of map-reduce."""
+
 
 class LLMSummarizer:
-    def __init__(self, llm: LLM, t: LocaleHandler):
+    def __init__(
+        self,
+        llm: LLM,
+        t: LocaleHandler,
+        max_input_tokens: int = DEFAULT_SUMMARIZATION_MAX_INPUT_TOKENS,
+        token_counter: Callable[[str], list[int]] | None = None,
+    ):
         self._llm: LLM = llm
         prompt_str: str = t("lib.prompt.summarizer.summarize")
         self._summarize_prompt_template: PromptTemplate = PromptTemplate(prompt_str)
+        self._token_counter = token_counter
+        self._budget = int(max_input_tokens * SUMMARIZATION_BUDGET_SAFETY_FACTOR)
+
+        # The splitter only ever sees raw text, but `_fits` measures the rendered template around it. Sizing
+        # the splitter to the full budget let it hand back chunks that were already over budget once wrapped,
+        # for any budget where the fixed template overhead isn't dwarfed by the safety factor's margin.
+        template_overhead = self._count_tokens(self._summarize_prompt_template.format(text=""))
+        self._splitter = SentenceSplitter(
+            chunk_size=max(1, self._budget - template_overhead),
+            chunk_overlap=0,
+            tokenizer=lambda text: [0] * self._count_tokens(text),
+        )
 
     def summarize(self, text: str) -> str:
         if not text or not text.strip():
             return ""
+        return self._summarize_within_budget(text, reduce_round=0)
+
+    def _summarize_within_budget(self, text: str, reduce_round: int) -> str:
+        if self._fits(text):
+            return self._predict(text)
+        if reduce_round >= MAX_REDUCE_ROUNDS:
+            raise SummaryDidNotConvergeError(
+                f"summary did not converge within {MAX_REDUCE_ROUNDS} reduce rounds "
+                f"({self._count_tokens(text)} tokens against a {self._budget}-token budget)"
+            )
+        partial = [
+            self._predict(batch) if already_fits else self._summarize_within_budget(batch, reduce_round + 1)
+            for batch, already_fits in self._batches(text)
+        ]
+        return self._summarize_within_budget("\n\n".join(p for p in partial if p), reduce_round + 1)
+
+    def _batches(self, text: str) -> list[tuple[str, bool]]:
+        """
+        Group paragraphs into batches that fit, measuring the joined string that will actually be sent.
+
+        Additive per-segment token counts drift from the real payload once separators and boundary effects
+        accumulate over many segments. Halving the segment list instead measures the real payload and always
+        makes progress, so it cannot loop.
+
+        Each batch is tagged with whether `_fits` already confirmed it, so the caller can predict directly
+        instead of re-measuring a string that hasn't changed since. Splitter leaves are tagged False:
+        `SentenceSplitter`'s boundary math is close but unverified, so they still need the recursive re-check
+        (and its termination bound) as a safety net.
+        """
+
+        def group(segments: list[str]) -> list[tuple[str, bool]]:
+            joined = "\n\n".join(segments)
+            if self._fits(joined):
+                return [(joined, True)]
+            if len(segments) == 1:
+                return [(leaf, False) for leaf in self._splitter.split_text(segments[0])]
+            mid = len(segments) // 2
+            return group(segments[:mid]) + group(segments[mid:])
+
+        return group(text.split("\n\n"))
+
+    def _fits(self, text: str) -> bool:
+        """
+        Decide whether `text`, once wrapped in the summarize prompt, is within budget.
+
+        For the Latin-script EU-language content this pipeline processes, a character never costs more than
+        `SHORT_CIRCUIT_MAX_TOKENS_PER_CHARACTER` tokens, so a render at or under `budget /
+        SHORT_CIRCUIT_MAX_TOKENS_PER_CHARACTER` is guaranteed to fit without the network round trip
+        `_count_tokens` costs. Symmetrically, no tokenizer we route through produces more than one token per
+        character, so a render past 4x the budget is guaranteed to overflow it. That round trip is only
+        load-bearing in the boundary between those two — never on a whole oversized document or a large
+        map-reduce batch, which the reject short-circuit keeps off `/utils/token_counter` entirely.
+        """
+        rendered = self._summarize_prompt_template.format(text=text)
+        if len(rendered) <= self._budget // SHORT_CIRCUIT_MAX_TOKENS_PER_CHARACTER:
+            return True
+        if len(rendered) > self._budget * 4:
+            return False
+        return self._count_tokens(rendered) <= self._budget
+
+    def _count_tokens(self, text: str) -> int:
+        if self._token_counter is None:
+            return len(text) // 4
+        return len(self._token_counter(text))
+
+    def _predict(self, text: str) -> str:
         response: str = self._llm.predict(self._summarize_prompt_template, text=text)
         return response.strip()
 
@@ -37,9 +145,13 @@ class RecursiveNodeSummarizer:
         self,
         llm: LLM,
         min_summarization_length: int = 250,
+        max_input_tokens: int = DEFAULT_SUMMARIZATION_MAX_INPUT_TOKENS,
+        token_counter: Callable[[str], list[int]] | None = None,
     ):
         self._llm = llm
         self.min_summarization_length = min_summarization_length
+        self._max_input_tokens = max_input_tokens
+        self._token_counter = token_counter
         self.node_id_to_node = {}
 
     @trace_fn
@@ -49,7 +161,12 @@ class RecursiveNodeSummarizer:
 
         locale = nodes[0].metadata.get(LANGUAGE, NODE_LANGUAGE_ENGLISH)
         locale_handler = LocaleHandler(locale=locale)
-        llm_summarizer: LLMSummarizer = LLMSummarizer(llm=self._llm, t=locale_handler)
+        llm_summarizer: LLMSummarizer = LLMSummarizer(
+            llm=self._llm,
+            t=locale_handler,
+            max_input_tokens=self._max_input_tokens,
+            token_counter=self._token_counter,
+        )
 
         self.node_id_to_node = {node.node_id: node for node in nodes}
         grouped_nodes = self._group_nodes_by_level(nodes)
@@ -99,16 +216,11 @@ class RecursiveNodeSummarizer:
         if not combined_text:
             return None
 
-        summary_text: str = combined_text
-        if len(combined_text) >= self.min_summarization_length or level == 0:
-            summary_text = summarizer.summarize(combined_text)
-            if not summary_text.strip() and combined_text:
-                summary_text = combined_text
-
-        if not summary_text.strip():
+        reference_node: TextNode = child_summaries[0]
+        summary_text: str | None = self._summarize_combined_text(combined_text, level, summarizer, reference_node)
+        if summary_text is None:
             return None
 
-        reference_node: TextNode = child_summaries[0]
         summary_node: TextNode = self._create_summary_node(reference_node, summary_text, level, index=index)
 
         for child in child_summaries:
@@ -172,13 +284,8 @@ class RecursiveNodeSummarizer:
             if not combined_text:
                 continue
 
-            summary_text: str = combined_text
-            if len(combined_text) >= self.min_summarization_length or level == 0:
-                summary_text = summarizer.summarize(combined_text)
-                if not summary_text.strip() and combined_text:
-                    summary_text = combined_text
-
-            if not summary_text.strip():
+            summary_text: str | None = self._summarize_combined_text(combined_text, level, summarizer, node)
+            if summary_text is None:
                 continue
 
             summary_node: TextNode = self._create_summary_node(node, summary_text, level, index=current_index_for_level)
@@ -192,6 +299,33 @@ class RecursiveNodeSummarizer:
             summarized_nodes_for_this_level.append(summary_node)
 
         return summarized_nodes_for_this_level
+
+    def _summarize_combined_text(
+        self, combined_text: str, level: int, summarizer: LLMSummarizer, reference_node: TextNode
+    ) -> str | None:
+        """
+        Return the summary for `combined_text`, or None if it should be skipped.
+
+        Catches summarization failure instead of letting it propagate (deviates from the repo's fail-fast
+        convention): one section that cannot be reduced within budget would otherwise abort the whole
+        document and discard every sibling summary already completed in this run, sometimes tens of
+        minutes of LLM work.
+        """
+        summary_text = combined_text
+        if len(combined_text) >= self.min_summarization_length or level == 0:
+            try:
+                summary_text = summarizer.summarize(combined_text)
+            except (SummaryDidNotConvergeError, BadRequestError) as summarization_failure:
+                logger.warning(
+                    "Skipping summary for %s: %s",
+                    self._get_header_hierarchy(reference_node),
+                    summarization_failure,
+                )
+                return None
+            if not summary_text.strip() and combined_text:
+                summary_text = combined_text
+
+        return summary_text if summary_text.strip() else None
 
     @staticmethod
     def _is_node_truly_headerless(node: TextNode) -> bool:

--- a/packages/core/swiss_ai_hub/core/generative_ai/document/parsers/tests/unit/test_recursive_summary_parser.py
+++ b/packages/core/swiss_ai_hub/core/generative_ai/document/parsers/tests/unit/test_recursive_summary_parser.py
@@ -1,16 +1,38 @@
+import json
+import logging
 from unittest.mock import MagicMock
 
 import pytest
 from llama_index.core.schema import NodeRelationship, RelatedNodeInfo, TextNode
 from llama_index.llms.openai_like import OpenAILike
 
-from swiss_ai_hub.core.generative_ai.document.parsers.recursive_summary_parser import RecursiveNodeSummarizer
+from swiss_ai_hub.core.generative_ai.document.parsers.recursive_summary_parser import (
+    SUMMARIZATION_BUDGET_SAFETY_FACTOR,
+    LLMSummarizer,
+    RecursiveNodeSummarizer,
+)
+from swiss_ai_hub.core.i18n.locale_handler import LocaleHandler
 from swiss_ai_hub.core.persistence.rag.vectors.node_metadata import HEADING_LEVEL, INDEX, NODE_TYPE_SUMMARY, TYPE
 
 
 @pytest.fixture
 def mock_llm():
     return MagicMock(spec=OpenAILike)
+
+
+def _recording_predict(prompts: list[str]):
+    """A `predict` side effect that records the exact rendered prompt each call sent."""
+
+    def predict(template, text):
+        prompts.append(template.format(text=text))
+        return "s"
+
+    return predict
+
+
+def _one_token_per_char(text: str) -> list[int]:
+    """A token counter with a 1:1 char-to-token ratio, so budget arithmetic in assertions is exact."""
+    return [0] * len(text)
 
 
 def test_nodes_with_next_relationship(mock_llm):
@@ -255,6 +277,123 @@ def test_sequential_indices(mock_llm):
     assert len(summary_nodes) == 2
     assert summary_nodes[0].metadata.get(INDEX) == 0
     assert summary_nodes[1].metadata.get(INDEX) == 1
+
+
+def test_flat_headerless_root_map_reduces_within_budget(mock_llm):
+    """Reproduces issue #158: a headerless root fans in every h1-only sibling as its child."""
+    prompts: list[str] = []
+    mock_llm.predict.side_effect = _recording_predict(prompts)
+
+    siblings = [TextNode(text="short section text", metadata={"h1": f"Section {i}"}) for i in range(2500)]
+    headerless_root = TextNode(text="", metadata={})
+    nodes = [headerless_root, *siblings]
+
+    summarizer = RecursiveNodeSummarizer(llm=mock_llm, max_input_tokens=4000, token_counter=_one_token_per_char)
+    summarized_nodes = summarizer.summarize_nodes(nodes)
+
+    budget = int(4000 * SUMMARIZATION_BUDGET_SAFETY_FACTOR)
+    assert prompts
+    assert all(len(p) <= budget for p in prompts)
+    assert mock_llm.predict.call_count > 1
+
+    summaries = [n for n in summarized_nodes if n.metadata.get(TYPE) == NODE_TYPE_SUMMARY]
+    assert len(summaries) == len(siblings) + 1
+
+
+def test_all_headerless_document_map_reduces_within_budget(mock_llm):
+    """A chain of headerless nodes merges into one group via the NEXT-relationship walk, not fan-in."""
+    prompts: list[str] = []
+    mock_llm.predict.side_effect = _recording_predict(prompts)
+
+    nodes = [TextNode(id_=f"n{i}", text="chunk of body text. " * 3, metadata={}) for i in range(2000)]
+    for previous_node, current_node in zip(nodes, nodes[1:]):
+        previous_node.relationships[NodeRelationship.NEXT] = RelatedNodeInfo(node_id=current_node.node_id)
+
+    summarizer = RecursiveNodeSummarizer(llm=mock_llm, max_input_tokens=4000, token_counter=_one_token_per_char)
+    summarized_nodes = summarizer.summarize_nodes(nodes)
+
+    budget = int(4000 * SUMMARIZATION_BUDGET_SAFETY_FACTOR)
+    assert prompts
+    assert all(len(p) <= budget for p in prompts)
+
+    summaries = [n for n in summarized_nodes if n.metadata.get(TYPE) == NODE_TYPE_SUMMARY]
+    assert len(summaries) == 1
+
+
+def test_parent_with_many_children_map_reduces_within_budget(mock_llm):
+    """Proves map-reduce actually ran, which `test_recursive_splitting_and_summarization` only claims by name."""
+    prompts: list[str] = []
+    mock_llm.predict.side_effect = _recording_predict(prompts)
+
+    parent = TextNode(text="Parent overview", metadata={"h1": "Parent"})
+    children = [
+        TextNode(text="child body text " * 5, metadata={"h1": "Parent", "h2": f"Child {i}"}) for i in range(600)
+    ]
+    nodes = [parent, *children]
+
+    summarizer = RecursiveNodeSummarizer(llm=mock_llm, max_input_tokens=3000, token_counter=_one_token_per_char)
+    summarizer.summarize_nodes(nodes)
+
+    budget = int(3000 * SUMMARIZATION_BUDGET_SAFETY_FACTOR)
+    assert prompts
+    assert all(len(p) <= budget for p in prompts)
+    assert mock_llm.predict.call_count > 1
+
+
+def test_unreducible_summary_is_skipped_and_logged(mock_llm, caplog):
+    """A budget smaller than the prompt template's own fixed overhead can never be satisfied by any input."""
+    node = TextNode(text="This section cannot ever be reduced to fit.", metadata={"h1": "Stuck Section"})
+
+    summarizer = RecursiveNodeSummarizer(
+        llm=mock_llm, min_summarization_length=0, max_input_tokens=1, token_counter=_one_token_per_char
+    )
+
+    with caplog.at_level(logging.WARNING):
+        summarized_nodes = summarizer.summarize_nodes([node])
+
+    summaries = [n for n in summarized_nodes if n.metadata.get(TYPE) == NODE_TYPE_SUMMARY]
+    assert summaries == []
+    assert "Stuck Section" in caplog.text
+    mock_llm.predict.assert_not_called()
+
+
+def test_token_counter_transport_failure_propagates_instead_of_being_swallowed(mock_llm):
+    """
+    A malformed response from the token-counter or LLM gateway (e.g. a 413/502 HTML error page) must not be
+    mistaken for the deliberate "this section can't be reduced" signal and silently dropped.
+    """
+
+    def raising_token_counter(text: str) -> list[int]:
+        raise json.JSONDecodeError("Expecting value", "<html>502 Bad Gateway</html>", 0)
+
+    node = TextNode(text="x" * 2000, metadata={"h1": "Section"})
+
+    summarizer = RecursiveNodeSummarizer(llm=mock_llm, max_input_tokens=4000, token_counter=raising_token_counter)
+
+    with pytest.raises(json.JSONDecodeError):
+        summarizer.summarize_nodes([node])
+
+
+def test_fits_short_circuits_without_touching_the_token_counter():
+    """The char-count thresholds in `_fits` are load-bearing: they keep oversized payloads off the network."""
+    calls: list[str] = []
+
+    def counting_token_counter(text: str) -> list[int]:
+        calls.append(text)
+        return [0] * len(text)
+
+    summarizer = LLMSummarizer(
+        llm=MagicMock(spec=OpenAILike),
+        t=LocaleHandler(locale="en"),
+        max_input_tokens=4000,
+        token_counter=counting_token_counter,
+    )
+    budget = summarizer._budget
+    calls.clear()  # __init__ already measured the template overhead once
+
+    assert summarizer._fits("s" * 10) is True
+    assert summarizer._fits("s" * (budget * 5)) is False
+    assert calls == []
 
 
 def test_sibling_relationships(mock_llm):

--- a/packages/core/swiss_ai_hub/core/generative_ai/document/parsers/text_chunk_size_limiter.py
+++ b/packages/core/swiss_ai_hub/core/generative_ai/document/parsers/text_chunk_size_limiter.py
@@ -4,6 +4,12 @@ from llama_index.core.node_parser import SentenceSplitter
 
 from swiss_ai_hub.core.generative_ai.document.parsers.text_chunk import TextChunk
 
+# Worst-case tokens per character assumed by `_within_budget`'s accept short-circuit -- see the identical
+# constant and rationale in recursive_summary_parser.py. Kept separate since the two budgets are independent
+# decisions that happen to share this assumption: deployments process Latin-script EU-language content, not
+# CJK, so a character costs at most ~2 tokens even under byte-level BPE fallback for multi-byte accents.
+SHORT_CIRCUIT_MAX_TOKENS_PER_CHARACTER = 2
+
 
 class TextChunkSizeLimiter:
     """
@@ -36,7 +42,13 @@ class TextChunkSizeLimiter:
         Short-circuit on character count before paying for a token count.
 
         `token_counter` is a LiteLLM round trip per call, and nearly every chunk arriving here is a ~512-token
-        split that cannot possibly breach the ceiling. A token is never fewer than one character, so a chunk
-        shorter than the budget is under it by construction - the check is exact, not an estimate.
+        split that cannot possibly breach the ceiling. The short-circuit is an estimate, not exact: a chunk
+        comfortably under budget / SHORT_CIRCUIT_MAX_TOKENS_PER_CHARACTER skips the real count; anything past
+        4x the budget is rejected without one either, since no tokenizer this routes through produces more
+        tokens than it has characters.
         """
-        return len(content) <= self.max_tokens or self.token_counter(content) <= self.max_tokens
+        if len(content) <= self.max_tokens // SHORT_CIRCUIT_MAX_TOKENS_PER_CHARACTER:
+            return True
+        if len(content) > self.max_tokens * 4:
+            return False
+        return self.token_counter(content) <= self.max_tokens

--- a/packages/pipeline/CLAUDE.md
+++ b/packages/pipeline/CLAUDE.md
@@ -213,7 +213,8 @@ assets.
 - `DocumentParserResource` — Selects parser by filetype. `LoaderType.MINERU` (default) or `DOCUMENT_INTELLIGENCE`.
   Fallbacks: `EpubReader`, `IPYNBReader`, `RawLoader`, `RTFReader`, `ImageLoader`.
 - `MarkdownStructuralNodeParserResource` — LlamaIndex MD structural parser for chunking.
-- `RecursiveSummaryParserResource` — Hierarchical summary generation for multi-level RAG.
+- `RecursiveSummaryParserResource` — Hierarchical summary generation for multi-level RAG. Takes `llm_config` and caps
+  each prompt to the LLM's input limit, map-reducing over oversized rollups instead of sending them whole.
 - `TableRefinementResource` — LLM-powered table detection and structure splitting.
 
 **LLM/Embedding**: `EmbeddingModelResource` (wraps `EmbeddingModelConfig`), `LanguageModelResource` (wraps `LLMConfig`).

--- a/packages/pipeline/playground/quick_start/my_document_pipeline.py
+++ b/packages/pipeline/playground/quick_start/my_document_pipeline.py
@@ -79,7 +79,7 @@ defs = Definitions(
         # Document processing resources
         "document_parser": DocumentParserResource(loader_type=LoaderType.MINERU),
         "node_parser": MarkdownStructuralNodeParserResource(llm_config=llm_config, embedding_config=embedding_config),
-        "summary_parser": RecursiveSummaryParserResource(),
+        "summary_parser": RecursiveSummaryParserResource(llm_config=llm_config),
         # Vector store and document store (MongoDB + Milvus)
         **local_mongo_milvus_storage_context_resource(
             vector_store_uri="http://localhost:19530",

--- a/packages/pipeline/swiss_ai_hub/pipeline/resources/parser/recursive_summary_parser_resource.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/resources/parser/recursive_summary_parser_resource.py
@@ -1,6 +1,18 @@
-from dagster import ConfigurableResource
+from dagster import ConfigurableResource, ResourceDependency
 from llama_index.core.llms import LLM
-from swiss_ai_hub.core.generative_ai.document.parsers.recursive_summary_parser import RecursiveNodeSummarizer
+from swiss_ai_hub.core.generative_ai.document.parsers.recursive_summary_parser import (
+    DEFAULT_SUMMARIZATION_MAX_INPUT_TOKENS,
+    RecursiveNodeSummarizer,
+)
+from swiss_ai_hub.core.generative_ai.resources.models.llm.llm_config import LLMConfig
+
+MAX_INPUT_TOKENS_CEILING = DEFAULT_SUMMARIZATION_MAX_INPUT_TOKENS
+"""
+Hard cap applied to a LiteLLM-declared window, regardless of what LiteLLM echoes. Shares a value with
+`RecursiveNodeSummarizer`'s own fallback default today, but the two are separate decisions -- this one is a
+deployment-level safety cap, that one is "what to budget when nobody says otherwise" -- and may diverge as
+models or providers change.
+"""
 
 
 class RecursiveSummaryParserResource(ConfigurableResource):
@@ -9,5 +21,20 @@ class RecursiveSummaryParserResource(ConfigurableResource):
     It is used to summarize nodes recursively using a language model (LLM).
     """
 
+    llm_config: ResourceDependency[LLMConfig]
+
     def get_summary_parser(self, llm: LLM) -> RecursiveNodeSummarizer:
-        return RecursiveNodeSummarizer(llm=llm)
+        return RecursiveNodeSummarizer(
+            llm=llm,
+            max_input_tokens=self._resolve_max_input_tokens(),
+            token_counter=self.llm_config.token_counter,
+        )
+
+    def _resolve_max_input_tokens(self) -> int:
+        """
+        Cap the declared window rather than trust it: LiteLLM echoes whatever we hand-configured for a
+        model, and the provider's OpenAI-compatible endpoint carries no context-length field for LiteLLM to
+        cross-check it against.
+        """
+        declared = self.llm_config.get_model_info()["model_info"].get("max_input_tokens")
+        return min(declared or MAX_INPUT_TOKENS_CEILING, MAX_INPUT_TOKENS_CEILING)

--- a/packages/pipeline/swiss_ai_hub/pipeline/resources/parser/tests/test_recursive_summary_parser_resource.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/resources/parser/tests/test_recursive_summary_parser_resource.py
@@ -1,0 +1,59 @@
+"""Tests for wiring the LLM's input limit and tokenizer into the recursive summary parser."""
+
+from unittest.mock import PropertyMock, patch
+
+from swiss_ai_hub.core.generative_ai.resources.models.llm.llm_config import LLMConfig
+
+from swiss_ai_hub.pipeline.resources.parser.recursive_summary_parser_resource import (
+    MAX_INPUT_TOKENS_CEILING,
+    RecursiveSummaryParserResource,
+)
+
+
+def build_resource() -> RecursiveSummaryParserResource:
+    """
+    Constructing the resource is the assertion.
+
+    Dagster validates ResourceDependency fields at construction, and `ResourceDependency[T] | None` fails that
+    validation — a shape that unit tests missed entirely because they never build the resource, so it would
+    only have surfaced when the Dagster code location loaded.
+    """
+    return RecursiveSummaryParserResource(llm_config=LLMConfig(model_name="text-generation/gemma-4-31B-it"))
+
+
+class TestRecursiveSummaryParserResource:
+    def test_resource_can_be_constructed_with_its_dependency(self) -> None:
+        assert build_resource() is not None
+
+    def test_overstated_declared_limit_is_capped_to_the_default(self) -> None:
+        """The model in use declares 131072 and is served at 100000 by the provider."""
+        resource = build_resource()
+
+        with patch.object(LLMConfig, "get_model_info", return_value={"model_info": {"max_input_tokens": 131072}}):
+            assert resource._resolve_max_input_tokens() == MAX_INPUT_TOKENS_CEILING
+
+    def test_smaller_declared_limit_is_respected(self) -> None:
+        resource = build_resource()
+
+        with patch.object(LLMConfig, "get_model_info", return_value={"model_info": {"max_input_tokens": 8192}}):
+            assert resource._resolve_max_input_tokens() == 8192
+
+    def test_null_max_input_tokens_falls_back_to_the_default(self) -> None:
+        """LiteLLM reports null for any model it holds no metadata for."""
+        resource = build_resource()
+
+        with patch.object(LLMConfig, "get_model_info", return_value={"model_info": {"max_input_tokens": None}}):
+            assert resource._resolve_max_input_tokens() == MAX_INPUT_TOKENS_CEILING
+
+    def test_summary_parser_receives_the_resolved_ceiling_and_token_counter(self) -> None:
+        resource = build_resource()
+        sentinel_counter = lambda text: [0] * len(text)  # noqa: E731 - identity-checked below, not called
+
+        with (
+            patch.object(LLMConfig, "get_model_info", return_value={"model_info": {"max_input_tokens": 8192}}),
+            patch.object(LLMConfig, "token_counter", new_callable=PropertyMock, return_value=sentinel_counter),
+        ):
+            summary_parser = resource.get_summary_parser(llm=object())
+
+        assert summary_parser._max_input_tokens == 8192
+        assert summary_parser._token_counter is sentinel_counter

--- a/packages/pipeline/swiss_ai_hub/pipeline/util/definitions_util.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/util/definitions_util.py
@@ -152,7 +152,7 @@ def default_definitions(
     resources: dict = {
         "document_parser": DocumentParserResource(loader_type=document_parser_loader_type),
         "node_parser": MarkdownStructuralNodeParserResource(llm_config=llm_config, embedding_config=embedding_config),
-        "summary_parser": RecursiveSummaryParserResource(),
+        "summary_parser": RecursiveSummaryParserResource(llm_config=llm_config),
         **default_io_manager_s3_datalake_resources(container_name=datalake_container_name),
         **local_mongo_milvus_storage_context_resource(
             vector_store_uri=milvus_settings.URL, store_name=store_name, dimensions=dimensions


### PR DESCRIPTION
## Summary

Fixes #158. `LLMSummarizer.summarize` concatenated a parent node with all of its children into a single prompt with no token budget anywhere in the path. A headerless heading tree collapses every section into one root's children, so the root prompt grows linearly with the document and eventually exceeds the model's real context window — discarding every completed leaf summary in the same partition.

## Changes

- `LLMSummarizer` now measures the rendered prompt against a token budget and map-reduces over oversized input: split into batches that fit, summarize each, then summarize the joined batch summaries, repeating until one call fits or `MAX_REDUCE_ROUNDS` is exhausted.
- `_fits()` short-circuits on character count before paying for a network-based token count, bounded on both sides so a whole oversized document or a large map-reduce batch never gets sent to `/utils/token_counter` as a multi-megabyte payload — only the boundary case needs the real, network-backed count. Thresholds assume Latin-script EU-language content (this deployment's documents), not CJK.
- `_batches` tags each returned batch with whether it was already verified to fit, so already-confirmed batches predict directly instead of re-measuring a string that hasn't changed; unverified splitter leaves still get the recursive re-check as a safety net.
- A section that still can't be reduced within budget is skipped and logged rather than aborting the whole document — a deliberate, narrowly-scoped deviation from fail-fast via a dedicated `SummaryDidNotConvergeError`, so a genuine transport failure (e.g. a malformed response from an overloaded gateway) still propagates instead of being mistaken for non-convergence.
- Applied the identical budget-based short-circuit fix to the sibling `TextChunkSizeLimiter`, which guards the embedding model's input limit with the same char-count check and the same previously-unsound assumption.
- `RecursiveSummaryParserResource` caps the LLM's declared context window rather than trusting it: LiteLLM echoes whatever was hand-configured, and the provider's OpenAI-compatible endpoint carries no context-length field to cross-check it against.
- Corrected the declared `max_input_tokens` for `gemma-4-31B-it` and `Ministral-3-14B-Instruct-2512` in the LiteLLM config templates to match what the provider actually serves, rather than the unverified value previously hand-written there.

## Testing

- `packages/core`: 1078 passed
- `packages/pipeline`: 74 passed
- Lint clean across all touched scopes