### PR TITLE
fix(workflows): Make scheduled agent runs actually complete

### DIFF
--- a/packages/core/swiss_ai_hub/core/events/agent/control/start/start_event.py
+++ b/packages/core/swiss_ai_hub/core/events/agent/control/start/start_event.py
@@ -31,8 +31,14 @@ class StartEvent(ControlAndDisplayEvent):
         """
         Returns a dictionary suitable for context injection, excluding internal event fields like
         event_id and created_at. This helps workflows pass only essential context to downstream steps.
+
+        Dumped in JSON mode because the dispatcher writes every value here into `RunContext`, which
+        serializes with `json.dumps` and reads back with `json.loads`. Python mode left the two halves
+        inconsistent: a field of any type JSON cannot represent — a `datetime`, say — dumped fine here
+        and then raised `TypeError` inside the store, killing the run before a single step executed.
+        JSON mode is what the read path already returns, so it aligns them.
         """
-        non_private = {k: v for k, v in self.model_dump().items() if not k.startswith("_")}
+        non_private = {k: v for k, v in self.model_dump(mode="json").items() if not k.startswith("_")}
         del non_private["event_id"]
         del non_private["created_at"]
         return non_private

--- a/packages/core/swiss_ai_hub/core/events/agent/control/start/tests/unit/test_scheduled_start_event.py
+++ b/packages/core/swiss_ai_hub/core/events/agent/control/start/tests/unit/test_scheduled_start_event.py
@@ -1,3 +1,4 @@
+import json
 from datetime import UTC, datetime
 
 import pytest
@@ -37,6 +38,25 @@ class TestScheduledStartEvent:
         assert isinstance(restored, ScheduledStartEvent)
         assert restored.scheduled_for == _OCCURRENCE
         assert restored.user is None
+
+    def test_context_dict_is_json_serializable(self):
+        """The dispatcher writes every context value into RunContext, which serializes with json.dumps.
+
+        Without this, `scheduled_for` being a `datetime` raised TypeError inside the store on every
+        single run — the scheduler fired correctly, the agent fetched its config, and then the run died
+        before any step executed. Nothing else covered the path from a start event into RunContext, so
+        the whole feature shipped green and non-functional.
+        """
+        context = ScheduledStartEvent(scheduled_for=_OCCURRENCE).to_context_dict()
+
+        json.dumps(context)
+        assert isinstance(context["scheduled_for"], str)
+
+    def test_occurrence_survives_the_context_round_trip(self):
+        """RunContext reads back with json.loads, so the value must still identify the occurrence."""
+        context = json.loads(json.dumps(ScheduledStartEvent(scheduled_for=_OCCURRENCE).to_context_dict()))
+
+        assert datetime.fromisoformat(context["scheduled_for"]) == _OCCURRENCE
 
     @pytest.mark.parametrize("locale", ["de", "en", "fr", "it"])
     def test_display_name_and_description_resolve(self, locale: str):

