### PR TITLE
fix(swiss-ai-hub): Paginate OpenWebUI model list and survive provisioning failures

### DIFF
--- a/packages/api/playground/testing/tests/runners/test_provisioning_guard.py
+++ b/packages/api/playground/testing/tests/runners/test_provisioning_guard.py
@@ -1,0 +1,28 @@
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+
+from swiss_ai_hub.api.runners.lifetime.lifetime_manager import _provision_non_fatal
+
+
+class TestProvisionNonFatal:
+    @pytest.mark.asyncio
+    async def test_failure_is_swallowed_and_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        provision = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with caplog.at_level(logging.ERROR):
+            await _provision_non_fatal("OpenWebUI", provision)
+
+        assert "OpenWebUI provisioning failed (non-fatal)" in caplog.text
+        assert "boom" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_success_awaits_provisioner_without_logging(self, caplog: pytest.LogCaptureFixture) -> None:
+        provision = AsyncMock()
+
+        with caplog.at_level(logging.ERROR):
+            await _provision_non_fatal("Langfuse", provision)
+
+        provision.assert_awaited_once()
+        assert not caplog.records

--- a/packages/api/swiss_ai_hub/api/runners/lifetime/lifetime_manager.py
+++ b/packages/api/swiss_ai_hub/api/runners/lifetime/lifetime_manager.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
 
 import boto3
@@ -42,6 +42,17 @@ from swiss_ai_hub.api.sockets.sender.web_socket_sender import WebSocketSender
 
 logger = logging.getLogger(__name__)
 _background_tasks: set[asyncio.Task] = set()
+
+
+async def _provision_non_fatal(name: str, provision: Callable[[], Awaitable[None]]) -> None:
+    """Provisioning targets external services; their outage must not stop the API from serving.
+
+    The periodic discovery sync already reconciles OpenWebUI non-fatally, so a startup failure
+    here only degrades the model picker until the next cycle instead of crash-looping the pod."""
+    try:
+        await provision()
+    except Exception as exception:
+        logger.error(f"{name} provisioning failed (non-fatal): {exception}", exc_info=True)
 
 
 @asynccontextmanager
@@ -237,10 +248,10 @@ async def lifetime_manager(app: FastAPI) -> AsyncGenerator:
         await initialize_knowledge_buckets()
 
         # Provision Langfuse with AI-Hub LLM connections
-        await langfuse_provisioner.provision()
+        await _provision_non_fatal("Langfuse", langfuse_provisioner.provision)
 
         # Provision OpenWebUI with groups, workspace models, and access grants
-        await openwebui_provisioner.provision()
+        await _provision_non_fatal("OpenWebUI", openwebui_provisioner.provision)
 
         # Re-sync OpenWebUI when access entities change (active tenant switches notify explicitly)
         AccessChangeHook.connect(openwebui_provisioner)

