### PR TITLE
fix(swiss-ai-hub): Keep system messages at the beginning of the LLM message list

### DIFF
--- a/packages/agent/swiss_ai_hub/agent/agents/expert_rag_agent/expert_rag_agent.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/expert_rag_agent/expert_rag_agent.py
@@ -682,8 +682,12 @@ class ExpertRAGAgent(Agent):
         context_content = t("agent.prompt.expert_context", expert_conversation=expert_conversation_text)
         await displayer.display_thought(f"Expert context: {context_content}")
 
+        # USER, not SYSTEM: limit_chat_history_with_context places context messages *after* the conversation
+        # turns, and strict providers (e.g. Qwen3.5 on Infomaniak) reject a 400 "System message must be at
+        # the beginning" for any system message past index 0. This matches the retrieval context message,
+        # which lib.prompt.rag.context_prompt already renders with role="user".
         context_message = ChatMessage(
-            role=MessageRole.SYSTEM,
+            role=MessageRole.USER,
             content=context_content,
         )
         return ExpertAnswerContextEvent(context_message=context_message)

--- a/packages/agent/swiss_ai_hub/agent/agents/few_shot_agent/few_shot_agent.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/few_shot_agent/few_shot_agent.py
@@ -17,6 +17,7 @@ from swiss_ai_hub.core.generative_ai import (
     condense_standalone_question,
     create_few_shot_messages,
     limit_chat_history,
+    merge_consecutive_messages,
 )
 from swiss_ai_hub.core.i18n import LocaleHandler
 
@@ -244,12 +245,18 @@ class FewShotAgent(Agent):
         system_prompt = ChatMessage(
             role=MessageRole.SYSTEM, content=agent_config.few_shot.system_prompt.in_locale(locale)
         )
