### PR TITLE
fix(swiss-ai-hub): Inject model identity system prompt for plain LLM chats

### DIFF
--- a/docs/arc42/decisions/2026_08_14_model_identity_system_prompt_for_plain_llm_chats.md
+++ b/docs/arc42/decisions/2026_08_14_model_identity_system_prompt_for_plain_llm_chats.md
@@ -62,7 +62,18 @@ three things:
 
 - names the model as itself;
 - states that earlier assistant turns may come from a different model and are not its own;
-- declares the statement authoritative and forbids deliberating about which identity is correct.
+- declares the statement authoritative and, **for identity questions only**, forbids deliberating and asks for a
+  one-sentence answer.
+
+That last clause is scoped on purpose. Injection is unconditional (Decision 3), so the message also leads OpenWebUI's
+*task-model* calls: search- and retrieval-query generation both default to on in v0.9.5
+(`ENABLE_SEARCH_QUERY_GENERATION`, `ENABLE_RETRIEVAL_QUERY_GENERATION`), neither is set in any compose file, and both
+route through `TASK_MODEL` to this same endpoint. Their prompt demands a strict JSON object, and an unscoped *"answer in
+one short sentence"* would lead it. The damage would be silent: on a parse failure OpenWebUI turns the raw response into
+a single search query rather than erroring (`utils/middleware.py`). Gating the injection off those calls is not
+available — OpenWebUI pops `metadata`, which is what carries `task`, before forwarding (`routers/openai.py:1101`), so a
+task call arrives indistinguishable from a chat turn. Wording is the only lever. The sweep below sampled identity
+questions exclusively, so scoping the clause to exactly that traffic leaves every cell of it valid.
 
 The middle clause is the one that fixes the bug. **"served by Swiss AI Hub" is deliberately absent and must not be added
 back for branding**: models routinely conflate "served by" with "created by", so naming the deployment next to an
@@ -80,6 +91,11 @@ caller still wins on task behaviour. Multiple leading system messages are alread
 (`extend_chat_history_with_user_memory` inserts after existing leading system messages), so no merging is needed. The
 display name is `model_name.rpartition("/")[2]`, which strips the capability prefix (`text-generation/Kimi-K2.6` →
 `Kimi-K2.6`) and leaves an unprefixed name untouched.
+
+The call site is pinned by `test_streaming_response_outlives_the_handler`, the suite's only happy path through
+`chat_completion`. Every other identity test either calls `_apply_model_identity` directly or asserts it did *not* run,
+so without that assertion the call could be deleted from `chat_completion` and the whole suite would stay green while
+#144 silently returned.
 
 **3 — Injection is unconditional.** OpenWebUI does **not** reach this endpoint through `openai_pipeline`; it reaches it
 through its own native OpenAI connection (`OPENAI_API_BASE_URL=…/api/v1/active/openai`), and the models users actually
@@ -176,6 +192,9 @@ convention for no measured gain.
   `LiteLLMService.openai_aclient_for_user`, so none of that ADR's reasoning-model mitigations apply here.
 - **Mitigation, not a guarantee.** A long transcript with many contrary assistant turns can still outweigh a single
   leading system message.
+- **Task-model calls still receive the identity message.** Query generation for web search and RAG retrieval gets the
+  two identity clauses prepended to a JSON-only prompt. They are inert for that task — neither names a format nor asks
+  for brevity — but they are tokens those calls did not ask for, and no sweep covers non-identity traffic.
 - **One existing test double had to become real.** `test_streaming_response_outlives_the_handler` passed
   `t=Mock(locale="en")`, which reached the message list as an unserializable `Mock` once `chat_completion` began
   resolving a translation through `t`. The test now uses a real `LocaleHandler`; making the production code tolerate a

