### PR TITLE
feat(tracing): Serve request metrics on a Prometheus scrape endpoint

### DIFF
--- a/docs/docs/2_platform/3_deployment_guide/9_environment_variables/index.en.md
+++ b/docs/docs/2_platform/3_deployment_guide/9_environment_variables/index.en.md
@@ -127,6 +127,7 @@ These variables are referenced as `${VAR}` (without a `${VAR:-default}` fallback
 | `OTEL_CLOUD_ENDPOINT` | `otel-config.yml` | `otel-collector` |  |
 | `OTEL_CLOUD_HEADERS` | `otel-config.yml` | `otel-collector` |  |
 | `OTEL_ENABLED` | `OpenTelemetrySettings.ENABLED` | `api`, `expert_asking_agent`, `expert_rag_agent`, `few_shot_agent`, `imap_agent`, `llm_wrapping_agent`, `memory_writer_agent`, `namespace_selection_agent`, `rag_agent`, `retrieval_agent`, `sysadmin-api` | Enable/disable OpenTelemetry tracing entirely |
+| `OTEL_METRICS_ENABLED` | `OpenTelemetrySettings.METRICS_ENABLED` | `api` | Expose request metrics on a Prometheus scrape endpoint (separate from tracing) |
 | `POSTGRES_PASSWORD` | `openwebui-init-openwebui.sh` | `backup-code`, `dagster-daemon`, `dagster-webserver`, `default_rag_pipeline`, `keycloak`, `langfuse-web`, `langfuse-worker`, `litellm`, `open-webui`, `openwebui-init`, `pgbouncer`, `postgres`, `postgres-ferretdb`, `shared_rag_pipeline` |  |
 | `POSTGRES_PORT` | `openwebui-init-openwebui.sh` | `backup-code`, `openwebui-init` |  |
 | `POSTGRES_USER` | `openwebui-init-openwebui.sh` | `backup-code`, `dagster-daemon`, `dagster-webserver`, `default_rag_pipeline`, `keycloak`, `langfuse-web`, `langfuse-worker`, `litellm`, `open-webui`, `openwebui-init`, `pgbouncer`, `postgres`, `postgres-ferretdb`, `shared_rag_pipeline` |  |

--- a/infra/deployment/templates/docker-compose.yml.j2
+++ b/infra/deployment/templates/docker-compose.yml.j2
@@ -2932,10 +2932,12 @@ services:
       MINERU_MAX_CONCURRENT_BATCH_REQUESTS: ${MINERU_MAX_CONCURRENT_BATCH_REQUESTS}
 
       # OpenTelemetry Configuration
-      # Traces always on. Request metrics are opt-in: the FastAPI auto-instrumentation's
-      # http.server.* histograms were the high-cardinality driver behind issue 1496, so they
-      # default off (OTEL_METRICS_ENABLED=false in .env.dev/.env.prod) and any deploy can turn
-      # them back on via its own env.
+      # Traces always on. Request metrics are opt-in (OTEL_METRICS_ENABLED, default off): the
+      # FastAPI auto-instrumentation's http.server.* histograms were the high-cardinality driver
+      # behind issue 1496. When enabled the metrics are served on /metrics for a scraping store
+      # to pull — nothing is pushed to otel-collector, whose filter/metrics_cardinality drops
+      # every http.server.* metric anyway. Traefik routes this service on PathPrefix(`/api/v1`)
+      # only, so /metrics stays reachable from inside the network and not from the internet.
       OTEL_ENABLED: ${OTEL_ENABLED}
       OTEL_METRICS_ENABLED: ${OTEL_METRICS_ENABLED}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317

--- a/infra/docker-compose.build.gpu.yml
+++ b/infra/docker-compose.build.gpu.yml
@@ -2607,10 +2607,12 @@ services:
       MINERU_MAX_CONCURRENT_BATCH_REQUESTS: ${MINERU_MAX_CONCURRENT_BATCH_REQUESTS}
 
       # OpenTelemetry Configuration
-      # Traces always on. Request metrics are opt-in: the FastAPI auto-instrumentation's
-      # http.server.* histograms were the high-cardinality driver behind issue 1496, so they
-      # default off (OTEL_METRICS_ENABLED=false in .env.dev/.env.prod) and any deploy can turn
-      # them back on via its own env.
+      # Traces always on. Request metrics are opt-in (OTEL_METRICS_ENABLED, default off): the
+      # FastAPI auto-instrumentation's http.server.* histograms were the high-cardinality driver
+      # behind issue 1496. When enabled the metrics are served on /metrics for a scraping store
+      # to pull — nothing is pushed to otel-collector, whose filter/metrics_cardinality drops
+      # every http.server.* metric anyway. Traefik routes this service on PathPrefix(`/api/v1`)
+      # only, so /metrics stays reachable from inside the network and not from the internet.
       OTEL_ENABLED: ${OTEL_ENABLED}
       OTEL_METRICS_ENABLED: ${OTEL_METRICS_ENABLED}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317

--- a/infra/docker-compose.build.yml
+++ b/infra/docker-compose.build.yml
@@ -2395,10 +2395,12 @@ services:
       MINERU_MAX_CONCURRENT_BATCH_REQUESTS: ${MINERU_MAX_CONCURRENT_BATCH_REQUESTS}
 
       # OpenTelemetry Configuration
-      # Traces always on. Request metrics are opt-in: the FastAPI auto-instrumentation's
-      # http.server.* histograms were the high-cardinality driver behind issue 1496, so they
-      # default off (OTEL_METRICS_ENABLED=false in .env.dev/.env.prod) and any deploy can turn
-      # them back on via its own env.
+      # Traces always on. Request metrics are opt-in (OTEL_METRICS_ENABLED, default off): the
+      # FastAPI auto-instrumentation's http.server.* histograms were the high-cardinality driver
+      # behind issue 1496. When enabled the metrics are served on /metrics for a scraping store
+      # to pull — nothing is pushed to otel-collector, whose filter/metrics_cardinality drops
+      # every http.server.* metric anyway. Traefik routes this service on PathPrefix(`/api/v1`)
+      # only, so /metrics stays reachable from inside the network and not from the internet.
       OTEL_ENABLED: ${OTEL_ENABLED}
       OTEL_METRICS_ENABLED: ${OTEL_METRICS_ENABLED}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317

--- a/infra/docker-compose.latest.gpu.yml
+++ b/infra/docker-compose.latest.gpu.yml
@@ -2558,10 +2558,12 @@ services:
       MINERU_MAX_CONCURRENT_BATCH_REQUESTS: ${MINERU_MAX_CONCURRENT_BATCH_REQUESTS}
 
       # OpenTelemetry Configuration
-      # Traces always on. Request metrics are opt-in: the FastAPI auto-instrumentation's
-      # http.server.* histograms were the high-cardinality driver behind issue 1496, so they
-      # default off (OTEL_METRICS_ENABLED=false in .env.dev/.env.prod) and any deploy can turn
-      # them back on via its own env.
+      # Traces always on. Request metrics are opt-in (OTEL_METRICS_ENABLED, default off): the
+      # FastAPI auto-instrumentation's http.server.* histograms were the high-cardinality driver
+      # behind issue 1496. When enabled the metrics are served on /metrics for a scraping store
+      # to pull — nothing is pushed to otel-collector, whose filter/metrics_cardinality drops
+      # every http.server.* metric anyway. Traefik routes this service on PathPrefix(`/api/v1`)
+      # only, so /metrics stays reachable from inside the network and not from the internet.
       OTEL_ENABLED: ${OTEL_ENABLED}
       OTEL_METRICS_ENABLED: ${OTEL_METRICS_ENABLED}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317

--- a/infra/docker-compose.latest.yml
+++ b/infra/docker-compose.latest.yml
@@ -2352,10 +2352,12 @@ services:
       MINERU_MAX_CONCURRENT_BATCH_REQUESTS: ${MINERU_MAX_CONCURRENT_BATCH_REQUESTS}
 
       # OpenTelemetry Configuration
-      # Traces always on. Request metrics are opt-in: the FastAPI auto-instrumentation's
-      # http.server.* histograms were the high-cardinality driver behind issue 1496, so they
-      # default off (OTEL_METRICS_ENABLED=false in .env.dev/.env.prod) and any deploy can turn
-      # them back on via its own env.
+      # Traces always on. Request metrics are opt-in (OTEL_METRICS_ENABLED, default off): the
+      # FastAPI auto-instrumentation's http.server.* histograms were the high-cardinality driver
+      # behind issue 1496. When enabled the metrics are served on /metrics for a scraping store
+      # to pull — nothing is pushed to otel-collector, whose filter/metrics_cardinality drops
+      # every http.server.* metric anyway. Traefik routes this service on PathPrefix(`/api/v1`)
+      # only, so /metrics stays reachable from inside the network and not from the internet.
       OTEL_ENABLED: ${OTEL_ENABLED}
       OTEL_METRICS_ENABLED: ${OTEL_METRICS_ENABLED}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317

--- a/infra/docker-compose.local.gpu.yml
+++ b/infra/docker-compose.local.gpu.yml
@@ -2594,10 +2594,12 @@ services:
       MINERU_MAX_CONCURRENT_BATCH_REQUESTS: ${MINERU_MAX_CONCURRENT_BATCH_REQUESTS}
 
       # OpenTelemetry Configuration
-      # Traces always on. Request metrics are opt-in: the FastAPI auto-instrumentation's
-      # http.server.* histograms were the high-cardinality driver behind issue 1496, so they
-      # default off (OTEL_METRICS_ENABLED=false in .env.dev/.env.prod) and any deploy can turn
-      # them back on via its own env.
+      # Traces always on. Request metrics are opt-in (OTEL_METRICS_ENABLED, default off): the
+      # FastAPI auto-instrumentation's http.server.* histograms were the high-cardinality driver
+      # behind issue 1496. When enabled the metrics are served on /metrics for a scraping store
+      # to pull — nothing is pushed to otel-collector, whose filter/metrics_cardinality drops
+      # every http.server.* metric anyway. Traefik routes this service on PathPrefix(`/api/v1`)
+      # only, so /metrics stays reachable from inside the network and not from the internet.
       OTEL_ENABLED: ${OTEL_ENABLED}
       OTEL_METRICS_ENABLED: ${OTEL_METRICS_ENABLED}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -2382,10 +2382,12 @@ services:
       MINERU_MAX_CONCURRENT_BATCH_REQUESTS: ${MINERU_MAX_CONCURRENT_BATCH_REQUESTS}
 
       # OpenTelemetry Configuration
-      # Traces always on. Request metrics are opt-in: the FastAPI auto-instrumentation's
-      # http.server.* histograms were the high-cardinality driver behind issue 1496, so they
-      # default off (OTEL_METRICS_ENABLED=false in .env.dev/.env.prod) and any deploy can turn
-      # them back on via its own env.
+      # Traces always on. Request metrics are opt-in (OTEL_METRICS_ENABLED, default off): the
+      # FastAPI auto-instrumentation's http.server.* histograms were the high-cardinality driver
+      # behind issue 1496. When enabled the metrics are served on /metrics for a scraping store
+      # to pull — nothing is pushed to otel-collector, whose filter/metrics_cardinality drops
+      # every http.server.* metric anyway. Traefik routes this service on PathPrefix(`/api/v1`)
+      # only, so /metrics stays reachable from inside the network and not from the internet.
       OTEL_ENABLED: ${OTEL_ENABLED}
       OTEL_METRICS_ENABLED: ${OTEL_METRICS_ENABLED}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317

--- a/infra/docker-compose.nightly.gpu.yml
+++ b/infra/docker-compose.nightly.gpu.yml
@@ -2558,10 +2558,12 @@ services:
       MINERU_MAX_CONCURRENT_BATCH_REQUESTS: ${MINERU_MAX_CONCURRENT_BATCH_REQUESTS}
 
       # OpenTelemetry Configuration
-      # Traces always on. Request metrics are opt-in: the FastAPI auto-instrumentation's
-      # http.server.* histograms were the high-cardinality driver behind issue 1496, so they
-      # default off (OTEL_METRICS_ENABLED=false in .env.dev/.env.prod) and any deploy can turn
-      # them back on via its own env.
+      # Traces always on. Request metrics are opt-in (OTEL_METRICS_ENABLED, default off): the
+      # FastAPI auto-instrumentation's http.server.* histograms were the high-cardinality driver
+      # behind issue 1496. When enabled the metrics are served on /metrics for a scraping store
+      # to pull — nothing is pushed to otel-collector, whose filter/metrics_cardinality drops
+      # every http.server.* metric anyway. Traefik routes this service on PathPrefix(`/api/v1`)
+      # only, so /metrics stays reachable from inside the network and not from the internet.
       OTEL_ENABLED: ${OTEL_ENABLED}
       OTEL_METRICS_ENABLED: ${OTEL_METRICS_ENABLED}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317

--- a/infra/docker-compose.nightly.yml
+++ b/infra/docker-compose.nightly.yml
@@ -2352,10 +2352,12 @@ services:
       MINERU_MAX_CONCURRENT_BATCH_REQUESTS: ${MINERU_MAX_CONCURRENT_BATCH_REQUESTS}
 
       # OpenTelemetry Configuration
-      # Traces always on. Request metrics are opt-in: the FastAPI auto-instrumentation's
-      # http.server.* histograms were the high-cardinality driver behind issue 1496, so they
-      # default off (OTEL_METRICS_ENABLED=false in .env.dev/.env.prod) and any deploy can turn
-      # them back on via its own env.
+      # Traces always on. Request metrics are opt-in (OTEL_METRICS_ENABLED, default off): the
+      # FastAPI auto-instrumentation's http.server.* histograms were the high-cardinality driver
+      # behind issue 1496. When enabled the metrics are served on /metrics for a scraping store
+      # to pull — nothing is pushed to otel-collector, whose filter/metrics_cardinality drops
+      # every http.server.* metric anyway. Traefik routes this service on PathPrefix(`/api/v1`)
+      # only, so /metrics stays reachable from inside the network and not from the internet.
       OTEL_ENABLED: ${OTEL_ENABLED}
       OTEL_METRICS_ENABLED: ${OTEL_METRICS_ENABLED}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317

--- a/packages/api/playground/testing/tests/runners/test_api_runner_otel.py
+++ b/packages/api/playground/testing/tests/runners/test_api_runner_otel.py
@@ -1,4 +1,8 @@
-from swiss_ai_hub.api.runners.api_runner import CAPTURED_REQUEST_HEADERS
+from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, Counter
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from swiss_ai_hub.api.runners.api_runner import CAPTURED_REQUEST_HEADERS, ApiRunner
 
 
 def test_captured_request_headers_is_a_bounded_allowlist() -> None:
@@ -11,3 +15,49 @@ def test_captured_request_headers_is_a_bounded_allowlist() -> None:
     assert ".*" not in CAPTURED_REQUEST_HEADERS
     assert 0 < len(CAPTURED_REQUEST_HEADERS) <= 5
     assert all(isinstance(header, str) for header in CAPTURED_REQUEST_HEADERS)
+
+
+def test_metrics_route_is_served_outside_the_api_path() -> None:
+    """
+    The scrape endpoint must sit on the outer Starlette app, not under api_path.
+
+    Traefik routes this service on PathPrefix(`/api/v1`) only, so a route at /metrics is
+    reachable from inside the network and not from the internet. Moving it under api_path would
+    publish request latencies and the full route list, and would also turn it into an MCP
+    resource via FastMCP.from_fastapi().
+    """
+    route = ApiRunner._build_metrics_route(CollectorRegistry())
+
+    assert route.path == "/metrics"
+    assert not route.path.startswith("/api")
+
+
+def test_metrics_route_serves_the_registry_it_was_given() -> None:
+    """A scraper must get this app's measurements in Prometheus exposition format."""
+    registry = CollectorRegistry()
+    Counter("aihub_probe", "probe counter", registry=registry).inc()
+
+    app = Starlette(routes=[ApiRunner._build_metrics_route(registry)])
+    response = TestClient(app).get("/metrics")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == CONTENT_TYPE_LATEST
+    assert "aihub_probe_total" in response.text
+
+
+def test_metrics_routes_from_separate_registries_do_not_share_series() -> None:
+    """
+    Two apps in one process must not see each other's metrics. This is the property that a
+    per-app CollectorRegistry buys and prometheus_client's global REGISTRY would lose.
+    """
+    first_registry, second_registry = CollectorRegistry(), CollectorRegistry()
+    Counter("aihub_first", "first", registry=first_registry).inc()
+    Counter("aihub_second", "second", registry=second_registry).inc()
+
+    first = TestClient(Starlette(routes=[ApiRunner._build_metrics_route(first_registry)])).get("/metrics")
+    second = TestClient(Starlette(routes=[ApiRunner._build_metrics_route(second_registry)])).get("/metrics")
+
+    assert "aihub_first_total" in first.text
+    assert "aihub_second_total" not in first.text
+    assert "aihub_second_total" in second.text
+    assert "aihub_first_total" not in second.text

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "opentelemetry-instrumentation-fastapi>=0.60b1",
     "starlette>=1.0.1",
     "swiss-ai-hub-jambo>=0.5.0",
+    "prometheus-client>=0.26.0",
 ]
 
 [dependency-groups]