-        context = [
-            *system_messages,
-            system_prompt,
-            *few_shot_messages,
-            event.condensed_chat_message,
-        ]
+        # Only one leading system message may survive: strict providers (e.g. Qwen3.5 on Infomaniak) reject a
+        # 400 "System message must be at the beginning" for any system message past index 0, and the chat
+        # client's own system prompt (OpenWebUI model prompt, bot PathEntity.system_message) would push ours
+        # to index 1.
+        context = merge_consecutive_messages(
+            [
+                *system_messages,
+                system_prompt,
+                *few_shot_messages,
+                event.condensed_chat_message,
+            ]
+        )
         return FewShotEvent(
             few_shot_examples=few_shot_messages,
             system_prompt=system_prompt,

--- a/packages/agent/swiss_ai_hub/agent/agents/few_shot_agent/tests/test_few_shot_system_message_ordering.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/few_shot_agent/tests/test_few_shot_system_message_ordering.py
@@ -1,0 +1,72 @@
+"""
+Regression guard for the 400 "System message must be at the beginning" from strict providers
+(e.g. Qwen3.5 on Infomaniak): the agent's own few-shot system prompt used to land at index 1
+whenever the chat client supplied its own system message (OpenWebUI model prompt, bot
+PathEntity.system_message).
+
+Pure unit test — create_few_shot_examples touches no infrastructure.
+"""
+
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from swiss_ai_hub.core.events.agent import LimitChatHistoryEvent, UserMessageEvent
+from swiss_ai_hub.core.generative_ai import FewShotExample, LLMConfig
+from swiss_ai_hub.core.i18n import LocaleString
+from swiss_ai_hub.core.testing import async_test
+from swiss_ai_hub.core.testing.auth_utils import fake_user
+
+from swiss_ai_hub.agent.agents.few_shot_agent.events.few_shot_standalone_question_condenser_event import (
+    FewShotStandaloneQuestionCondenserEvent,
+)
+from swiss_ai_hub.agent.agents.few_shot_agent.few_shot_agent import FewShotAgent
+from swiss_ai_hub.agent.agents.few_shot_agent.few_shot_agent_config import FewShotAgentConfig
+from swiss_ai_hub.agent.steps.prompting.few_shot_step.few_shot_step_config import FewShotStepConfig
+
+
+def _config() -> FewShotAgentConfig:
+    return FewShotAgentConfig(
+        agent_id="system_message_ordering_test",
+        name=LocaleString(en="Test FewShot"),
+        description=LocaleString(en="A test few-shot agent."),
+        llm=LLMConfig(model_name="text-generation/gemma-4-31B-it"),
+        few_shot=FewShotStepConfig(
+            few_shot_examples=[FewShotExample(user=LocaleString(en="hi"), agent=LocaleString(en="hello"))],
+            system_prompt=LocaleString(en="Respond briefly."),
+        ),
+    )
+
+
+async def _build_context(chat_history: list[ChatMessage]) -> list[ChatMessage]:
+    event = await FewShotAgent().create_few_shot_examples(
+        event=FewShotStandaloneQuestionCondenserEvent(
+            condensed_chat_message=ChatMessage(role=MessageRole.USER, content="What is Fight Club about?")
+        ),
+        start_event=UserMessageEvent(messages=chat_history, user=fake_user(), locale="en"),
+        chat_history_event=LimitChatHistoryEvent(limited_history=chat_history),
+        agent_config=_config(),
+    )
+    return event.full_context
+
+
+@async_test
+async def test_client_system_prompt_does_not_displace_the_agent_system_prompt():
+    context = await _build_context(
+        [
+            ChatMessage(role=MessageRole.SYSTEM, content="You are a helpful assistant."),
+            ChatMessage(role=MessageRole.USER, content="Tell me about Fight Club"),
+        ]
+    )
+
+    system_indices = [index for index, message in enumerate(context) if message.role == MessageRole.SYSTEM]
+    assert system_indices == [0], f"system messages must collapse into index 0, got {system_indices}"
+    assert "You are a helpful assistant." in context[0].content
+    assert "Respond briefly." in context[0].content
+
+
+@async_test
+async def test_agent_system_prompt_leads_when_client_sends_none():
+    context = await _build_context([ChatMessage(role=MessageRole.USER, content="Tell me about Fight Club")])
+
+    system_indices = [index for index, message in enumerate(context) if message.role == MessageRole.SYSTEM]
+    assert system_indices == [0]
+    assert context[0].content == "Respond briefly."
+    assert context[-1].role == MessageRole.USER

--- a/packages/agent/swiss_ai_hub/agent/agents/llm_wrapping_agent/llm_wrapping_agent.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/llm_wrapping_agent/llm_wrapping_agent.py
@@ -9,7 +9,7 @@ from swiss_ai_hub.core.events.agent import (
     NotAMetaQuestionEvent,
     UserMessageEvent,
 )
-from swiss_ai_hub.core.generative_ai import limit_chat_history
+from swiss_ai_hub.core.generative_ai import limit_chat_history, merge_consecutive_messages
 from swiss_ai_hub.core.i18n import LocaleHandler
 
 from swiss_ai_hub.agent.agents.agent import Agent
@@ -134,11 +134,17 @@ class LLMWrappingAgent(Agent):
         system_messages = [msg for msg in event.messages if msg.role == MessageRole.SYSTEM]
         system_prompt = ChatMessage(role=MessageRole.SYSTEM, content=agent_config.system_prompt.in_locale(locale))
         regular_messages = [msg for msg in event.messages if msg.role != MessageRole.SYSTEM]
-        chat_history = [
-            *system_messages,
-            system_prompt,
-            *regular_messages,
-        ]
+        # Only one leading system message may survive: strict providers (e.g. Qwen3.5 on Infomaniak) reject a
+        # 400 "System message must be at the beginning" for any system message past index 0, and the chat
+        # client's own system prompt (OpenWebUI model prompt, bot PathEntity.system_message) would push ours
+        # to index 1. Merge before limiting so the token budget reflects what is actually sent.
+        chat_history = merge_consecutive_messages(
+            [
+                *system_messages,
+                system_prompt,
+                *regular_messages,
+            ]
+        )
         limited_chat_history = limit_chat_history(
             chat_history=chat_history,
             number_of_input_tokens=agent_config.number_of_input_tokens,

--- a/packages/agent/swiss_ai_hub/agent/agents/llm_wrapping_agent/tests/test_llm_wrapping_system_message_ordering.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/llm_wrapping_agent/tests/test_llm_wrapping_system_message_ordering.py
@@ -1,0 +1,60 @@
+"""
+Regression guard for the 400 "System message must be at the beginning" from strict providers
+(e.g. Qwen3.5 on Infomaniak): the agent's own system prompt used to land at index 1 whenever the
+chat client supplied its own system message (OpenWebUI model prompt, bot PathEntity.system_message).
+
+Pure unit test — limit_chat_history_step touches no infrastructure.
+"""
+
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from swiss_ai_hub.core.events.agent import NotAMetaQuestionEvent, UserMessageEvent
+from swiss_ai_hub.core.generative_ai import LLMConfig
+from swiss_ai_hub.core.i18n import LocaleString
+from swiss_ai_hub.core.testing import async_test
+from swiss_ai_hub.core.testing.auth_utils import fake_user
+
+from swiss_ai_hub.agent.agents.llm_wrapping_agent.llm_wrapping_agent import LLMWrappingAgent
+from swiss_ai_hub.agent.agents.llm_wrapping_agent.llm_wrapping_agent_config import LLMWrappingAgentConfig
+
+
+def _config() -> LLMWrappingAgentConfig:
+    return LLMWrappingAgentConfig(
+        agent_id="system_message_ordering_test",
+        name=LocaleString(en="Test LLM Wrapper"),
+        description=LocaleString(en="A test llm wrapping agent."),
+        system_prompt=LocaleString(en="Respond briefly."),
+        llm=LLMConfig(model_name="text-generation/gemma-4-31B-it"),
+    )
+
+
+async def _limited_history(chat_history: list[ChatMessage]) -> list[ChatMessage]:
+    event = await LLMWrappingAgent().limit_chat_history_step(
+        event=UserMessageEvent(messages=chat_history, user=fake_user(), locale="en"),
+        agent_config=_config(),
+        _clear=NotAMetaQuestionEvent(reasoning="forced normal"),
+    )
+    return event.limited_history
+
+
+@async_test
+async def test_client_system_prompt_does_not_displace_the_agent_system_prompt():
+    history = await _limited_history(
+        [
+            ChatMessage(role=MessageRole.SYSTEM, content="You are a helpful assistant."),
+            ChatMessage(role=MessageRole.USER, content="Tell me about Fight Club"),
+        ]
+    )
+
+    system_indices = [index for index, message in enumerate(history) if message.role == MessageRole.SYSTEM]
+    assert system_indices == [0], f"system messages must collapse into index 0, got {system_indices}"
+    assert "You are a helpful assistant." in history[0].content
+    assert "Respond briefly." in history[0].content
+
+
+@async_test
+async def test_agent_system_prompt_leads_when_client_sends_none():
+    history = await _limited_history([ChatMessage(role=MessageRole.USER, content="Tell me about Fight Club")])
+
+    system_indices = [index for index, message in enumerate(history) if message.role == MessageRole.SYSTEM]
+    assert system_indices == [0]
+    assert history[0].content == "Respond briefly."


### PR DESCRIPTION
Ticket: bbvch-ai/aihub-core-private#185

## Problem

`FewShotAgent` crashes with a 400 from the LLM gateway:

```
upstream 400 on Qwen/Qwen3.5-122B-A10B-FP8:
{"error":{"message":"System message must be at the beginning.","type":"BadRequestError"}}
```

Strict providers reject **any** system message past index 0. Three places in the agent SDK can produce one.

## Root causes

**1. `FewShotAgent` / `LLMWrappingAgent` — two consecutive system messages**

Both build the LLM message list as:

```python
[*system_messages,  # the chat client's system prompt
 system_prompt,     # the agent's own -> index 1
 ...]
```

The first entry comes from the client — OpenWebUI's model system prompt, or the bot's `PathEntity.system_message`, which is prepended to every Teams/Slack conversation. When the client sends none the list is valid, which is why this only fails for some profiles.

`RAGAgent` ([`rag/step_functions.py:116`](https://github.com/bbvch-ai/aihub-core/blob/release/0.319/packages/agent/swiss_ai_hub/agent/rag/step_functions.py#L116)) and the meta-question path ([`self_awareness_step_functions.py:60`](https://github.com/bbvch-ai/aihub-core/blob/release/0.319/packages/agent/swiss_ai_hub/agent/self_awareness/self_awareness_step_functions.py#L60)) already guard against this with `merge_consecutive_messages` — the latter with a comment naming this exact error. These two agents were never given the same treatment.

**2. `ExpertRAGAgent` — a system message in the middle**

`expert_answered_step` builds the expert-answer context as `role=SYSTEM`, and `limit_chat_history_with_context` places context messages **after** the conversation turns:

```
[*system_messages, *limited_history, SYSTEM(expert context), USER(last)]
```

`merge_consecutive_messages` cannot help here — it is not adjacent to the leading systems. Triggers whenever the expert flow runs with non-empty prior history.

## Fix

| File | Change |
| --- | --- |
| `few_shot_agent.py` | Wrap `full_context` in `merge_consecutive_messages` |
| `llm_wrapping_agent.py` | Same, merged before `limit_chat_history` so the token budget reflects what is sent |
| `expert_rag_agent.py` | Expert context message `SYSTEM` -> `USER`, matching the retrieval context message that `lib.prompt.rag.context_prompt` already renders with `role="user"` |

## Scope of the audit

Every LLM call site was checked.

**Safe, unchanged:** `RAGAgent`, meta-question answering, `ImapAgent` (`[SYSTEM, USER]`), `RetrievalAgent` (no LLM), `ExpertAskingAgent`, `NamespaceSelectionAgent`, conversation metadata, LLM routing, `condense_standalone_question`, and all four guards — all single-message or system-first templates.

**`McpReactAgent` — deliberately left alone.** [`mcp_react_agent.py:102`](https://github.com/bbvch-ai/aihub-core/blob/release/0.319/packages/agent/swiss_ai_hub/agent/agents/mcp_react_agent/mcp_react_agent.py#L102) strips client system messages outright, so the trigger above cannot occur. It can still stack 2-3 system messages from server-side sources (`config.system_prompt`, MCP `initialize_result.instructions`, static resource context) — latent, dependent on the MCP server, and out of scope here.

**Playground demos** (`user_memory_agent`, `organization_memory_agent`) have the same latent issue via `extend_chat_history_with_user_memory`, which inserts its system message *after* existing ones. Not fixed — demo code.

## Behavioural note

`merge_consecutive_messages` also collapses consecutive *user* or *assistant* turns, not just system ones. For `LLMWrappingAgent` a history with two adjacent user turns now arrives as one. This is the same treatment `RAGAgent` has always applied ("required by LiteLLM"), and strict providers reject non-alternating roles anyway — but it is a change beyond the system-message fix.

## Tests

Two new unit tests per affected agent asserting exactly one system message at index 0, with and without a client-supplied system prompt:

- `test_few_shot_system_message_ordering.py`
- `test_llm_wrapping_system_message_ordering.py`

`packages/agent`: **363 passed, 3 skipped, 12 deselected**.

> [!IMPORTANT]
> The 12 deselected are the `flaky` + `self_hosted` tests — they need the Docker dev stack, which was not available locally. They have not been exercised for this change and should be confirmed in CI.