--- a/docs/arc42/decisions/2026_08_14_model_identity_system_prompt_for_plain_llm_chats.md
+++ b/docs/arc42/decisions/2026_08_14_model_identity_system_prompt_for_plain_llm_chats.md
@@ -1,0 +1,182 @@
+# Model Identity as a Platform-Injected System Prompt for Plain LLM Chats
+
+## Context
+
+Issue #144: a user asked "who are you" with `Kimi-K2.6` selected, switched the model picker to `Qwen3.5-122B-A10B-FP8`
+**within the same conversation**, and asked again. Qwen answered *"I'm Kimi, an AI assistant created by Moonshot AI."*
+
+This is not a routing fault. Every chat model in `litellm-config.yml.j2` maps 1:1 to a distinct upstream deployment, the
+only fallback target is `text-generation/gemma-4-31B-it`, and Kimi is never a fallback target — so a Qwen request cannot
+be served by Kimi. The cause is the message list. OpenWebUI keeps **one history per conversation across a model
+switch**, and `OpenaiService.chat_completion` passes `messages` to LiteLLM untouched. Nothing on the plain-LLM path ever
+established who the model is, so the model resolved the question from the transcript — where "the assistant" had already
+claimed to be Kimi. The model's own reasoning trace states the mechanism outright:
+
+> *"In the first turn, I identified myself as Kimi […] I don't have access to my external system prompt to know my exact
+> brand name right now. I must rely on the context provided."*
+
+**The defect is probabilistic, not deterministic.** Replaying the contaminated history against Qwen3.5 four times with
+no system prompt produced the wrong identity **3 of 4 times** in an English conversation and **0 of 4 times** in a
+German one. Any single reproduction — or any single "it works now" — is therefore weak evidence, and this ADR's claims
+rest on repeated sampling rather than one observation.
+
+One trace also showed the model unable to resolve its trained identity against the transcript persona and looping —
+`Wait, I am Qwen. → Okay, I should not say Kimi. → Wait, I don't know.` — for 38 seconds. That was observed once and is
+recorded as a symptom, **not** as a cost this decision claims to remove (see Trade-offs).
+
+Agents do not have this problem. ADR `2026_06_04_self_awareness_as_explicit_per_agent_steps` gives each conversational
+blueprint explicit `detect_meta_question_step` / `answer_meta_question_step` methods that answer identity questions from
+the agent's own workflow definition. Plain LLM models bypass all agent machinery, so they inherit none of it. This issue
+is the plain-model gap in that same concept.
+
+## Decision Drivers
+
+- **A model must not misreport which model it is**\
+  The UI labels the answer with the selected model. An answer naming a different vendor makes that label a lie, and the
+  user cannot tell which model actually ran.
+- **The identity conflict must be *resolved*, not merely contradicted**\
+  A bare "you are X" competes with the transcript. The prompt has to name the foreign turns as foreign, or it is just
+  one more voice in the conversation.
+- **Qwen3.5 constrains where a system message may go**\
+  Per ADR `2026_06_29_resilience_for_reasoning_models_on_infomaniak`, Qwen3.5 rejects with
+  `400 - System message must be at the beginning` when a system message follows any user or assistant turn.
+- **Agents own their identity**\
+  Whatever the platform injects must not reach an agent, or it contradicts that agent's own self-awareness steps.
+- **A caller's own system prompt must keep winning on task behaviour**\
+  Platform identity is a default, not an override of what the customer configured.
+- **Changes to the prompt must be measured, not argued**\
+  Output token counts on this question swing 8-10x within a single prompt variant, so intuitions about prompt wording
+  are untestable by inspection. Every wording claim below is backed by a sweep or dropped.
+- **No new abstractions**\
+  The codebase already inserts system messages into a message list (`extend_chat_history_with_user_memory`) and already
+  keeps prompts in `lib/prompt.{locale}.yml`.
+
+## Decision
+
+**A platform-authored system message asserting the model's identity leads the message list of every plain-LLM chat
+completion.**
+
+**1 — The prompt lives in i18n.** `lib.prompt.model.identity_system_message` in
+`packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.{de,en,fr,it}.yml`, interpolating `{model_name}`. It does
+three things:
+
+- names the model as itself;
+- states that earlier assistant turns may come from a different model and are not its own;
+- declares the statement authoritative and forbids deliberating about which identity is correct.
+
+The middle clause is the one that fixes the bug. **"served by Swiss AI Hub" is deliberately absent and must not be added
+back for branding**: models routinely conflate "served by" with "created by", so naming the deployment next to an
+identity assertion invites a fresh misattribution ("I was created by Swiss AI Hub") of exactly the kind this ADR exists
+to remove. Verified live — asked "who created you?", Qwen answers *"I was created by Alibaba Cloud."*
+
+It uses `str.format` brace interpolation, not Jinja, because `jinja2` is not a declared dependency of `packages/api` or
+`packages/core` (only transitively present) and `lib.prompt.condenser.standalone_question` already establishes brace
+substitution in this very file. Note that yamlfix strips blank lines inside the YAML block scalar, so the prompt reaches
+the model as consecutive lines; do not reintroduce them expecting them to survive.
+
+**2 — Injection happens in `OpenaiService._apply_model_identity`,** called from `chat_completion`. The message is
+**prepended**, satisfying Qwen3.5's constraint, and any caller-supplied system prompt is preserved after ours — so the
+caller still wins on task behaviour. Multiple leading system messages are already production behaviour on this stack
+(`extend_chat_history_with_user_memory` inserts after existing leading system messages), so no merging is needed. The
+display name is `model_name.rpartition("/")[2]`, which strips the capability prefix (`text-generation/Kimi-K2.6` →
+`Kimi-K2.6`) and leaves an unprefixed name untouched.
+
+**3 — Injection is unconditional.** OpenWebUI does **not** reach this endpoint through `openai_pipeline`; it reaches it
+through its own native OpenAI connection (`OPENAI_API_BASE_URL=…/api/v1/active/openai`), and the models users actually
+pick are OpenWebUI workspace models whose `base_model_id` points at that connection. Its payload carries no `metadata`,
+no `thread_id` — nothing that distinguishes it from a stock OpenAI SDK client. There is therefore no field to gate on
+(see the rejected alternative below).
+
+**4 — Agents are excluded by call ordering, not by a conditional.** `chat_completion_with_assistants` reaches its agent
+branch only by catching the 404 that `chat_completion`'s `get_model` raises for a non-model. Placing the injection
+**after** `get_model` yields the correct behaviour with no branch: a plain model is injected, an agent raises before
+injection and reaches the agent branch with `messages` untouched. Two unit tests (`TestAssistantsKeepTheirOwnIdentity`)
+pin this ordering so reordering the two lines fails loudly instead of silently handing every agent a contradicting
+persona.
+
+**5 — Reasoning is not disabled for this call.** ADR `2026_06_29` disables reasoning for single-token classifiers but
+records that this is *"not a pattern to copy for answer generation"*. This is answer generation.
+
+**6 — Foreign assistant turns are not stripped or annotated.** Removing or relabelling another model's turns would be
+semantically tidier but changes the meaning of the history the caller sent and costs tokens. The system prompt is the
+smaller intervention; escalate only if measurement shows it insufficient.
+
+### Rejected: gate the injection on `metadata.thread_id`
+
+`OpenaiController` promises a drop-in OpenAI replacement, so injecting a system message the caller never wrote is a real
+change to that contract: it can collide with an external client's own persona, shifts their token accounting, and makes
+their evals non-reproducible against a direct provider call. Gating on the AI Hub-only `metadata.thread_id` looked like
+a way to protect external callers while still fixing the hub's own chat.
+
+**It was implemented, then reverted after live verification proved it inert.** With the gate in place, issue #144 still
+reproduced in the browser, because the hub's own chat does not send `thread_id` either (Decision 3). The gate protected
+external callers by also protecting the bug. Since the hub's payload and an external client's payload are
+indistinguishable, no gate can separate them, and fixing the product flow wins over passthrough purity.
+
+### Rejected: an explicit answer-language clause
+
+The prompt is localized, but on this path the locale always resolves to `LocaleHandler.DEFAULT_LOCALE = "de"` —
+OpenWebUI sends no locale header — so an English conversation receives a German system prompt. A trace showed the model
+spending part of its deliberation on *"the system instruction is in German, the user is in English, which language do I
+answer in?"*, which suggested adding an explicit "always reply in the user's language" clause.
+
+A sweep across both an English and a German conversation (4 samples per cell) showed the concern is unfounded and the
+cure is harmful:
+
+| variant                          | wrong identity     | wrong answer language | output tokens (median) en / de |
+| -------------------------------- | ------------------ | --------------------- | ------------------------------ |
+| no system prompt                 | **3/4 en**, 0/4 de | 0/8                   | 171 / 275                      |
+| German prompt (shipped)          | 0/8                | 0/8                   | 800 / 624                      |
+| English prompt                   | 0/8                | 0/8                   | 340 / 919                      |
+| English prompt + language clause | 0/7                | 0/7                   | **2576 / 1678**                |
+
+The model follows the **user's** language, not the system prompt's, in both directions (0 wrong-language across all 31
+samples), so the mismatch costs nothing in correctness. Adding the clause tripled output tokens and degraded the answer
+— some samples dropped the model name entirely (*"Ich bin ein KI-Assistent."*). The clause was dropped.
+
+The same sweep found no separable token difference between the German and English prompt (German cheaper in one
+conversation language, dearer in the other), so **English-only was also dropped**: it would trade the repo's i18n
+convention for no measured gain.
+
+## Consequences
+
+### Positive
+
+- Issue #144 is fixed at the single chokepoint every plain-model caller passes through. Across 23 sampled requests
+  carrying an identity-contaminated history, **0 returned the wrong identity**, against 3-of-4 wrong without the prompt.
+- Verified end-to-end in the browser through the real user flow (`packages/web` → iframe → OpenWebUI → API), not only in
+  unit tests.
+- Vendor attribution stays correct: the model names its real maker, not the platform.
+- Agents are unaffected, and the call ordering that guarantees it is test-enforced.
+- No change to `openai_pipeline.py`, so the fix needs no `openwebui-init` re-registration cycle to reach a running
+  stack.
+
+### Trade-offs
+
+- **Output tokens roughly double to quadruple on identity questions.** Median output tokens for this question went from
+  171 → 340-800 (English) and 275 → 624-919 (German). This is the measured price of a correct answer, not a free fix. It
+  applies only to the model's response length on such questions; the added input is a handful of lines.
+- **This decision does not claim to stop the reasoning loop.** The earlier draft asserted the anti-deliberation clause
+  removed an unbounded token cost. No measurement supports that: no sample in the sweep hit `finish_reason: "length"`
+  either with or without the prompt, and a browser trace still showed the model looping on *wording*
+  (`"Wait, I'll check…" → "Okay." → "Wait…"`) after the prompt was added. The clause stays because it is cheap and
+  plausibly helps, not because it is proven.
+- **External callers get no protection from this class of bug.** A customer building their own model-switching UI on
+  this endpoint will reproduce #144 and must set their own system prompt. They own their message list, so they own the
+  fix — and per Decision 3 we cannot tell them apart from the hub anyway.
+- **The endpoint is no longer a byte-for-byte passthrough.** Every plain-model caller receives a leading system message
+  it did not author.
+- **The identity string is config-derived.** It comes from the LiteLLM `model_name`, so renaming a model in
+  `litellm-config.yml.j2` silently changes what the model calls itself.
+- **The localization is nominal on this path.** Because the locale always resolves to `de` here, the fr/it translations
+  are effectively unreachable and the de one is correct only by coincidence. Fixing that needs a real locale signal from
+  the caller, which OpenWebUI's native connection does not send; it is out of scope here.
+- **The plain-model path still has no resilience wrapper.** `ResilientOpenAILike` from ADR `2026_06_29` sits in
+  `LLMConfig.to_llama_index()`, the agent path. Plain-model chat uses a raw `AsyncOpenAI` client via
+  `LiteLLMService.openai_aclient_for_user`, so none of that ADR's reasoning-model mitigations apply here.
+- **Mitigation, not a guarantee.** A long transcript with many contrary assistant turns can still outweigh a single
+  leading system message.
+- **One existing test double had to become real.** `test_streaming_response_outlives_the_handler` passed
+  `t=Mock(locale="en")`, which reached the message list as an unserializable `Mock` once `chat_completion` began
+  resolving a translation through `t`. The test now uses a real `LocaleHandler`; making the production code tolerate a
+  non-resolving `t` was rejected as defensive.