--- a/packages/api/swiss_ai_hub/api/runners/api_runner.py
+++ b/packages/api/swiss_ai_hub/api/runners/api_runner.py
@@ -8,9 +8,12 @@ from fastmcp import FastMCP
 from fastmcp.server.openapi import MCPType, RouteMap
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.metrics import NoOpMeterProvider
+from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, generate_latest
 from starlette.applications import Starlette
 from starlette.middleware.cors import CORSMiddleware
-from starlette.routing import Mount
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.routing import Mount, Route
 from swiss_ai_hub.core.infrastructure import AIHubSettings
 from swiss_ai_hub.core.routes import Controller
 from swiss_ai_hub.core.runners import OpenApiSchemaService, Runner
@@ -116,7 +119,10 @@ class ApiRunner(Runner):
         self._api_app.state = app.state
         mcp_app.state = app.state
 
-        self._configure_opentelemetry()
+        prometheus_registry = self._configure_opentelemetry()
+        if prometheus_registry is not None:
+            app.routes.append(self._build_metrics_route(prometheus_registry))
+            logger.info("Prometheus scrape endpoint served at /metrics")
 
         return app
 
@@ -188,9 +194,12 @@ class ApiRunner(Runner):
 
         return self
 
-    def _configure_opentelemetry(self) -> None:
+    def _configure_opentelemetry(self) -> CollectorRegistry | None:
         """
         Configure FastAPI-specific OpenTelemetry instrumentation.
+
+        Returns the registry backing the scrape endpoint when Prometheus metrics are enabled, so
+        create_app() knows whether to serve /metrics; None otherwise.
         """
         from swiss_ai_hub.core.infrastructure import OpenTelemetrySettings
 