--- a/packages/core/swiss_ai_hub/core/events/agent/control/start/tests/unit/test_start_event_context.py
+++ b/packages/core/swiss_ai_hub/core/events/agent/control/start/tests/unit/test_start_event_context.py
@@ -1,0 +1,44 @@
+import json
+from datetime import UTC, datetime
+from typing import Annotated
+
+from pydantic import Field
+
+from swiss_ai_hub.core.events.agent.control.start.start_event import StartEvent
+
+
+class _StartEventWithRichTypes(StartEvent):
+    """A start event whose fields JSON cannot represent natively.
+
+    Declared here rather than reusing a production event so the guard keeps working as the real events
+    change — it protects the mechanism, not one event's current field list.
+    """
+
+    occurrence: Annotated[datetime, Field(description="A timezone-aware instant.")]
+    ratio: Annotated[float, Field(description="A plain float, to confirm ordinary types are untouched.")] = 0.5
+
+
+class TestToContextDict:
+    """`RunContext.set` serializes with `json.dumps` and `get` reads back with `json.loads`, so a
+    context dict that is not JSON-serializable kills the run before any step executes — and does it
+    inside the store, far from the event that caused it."""
+
+    def test_rich_types_are_serializable(self):
+        event = _StartEventWithRichTypes(occurrence=datetime(2026, 8, 18, 9, 10, tzinfo=UTC))
+
+        json.dumps(event.to_context_dict())
+
+    def test_values_match_what_the_store_reads_back(self):
+        """Dumping in JSON mode is what makes the write and read halves agree on types."""
+        event = _StartEventWithRichTypes(occurrence=datetime(2026, 8, 18, 9, 10, tzinfo=UTC))
+
+        context = event.to_context_dict()
+        assert json.loads(json.dumps(context)) == context
+
+    def test_framework_fields_are_excluded(self):
+        event = _StartEventWithRichTypes(occurrence=datetime(2026, 8, 18, 9, 10, tzinfo=UTC))
+
+        context = event.to_context_dict()
+        assert "event_id" not in context
+        assert "created_at" not in context
+        assert context["ratio"] == 0.5

--- a/packages/core/swiss_ai_hub/core/scheduling/agent_schedule.py
+++ b/packages/core/swiss_ai_hub/core/scheduling/agent_schedule.py
@@ -21,7 +21,13 @@ class AgentSchedule(Form):
     # Every position is required, and unknown keys are rejected. Defaulting them would make an
     # unrecognised payload — a form-mode CronInput dict that reached storage, say — validate silently
     # into "every hour" and start unattended runs nobody configured.
-    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+    # Extras are tolerated, unlike an earlier `extra="forbid"`. Form emits `_form_name` as a computed
+    # field, so forbidding extras made a schedule unable to survive its own `model_dump()` — anything
+    # that stored one from a model instance rather than raw request JSON became permanently unreadable,
+    # and the scheduler skipped that profile forever. Requiring every position below is what actually
+    # guards the case forbidding was added for: an unrecognised payload has none of them and is
+    # rejected on the missing fields, not on the surplus ones.
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     minute: Annotated[str, Field(description="Cron minute position (0-59).")]
     hour: Annotated[str, Field(description="Cron hour position (0-23).")]

--- a/packages/core/swiss_ai_hub/core/scheduling/tests/unit/test_agent_schedule.py
+++ b/packages/core/swiss_ai_hub/core/scheduling/tests/unit/test_agent_schedule.py
@@ -47,8 +47,20 @@ class TestValidation:
         with pytest.raises(ValidationError):
             AgentSchedule.model_validate({"$formkit": "cronInput", "label": "Schedule"})
 
-    def test_rejects_unknown_keys(self):
-        with pytest.raises(ValidationError):
-            AgentSchedule.model_validate(
-                {"minute": "0", "hour": "*", "day_of_month": "*", "month": "*", "day_of_week": "*", "label": "x"}
-            )
+    def test_survives_its_own_dump(self):
+        """A schedule stored from a model instance must be readable again.
+
+        `Form` emits `_form_name` as a computed field, so forbidding extras made a schedule fail to
+        validate its own `model_dump()` — every profile written that way became unreadable and the
+        scheduler skipped it forever, silently."""
+        schedule = AgentSchedule(minute="0", hour="12", day_of_month="*", month="*", day_of_week="*")
+
+        assert AgentSchedule.model_validate(schedule.model_dump()) == schedule
+
+    def test_tolerates_surplus_keys_while_still_requiring_positions(self):
+        """Required positions, not forbidden extras, are what reject a non-schedule payload."""
+        schedule = AgentSchedule.model_validate(
+            {"minute": "0", "hour": "*", "day_of_month": "*", "month": "*", "day_of_week": "*", "label": "x"}
+        )
+
+        assert schedule.expression == "0 * * * *"