--- a/packages/api/playground/testing/tests/openai/test_openai_model_identity_unit_tests.py
+++ b/packages/api/playground/testing/tests/openai/test_openai_model_identity_unit_tests.py
@@ -1,0 +1,167 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+from swiss_ai_hub.core.auth import AccessChecker
+from swiss_ai_hub.core.i18n import LocaleHandler
+from swiss_ai_hub.core.testing.auth_utils.test_identity import fake_user
+
+from swiss_ai_hub.api.routes.openai.dto.chat_completion_request import ChatCompletionRequest
+from swiss_ai_hub.api.routes.openai.openai_service import OpenaiService
+
+_SERVICE = "swiss_ai_hub.api.routes.openai.openai_service"
+
+_QWEN = "text-generation/Qwen3.5-122B-A10B-FP8"
+_IDENTITY_KEY = "lib.prompt.model.identity_system_message"
+_THREAD_ID = "507f1f77bcf86cd799439011"
+
+# The reproduction from issue #144: the user asked Kimi first, switched model, and asked again. OpenWebUI
+# forwards one history across the switch, so the next model reads a Kimi self-identification as its own turn.
+_CONTAMINATED_HISTORY: list[dict] = [
+    {"role": "user", "content": "who are you"},
+    {"role": "assistant", "content": "I am Kimi, an AI assistant created by Moonshot AI."},
+    {"role": "user", "content": "who are you"},
+]
+
+
+def _hub_request(messages: list[dict], model: str = _QWEN) -> ChatCompletionRequest:
+    """A request as `openai_pipeline` sends it: carrying the AI Hub `thread_id` extension."""
+    return ChatCompletionRequest(model=model, messages=messages, metadata={"thread_id": _THREAD_ID})
+
+
+def _roles(request: ChatCompletionRequest) -> list[str]:
+    return [message["role"] for message in request.messages]
+
+
+def _en() -> LocaleHandler:
+    return LocaleHandler(locale="en")
+
+
+class TestIdentitySystemMessage:
+    def test_leads_the_message_list(self):
+        request = _hub_request(list(_CONTAMINATED_HISTORY))
+
+        OpenaiService._apply_model_identity(request, _QWEN, _en())
+
+        assert _roles(request) == ["system", "user", "assistant", "user"]
+
+    def test_names_the_selected_model_without_its_capability_prefix(self):
+        request = _hub_request(list(_CONTAMINATED_HISTORY))
+
+        OpenaiService._apply_model_identity(request, _QWEN, _en())
+
+        assert "Qwen3.5-122B-A10B-FP8" in request.messages[0]["content"]
+        assert "text-generation/" not in request.messages[0]["content"]
+
+    def test_keeps_a_model_name_that_carries_no_capability_prefix(self):
+        request = _hub_request(list(_CONTAMINATED_HISTORY), model="gemma-4-31B-it")
+
+        OpenaiService._apply_model_identity(request, "gemma-4-31B-it", _en())
+
+        assert "gemma-4-31B-it" in request.messages[0]["content"]
+
+    def test_leaves_the_original_history_untouched(self):
+        request = _hub_request(list(_CONTAMINATED_HISTORY))
+
+        OpenaiService._apply_model_identity(request, _QWEN, _en())
+
+        assert request.messages[1:] == _CONTAMINATED_HISTORY
+
+    def test_orders_a_client_system_prompt_after_ours(self):
+        """A caller's own system prompt must survive and stay later in the list, so it still wins on task
+        behaviour while the platform identity is merely the default."""
+        client_prompt = {"role": "system", "content": "You only answer in haiku."}
+        request = _hub_request([client_prompt, *_CONTAMINATED_HISTORY])
+
+        OpenaiService._apply_model_identity(request, _QWEN, _en())
+
+        assert _roles(request) == ["system", "system", "user", "assistant", "user"]
+        assert request.messages[1] == client_prompt
+
+    def test_tolerates_a_request_without_messages(self):
+        request = _hub_request([])
+        request.messages = None
+
+        OpenaiService._apply_model_identity(request, _QWEN, _en())
+
+        assert _roles(request) == ["system"]
+
+    @pytest.mark.parametrize("locale", LocaleHandler.LOCALE_WHITE_LIST)
+    def test_every_locale_defines_the_prompt(self, locale: str):
+        """`t_object` reads `lib/prompt.{locale}.yml` directly, so a locale missing the key raises here
+        instead of silently falling back to another language."""
+        template = LocaleHandler(locale=locale).t_object(_IDENTITY_KEY, locale=locale)
+
+        assert "{model_name}" in template
+
+
+class TestEveryPlainModelRequestGetsAnIdentity:
+    """Gating on the AI Hub-only `metadata.thread_id` was tried and reverted: OpenWebUI does not reach this
+    endpoint through `openai_pipeline`, it reaches it through its own native OpenAI connection
+    (`OPENAI_API_BASE_URL`), whose payload carries no `metadata` at all. Verified live — with the gate in
+    place, issue #144 still reproduced in the browser. There is no field that separates the hub's own chat
+    from an external SDK client, so injection is unconditional."""
+
+    def test_a_request_without_metadata_is_still_injected(self):
+        request = ChatCompletionRequest(model=_QWEN, messages=list(_CONTAMINATED_HISTORY))
+
+        OpenaiService._apply_model_identity(request, _QWEN, _en())
+
+        assert _roles(request) == ["system", "user", "assistant", "user"]
+        assert "Qwen3.5-122B-A10B-FP8" in request.messages[0]["content"]
+
+    def test_metadata_without_a_thread_id_is_still_injected(self):
+        request = ChatCompletionRequest(
+            model=_QWEN, messages=list(_CONTAMINATED_HISTORY), metadata={"display_id": _THREAD_ID}
+        )
+
+        OpenaiService._apply_model_identity(request, _QWEN, _en())
+
+        assert _roles(request) == ["system", "user", "assistant", "user"]
+
+
+class TestAssistantsKeepTheirOwnIdentity:
+    """`chat_completion_with_assistants` reaches its agent branch only via `chat_completion`'s 404, so the
+    injection must sit after `get_model`. Agents answer identity questions from their own workflow
+    definition (ADR 2026_06_04) and must not be handed a contradicting persona. Both requests carry a
+    `thread_id`, so the assertions fail if the ordering breaks rather than passing on the hub gate."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_model_raises_404_before_injecting(self):
+        agent_model = "MyAgent/507f1f77bcf86cd799439011"
+        request = _hub_request(list(_CONTAMINATED_HISTORY), model=agent_model)
+        not_a_model = HTTPException(status_code=404, detail=f"Model {agent_model} not found.")
+
+        with patch.object(OpenaiService, "get_model", new=AsyncMock(side_effect=not_a_model)):
+            with pytest.raises(HTTPException) as exc:
+                await OpenaiService.chat_completion(
+                    model_name=agent_model,
+                    chat_completion_request=request,
+                    user=fake_user(),
+                    t=_en(),
+                )
+
+        assert exc.value.status_code == 404
+        assert request.messages == _CONTAMINATED_HISTORY
+
+    @pytest.mark.asyncio
+    async def test_denied_model_raises_403_before_injecting(self):
+        request = _hub_request(list(_CONTAMINATED_HISTORY))
+
+        with (
+            patch.object(OpenaiService, "get_model", new=AsyncMock()),
+            patch(
+                f"{_SERVICE}.AccessChecker.from_user",
+                return_value=AccessChecker([], tenant_access_rules=["aihub.admin.>"]),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await OpenaiService.chat_completion(
+                    model_name=_QWEN,
+                    chat_completion_request=request,
+                    user=fake_user(),
+                    t=_en(),
+                )
+
+        assert exc.value.status_code == 403
+        assert request.messages == _CONTAMINATED_HISTORY

--- a/packages/api/playground/testing/tests/openai/test_openai_streaming_client_lifetime_unit_tests.py
+++ b/packages/api/playground/testing/tests/openai/test_openai_streaming_client_lifetime_unit_tests.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import httpx
 import openai
 import pytest
+from swiss_ai_hub.core.i18n import LocaleHandler
 from swiss_ai_hub.core.testing.auth_utils.test_identity import fake_user
 
 from swiss_ai_hub.api.routes.openai.dto.chat_completion_request import ChatCompletionRequest
@@ -61,7 +62,7 @@ async def test_streaming_response_outlives_the_handler() -> None:
         patch(f"{_SERVICE}.LiteLLMService.openai_aclient_for_user", new=AsyncMock(return_value=client)),
     ):
         response = await OpenaiService.chat_completion(
-            model_name=_MODEL, chat_completion_request=request, user=fake_user(), t=Mock(locale="en")
+            model_name=_MODEL, chat_completion_request=request, user=fake_user(), t=LocaleHandler(locale="en")
         )
 
     streamed = [chunk async for chunk in response.body_iterator]

--- a/packages/api/playground/testing/tests/openai/test_openai_streaming_client_lifetime_unit_tests.py
+++ b/packages/api/playground/testing/tests/openai/test_openai_streaming_client_lifetime_unit_tests.py
@@ -69,3 +69,10 @@ async def test_streaming_response_outlives_the_handler() -> None:
 
     assert _streamed_contents(streamed) == ["Hello", " world"]
     assert not client.is_closed()
+
+    # The only happy path through `chat_completion` in the suite, so it is the only place the identity
+    # injection's call site can be pinned: every test in test_openai_model_identity_unit_tests.py either
+    # calls `_apply_model_identity` directly or asserts it did *not* run, so deleting the call from
+    # `chat_completion` would otherwise leave the suite green and silently reopen issue #144.
+    assert request.messages[0]["role"] == "system"
+    assert "gemma-4-31B-it" in request.messages[0]["content"]

--- a/packages/api/swiss_ai_hub/api/routes/openai/openai_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/openai/openai_service.py
@@ -157,6 +157,22 @@ class OpenaiService:
             )
 
     @staticmethod
+    def _apply_model_identity(
+        chat_completion_request: ChatCompletionRequest, model_name: str, t: LocaleHandler
+    ) -> None:
+        """Names the model to itself, because OpenWebUI keeps one history across a model switch and a model
+        asked who it is otherwise answers from the transcript — adopting whichever model spoke earlier, and
+        looping on the conflict until it exhausts its output budget. Applies to every plain-model request:
+        OpenWebUI reaches this endpoint through its own OpenAI connection, whose payload is indistinguishable
+        from an external SDK client's, so there is nothing to gate on. Leads the list because Qwen3.5 rejects
+        a system message that follows any user or assistant turn. See ADR 2026_08_14."""
+        identity = t("lib.prompt.model.identity_system_message").format(model_name=model_name.rpartition("/")[2])
+        chat_completion_request.messages = [
+            {"role": "system", "content": identity},
+            *(chat_completion_request.messages or []),
+        ]
+
+    @staticmethod
     @trace_fn
     async def get_embeddings(
         *,
@@ -206,6 +222,10 @@ class OpenaiService:
         """
         await OpenaiService.get_model(model_name)  # Ensures model exists
         OpenaiService._assert_model_access(user, model_name)