@@ -198,13 +207,18 @@ class ApiRunner(Runner):
 
         if not otel_settings.ENABLED:
             logger.info("OpenTelemetry instrumentation disabled: OTEL_ENABLED=False")
-            return
+            return None
 
         # Metrics are a separate opt-in from tracing (OTEL_METRICS_ENABLED, default off): the
         # FastAPI/ASGI auto-instrumentation's request-count/duration histograms were the
         # unbounded, high-cardinality metric source behind issue #1496. configure_metrics()
         # returns None (NoOpMeterProvider fallback) unless explicitly enabled.
-        meter_provider = otel_settings.configure_metrics() or NoOpMeterProvider()
+        #
+        # A registry per app instance, never prometheus_client's global REGISTRY: the test suite
+        # builds many apps in one process, and a shared registry raises "Duplicated timeseries"
+        # on the second one.
+        prometheus_registry = CollectorRegistry() if otel_settings.METRICS_ENABLED else None
+        meter_provider = otel_settings.configure_metrics(prometheus_registry) or NoOpMeterProvider()
 
         FastAPIInstrumentor.instrument_app(
             self._api_app,
@@ -214,3 +228,22 @@ class ApiRunner(Runner):
         )
         logger.info("FastAPI application instrumented with OpenTelemetry")
         logger.info("Note: Core OpenTelemetry, MongoDB, and HTTP client configuration handled in lifetime_manager")
