### PR TITLE
fix(swiss-ai-hub): Make the playground server and meta-routing tests usable

### DIFF
--- a/packages/agent/swiss_ai_hub/agent/self_awareness/tests/test_rag_agent_meta_routing.py
+++ b/packages/agent/swiss_ai_hub/agent/self_awareness/tests/test_rag_agent_meta_routing.py
@@ -37,9 +37,17 @@ pytestmark = pytest.mark.self_hosted
 RAG_MODULE = "swiss_ai_hub.agent.agents.rag_agent.rag_agent"
 
 
-def _config() -> RAGAgentConfig:
+def _config(agent_id: str) -> RAGAgentConfig:
+    """Each test gets its own agent_id.
+
+    The dispatcher's JetStream consumer is durable and named from the agent identity, so tests
+    sharing one competed for the same queue group: whichever runner was still subscribed when the
+    next test started could receive that test's start event and drop it, and the waiting test timed
+    out. It failed a different subset on each run, which reads as an agent bug rather than tests
+    interfering with each other.
+    """
     return RAGAgentConfig(
-        agent_id="meta_routing_rag",
+        agent_id=agent_id,
         name=LocaleString(en="Test RAG"),
         description=LocaleString(en="A test RAG agent."),
         llm=LLMConfig(model_name="text-generation/dummy"),
@@ -80,7 +88,7 @@ async def test_meta_question_answers_without_retrieval(monkeypatch):
     monkeypatch.setattr(f"{RAG_MODULE}.generate_title", fake_generate_title)
     monkeypatch.setattr(f"{RAG_MODULE}.generate_follow_up_questions", fake_generate_follow_ups)
 
-    runner = AgentTestRunner(agent_type=RAGAgent, agent_config=_config())
+    runner = AgentTestRunner(agent_type=RAGAgent, agent_config=_config("meta_routing_answers"))
     async with runner.test_run(delay_before_stop=30) as topic:
         await runner.send_event_from_topic(topic=topic, start_event=_user_message("What can you do?"))
 
@@ -116,7 +124,7 @@ async def test_meta_question_branch_generates_title_and_follow_ups(monkeypatch):
     monkeypatch.setattr(f"{RAG_MODULE}.generate_title", fake_generate_title)
     monkeypatch.setattr(f"{RAG_MODULE}.generate_follow_up_questions", fake_generate_follow_ups)
 
-    runner = AgentTestRunner(agent_type=RAGAgent, agent_config=_config())
+    runner = AgentTestRunner(agent_type=RAGAgent, agent_config=_config("meta_routing_metadata"))
     async with runner.test_run(delay_before_stop=30) as topic:
         await runner.send_event_from_topic(topic=topic, start_event=_user_message("who are you?"))
 
@@ -135,7 +143,7 @@ async def test_normal_question_opens_the_gate(monkeypatch):
 
     monkeypatch.setattr(f"{RAG_MODULE}.do_detect_meta_question", fake_detect)
 
-    runner = AgentTestRunner(agent_type=RAGAgent, agent_config=_config())
+    runner = AgentTestRunner(agent_type=RAGAgent, agent_config=_config("meta_routing_gate"))
     async with runner.test_run(delay_before_stop=20) as topic:
         await runner.send_event_from_topic(topic=topic, start_event=_user_message("What is the vacation policy?"))
 

--- a/packages/api/playground/testing/main.py
+++ b/packages/api/playground/testing/main.py
@@ -3,7 +3,6 @@ from dotenv import find_dotenv, load_dotenv
 load_dotenv(find_dotenv(usecwd=True))
 
 import asyncio  # noqa: E402
-from os.path import abspath, dirname, join  # noqa: E402
 
 from swiss_ai_hub.core.infrastructure import enable_logging  # noqa: E402
 from swiss_ai_hub.core.routes import HealthController  # noqa: E402
@@ -28,8 +27,6 @@ async def main():
         agent_class="my_agent_class",
         agent_id="my_agent_id",
     ).with_simple_chunk_events()
-
-    runner.mount_frontend(join(dirname(abspath(__file__)), "frontend"))
 
     auth = TestAuthHandler()
 