+        # Must stay after get_model: its 404 is what routes an assistant to chat_completion_with_assistants'
+        # agent branch, and agents own their identity (ADR 2026_06_04). Injecting before it would hand every
+        # agent a contradicting persona.
+        OpenaiService._apply_model_identity(chat_completion_request, model_name, t)
         client: AsyncOpenAI = await LiteLLMService.openai_aclient_for_user(user)
 
         thread_id, display_id = OpenaiService._extract_thread_and_display_id(chat_completion_request)

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.de.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.de.yml
@@ -1599,3 +1599,9 @@ figure_description_generator:
     {% chat role="user" %}
     Bitte geben Sie eine detaillierte, genaue Beschreibung dieses Bildes an, die als effektiver Alt-Text dienen kann. Denken Sie daran: Beschreiben Sie nur, was Sie tatsächlich sehen, nicht das, was der umgebende Text vermuten lässt.
     {% endchat %}
+model:
+  identity_system_message: |-
+    Sie sind {model_name}, ein Sprachmodell.
+    Frühere Assistenten-Beiträge in diesem Gespräch können von einem anderen Modell erzeugt worden sein, da der Benutzer das Modell mitten im Gespräch wechseln kann. Sie stammen nicht von Ihnen.
+    - Übernehmen Sie niemals einen Namen, Anbieter oder eine Identität aus einem früheren Assistenten-Beitrag.
+    - Erwägen Sie nicht, welche Identität richtig ist. Die obige Aussage ist verbindlich: Behandeln Sie die Frage als geklärt und antworten Sie in einem kurzen Satz.

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.de.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.de.yml
@@ -1604,4 +1604,4 @@ model:
     Sie sind {model_name}, ein Sprachmodell.
     Frühere Assistenten-Beiträge in diesem Gespräch können von einem anderen Modell erzeugt worden sein, da der Benutzer das Modell mitten im Gespräch wechseln kann. Sie stammen nicht von Ihnen.
     - Übernehmen Sie niemals einen Namen, Anbieter oder eine Identität aus einem früheren Assistenten-Beitrag.