+
+        return prometheus_registry
+
+    @staticmethod
+    def _build_metrics_route(registry: CollectorRegistry) -> Route:
+        """
+        Serve the scrape endpoint on the OUTER Starlette app, deliberately not under api_path.
+
+        Three consequences follow from that placement, all of them wanted: Traefik routes the API
+        on PathPrefix(`/api/v1`) only, so /metrics is unreachable from the internet and stays a
+        cluster-internal target; FastMCP.from_fastapi() turns every GET on the inner app into an
+        MCP resource, which this must not become; and the inner app's auth and i18n middleware
+        never runs for a scraper that carries no token and no Accept-Language.
+        """
+
+        async def serve_metrics(_: Request) -> Response:
+            return Response(generate_latest(registry), media_type=CONTENT_TYPE_LATEST)
+
+        return Route("/metrics", serve_metrics, methods=["GET"])

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -87,6 +87,7 @@ dependencies = [
     "rank-bm25>=0.2.2",
     "starlette>=1.0.1",
     "croniter>=6.2.4",
+    "opentelemetry-exporter-prometheus>=0.63b0",
 ]
 
 [dependency-groups]

--- a/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/open_telemetry_settings.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/open_telemetry_settings.py
@@ -4,18 +4,17 @@ from typing import Annotated, Literal
 from opentelemetry import trace
 from opentelemetry._logs import set_logger_provider
 from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter as GRPCLogExporter
-from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter as GRPCMetricExporter
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter as GRPCSpanExporter
 from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter as HTTPLogExporter
-from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter as HTTPMetricExporter
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter as HTTPSpanExporter
+from opentelemetry.exporter.prometheus import PrometheusMetricReader
 from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import SpanLimits, TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from prometheus_client import CollectorRegistry
 from pydantic import Field
 
 from swiss_ai_hub.core.settings.environment_settings import EnvironmentSettings
@@ -30,7 +29,7 @@ class OpenTelemetrySettings(EnvironmentSettings):
 
     ENABLED: Annotated[bool, Field(description="Enable/disable OpenTelemetry tracing entirely")] = False
     METRICS_ENABLED: Annotated[
-        bool, Field(description="Enable/disable OpenTelemetry request metrics (separate from tracing)")
+        bool, Field(description="Expose request metrics on a Prometheus scrape endpoint (separate from tracing)")
     ] = False
     RESOURCE_SERVICE_NAME: Annotated[str | None, Field(description="Resource service name")] = None
     RESOURCE_SERVICE_VERSION: Annotated[str | None, Field(description="Resource service version")] = None
@@ -51,24 +50,9 @@ class OpenTelemetrySettings(EnvironmentSettings):
                 "Either set OTEL_ENABLED=False to disable tracing or provide a valid OTLP endpoint."
             )
 
-        if not all([self.RESOURCE_SERVICE_NAME, self.RESOURCE_SERVICE_VERSION, self.RESOURCE_SERVICE_NAMESPACE]):
-            raise ValueError(
-                "OpenTelemetry is enabled but missing required service configuration. "
-                "Please set OTEL_RESOURCE_SERVICE_NAME, OTEL_RESOURCE_SERVICE_VERSION, "
-                "and OTEL_RESOURCE_SERVICE_NAMESPACE."
-            )
-
-        resource = Resource.create(
-            {
-                "service.name": self.RESOURCE_SERVICE_NAME,
-                "service.version": self.RESOURCE_SERVICE_VERSION,
-                "service.namespace": self.RESOURCE_SERVICE_NAMESPACE,
-            }
-        )
-
         # RetrieverEvent spans can exceed the default 128-attribute limit
         span_limits = SpanLimits(max_attributes=512)
-        tracer_provider = TracerProvider(resource=resource, span_limits=span_limits)
+        tracer_provider = TracerProvider(resource=self._build_resource(), span_limits=span_limits)
 
         if self.EXPORTER_OTLP_PROTOCOL == "grpc":
             otlp_exporter = GRPCSpanExporter(endpoint=self.EXPORTER_OTLP_ENDPOINT, insecure=self.EXPORTER_OTLP_INSECURE)