--- a/packages/api/swiss_ai_hub/api/runners/api_runner.py
+++ b/packages/api/swiss_ai_hub/api/runners/api_runner.py
@@ -52,7 +52,6 @@ class ApiRunner(Runner):
     ```python
     runner = ApiRunner(api_path="/api/v1", title="My API")
     runner.mount(UserController(), ProductController())  # Mount controllers
-    runner.mount_frontend("path/to/frontend/dist")  # Optional: serve frontend
     app = runner.create_app()  # Get the FastAPI instance
     ```
 

--- a/packages/core/swiss_ai_hub/core/persistence/access/entities/role_entity.py
+++ b/packages/core/swiss_ai_hub/core/persistence/access/entities/role_entity.py
@@ -89,6 +89,14 @@ class RoleEntity(Document):
 
     @classmethod
     @trace_fn
+    def tenant_role_exists(cls, name: str, tenant_id: str) -> bool:
+        """Whether a single named role exists within the tenant. Kept as a dedicated
+        method so idempotent seeding has a stable, mockable seam instead of inlining
+        ``cls.objects(...).first()``."""
+        return cls.objects(name=name, tenant_id=tenant_id).first() is not None
+
+    @classmethod
+    @trace_fn
     def create_tenant_role(
         cls,
         name: str,

--- a/packages/core/swiss_ai_hub/core/runners/runner.py
+++ b/packages/core/swiss_ai_hub/core/runners/runner.py
@@ -35,14 +35,12 @@ class Runner(abc.ABC):
       `.mount()` call.
     - **Abstract Lifetime Management:** Each implementation must provide a `lifetime_manager`
       for handling async startup/shutdown.
-    - **Optional Frontend Integration:** Serve a frontend directly by calling `.mount_frontend(directory)`.
 
     ### Usage
     ```python
     # Typically you'd use a concrete implementation like ApiRunner or BotRunner
     runner = ConcreteRunner(api_path="/api/v1", title="My API")
     runner.mount(MyController())  # Mounting a controller
-    runner.mount_frontend("path/to/frontend/dist")  # Serve frontend if desired
     app = runner.create_app()  # This is the main FastAPI instance to run
     ```
 

--- a/packages/core/swiss_ai_hub/core/testing/auth_utils/role_mocks.py
+++ b/packages/core/swiss_ai_hub/core/testing/auth_utils/role_mocks.py
@@ -29,9 +29,15 @@ def mock_role_entity_methods():
             access_rules.add("aihub.admin.>")
         return access_rules
 
-    with patch.object(RoleEntity, "filter_existing_roles", side_effect=mock_filter_existing_roles):
-        with patch.object(RoleEntity, "get_access_rules_for_roles", side_effect=mock_get_access_rules_for_roles):
-            yield
+    # ``TestAuthHandler`` seeds the role on every call. Reporting it as already present keeps that
+    # seeding out of the database entirely, so suites that never boot the API lifespan (and therefore
+    # never call ``mongoengine.connect``) can still mount the handler.
+    with (
+        patch.object(RoleEntity, "filter_existing_roles", side_effect=mock_filter_existing_roles),
+        patch.object(RoleEntity, "get_access_rules_for_roles", side_effect=mock_get_access_rules_for_roles),
+        patch.object(RoleEntity, "tenant_role_exists", return_value=True),
+    ):
+        yield
 
 
 @pytest.fixture()

--- a/packages/core/swiss_ai_hub/core/testing/auth_utils/test_auth_handler.py
+++ b/packages/core/swiss_ai_hub/core/testing/auth_utils/test_auth_handler.py
@@ -9,27 +9,36 @@ deployments.
 
 The handler bypasses token parsing and returns the constant ``TEST_USER_OID``
 identity. To make tenant-scoped flows work end-to-end, it seeds a role row for
-the test user in the default tenant on every call and sets an active-tenant
-attribute if one is not present, then delegates to
-``AuthHandler.build_identity()`` so the normal Keycloak-first membership
-pipeline runs (with mocks in pytest, with the real dev Keycloak interactively).
+the test user in the default tenant on every call, then delegates to
+``AuthHandler.build_identity()``.
+
+Tenant resolution is overridden to read MongoDB instead of Keycloak. ``TEST_USER_OID``
+is a MongoDB ObjectId, so it can never name a Keycloak user: the production pipeline's
+``get_user`` lookup always 404s. pytest concealed that by mocking
+``KeycloakAdminService``, while an interactive playground server against a real dev
+Keycloak returned 500 on every tenant-scoped request. Since the handler already
+fabricates the identity, asking the identity provider about it was never meaningful.
 """
 
 import logging
 
-from fastapi import Request
+from fastapi import HTTPException, Request
 
 from swiss_ai_hub.core.auth.dependencies.auth_handler import AuthHandler
+from swiss_ai_hub.core.auth.identity.tenant_identity import TenantIdentity
 from swiss_ai_hub.core.auth.identity.user_identity import UserIdentity
-from swiss_ai_hub.core.auth.keycloak.keycloak_admin_service import KeycloakAdminService
+from swiss_ai_hub.core.persistence.access.entities.role_entity import RoleEntity
 from swiss_ai_hub.core.persistence.access.entities.tenant_metadata_entity import TenantMetadataEntity
 from swiss_ai_hub.core.persistence.access.entities.user_tenant_role_entity import UserTenantRoleEntity
 from swiss_ai_hub.core.testing.auth_utils.test_identity import (
+    TEST_TENANT_ACCESS_RULES,
     TEST_USER_EMAIL,
     TEST_USER_NAME,
     TEST_USER_OID,
     TEST_USER_ROLES,
 )
+
+TEST_USER_ROLE_NAME = TEST_USER_ROLES[0]
 
 logger = logging.getLogger(__name__)
 
@@ -45,15 +54,13 @@ class TestAuthHandler(AuthHandler):
 
         default_tenant = TenantMetadataEntity.get_startup_tenant_metadata()
         if default_tenant:
+            self._seed_test_role(str(default_tenant.id))
             UserTenantRoleEntity.create_or_update(
                 user_id=TEST_USER_OID,
                 tenant_id=str(default_tenant.id),
                 roles=list(TEST_USER_ROLES),
                 validate_roles=False,
             )
-            active_tenant_id = await KeycloakAdminService.get_active_tenant_id(TEST_USER_OID)
-            if not active_tenant_id:
-                await KeycloakAdminService.set_active_tenant(TEST_USER_OID, str(default_tenant.id))
 
         return await self.build_identity(
             user_id=TEST_USER_OID,
@@ -61,3 +68,49 @@ class TestAuthHandler(AuthHandler):
             email=TEST_USER_EMAIL,
             request=request,
         )
+
+    @staticmethod
+    def _seed_test_role(tenant_id: str) -> None:
+        """Ensures the role the test identity claims actually grants something.
+
+        Seeding only the user-to-role assignment left the role itself undefined, so
+        `get_access_rules_for_roles` returned an empty set and every endpoint answered 403. pytest
+        concealed it by mocking the role lookup; interactively the server authenticated fine and then
+        refused every request. The name is deliberately unmistakable in a role list.
+        """
+        if RoleEntity.objects(name=TEST_USER_ROLE_NAME, tenant_id=tenant_id).first():
+            return
+
+        RoleEntity.create_tenant_role(
+            name=TEST_USER_ROLE_NAME,
+            description="Full access for the bypass-auth test handler. Never create this by hand.",
+            access_rules=list(TEST_TENANT_ACCESS_RULES),
+            tenant_id=tenant_id,
+        )
+
+    @staticmethod
+    async def resolve_tenant_for_user(request: Request, user_id: str) -> TenantIdentity:
+        """Resolves the tenant from MongoDB, never from Keycloak.
+
+        `TEST_USER_OID` is a MongoDB ObjectId, so it can never name a Keycloak user — the production
+        pipeline's `get_user` call always 404s and every tenant-scoped request became a 500. pytest hid
+        it by mocking `KeycloakAdminService`; an interactive playground server against a real Keycloak
+        had no such mock and was simply unusable.
+
+        Resolving from Mongo is also the more honest bypass: this handler already fabricates the
+        identity, so consulting the identity provider about it was never going to mean anything.
+        """
+        requested = (request.path_params.get("tenant_id") or "").strip()
+        if requested and requested != AuthHandler.ACTIVE_TENANT_SLUG:
+            tenant = TenantMetadataEntity.objects(id=requested).first()
+            if tenant:
+                return TenantIdentity.from_tenant_metadata_entity(tenant)
+        return await TestAuthHandler.get_active_tenant_for_user(user_id)
+
+    @staticmethod
+    async def get_active_tenant_for_user(user_id: str) -> TenantIdentity:
+        """The startup tenant stands in for the active one, which Keycloak would otherwise own."""
+        tenant = TenantMetadataEntity.get_startup_tenant_metadata()
+        if not tenant:
+            raise HTTPException(status_code=400, detail="No startup tenant exists to act within")
+        return TenantIdentity.from_tenant_metadata_entity(tenant)

--- a/packages/core/swiss_ai_hub/core/testing/auth_utils/test_auth_handler.py
+++ b/packages/core/swiss_ai_hub/core/testing/auth_utils/test_auth_handler.py
@@ -78,7 +78,7 @@ class TestAuthHandler(AuthHandler):
         concealed it by mocking the role lookup; interactively the server authenticated fine and then
         refused every request. The name is deliberately unmistakable in a role list.
         """
-        if RoleEntity.objects(name=TEST_USER_ROLE_NAME, tenant_id=tenant_id).first():
+        if RoleEntity.tenant_role_exists(TEST_USER_ROLE_NAME, tenant_id):
             return
 
         RoleEntity.create_tenant_role(
@@ -102,7 +102,7 @@ class TestAuthHandler(AuthHandler):
         """
         requested = (request.path_params.get("tenant_id") or "").strip()
         if requested and requested != AuthHandler.ACTIVE_TENANT_SLUG:
-            tenant = TenantMetadataEntity.objects(id=requested).first()
+            tenant = TenantMetadataEntity.get_metadata_by_tenant_id(requested)
             if tenant:
                 return TenantIdentity.from_tenant_metadata_entity(tenant)
         return await TestAuthHandler.get_active_tenant_for_user(user_id)


### PR DESCRIPTION
Three defects found while trying to verify scheduled agents locally. All pre-existing on `main`, none related to scheduling — but together they made the playground API server unusable and one agent test suite untrustworthy.

## 1. The playground server crashed on startup

`packages/api/playground/testing/main.py` called `runner.mount_frontend(...)`, which is **defined nowhere in the repo**, so the server died immediately for everyone:

```
AttributeError: 'SimulatedAgentApiTestRunner' object has no attribute 'mount_frontend'
```

The directory it pointed at does not exist either. Removed the call, plus the two runner docstrings still advertising the method — those are what send the next person hunting for it.

## 2. Behind that: 500 on every tenant-scoped request

With the crash fixed, the server authenticated and then failed:

```
keycloak.exceptions.KeycloakGetError: 404: {"error":"User not found"}
```

`TEST_USER_OID` is a **MongoDB ObjectId**, so it can never name a Keycloak user — the tenant-resolution pipeline's `get_user` lookup always 404s. pytest concealed this by mocking `KeycloakAdminService`; an interactive server against the real dev Keycloak had no such mock.

Tenant resolution is now overridden **in the test handler** to read MongoDB, honouring a concrete tenant id in the path and falling back to the startup tenant for `active`. **Production auth code is untouched** — the seam already exists, since `build_identity` calls both resolvers through `self`.

## 3. Behind that: 403 on every request

The handler seeded only the user-to-role *assignment*, never the role itself, so `get_access_rules_for_roles` returned an empty set. Again invisible to pytest, which mocks the role lookup. It now seeds the role with the test access rules — which is what the assignment always implied.

**Result:** the playground server now serves an unauthenticated request for the first time.

```
GET /api/v1/active/agents/classes   →  HTTP 200, 20 agent classes
GET /api/v1/<tenant-id>/agents/classes → HTTP 200
```

## 4. `test_rag_agent_meta_routing` was not flaky — it was self-interfering

All three tests built their config with `agent_id="meta_routing_rag"`, and the dispatcher's JetStream consumer is **durable and named from the agent identity**. They therefore shared a queue group: whichever runner was still subscribed when the next test began could receive that test's start event and drop it, leaving the waiting test to time out.

A different subset failed on each run, which reads as an agent bug rather than tests interfering. Confirmed by running the failing test alone, where it passes.

Each test now gets its own `agent_id`, and so its own durable consumer.

| | before | after |
|---|---|---|
| Full-file runs | 1–3 failures each run | **3 consecutive clean runs** |

Worth knowing separately, and not fixable in code: **any real agent of the same class running on the machine competes for that queue group and steals these events.** A live `app/rag_agent/main.py` process accounted for two of the three failures before this change. Local runs should not have production agents running.

## Verification

core **1285 passed** · api **514 passed** · bot **15 passed** · `make pr-ready` clean.

The one api failure is `test_get_user_with_valid_token`, pre-existing and environment-dependent — it asserts a user name against the machine hostname and fails identically on a clean checkout.