-    - Erwägen Sie nicht, welche Identität richtig ist. Die obige Aussage ist verbindlich: Behandeln Sie die Frage als geklärt und antworten Sie in einem kurzen Satz.
+    - Wenn Sie nach Ihrer Identität gefragt werden, erwägen Sie nicht, welche richtig ist: Die obige Aussage ist verbindlich — behandeln Sie die Frage als geklärt und antworten Sie in einem kurzen Satz.

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.en.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.en.yml
@@ -1598,3 +1598,9 @@ memory:
 
     ### Example: Nothing to Delete
     If no relationships should be deleted, simply do not call the tool at all.
+model:
+  identity_system_message: |-
+    You are {model_name}, a language model.
+    Earlier assistant turns in this conversation may have been produced by a different model, because the user can switch models mid-conversation. They are not yours.
+    - Never adopt a name, vendor, or identity that appears in an earlier assistant turn.
+    - Do not deliberate about which identity is correct. The statement above is authoritative: treat the question as settled and answer in one short sentence.

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.en.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.en.yml
@@ -1603,4 +1603,4 @@ model:
     You are {model_name}, a language model.
     Earlier assistant turns in this conversation may have been produced by a different model, because the user can switch models mid-conversation. They are not yours.
     - Never adopt a name, vendor, or identity that appears in an earlier assistant turn.