@@ -81,33 +65,45 @@ class OpenTelemetrySettings(EnvironmentSettings):
         trace.set_tracer_provider(tracer_provider)
         return tracer_provider
 
-    def configure_metrics(self) -> MeterProvider | None:
+    def configure_metrics(self, prometheus_registry: CollectorRegistry | None = None) -> MeterProvider | None:
         """
-        Configure OpenTelemetry request metrics for any OTLP-compatible backend.
+        Configure request metrics for Prometheus-style scraping.
 
-        Separate from tracing: OTEL_ENABLED alone keeps this off, since the FastAPI/ASGI
+        A separate opt-in from tracing (OTEL_ENABLED alone keeps this off), since the FastAPI/ASGI
         auto-instrumentation's request-count/duration histograms were the unbounded,
-        high-cardinality metric source behind issue #1496. Requires both OTEL_ENABLED and
-        OTEL_METRICS_ENABLED.
+        high-cardinality metric source behind issue #1496.
+
+        Scraping rather than OTLP push, because push has no destination here: the collector's
+        filter/metrics_cardinality processor names every metric the ASGI instrumentation can emit
+        and sits on the only metrics pipeline, and on Kubernetes that pipeline is not even
+        rendered (OTEL_CLOUD_ENDPOINT is empty in every instance) while the metrics store scrapes
+        rather than receives. Keeping the measurements in memory for a scraper to pull skips the
+        collector entirely, so nothing is filtered and nothing reaches a paid backend; cardinality
+        is bounded in the scrape config instead.
 
         Deliberately does NOT call metrics.set_meter_provider(): the httpx/requests/aiohttp/
         botocore/asyncio instrumentors in AihubInstrumentor take no explicit meter_provider, so
         setting the global one would also start emitting client-side metrics (http.client.duration
-        and friends) that nothing asked for — and the collector's filter/metrics_cardinality
-        backstop only names http.server.*, so those would reach a paid backend unfiltered. The
-        caller passes the returned provider to the one instrumentor that should use it.
+        and friends) that nothing asked for. The caller passes the returned provider to the one
+        instrumentor that should use it.
         """
         if not self.ENABLED or not self.METRICS_ENABLED:
             logger.info("OpenTelemetry metrics disabled: OTEL_ENABLED=False or OTEL_METRICS_ENABLED=False")
             return None
 
-        if not self.EXPORTER_OTLP_ENDPOINT:
+        if prometheus_registry is None:
             raise ValueError(
-                "OpenTelemetry metrics are enabled (OTEL_METRICS_ENABLED=True) but "
-                "OTEL_EXPORTER_OTLP_ENDPOINT is not configured. Either set OTEL_METRICS_ENABLED=False "
-                "to disable metrics or provide a valid OTLP endpoint."
+                "OpenTelemetry metrics are enabled (OTEL_METRICS_ENABLED=True) but configure_metrics() "
+                "received no CollectorRegistry. The caller owns the registry because it also owns the scrape "
+                "endpoint that serves it; falling back to prometheus_client's global REGISTRY raises "
+                "'Duplicated timeseries' the second time a provider is built in one process."
             )
 
+        metric_reader = PrometheusMetricReader(registry=prometheus_registry)
+        return MeterProvider(resource=self._build_resource(), metric_readers=[metric_reader])
+
+    def _build_resource(self) -> Resource:
+        """The three service attributes every backend keys on; shared by all configure_* methods."""
         if not all([self.RESOURCE_SERVICE_NAME, self.RESOURCE_SERVICE_VERSION, self.RESOURCE_SERVICE_NAMESPACE]):
             raise ValueError(
                 "OpenTelemetry is enabled but missing required service configuration. "
@@ -115,23 +111,13 @@ class OpenTelemetrySettings(EnvironmentSettings):
                 "and OTEL_RESOURCE_SERVICE_NAMESPACE."
             )
 
-        resource = Resource.create(
+        return Resource.create(
             {
                 "service.name": self.RESOURCE_SERVICE_NAME,
                 "service.version": self.RESOURCE_SERVICE_VERSION,
                 "service.namespace": self.RESOURCE_SERVICE_NAMESPACE,
             }
         )
-
-        if self.EXPORTER_OTLP_PROTOCOL == "grpc":
-            otlp_exporter = GRPCMetricExporter(
-                endpoint=self.EXPORTER_OTLP_ENDPOINT, insecure=self.EXPORTER_OTLP_INSECURE
-            )
-        else:
-            otlp_exporter = HTTPMetricExporter(endpoint=self.EXPORTER_OTLP_ENDPOINT)
-
-        metric_reader = PeriodicExportingMetricReader(otlp_exporter)
-        return MeterProvider(resource=resource, metric_readers=[metric_reader])
 
     def configure_logging(self) -> LoggerProvider | None:
         """Configure OpenTelemetry logging for any OTLP-compatible backend."""
@@ -145,22 +131,7 @@ class OpenTelemetrySettings(EnvironmentSettings):
                 "Either set OTEL_ENABLED=False to disable logging or provide a valid OTLP endpoint."
             )
 