--- a/packages/api/swiss_ai_hub/api/runners/lifetime/lifetime_manager.py
+++ b/packages/api/swiss_ai_hub/api/runners/lifetime/lifetime_manager.py
@@ -52,7 +52,7 @@ async def _provision_non_fatal(name: str, provision: Callable[[], Awaitable[None
     try:
         await provision()
     except Exception as exception:
-        logger.error(f"{name} provisioning failed (non-fatal): {exception}", exc_info=True)
+        logger.exception(f"{name} provisioning failed (non-fatal): {exception}")
 
 
 @asynccontextmanager

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_client.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_client.py
@@ -23,6 +23,19 @@ SCIM_PAGE_SIZE = 100
 # Backstop so a server that ignores startIndex can't spin the provisioner forever.
 MAX_SCIM_PAGES = 10_000
 
+# Backstop so a server that ignores the page parameter can't spin the provisioner forever.
+MODELS_MAX_PAGES = 10_000
+
+
+def _raise_with_detail(response: httpx.Response) -> None:
+    """OpenWebUI names the real cause in the response body (e.g. MODEL_ID_TAKEN behind a 401),
+    which a bare ``raise_for_status`` discards."""
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exception:
+        exception.add_note(response.text)
+        raise
+
 
 class OpenWebuiClient:
     def __init__(self, base_url: str, secret_key: str, scim_token: str, service_account_id: str) -> None:
@@ -155,10 +168,41 @@ class OpenWebuiClient:
     # ------------------------------------------------------------------
 
     async def list_models(self, http: httpx.AsyncClient) -> list[dict[str, Any]]:
-        response = await http.get(f"{self._base_url}{MODELS_ENDPOINT}/list", headers=self._jwt_headers)
-        response.raise_for_status()
-        data = response.json()
-        return data.get("items", []) if isinstance(data, dict) else data
+        """Returns every workspace model, following OpenWebUI's page-based pagination.
+
+        OpenWebUI caps ``/models/list`` at a fixed server-side page size (30) with no way to
+        raise it, so a bare GET silently drops every model past the first page — the provisioner
+        then re-creates existing models and never reconciles grants for the rest. The explicit
+        ``order_by`` matters: the server only orders implicitly when its access filter is empty,
+        and paging over an unordered result set can repeat and drop rows.
+
+        Termination keys off the server's reported ``total`` (counted before pagination), with
+        an empty page as fallback — never a short page, since the server's page size is not ours
+        to assume across versions.
+        """
+        results: list[dict[str, Any]] = []
+        page = 1
+        for _ in range(MODELS_MAX_PAGES):
+            response = await http.get(
+                f"{self._base_url}{MODELS_ENDPOINT}/list",
+                headers=self._jwt_headers,
+                params={"page": page, "order_by": "created_at", "direction": "desc"},
+            )
+            _raise_with_detail(response)
+            data = response.json()
+            if isinstance(data, list):
+                return data
+            items = data.get("items", [])
+            results.extend(items)
+            total = data.get("total")
+            if total is not None and len(results) >= total:
+                break
+            if not items:
+                break
+            page += 1
+        else:
+            raise RuntimeError(f"OpenWebUI model pagination exceeded {MODELS_MAX_PAGES} pages")
+        return results
 
     async def list_base_models(self, http: httpx.AsyncClient) -> list[dict[str, Any]]:
         """Lists registry entries that override a raw provider model (``base_model_id`` unset).
@@ -167,18 +211,42 @@ class OpenWebuiClient:
         base-model overrides are invisible to it — and to the workspace UI that renders it.
         """
         response = await http.get(f"{self._base_url}{MODELS_ENDPOINT}/base", headers=self._jwt_headers)
-        response.raise_for_status()
+        _raise_with_detail(response)
         return response.json()
 
     async def create_model(self, http: httpx.AsyncClient, model_data: dict[str, Any]) -> dict[str, Any]:
+        """Creates a model, or updates the existing one if the id is already registered.
+
+        Concurrent syncs can race the list→create window, and OpenWebUI signals a taken id with
+        HTTP 401 MODEL_ID_TAKEN — the same status as a genuine permission denial, so the body's
+        ``detail`` is inspected rather than the status code. Falling back to update reconciles
+        name/meta/base_model_id and leaves access grants untouched (the update endpoint ignores
+        an absent ``access_grants``).
+        """
         model_data.setdefault("params", {})
         response = await http.post(
             f"{self._base_url}{MODELS_ENDPOINT}/create",
             headers=self._jwt_headers,
             json=model_data,
         )
-        response.raise_for_status()
+        if response.is_success:
+            return response.json()
+        if "already registered" in self._error_detail(response):
+            logger.warning(
+                "OpenWebUI model '%s' already exists; updating it instead of creating a duplicate",
+                model_data["id"],
+            )
+            return await self.update_model(http, model_data)
+        _raise_with_detail(response)
         return response.json()
+
+    @staticmethod
+    def _error_detail(response: httpx.Response) -> str:
+        try:
+            data = response.json()
+        except ValueError:
+            return response.text
+        return data.get("detail", "") if isinstance(data, dict) else response.text
 
     async def update_model(self, http: httpx.AsyncClient, model_data: dict[str, Any]) -> dict[str, Any]:
         model_data.setdefault("params", {})
@@ -187,7 +255,7 @@ class OpenWebuiClient:
             headers=self._jwt_headers,
             json=model_data,
         )
-        response.raise_for_status()
+        _raise_with_detail(response)
         return response.json()
 
     async def delete_model(self, http: httpx.AsyncClient, model_id: str) -> None:
@@ -196,7 +264,7 @@ class OpenWebuiClient:
             headers=self._jwt_headers,
             json={"id": model_id},
         )
-        response.raise_for_status()
+        _raise_with_detail(response)
 
     async def get_model(self, http: httpx.AsyncClient, model_id: str) -> dict[str, Any]:
         response = await http.get(
@@ -204,7 +272,7 @@ class OpenWebuiClient:
             headers=self._jwt_headers,
             params={"id": model_id},
         )
-        response.raise_for_status()
+        _raise_with_detail(response)
         return response.json()
 
     async def update_model_access(
@@ -228,5 +296,5 @@ class OpenWebuiClient:
             headers=self._jwt_headers,
             json=form,
         )
-        response.raise_for_status()
+        _raise_with_detail(response)
         return response.json()

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_client.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_client.py
@@ -173,14 +173,21 @@ class OpenWebuiClient:
         OpenWebUI caps ``/models/list`` at a fixed server-side page size (30) with no way to
         raise it, so a bare GET silently drops every model past the first page — the provisioner
         then re-creates existing models and never reconciles grants for the rest. The explicit
-        ``order_by`` matters: the server only orders implicitly when its access filter is empty,
-        and paging over an unordered result set can repeat and drop rows.
+        ``order_by`` narrows that: the server only orders implicitly when its access filter is
+        empty, so paging over an unordered result set can repeat and drop rows outright.
+
+        ``created_at`` is not unique, though, so ties can still shuffle between two OFFSET queries
+        and hand the same row back twice. Accumulating by id absorbs that — and, crucially, keeps
+        the ``total`` check counting *distinct* models: against a raw running count a repeat would
+        satisfy it early and silently strip whichever row the repeat displaced. Drops need a stable
+        server-side tiebreaker to prevent, so a short final result is reported rather than hidden.
 
         Termination keys off the server's reported ``total`` (counted before pagination), with
         an empty page as fallback — never a short page, since the server's page size is not ours
         to assume across versions.
         """
-        results: list[dict[str, Any]] = []
+        by_id: dict[str, dict[str, Any]] = {}
+        total: int | None = None
         page = 1
         for _ in range(MODELS_MAX_PAGES):
             response = await http.get(
@@ -193,16 +200,23 @@ class OpenWebuiClient:
             if isinstance(data, list):
                 return data
             items = data.get("items", [])
-            results.extend(items)
+            for item in items:
+                by_id.setdefault(item["id"], item)
             total = data.get("total")
-            if total is not None and len(results) >= total:
+            if total is not None and len(by_id) >= total:
                 break
             if not items:
                 break
             page += 1
         else:
             raise RuntimeError(f"OpenWebUI model pagination exceeded {MODELS_MAX_PAGES} pages")
-        return results
+
+        if total is not None and len(by_id) < total:
+            logger.warning(
+                f"OpenWebUI reported total={total} models but pagination yielded {len(by_id)} distinct ones; "
+                f"rows were dropped (unstable sort on the non-unique created_at key)"
+            )
+        return list(by_id.values())
 
     async def list_base_models(self, http: httpx.AsyncClient) -> list[dict[str, Any]]:
         """Lists registry entries that override a raw provider model (``base_model_id`` unset).

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_provisioner.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_provisioner.py
@@ -332,6 +332,13 @@ class OpenWebuiProvisioner:
 
         to_create, to_update, to_delete = self._compute_model_diff(online_agents, existing_aihub)
 
+        if not online_agents and to_delete:
+            logger.warning(
+                f"OpenWebUI: Skipping deletion of {len(to_delete)} workspace models — no agent class is "
+                f"online, which reads as agent downtime rather than deprovisioning"
+            )
+            to_delete = set()
+
         for agent in to_create:
             model_data = self._build_model_data(agent)
             await self._openwebui.create_model(http, model_data)

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_client.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_client.py
@@ -5,6 +5,7 @@ import httpx
 import pytest
 from scim2_models import Group, User
 
+import swiss_ai_hub.core.infrastructure.openwebui.openwebui_client as openwebui_client_module
 from swiss_ai_hub.core.infrastructure.openwebui.openwebui_client import SCIM_PAGE_SIZE, OpenWebuiClient
 
 BASE_URL = "http://open-webui:8080"
@@ -72,15 +73,76 @@ class TestUpdateModel:
             await owui_client.update_model(mock_client, {"id": "m1", "name": "New Name"})
 
 
+def _model_pages(pages: list[list[dict]], *, total: int | None = -1) -> list[httpx.Response]:
+    """One paginated ``/models/list`` response per page; ``total`` defaults to the overall count,
+    pass ``None`` to simulate a server that omits it."""
+    overall = sum(len(p) for p in pages)
+    return [_response(json_data={"items": page, "total": overall if total == -1 else total}) for page in pages]
+
+
 class TestListModels:
     @pytest.mark.asyncio
-    async def test_list_models_handles_dict_response_with_items(self, owui_client: OpenWebuiClient) -> None:
+    async def test_single_page_below_cap_needs_one_request(self, owui_client: OpenWebuiClient) -> None:
         mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.get.return_value = _response(json_data={"items": [{"id": "m1"}]})
+        mock_client.get.side_effect = _model_pages([[{"id": f"m{i}"} for i in range(6)]])
 
         result = await owui_client.list_models(mock_client)
 
-        assert result == [{"id": "m1"}]
+        assert len(result) == 6
+        assert mock_client.get.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_follows_all_pages(self, owui_client: OpenWebuiClient) -> None:
+        pages = [
+            [{"id": f"m{i}"} for i in range(30)],
+            [{"id": f"m{i}"} for i in range(30, 60)],
+            [{"id": f"m{i}"} for i in range(60, 65)],
+        ]
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.side_effect = _model_pages(pages)
+
+        result = await owui_client.list_models(mock_client)
+
+        assert [m["id"] for m in result] == [f"m{i}" for i in range(65)]
+        assert mock_client.get.await_count == 3
+        for call, expected_page in zip(mock_client.get.await_args_list, (1, 2, 3), strict=True):
+            params = call.kwargs["params"]
+            assert params["page"] == expected_page
+            assert params["order_by"] == "created_at"
+            assert params["direction"] == "desc"
+
+    @pytest.mark.asyncio
+    async def test_stops_at_exact_page_multiple(self, owui_client: OpenWebuiClient) -> None:
+        pages = [[{"id": f"m{i}"} for i in range(30)], [{"id": f"m{i}"} for i in range(30, 60)]]
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.side_effect = _model_pages(pages)
+
+        result = await owui_client.list_models(mock_client)
+
+        assert len(result) == 60
+        assert mock_client.get.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_missing_total_stops_on_empty_page(self, owui_client: OpenWebuiClient) -> None:
+        pages = [[{"id": f"m{i}"} for i in range(30)], [{"id": f"m{i}"} for i in range(30, 60)], []]
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.side_effect = _model_pages(pages, total=None)
+
+        result = await owui_client.list_models(mock_client)
+
+        assert len(result) == 60
+        assert mock_client.get.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_backstop_raises_when_pagination_never_terminates(
+        self, owui_client: OpenWebuiClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(openwebui_client_module, "MODELS_MAX_PAGES", 3)
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = _response(json_data={"items": [{"id": "m"}] * 30, "total": None})
+
+        with pytest.raises(RuntimeError, match="pagination exceeded"):
+            await owui_client.list_models(mock_client)
 
     @pytest.mark.asyncio
     async def test_list_models_handles_bare_list_response(self, owui_client: OpenWebuiClient) -> None:
@@ -90,6 +152,40 @@ class TestListModels:
         result = await owui_client.list_models(mock_client)
 
         assert result == [{"id": "m1"}]
+        assert mock_client.get.await_count == 1
+
+
+MODEL_ID_TAKEN_DETAIL = "Uh-oh! This model id is already registered. Please choose another model id string."
+
+
+class TestCreateModelIdempotent:
+    @pytest.mark.asyncio
+    async def test_falls_back_to_update_when_model_id_taken(
+        self, owui_client: OpenWebuiClient, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post.side_effect = [
+            _response(status_code=401, json_data={"detail": MODEL_ID_TAKEN_DETAIL}),
+            _response(json_data={"id": "m1", "name": "Updated"}),
+        ]
+
+        with caplog.at_level("WARNING"):
+            result = await owui_client.create_model(mock_client, {"id": "m1", "name": "Updated"})
+
+        assert result == {"id": "m1", "name": "Updated"}
+        assert mock_client.post.await_count == 2
+        assert mock_client.post.await_args_list[1].args[0].endswith("/api/v1/models/model/update")
+        assert "already exists" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_raises_on_genuine_unauthorized(self, owui_client: OpenWebuiClient) -> None:
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post.return_value = _response(status_code=401, json_data={"detail": "Unauthorized"})
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await owui_client.create_model(mock_client, {"id": "m1"})
+
+        assert mock_client.post.await_count == 1
 
 
 class TestErrorPropagation:
@@ -102,12 +198,16 @@ class TestErrorPropagation:
             await owui_client.list_models(mock_client)
 
     @pytest.mark.asyncio
-    async def test_create_model_raises_on_validation_error(self, owui_client: OpenWebuiClient) -> None:
+    async def test_create_model_raises_on_validation_error_with_body_attached(
+        self, owui_client: OpenWebuiClient
+    ) -> None:
         mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.post.return_value = _response(status_code=422)
+        mock_client.post.return_value = _response(status_code=422, json_data={"detail": "field required"})
 
-        with pytest.raises(httpx.HTTPStatusError):
+        with pytest.raises(httpx.HTTPStatusError) as excinfo:
             await owui_client.create_model(mock_client, {"id": "test"})
+
+        assert any("field required" in note for note in excinfo.value.__notes__)
 
     @pytest.mark.asyncio
     async def test_delete_model_raises_on_not_found(self, owui_client: OpenWebuiClient) -> None:

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_client.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_client.py
@@ -1,3 +1,4 @@
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -153,6 +154,44 @@ class TestListModels:
 
         assert result == [{"id": "m1"}]
         assert mock_client.get.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_repeated_row_is_returned_once_and_does_not_end_pagination_early(
+        self, owui_client: OpenWebuiClient
+    ) -> None:
+        """``created_at`` is not unique, so ties can reshuffle between OFFSET queries and repeat a row.
+
+        Counting raw rows against ``total`` would satisfy the check one row short and silently strip
+        whichever model the repeat displaced — here, m59 on the last page.
+        """
+        pages = [
+            [{"id": f"m{i}"} for i in range(30)],
+            [{"id": "m29"}] + [{"id": f"m{i}"} for i in range(30, 59)],
+            [{"id": "m59"}],
+        ]
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.side_effect = _model_pages(pages, total=60)
+
+        result = await owui_client.list_models(mock_client)
+
+        assert [m["id"] for m in result] == [f"m{i}" for i in range(60)]
+        assert mock_client.get.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_dropped_rows_are_reported_rather_than_hidden(
+        self, owui_client: OpenWebuiClient, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A drop needs a stable server-side tiebreaker to prevent, so the gap is surfaced instead."""
+        pages = [[{"id": f"m{i}"} for i in range(30)], [{"id": f"m{i}"} for i in range(30, 60)], []]
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.side_effect = _model_pages(pages, total=61)
+
+        with caplog.at_level(logging.WARNING):
+            result = await owui_client.list_models(mock_client)
+
+        assert len(result) == 60
+        assert "total=61" in caplog.text
+        assert "60 distinct" in caplog.text
 
 
 MODEL_ID_TAKEN_DETAIL = "Uh-oh! This model id is already registered. Please choose another model id string."

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_provisioner_models.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_provisioner_models.py
@@ -102,13 +102,34 @@ class TestSyncWorkspaceModels:
 
     @pytest.mark.asyncio
     async def test_sync_deletes_model_for_offline_agent(self, provisioner: OpenWebuiProvisioner) -> None:
+        """A stale model still goes, as long as something is online to make 'stale' meaningful."""
         mock_client = AsyncMock(spec=httpx.AsyncClient)
 
         with (
             patch.object(
                 provisioner._openwebui,
                 "list_models",
-                return_value=[{"id": "aihub-agent-rag-default"}],
+                return_value=[{"id": "aihub-agent-rag-default", "name": "RAG Agent"}, {"id": "aihub-agent-gone-old"}],
+            ),
+            patch.object(provisioner._openwebui, "create_model") as mock_create,
+            patch.object(provisioner._openwebui, "delete_model") as mock_delete,
+        ):
+            await provisioner._sync_workspace_models(mock_client, [_RAG_AGENT])
+
+            mock_create.assert_not_called()
+            mock_delete.assert_called_once_with(mock_client, "aihub-agent-gone-old")
+
+    @pytest.mark.asyncio
+    async def test_sync_skips_deletion_when_no_agent_is_online(self, provisioner: OpenWebuiProvisioner) -> None:
+        """An empty online set means agent downtime, not deprovisioning — deleting every model on a
+        cold start where the API pod outraces the agent pods would wipe the whole picker."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        with (
+            patch.object(
+                provisioner._openwebui,
+                "list_models",
+                return_value=[{"id": "aihub-agent-rag-default"}, {"id": "aihub-agent-search-default"}],
             ),
             patch.object(provisioner._openwebui, "create_model") as mock_create,
             patch.object(provisioner._openwebui, "delete_model") as mock_delete,
@@ -116,7 +137,7 @@ class TestSyncWorkspaceModels:
             await provisioner._sync_workspace_models(mock_client, [])
 
             mock_create.assert_not_called()
-            mock_delete.assert_called_once_with(mock_client, "aihub-agent-rag-default")
+            mock_delete.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_sync_updates_model_name_on_rename(self, provisioner: OpenWebuiProvisioner) -> None:


### PR DESCRIPTION
## Summary

Fixes bbvch-ai/aihub-core-private#162 — the API pod crash-loops on instances with more than 30 OpenWebUI workspace models.

OpenWebUI caps `GET /api/v1/models/list` at a fixed 30 items per page (verified in the v0.9.5 container source: `PAGE_ITEM_COUNT = 30`, no client override). `OpenWebuiClient.list_models()` did one bare GET, so every model past page 1 was invisible: the provisioner re-created existing models (rejected with HTTP 401 `MODEL_ID_TAKEN`, whose body `raise_for_status()` discarded), the exception escaped the FastAPI lifespan, and the pod crash-looped. Separately, `_sync_access_grants` reconciled grants only for the first page, so models past it stayed invisible to non-admin users.

## Changes

- **`list_models` paginates**: follows the 1-based `page` cursor with explicit `order_by=created_at&direction=desc` (the server only orders implicitly when its access filter is empty — paging over an unordered set can repeat/drop rows), terminating on the server-reported `total` with an empty-page fallback and a `MODELS_MAX_PAGES` backstop, mirroring the SCIM `_query_all` pattern from #1525. `list_base_models` needs no pagination — `/models/base` is unpaginated server-side (bare list, no skip/limit).
- **`create_model` is idempotent** (mirrors `create_group`): on failure it inspects the body `detail` for "already registered" — OpenWebUI uses 401 for both `MODEL_ID_TAKEN` and genuine permission denials, so the status code alone is ambiguous — logs a warning and falls back to `update_model`, which reconciles name/meta/base_model_id and leaves access grants untouched (the update endpoint ignores an absent `access_grants`).
- **Errors keep the real cause**: all model-endpoint methods raise through `_raise_with_detail`, attaching the response body via `add_note` so logs name `MODEL_ID_TAKEN` instead of a bare 401.
- **Lifespan guard**: `langfuse_provisioner.provision()` and `openwebui_provisioner.provision()` now run through `_provision_non_fatal` — a provisioning failure degrades the model picker until the next periodic sync (which was already non-fatal) instead of stopping the API from serving.

## Test plan

- [x] Unit: paginated `list_models` (single page, multi-page, exact page multiple, missing `total`, bare-list legacy shape, backstop), idempotent `create_model` (taken-id fallback, genuine-401 raise, body attached on 422), lifespan guard (failure swallowed + logged, success path)
- [x] `make test` in `packages/core` (1110 passed) and `packages/api` (501 passed; 2 pre-existing environment-dependent failures reproduced identically on clean `main`)
- [x] Live smoke against dev OpenWebUI v0.9.5: seeded 35 models → 41 found across 2 pages, no duplicates or gaps; re-creating an existing id hit the real `MODEL_ID_TAKEN` 401 and reconciled via update; cleaned up to baseline
- [x] Below-page-size instances unchanged: single request, identical results

## Deploy notes

- The k8s initContainer workaround on `be` (raised page size) only moves the threshold — remove it once this is deployed.
- **Heads-up on the out-of-scope cold-start issue**: when agent pods are down past `ONLINE_THRESHOLD`, `_sync_workspace_models` deletes every `aihub-agent-*` model it sees. Pagination makes that pass see *all* models instead of 30, so its blast radius grows. It needs its own issue and should land before or with this reaching affected instances.