-    - Do not deliberate about which identity is correct. The statement above is authoritative: treat the question as settled and answer in one short sentence.
+    - If you are asked about your identity, do not deliberate about which one is correct: the statement above is authoritative — treat the question as settled and answer in one short sentence.

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.fr.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.fr.yml
@@ -1603,4 +1603,4 @@ model:
     Vous êtes {model_name}, un modèle de langage.
     Les tours d'assistant antérieurs de cette conversation peuvent avoir été produits par un autre modèle, car l'utilisateur peut changer de modèle en cours de conversation. Ils ne sont pas les vôtres.
     - N'adoptez jamais un nom, un fournisseur ou une identité apparaissant dans un tour d'assistant antérieur.
-    - Ne délibérez pas sur l'identité correcte. La déclaration ci-dessus fait autorité : considérez la question comme tranchée et répondez en une courte phrase.
+    - Si l'on vous interroge sur votre identité, ne délibérez pas sur celle qui est correcte : la déclaration ci-dessus fait autorité — considérez la question comme tranchée et répondez en une courte phrase.

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.fr.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.fr.yml
@@ -1598,3 +1598,9 @@ figure_description_generator:
     {% chat role="user" %}
     Veuillez fournir une description détaillée et précise de cette image qui servirait de texte alt efficace. Rappel : décrivez uniquement ce que vous voyez réellement, pas ce que le texte environnant suggère.
     {% endchat %}