-        if not all([self.RESOURCE_SERVICE_NAME, self.RESOURCE_SERVICE_VERSION, self.RESOURCE_SERVICE_NAMESPACE]):
-            raise ValueError(
-                "OpenTelemetry is enabled but missing required service configuration. "
-                "Please set OTEL_RESOURCE_SERVICE_NAME, OTEL_RESOURCE_SERVICE_VERSION, "
-                "and OTEL_RESOURCE_SERVICE_NAMESPACE."
-            )
-
-        resource = Resource.create(
-            {
-                "service.name": self.RESOURCE_SERVICE_NAME,
-                "service.version": self.RESOURCE_SERVICE_VERSION,
-                "service.namespace": self.RESOURCE_SERVICE_NAMESPACE,
-            }
-        )
-
-        logger_provider = LoggerProvider(resource=resource)
+        logger_provider = LoggerProvider(resource=self._build_resource())
 
         if self.EXPORTER_OTLP_PROTOCOL == "grpc":
             otlp_log_exporter = GRPCLogExporter(

--- a/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/tests/unit/test_open_telemetry_settings.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/tests/unit/test_open_telemetry_settings.py
@@ -1,20 +1,21 @@
+from typing import Any
 from unittest.mock import patch
 
 import pytest
 from opentelemetry import metrics
 from opentelemetry.sdk.metrics import MeterProvider
+from prometheus_client import CollectorRegistry, generate_latest
 
 from swiss_ai_hub.core.infrastructure.opentelemetry.open_telemetry_settings import OpenTelemetrySettings
 
 pytestmark = pytest.mark.unit
 
 
-def _enabled_settings(**overrides) -> OpenTelemetrySettings:
+def _enabled_settings(**overrides: Any) -> OpenTelemetrySettings:
     return OpenTelemetrySettings(
         **{
             "ENABLED": True,
             "METRICS_ENABLED": True,
-            "EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
             "RESOURCE_SERVICE_NAME": "api",
             "RESOURCE_SERVICE_VERSION": "0.0.1",
             "RESOURCE_SERVICE_NAMESPACE": "swiss-ai-hub",
@@ -30,38 +31,83 @@ def test_metrics_are_off_by_default() -> None:
 
 def test_tracing_alone_does_not_enable_metrics() -> None:
     """OTEL_ENABLED turns on traces only — metrics need their own opt-in."""
-    assert _enabled_settings(METRICS_ENABLED=False).configure_metrics() is None
+    assert _enabled_settings(METRICS_ENABLED=False).configure_metrics(CollectorRegistry()) is None
 
 
-def test_metrics_disabled_needs_no_otlp_endpoint() -> None:
-    """The disabled path must stay inert, not raise on missing configuration."""
-    settings = OpenTelemetrySettings(ENABLED=True, METRICS_ENABLED=False, EXPORTER_OTLP_ENDPOINT=None)
-
-    assert settings.configure_metrics() is None
+def test_disabled_path_stays_inert_without_a_registry() -> None:
+    """The disabled path must not raise just because the caller passed nothing."""
+    assert OpenTelemetrySettings(ENABLED=True, METRICS_ENABLED=False).configure_metrics() is None
 
 
-def test_both_flags_enabled_returns_a_real_meter_provider() -> None:
-    assert isinstance(_enabled_settings().configure_metrics(), MeterProvider)
+def test_enabled_returns_a_real_meter_provider() -> None:
+    assert isinstance(_enabled_settings().configure_metrics(CollectorRegistry()), MeterProvider)
+
+
+def test_scraping_needs_no_otlp_endpoint() -> None:
+    """
+    The point of scraping: the store pulls, so no exporter endpoint is involved. Requiring one
+    would make the scrape path inherit a configuration burden it has no use for.
+    """
+    settings = _enabled_settings(EXPORTER_OTLP_ENDPOINT=None)
+
+    assert isinstance(settings.configure_metrics(CollectorRegistry()), MeterProvider)
+
+
+def test_enabled_without_registry_fails_loudly() -> None:
+    """
+    Falling back to prometheus_client's global REGISTRY would work once and then break, so a
+    missing registry has to be an error rather than a silent default.
+    """
+    with pytest.raises(ValueError, match="CollectorRegistry"):
+        _enabled_settings().configure_metrics()
+
+
+def test_each_registry_is_independent() -> None:
+    """
+    Pins the failure the global default registry produces: registering the same collector twice
+    raises "Duplicated timeseries". The API builds one app per test, so this has to hold for
+    arbitrarily many providers in one process.
+    """
+    first = _enabled_settings().configure_metrics(CollectorRegistry())
+    second = _enabled_settings().configure_metrics(CollectorRegistry())
+
+    assert first is not second
+
+
+def test_recorded_measurements_reach_the_scrape_output() -> None:
+    """
+    End-to-end within the process: a measurement recorded through the provider must be readable
+    in the registry's exposition text. This is what the OTLP push path could not demonstrate —
+    there, every http.server.* metric is named in the collector's filter/metrics_cardinality.
+    """
+    registry = CollectorRegistry()
+    provider = _enabled_settings().configure_metrics(registry)
+
+    provider.get_meter("test").create_counter("requests").add(1, {"route": "/health"})
+
+    exposition = generate_latest(registry).decode()
+    assert "requests_total" in exposition
+    assert 'route="/health"' in exposition
 
 
 def test_configure_metrics_does_not_set_the_global_meter_provider() -> None:
     """
-    The provider must stay scoped to the caller that receives it. AihubInstrumentor
-    instruments httpx/requests/aiohttp/botocore/asyncio without an explicit meter_provider,
-    so a global one would also switch on client-side metrics nothing asked for — and the
-    collector's filter/metrics_cardinality backstop only names http.server.*.
+    The provider must stay scoped to the caller that receives it. AihubInstrumentor instruments
+    httpx/requests/aiohttp/botocore/asyncio without an explicit meter_provider, so a global one
+    would also switch on client-side metrics nothing asked for.
 
     Asserts on the call rather than on get_meter_provider(): OTel ignores every
     set_meter_provider() after the first, so an identity check silently passes.
     """
     with patch.object(metrics, "set_meter_provider") as set_global_provider:
-        assert _enabled_settings().configure_metrics() is not None
+        assert _enabled_settings().configure_metrics(CollectorRegistry()) is not None
 
     set_global_provider.assert_not_called()
 
 
-def test_metrics_enabled_without_endpoint_fails_loudly() -> None:
-    settings = OpenTelemetrySettings(ENABLED=True, METRICS_ENABLED=True, EXPORTER_OTLP_ENDPOINT=None)
+def test_metrics_still_require_service_attributes() -> None:
+    """The scrape path drops the endpoint requirement, not the resource identity one."""
+    settings = _enabled_settings(RESOURCE_SERVICE_NAMESPACE=None)
 
-    with pytest.raises(ValueError, match="OTEL_EXPORTER_OTLP_ENDPOINT"):
-        settings.configure_metrics()
+    with pytest.raises(ValueError, match="OTEL_RESOURCE_SERVICE_NAMESPACE"):
+        settings.configure_metrics(CollectorRegistry())

--- a/uv.lock
+++ b/uv.lock
@@ -1300,8 +1300,8 @@ name = "faiss-cpu"
 version = "1.13.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "packaging" },
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "packaging", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/c9/671f66f6b31ec48e5825d36435f0cb91189fa8bb6b50724029dbff4ca83c/faiss_cpu-1.13.2-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a9064eb34f8f64438dd5b95c8f03a780b1a3f0b99c46eeacb1f0b5d15fc02dc1", size = 3452776, upload-time = "2025-12-24T10:27:01.419Z" },
@@ -3114,10 +3114,10 @@ name = "milvus-lite"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "faiss-cpu" },
-    { name = "grpcio" },
-    { name = "numpy" },
-    { name = "pyarrow" },
+    { name = "faiss-cpu", marker = "sys_platform != 'win32'" },
+    { name = "grpcio", marker = "sys_platform != 'win32'" },
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "pyarrow", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/9a/d80d260e6fe1246818a8ef782c374ba9c6ca46ca3b987c14eabe914ef805/milvus_lite-3.0.tar.gz", hash = "sha256:2c35d0d046b1faae3402cde1fb73d65f51ee8c6aba65f54de1dda46f7bb18b9b", size = 589749, upload-time = "2026-05-13T07:14:05.827Z" }
 wheels = [
@@ -3582,6 +3582,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8a/da/be1a80ca82f155e6067213243f5bae5c10985d3c7603eadaf8c750ebe9eb/opentelemetry_exporter_otlp_proto_http-1.42.0.tar.gz", hash = "sha256:640013aacdbbe01bfb187c66dd331b24249517b7f36c0cd994ef75544d1dbd0b", size = 25405, upload-time = "2026-05-19T09:46:34.356Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/97/df/a5b8df72a4ef59519170d6f5fc4bd06528fed42e593b9b16b027cb477e50/opentelemetry_exporter_otlp_proto_http-1.42.0-py3-none-any.whl", hash = "sha256:f2cb9ea5dfac29e91b7b04034ca5a4bfae14b51cb334172c5b42b86a48843324", size = 21792, upload-time = "2026-05-19T09:46:13.67Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-prometheus"
+version = "0.63b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "prometheus-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/2c/0643113a5bef20e8242f7ae7915913fab61e8c901d391518a0aefa2da6fc/opentelemetry_exporter_prometheus-0.63b0.tar.gz", hash = "sha256:76b52078ee70131542e53d5cf1942cadd6d5628e7a1bf1f60047f29fa079e9b1", size = 15231, upload-time = "2026-05-19T09:46:35.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/48/18e2b0eec9242beb168b1100ed6c602c2a378d0ccb779d1c0a1b85b9ba89/opentelemetry_exporter_prometheus-0.63b0-py3-none-any.whl", hash = "sha256:0cfe4846bf5905f096a4d9678ffe25c7fe6f662f6c7282d2b191138d6bf487fb", size = 12466, upload-time = "2026-05-19T09:46:15.025Z" },
 ]
 
 [[package]]
@@ -4125,7 +4139,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -4241,6 +4255,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/79/45/b0847d88d6cfeb4413566738c8bbf1e1995fad3d42515327ff32cc1eb578/prettytable-3.17.0.tar.gz", hash = "sha256:59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0", size = 67892, upload-time = "2025-11-14T17:33:20.212Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/8c/83087ebc47ab0396ce092363001fa37c17153119ee282700c0713a195853/prettytable-3.17.0-py3-none-any.whl", hash = "sha256:aad69b294ddbe3e1f95ef8886a060ed1666a0b83018bbf56295f6f226c43d287", size = 34433, upload-time = "2025-11-14T17:33:19.093Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/73/f1334c29c2af4cd9dba6c7817e61b611bd0215e2eb5565c6064a4de18802/prometheus_client-0.26.0.tar.gz", hash = "sha256:04a91bcf94e2cf74a44a1a874d651a2e853ed354b6e822f3b7487751465d5c2b", size = 92910, upload-time = "2026-07-24T19:36:41.893Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/a3/b69efbf4143b5b9859b977770bbbabcc2796b702fa69dc40271e45cd5a56/prometheus_client-0.26.0-py3-none-any.whl", hash = "sha256:fa93d06737aa02bacd05794768508bb97d2fbee28cb3bca04eaae92f0ca953d6", size = 64494, upload-time = "2026-07-24T19:36:40.854Z" },
 ]
 
 [[package]]
@@ -5268,8 +5291,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -5500,6 +5523,7 @@ dependencies = [
     { name = "httpx" },
     { name = "llama-index-embeddings-text-embeddings-inference" },
     { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "prometheus-client" },
     { name = "pydub" },
     { name = "pyjwt" },
     { name = "python-multipart" },
@@ -5527,6 +5551,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "llama-index-embeddings-text-embeddings-inference", specifier = ">=0.4.2" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.60b1" },
+    { name = "prometheus-client", specifier = ">=0.26.0" },
     { name = "pydub", specifier = ">=0.25.1" },
     { name = "pyjwt", specifier = ">=2.10.1" },
     { name = "python-multipart", specifier = ">=0.0.20" },
@@ -5683,6 +5708,7 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-prometheus" },
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-instrumentation-aiohttp-client" },
     { name = "opentelemetry-instrumentation-asyncio" },
@@ -5758,6 +5784,7 @@ requires-dist = [
     { name = "opentelemetry-api", specifier = ">=1.39.1" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.39.1" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.39.1" },
+    { name = "opentelemetry-exporter-prometheus", specifier = ">=0.63b0" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.60b1" },
     { name = "opentelemetry-instrumentation-aiohttp-client", specifier = ">=0.60b1" },
     { name = "opentelemetry-instrumentation-asyncio", specifier = ">=0.60b1" },


### PR DESCRIPTION
## Summary

Follow-up to #1734. That PR wired the API's request metrics to OTLP push; this one switches the same
`OTEL_METRICS_ENABLED` flag to a Prometheus scrape endpoint at `GET /metrics`, which is what the
Kubernetes metrics stack can actually consume.

**Why the push path had no destination.** Three independent blocks sit on it, none of which #1734 could
remove from application code:

1. The collector's `filter/metrics_cardinality` processor (`infra/configs/otel/otel-config.*.yml`) names
   **every** metric the ASGI instrumentation can emit — `http.server.duration`,
   `http.server.request.duration`, `http.server.active_requests`, `http.server.request.size`,
   `http.server.response.size` — and it sits on the collector's only metrics pipeline.
2. On Kubernetes that pipeline is not even rendered: `helm/aihub/templates/otel-collector/` guards it
   behind `OTEL_CLOUD_ENDPOINT`, which is `""` in `helm/aihub/values.yaml` and overridden nowhere.
3. VictoriaMetrics **scrapes**; no OTLP receiver is wired into `vmsingle`, and the annotation-driven
   `kubernetes-pods` scrape job is deliberately disabled.

`docs/K8S_METRICS_STACK.md` in the k8s repo already records the same outcome for Open WebUI: it sets
`ENABLED_OTEL_METRICS=True` and "those metrics are discarded."

Scraping bypasses all three. Nothing traverses the collector, so nothing is filtered and nothing reaches
a paid backend; cardinality is bounded in the scrape config instead of by a drop list.

## Changes

- `OpenTelemetrySettings.configure_metrics()` now takes a `CollectorRegistry` and returns a
  `MeterProvider` fed by `PrometheusMetricReader` instead of `PeriodicExportingMetricReader`. Same flag
  (`OTEL_METRICS_ENABLED`), same default (off), same "never call `set_meter_provider()`" reasoning as
  #1734 — only the reader changed.
- A registry **per app instance**, never `prometheus_client`'s global `REGISTRY`. This is the
  "Duplicated timeseries" collision #1734's original description ran into; a missing registry is a
  `ValueError` rather than a silent fallback, since the global would work once and then break.
- `ApiRunner` serves `/metrics` on the **outer Starlette app**, deliberately not under `api_path`. Three
  consequences, all wanted: Traefik routes this service on ``PathPrefix(`/api/v1`)`` only, so `/metrics`
  is a cluster-internal target and not internet-reachable; `FastMCP.from_fastapi()` turns every inner-app
  GET into an MCP resource, which this must not become; and the inner app's auth and i18n middleware
  never runs for a scraper carrying no token and no `Accept-Language`.
- Extracted `_build_resource()`. The endpoint check and the `Resource.create({...})` literal were
  copy-pasted across `configure_tracing`/`configure_logging`/`configure_metrics`; this removes the
  duplication rather than adding a fourth copy. Net **-128 lines** against +276.
- Dropped the now-unused OTLP metric exporter imports. Per the repo's no-backwards-compatibility rule
  there is no shim: the push path is gone rather than left as dead code behind a second flag.
- `uv add opentelemetry-exporter-prometheus` (core), `prometheus-client` (api).
- Regenerated the 8 compose files that carry the `api` service, and the auto-generated env-var docs page
  — #1734 added `OTEL_METRICS_ENABLED` without running `make generate-env-docs`, so that table was
  missing the row.

## Not in this PR

The k8s side. `helm/monitoring/values.victoriametrics.yaml` needs a scrape job; the existing
`dagster-postgres-exporter` job (endpoints-role discovery, keep-regex on service name, no `namespaces:`
restriction) already solves the "one target per open-ended set of `aihub-*` namespaces" problem and is
the pattern to copy. Add `metric_relabel_configs` keep-list there to bound cardinality at the source —
that is the durable fix for #1496, rather than a drop list downstream.

Also left alone: the `OTEL_METRICS_ENABLED` comments in `.env.dev` / `.env.prod` still describe the OTLP
push path. They are now inaccurate, but a local hook blocks edits to those files; happy to update them
if a reviewer can unblock, or as a follow-up.

## Test plan

- 10 unit tests in `packages/core/.../opentelemetry/tests/unit/`, including
  `test_recorded_measurements_reach_the_scrape_output`, which asserts a recorded measurement is readable
  in the registry's exposition text. This is the assertion the OTLP path could not support — there,
  every metric it emits is in the collector's drop list.
- 3 tests in `packages/api/playground/testing/tests/runners/test_api_runner_otel.py`: the route is served
  outside `api_path`, it returns exposition text with the right `Content-Type`, and two apps with
  separate registries do not see each other's series.
- `packages/core`: 1259 passed. `packages/api`: 506 passed. Remaining failures are pre-existing and
  environmental — verified by stashing this branch and re-running the same files on `main`, where they
  fail identically (Keycloak on :8080, LiteLLM on :4000, Milvus not running locally).
- `make generate-compose` + `make check-env`: clean, no drift. No new env var, so `.env` needs no change.
- Not yet verified end-to-end against a live scrape — that needs the k8s job above.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>`
- [ ] Exactly one of `major` / `minor` / `patch` label applied
- [x] Tests added or updated where relevant

## Also fixes the SonarCloud issues #1734 introduced

Lib Core reported **4 New issues** on #1734 (quality gate still passed, so they merged). All four are
`python:S1192` *"String literals should not be duplicated"*: `configure_metrics()` was the **third**
copy of each of these strings in `open_telemetry_settings.py`, which is exactly Sonar's default
threshold of 3 —

| Duplicated string | On `main` | After this PR |
| --- | --- | --- |
| `"OpenTelemetry is enabled but missing required service configuration. "` | 3 | 1 |
| `"Please set OTEL_RESOURCE_SERVICE_NAME, OTEL_RESOURCE_SERVICE_VERSION, "` | 3 | 1 |
| `"...OTEL_EXPORTER_OTLP_ENDPOINT is not configured. "` | 3 | 2 |
| `Resource.create({...})` block | 3 | 1 |

Extracting `_build_resource()` collapses three of them to a single occurrence and the fourth to two —
below the threshold either way. Verified by counting occurrences against `origin/main`; the count of
distinct 3× strings matches the reported issue count exactly. I could not read the SonarCloud issue
list directly (the API needs a token), so if the four issues turn out to be something else, say so and
I will address those instead.

The **89.5% coverage on new code** figure resolves for the same reason: the untested branch was the
`HTTPMetricExporter` arm of the grpc/http split, and that code is gone with the push path. Coverage of
the new `configure_metrics()` / `_build_resource()` is 100% (`pytest --cov-report=term-missing` shows
only the pre-existing `configure_tracing` / `configure_logging` bodies as uncovered).

> Note: this PR is a draft, and draft PRs skip CI in this repo — SonarCloud has not run on it yet. Mark
> it ready for review to get the confirming scan.