### PR DESCRIPTION
Follow-up to #1723. Scheduled agent runs were merged but **could not complete a single run** — the scheduler half worked, then every run died inside the agent. Two bugs, both introduced by that PR.

## 1. Every scheduled run died on context serialization

`AgentDispatcher._start_run` copies each field of a `StartEvent` into `RunContext`, which serializes with `json.dumps` and reads back with `json.loads`. But `to_context_dict()` dumped in **python** mode, so the two halves disagreed on types. `ScheduledStartEvent.scheduled_for` is a `datetime`, which `json.dumps` cannot encode:

```
TypeError: Object of type datetime is not JSON serializable
  agent_dispatcher.py:199  →  await run_context.set(key, value)
  base_context.py:53       →  serialized_value = json.dumps(value)
```

The scheduler fired on time, created the thread, published to NATS and served the config RPC — then the run blew up before a single step executed.

**Fixed at the mechanism, not the field:** `to_context_dict()` now dumps with `mode="json"`, which is exactly what the read path already returns. Verified to be a **no-op for existing events** — `UserMessageEvent` and `RAGStartEvent` produce byte-identical output in both modes — so this is safe, and it protects any future start event carrying a type JSON cannot represent.

The alternative was retyping `scheduled_for` as a string. Rejected: it leaves the same trap armed for the next event and pushes date parsing onto every step author.

## 2. A schedule could not survive its own `model_dump()`

`Form` emits `_form_name` as a `@computed_field`, so `extra="forbid"` on `AgentSchedule` made it fail to validate its own dump:

```
dump keys: ['_form_name', 'day_of_month', 'day_of_week', 'hour', 'minute', 'month', 'timezone']
round-trip: FAILS -> _form_name
```

Any profile whose schedule was stored from a model instance rather than raw request JSON became **permanently unreadable** — the scheduler logged `stored schedule is not valid` and skipped it forever. Reachable from a seeder, a profile template, a copy feature, or a migration.

Extras are tolerated again. The case forbidding was added for — an unrecognised payload validating into a default hourly cron and starting unattended runs nobody configured — is guarded by every position being **required**, not by rejecting surplus keys: such a payload has none of the positions and fails on the missing fields.

The REST path was never affected, which is why CI and manual API testing looked fine.

## Why CI was green

Nothing covered the path from a start event into `RunContext`. The 58 scheduling tests construct events directly and never route them through the dispatcher's context. That gap is now closed:

- `test_context_dict_is_json_serializable` / `test_occurrence_survives_the_context_round_trip` on `ScheduledStartEvent`
- **`test_start_event_context.py`** — a guard on the mechanism using a locally declared start event with a `datetime` field, so it holds for events that don't exist yet
- `test_survives_its_own_dump` for the `_form_name` regression

## Verification

Tests: core **1291 passed** · api **514 passed** · scheduling + start-event suites **80 passed**.

More importantly, verified against a real local stack (NATS, Valkey, FerretDB, the production API and a live agent) — the thing tests could not prove:

```
Started scheduled run for ScheduledDemoAgent/walkthrough
  (occurrence 2026-08-18T09:31:00+00:00, thread 9d827660cfbaf8d0dff93900)
Started scheduled run for ScheduledDemoAgent/walkthrough
  (occurrence 2026-08-18T09:32:00+00:00, thread 9d827660cfbaf8d0dff93900)

Finished tracing step: ScheduledDemoAgent.report_scheduled_run
Handling final event: StopEvent
  completed runs total: 14
  serialization errors : 0
```

Two consecutive occurrences on exact minute boundaries, both executing the step to completion.

## Pre-existing failures, not from this change

`self_awareness/tests/test_rag_agent_meta_routing.py` fails non-deterministically (2–4 tests, varying between runs). I reverted this branch's changes and ran it against clean `origin/main`: **3 failed there**, versus 2 with this change. Pre-existing flakiness in tests that drive real NATS and Redis — worth its own issue.