+model:
+  identity_system_message: |-
+    Vous êtes {model_name}, un modèle de langage.
+    Les tours d'assistant antérieurs de cette conversation peuvent avoir été produits par un autre modèle, car l'utilisateur peut changer de modèle en cours de conversation. Ils ne sont pas les vôtres.
+    - N'adoptez jamais un nom, un fournisseur ou une identité apparaissant dans un tour d'assistant antérieur.
+    - Ne délibérez pas sur l'identité correcte. La déclaration ci-dessus fait autorité : considérez la question comme tranchée et répondez en une courte phrase.

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.it.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.it.yml
@@ -1598,3 +1598,9 @@ figure_description_generator:
     {% chat role="user" %}
     Si prega di fornire una descrizione dettagliata e accurata di questa immagine che possa servire come testo alternativo efficace. Ricordate: descrivete solo ciò che vedete realmente, non ciò che il testo circostante suggerisce.
     {% endchat %}
+model:
+  identity_system_message: |-
+    Sei {model_name}, un modello linguistico.
+    I turni dell'assistente precedenti in questa conversazione possono essere stati prodotti da un modello diverso, poiché l'utente può cambiare modello nel corso della conversazione. Non sono tuoi.
+    - Non adottare mai un nome, un fornitore o un'identità che appare in un turno precedente dell'assistente.
+    - Non deliberare su quale identità sia corretta. L'affermazione precedente è autorevole: considera la questione risolta e rispondi in una breve frase.

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.it.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/prompt.it.yml
@@ -1603,4 +1603,4 @@ model:
     Sei {model_name}, un modello linguistico.
     I turni dell'assistente precedenti in questa conversazione possono essere stati prodotti da un modello diverso, poiché l'utente può cambiare modello nel corso della conversazione. Non sono tuoi.
     - Non adottare mai un nome, un fornitore o un'identità che appare in un turno precedente dell'assistente.
-    - Non deliberare su quale identità sia corretta. L'affermazione precedente è autorevole: considera la questione risolta e rispondi in una breve frase.
+    - Se ti viene chiesto della tua identità, non deliberare su quale sia corretta: l'affermazione precedente è autorevole — considera la questione risolta e rispondi in una breve frase.


### PR DESCRIPTION
Fixes https://github.com/bbvch-ai/aihub-core-private/issues/144

## Problem

Ask "who are you" with `Kimi-K2.6` selected, switch the model picker to `Qwen3.5-122B-A10B-FP8` **in the same
conversation**, and ask again — Qwen answers *"I'm Kimi, an AI assistant developed by Moonshot AI."*

Not a routing fault: every chat model maps 1:1 to a distinct upstream, and Kimi is never a fallback target. The cause is
the message list. OpenWebUI keeps one history across a model switch, and `OpenaiService.chat_completion` forwarded
`messages` to LiteLLM untouched — nothing on the plain-LLM path ever told the model who it is, so it answered from the
transcript, where "the assistant" had already claimed to be Kimi. The model's own reasoning trace says it outright:

> *"In the first turn, I identified myself as Kimi […] I don't have access to my external system prompt to know my exact
> brand name right now. I must rely on the context provided."*

Agents don't have this problem — they answer identity questions from their own workflow definition (ADR
`2026_06_04_self_awareness_as_explicit_per_agent_steps`). This is the plain-model gap in that same concept.

## Change

A platform-authored system message naming the model **leads** the message list of every plain-LLM chat completion.

- `lib.prompt.model.identity_system_message` in `prompt.{de,en,fr,it}.yml` — names the model, states that earlier
  assistant turns may come from a different model and are not its own, and declares that authoritative.
- `OpenaiService._apply_model_identity`, called from `chat_completion` **after** `get_model`. That ordering is what
  excludes agents with no conditional: `chat_completion_with_assistants` reaches its agent branch only via the 404
  `get_model` raises, so an agent raises before injection and keeps its `messages` untouched. Two tests pin the ordering.
- Prepended, not appended: Qwen3.5 rejects with `400 - System message must be at the beginning` when a system message
  follows any user/assistant turn (ADR `2026_06_29`). A caller's own system prompt is preserved after ours, so it still
  wins on task behaviour.
- `"served by Swiss AI Hub"` is deliberately **not** in the prompt. Models conflate "served by" with "created by", so
  naming the deployment beside an identity assertion invites a fresh misattribution. Verified: asked "who created you?",
  Qwen answers *"I was created by Alibaba Cloud."*

## Verification

**Live, through the real user flow** (`packages/web` → iframe → OpenWebUI → API), on the dev stack. Seeded a chat with
`Kimi-K2.6`, switched to `Qwen3.5-122B-A10B-FP8` in the same chat, asked again:

| before | after |
| ------ | ----- |
| `I'm Kimi, an AI assistant developed by Moonshot AI.` | `I am Qwen3.5-122B-A10B-FP8.` |

**Sampled, because the defect is probabilistic.** Replaying the contaminated history against Qwen3.5 with no prompt gives
the wrong identity 3 of 4 times in an English chat and 0 of 4 in a German one — so any single before/after is weak
evidence. Across 23 sampled requests carrying a contaminated history, **0 returned the wrong identity** with the prompt.

## Rejected alternatives, both recorded in the ADR

**Gating injection on `metadata.thread_id`** to keep the endpoint a pure passthrough for external SDK clients. Implemented,
then reverted: OpenWebUI does not reach this endpoint through `openai_pipeline`, it reaches it through its own native
OpenAI connection (`OPENAI_API_BASE_URL`), whose payload carries no `metadata` at all. With the gate in place #144 still
reproduced in the browser — the gate protected the bug. The hub's payload and an external client's are
indistinguishable, so no gate can separate them.

**An explicit answer-language clause.** On this path the locale always resolves to `de` (OpenWebUI sends no locale
header), so an English chat gets a German prompt, and a trace showed the model deliberating about which language to
answer in. A sweep across both conversation languages (4 samples/cell) showed the concern is unfounded and the cure
harmful:

| variant                          | wrong identity     | wrong answer language | output tokens (median) en / de |
| -------------------------------- | ------------------ | --------------------- | ------------------------------ |
| no system prompt                 | **3/4 en**, 0/4 de | 0/8                   | 171 / 275                      |
| German prompt (this PR)          | 0/8                | 0/8                   | 800 / 624                      |
| English prompt                   | 0/8                | 0/8                   | 340 / 919                      |
| English prompt + language clause | 0/7                | 0/7                   | **2576 / 1678**                |

The model follows the **user's** language, not the prompt's, in both directions (0 wrong-language in 31 samples). The
clause tripled output tokens and degraded answers — some dropped the model name entirely (*"Ich bin ein KI-Assistent."*).
The same sweep found no separable token difference between the German and English prompt, so English-only was dropped too:
it would trade the repo's i18n convention for no measured gain.

## Known cost

Output tokens on identity questions roughly double to quadruple (171 → 340-800 en, 275 → 624-919 de). That is the
measured price of a correct answer, documented in the ADR rather than glossed as "kept short".

This PR does **not** claim to stop the reasoning loop seen in one trace. No sample hit `finish_reason: "length"` with or
without the prompt, and a browser trace still showed looping on *wording* after the prompt was added. The
anti-deliberation clause stays because it is cheap and plausibly helps, not because it is proven.

## Test plan

- [x] `pytest playground/testing/tests/openai/` — 52 passed (unit + integration, dev stack up)
- [x] 14 new unit tests: ordering, prefix stripping, client-prompt precedence, all four locales resolve, agents untouched
- [x] `pytest` in `packages/core` — 1179 passed; 8 failures are **pre-existing on `main`** (auth handlers needing
      Keycloak, mem0 telemetry env), verified by re-running them with this branch's changes stashed
- [x] Live browser verification of the #144 repro through `packages/web` → OpenWebUI

## Found while verifying — separate issue, not fixed here

`_extract_model_id` in `infra/deployment/templates/openwebui_functions/openai_pipeline.py` does `model_id.split(".")[1]`,
which truncates any model name containing a dot: `openai-pipeline.text-generation/Qwen3.5-122B-A10B-FP8` →
`text-generation/Qwen3` → **404**, empty response in the UI. It breaks `Qwen3.5-122B-A10B-FP8`, `Kimi-K2.6` and
`MinerU2.5-2509-1.2B` on the `openai/*` model path. `aihub_pipeline.py` handles the same format correctly with
`".".join(parts[2:])`. Worth its own issue.
