### PR TITLE
fix(tracing): Unblock the dev metrics pipeline and deduplicate the OTel resource

### DIFF
--- a/docs/docs/2_platform/3_deployment_guide/9_environment_variables/index.en.md
+++ b/docs/docs/2_platform/3_deployment_guide/9_environment_variables/index.en.md
@@ -127,6 +127,7 @@ These variables are referenced as `${VAR}` (without a `${VAR:-default}` fallback
 | `OTEL_CLOUD_ENDPOINT` | `otel-config.yml` | `otel-collector` |  |
 | `OTEL_CLOUD_HEADERS` | `otel-config.yml` | `otel-collector` |  |
 | `OTEL_ENABLED` | `OpenTelemetrySettings.ENABLED` | `api`, `expert_asking_agent`, `expert_rag_agent`, `few_shot_agent`, `imap_agent`, `llm_wrapping_agent`, `memory_writer_agent`, `namespace_selection_agent`, `rag_agent`, `retrieval_agent`, `sysadmin-api` | Enable/disable OpenTelemetry tracing entirely |
+| `OTEL_METRICS_ENABLED` | `OpenTelemetrySettings.METRICS_ENABLED` | `api` | Enable/disable OpenTelemetry request metrics (separate from tracing) |
 | `POSTGRES_PASSWORD` | `openwebui-init-openwebui.sh` | `backup-code`, `dagster-daemon`, `dagster-webserver`, `default_rag_pipeline`, `keycloak`, `langfuse-web`, `langfuse-worker`, `litellm`, `open-webui`, `openwebui-init`, `pgbouncer`, `postgres`, `postgres-ferretdb`, `shared_rag_pipeline` |  |
 | `POSTGRES_PORT` | `openwebui-init-openwebui.sh` | `backup-code`, `openwebui-init` |  |
 | `POSTGRES_USER` | `openwebui-init-openwebui.sh` | `backup-code`, `dagster-daemon`, `dagster-webserver`, `default_rag_pipeline`, `keycloak`, `langfuse-web`, `langfuse-worker`, `litellm`, `open-webui`, `openwebui-init`, `pgbouncer`, `postgres`, `postgres-ferretdb`, `shared_rag_pipeline` |  |

--- a/infra/configs/otel/otel-config.dev.gpu.yml
+++ b/infra/configs/otel/otel-config.dev.gpu.yml
@@ -110,8 +110,14 @@ service:
       processors: [batch]
       exporters: [debug]
 
-    # Accept metrics but use debug exporter (Langfuse doesn't support metrics via OTEL)
+    # Accept metrics but use debug exporter (Langfuse doesn't support metrics via OTEL).
+    # Deliberately WITHOUT filter/metrics_cardinality: that guard exists because SigNoz bills
+    # per ingested series (issue 1496), and this exporter is stdout. Keeping it here dropped
+    # every metric the FastAPI/ASGI instrumentation emits — its name list is exhaustive of them
+    # — so OTEL_METRICS_ENABLED=true produced no observable output at all, and there was no way
+    # to tell a broken metrics setup from a filtered one. The non-dev pipelines below keep the
+    # filter, so the paid backend stays protected.
     metrics:
       receivers: [otlp]
-      processors: [filter/metrics_cardinality, batch]
+      processors: [batch]
       exporters: [debug]

--- a/infra/configs/otel/otel-config.dev.yml
+++ b/infra/configs/otel/otel-config.dev.yml
@@ -110,8 +110,14 @@ service:
       processors: [batch]
       exporters: [debug]
 
-    # Accept metrics but use debug exporter (Langfuse doesn't support metrics via OTEL)
+    # Accept metrics but use debug exporter (Langfuse doesn't support metrics via OTEL).
+    # Deliberately WITHOUT filter/metrics_cardinality: that guard exists because SigNoz bills
+    # per ingested series (issue 1496), and this exporter is stdout. Keeping it here dropped
+    # every metric the FastAPI/ASGI instrumentation emits — its name list is exhaustive of them
+    # — so OTEL_METRICS_ENABLED=true produced no observable output at all, and there was no way
+    # to tell a broken metrics setup from a filtered one. The non-dev pipelines below keep the
+    # filter, so the paid backend stays protected.
     metrics:
       receivers: [otlp]
-      processors: [filter/metrics_cardinality, batch]
+      processors: [batch]
       exporters: [debug]

--- a/infra/deployment/templates/configs/otel-config.yml.j2
+++ b/infra/deployment/templates/configs/otel-config.yml.j2
@@ -126,10 +126,16 @@ service:
       processors: [batch]
       exporters: [debug]
 
-    # Accept metrics but use debug exporter (Langfuse doesn't support metrics via OTEL)
+    # Accept metrics but use debug exporter (Langfuse doesn't support metrics via OTEL).
+    # Deliberately WITHOUT filter/metrics_cardinality: that guard exists because SigNoz bills
+    # per ingested series (issue 1496), and this exporter is stdout. Keeping it here dropped
+    # every metric the FastAPI/ASGI instrumentation emits — its name list is exhaustive of them
+    # — so OTEL_METRICS_ENABLED=true produced no observable output at all, and there was no way
+    # to tell a broken metrics setup from a filtered one. The non-dev pipelines below keep the
+    # filter, so the paid backend stays protected.
     metrics:
       receivers: [otlp]
-      processors: [filter/metrics_cardinality, batch]
+      processors: [batch]
       exporters: [debug]
     {%- else %}
     # Send traces to cloud backend

--- a/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/open_telemetry_settings.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/open_telemetry_settings.py
@@ -93,6 +93,13 @@ class OpenTelemetrySettings(EnvironmentSettings):
                 "to disable metrics or provide a valid OTLP endpoint."
             )
 
+        # Built before the exporter, not inline in the MeterProvider call: constructing a
+        # PeriodicExportingMetricReader already starts a daemon thread, so a validation error
+        # raised after it would orphan that thread — it would then log "Cannot call collect on a
+        # MetricReader until it is registered on a MeterProvider" on every tick for the life of
+        # the process.
+        resource = self._build_resource()
+
         if self.EXPORTER_OTLP_PROTOCOL == "grpc":
             otlp_exporter = GRPCMetricExporter(
                 endpoint=self.EXPORTER_OTLP_ENDPOINT, insecure=self.EXPORTER_OTLP_INSECURE
@@ -101,7 +108,7 @@ class OpenTelemetrySettings(EnvironmentSettings):
             otlp_exporter = HTTPMetricExporter(endpoint=self.EXPORTER_OTLP_ENDPOINT)
 
         metric_reader = PeriodicExportingMetricReader(otlp_exporter)
-        return MeterProvider(resource=self._build_resource(), metric_readers=[metric_reader])
+        return MeterProvider(resource=resource, metric_readers=[metric_reader])
 
     def _build_resource(self) -> Resource:
         """The three service attributes every backend keys on; shared by all configure_* methods."""

--- a/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/open_telemetry_settings.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/open_telemetry_settings.py
@@ -51,24 +51,9 @@ class OpenTelemetrySettings(EnvironmentSettings):
                 "Either set OTEL_ENABLED=False to disable tracing or provide a valid OTLP endpoint."
             )
 
-        if not all([self.RESOURCE_SERVICE_NAME, self.RESOURCE_SERVICE_VERSION, self.RESOURCE_SERVICE_NAMESPACE]):
-            raise ValueError(
-                "OpenTelemetry is enabled but missing required service configuration. "
-                "Please set OTEL_RESOURCE_SERVICE_NAME, OTEL_RESOURCE_SERVICE_VERSION, "
-                "and OTEL_RESOURCE_SERVICE_NAMESPACE."
-            )
-
-        resource = Resource.create(
-            {
-                "service.name": self.RESOURCE_SERVICE_NAME,
-                "service.version": self.RESOURCE_SERVICE_VERSION,
-                "service.namespace": self.RESOURCE_SERVICE_NAMESPACE,
-            }
-        )
-
         # RetrieverEvent spans can exceed the default 128-attribute limit
         span_limits = SpanLimits(max_attributes=512)
-        tracer_provider = TracerProvider(resource=resource, span_limits=span_limits)
+        tracer_provider = TracerProvider(resource=self._build_resource(), span_limits=span_limits)
 
         if self.EXPORTER_OTLP_PROTOCOL == "grpc":
             otlp_exporter = GRPCSpanExporter(endpoint=self.EXPORTER_OTLP_ENDPOINT, insecure=self.EXPORTER_OTLP_INSECURE)
@@ -108,21 +93,6 @@ class OpenTelemetrySettings(EnvironmentSettings):
                 "to disable metrics or provide a valid OTLP endpoint."
             )
 
-        if not all([self.RESOURCE_SERVICE_NAME, self.RESOURCE_SERVICE_VERSION, self.RESOURCE_SERVICE_NAMESPACE]):
-            raise ValueError(
-                "OpenTelemetry is enabled but missing required service configuration. "
-                "Please set OTEL_RESOURCE_SERVICE_NAME, OTEL_RESOURCE_SERVICE_VERSION, "
-                "and OTEL_RESOURCE_SERVICE_NAMESPACE."
-            )
-
-        resource = Resource.create(
-            {
-                "service.name": self.RESOURCE_SERVICE_NAME,
-                "service.version": self.RESOURCE_SERVICE_VERSION,
-                "service.namespace": self.RESOURCE_SERVICE_NAMESPACE,
-            }
-        )
-
         if self.EXPORTER_OTLP_PROTOCOL == "grpc":
             otlp_exporter = GRPCMetricExporter(
                 endpoint=self.EXPORTER_OTLP_ENDPOINT, insecure=self.EXPORTER_OTLP_INSECURE
@@ -131,7 +101,24 @@ class OpenTelemetrySettings(EnvironmentSettings):
             otlp_exporter = HTTPMetricExporter(endpoint=self.EXPORTER_OTLP_ENDPOINT)
 
         metric_reader = PeriodicExportingMetricReader(otlp_exporter)
-        return MeterProvider(resource=resource, metric_readers=[metric_reader])
+        return MeterProvider(resource=self._build_resource(), metric_readers=[metric_reader])
+
+    def _build_resource(self) -> Resource:
+        """The three service attributes every backend keys on; shared by all configure_* methods."""
+        if not all([self.RESOURCE_SERVICE_NAME, self.RESOURCE_SERVICE_VERSION, self.RESOURCE_SERVICE_NAMESPACE]):
+            raise ValueError(
+                "OpenTelemetry is enabled but missing required service configuration. "
+                "Please set OTEL_RESOURCE_SERVICE_NAME, OTEL_RESOURCE_SERVICE_VERSION, "
+                "and OTEL_RESOURCE_SERVICE_NAMESPACE."
+            )
+
+        return Resource.create(
+            {
+                "service.name": self.RESOURCE_SERVICE_NAME,
+                "service.version": self.RESOURCE_SERVICE_VERSION,
+                "service.namespace": self.RESOURCE_SERVICE_NAMESPACE,
+            }
+        )
 
     def configure_logging(self) -> LoggerProvider | None:
         """Configure OpenTelemetry logging for any OTLP-compatible backend."""
@@ -145,22 +132,7 @@ class OpenTelemetrySettings(EnvironmentSettings):
                 "Either set OTEL_ENABLED=False to disable logging or provide a valid OTLP endpoint."
             )
 
-        if not all([self.RESOURCE_SERVICE_NAME, self.RESOURCE_SERVICE_VERSION, self.RESOURCE_SERVICE_NAMESPACE]):
-            raise ValueError(
-                "OpenTelemetry is enabled but missing required service configuration. "
-                "Please set OTEL_RESOURCE_SERVICE_NAME, OTEL_RESOURCE_SERVICE_VERSION, "
-                "and OTEL_RESOURCE_SERVICE_NAMESPACE."
-            )
-
-        resource = Resource.create(
-            {
-                "service.name": self.RESOURCE_SERVICE_NAME,
-                "service.version": self.RESOURCE_SERVICE_VERSION,
-                "service.namespace": self.RESOURCE_SERVICE_NAMESPACE,
-            }
-        )
-
-        logger_provider = LoggerProvider(resource=resource)
+        logger_provider = LoggerProvider(resource=self._build_resource())
 
         if self.EXPORTER_OTLP_PROTOCOL == "grpc":
             otlp_log_exporter = GRPCLogExporter(

--- a/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/tests/unit/test_open_telemetry_settings.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/tests/unit/test_open_telemetry_settings.py
@@ -28,6 +28,18 @@ def _enabled_settings(**overrides: Any) -> OpenTelemetrySettings:
     )
 
 
+def _enabled_provider(**overrides: Any) -> MeterProvider:
+    """
+    Narrowing accessor for the tests that exercise the enabled path. configure_metrics() returns
+    MeterProvider | None, so chaining onto it directly would dereference an Optional — and would
+    surface a configuration regression as an AttributeError rather than as this assertion.
+    """
+    provider = _enabled_settings(**overrides).configure_metrics()
+
+    assert provider is not None
+    return provider
+
+
 def test_metrics_are_off_by_default() -> None:
     """Regression guard for issue #1496: request metrics must never be on unless asked for."""
     assert OpenTelemetrySettings.model_fields["METRICS_ENABLED"].default is False
@@ -63,9 +75,8 @@ def test_configure_metrics_does_not_set_the_global_meter_provider() -> None:
     set_meter_provider() after the first, so an identity check silently passes.
     """
     with patch.object(metrics, "set_meter_provider") as set_global_provider:
-        provider = _enabled_settings().configure_metrics()
+        provider = _enabled_provider()
 
-    assert provider is not None
     set_global_provider.assert_not_called()
     provider.shutdown()
 
@@ -84,8 +95,7 @@ def test_grpc_protocol_passes_the_insecure_flag() -> None:
     which does not accept it.
     """
     with patch.object(settings_module, "GRPCMetricExporter") as grpc_exporter:
-        settings = _enabled_settings(EXPORTER_OTLP_PROTOCOL="grpc", EXPORTER_OTLP_INSECURE=True)
-        settings.configure_metrics().shutdown()
+        _enabled_provider(EXPORTER_OTLP_PROTOCOL="grpc", EXPORTER_OTLP_INSECURE=True).shutdown()
 
     grpc_exporter.assert_called_once_with(endpoint=OTLP_ENDPOINT, insecure=True)
 
@@ -93,7 +103,7 @@ def test_grpc_protocol_passes_the_insecure_flag() -> None:
 def test_http_protocol_uses_the_http_exporter_without_insecure() -> None:
     """The HTTP arm was the branch left uncovered when metrics were introduced."""
     with patch.object(settings_module, "HTTPMetricExporter") as http_exporter:
-        _enabled_settings(EXPORTER_OTLP_PROTOCOL="http").configure_metrics().shutdown()
+        _enabled_provider(EXPORTER_OTLP_PROTOCOL="http").shutdown()
 
     http_exporter.assert_called_once_with(endpoint=OTLP_ENDPOINT)
 

--- a/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/tests/unit/test_open_telemetry_settings.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/tests/unit/test_open_telemetry_settings.py
@@ -10,13 +10,15 @@ from swiss_ai_hub.core.infrastructure.opentelemetry.open_telemetry_settings impo
 
 pytestmark = pytest.mark.unit
 
+OTLP_ENDPOINT = "http://localhost:4317"
+
 
 def _enabled_settings(**overrides: Any) -> OpenTelemetrySettings:
     return OpenTelemetrySettings(
         **{
             "ENABLED": True,
             "METRICS_ENABLED": True,
-            "EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+            "EXPORTER_OTLP_ENDPOINT": OTLP_ENDPOINT,
             "RESOURCE_SERVICE_NAME": "api",
             "RESOURCE_SERVICE_VERSION": "0.0.1",
             "RESOURCE_SERVICE_NAMESPACE": "swiss-ai-hub",
@@ -78,7 +80,7 @@ def test_grpc_protocol_passes_the_insecure_flag() -> None:
     with patch.object(settings_module, "GRPCMetricExporter") as grpc_exporter:
         _enabled_settings(EXPORTER_OTLP_PROTOCOL="grpc", EXPORTER_OTLP_INSECURE=True).configure_metrics()
 
-    grpc_exporter.assert_called_once_with(endpoint="http://localhost:4317", insecure=True)
+    grpc_exporter.assert_called_once_with(endpoint=OTLP_ENDPOINT, insecure=True)
 
 
 def test_http_protocol_uses_the_http_exporter_without_insecure() -> None:
@@ -86,7 +88,7 @@ def test_http_protocol_uses_the_http_exporter_without_insecure() -> None:
     with patch.object(settings_module, "HTTPMetricExporter") as http_exporter:
         _enabled_settings(EXPORTER_OTLP_PROTOCOL="http").configure_metrics()
 
-    http_exporter.assert_called_once_with(endpoint="http://localhost:4317")
+    http_exporter.assert_called_once_with(endpoint=OTLP_ENDPOINT)
 
 
 @pytest.mark.parametrize(

--- a/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/tests/unit/test_open_telemetry_settings.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/tests/unit/test_open_telemetry_settings.py
@@ -1,3 +1,4 @@
+import threading
 from typing import Any
 from unittest.mock import patch
 
@@ -45,7 +46,10 @@ def test_metrics_disabled_needs_no_otlp_endpoint() -> None:
 
 
 def test_both_flags_enabled_returns_a_real_meter_provider() -> None:
-    assert isinstance(_enabled_settings().configure_metrics(), MeterProvider)
+    provider = _enabled_settings().configure_metrics()
+
+    assert isinstance(provider, MeterProvider)
+    provider.shutdown()
 
 
 def test_configure_metrics_does_not_set_the_global_meter_provider() -> None:
@@ -59,9 +63,11 @@ def test_configure_metrics_does_not_set_the_global_meter_provider() -> None:
     set_meter_provider() after the first, so an identity check silently passes.
     """
     with patch.object(metrics, "set_meter_provider") as set_global_provider:
-        assert _enabled_settings().configure_metrics() is not None
+        provider = _enabled_settings().configure_metrics()
 
+    assert provider is not None
     set_global_provider.assert_not_called()
+    provider.shutdown()
 
 
 def test_metrics_enabled_without_endpoint_fails_loudly() -> None:
@@ -78,7 +84,8 @@ def test_grpc_protocol_passes_the_insecure_flag() -> None:
     which does not accept it.
     """
     with patch.object(settings_module, "GRPCMetricExporter") as grpc_exporter:
-        _enabled_settings(EXPORTER_OTLP_PROTOCOL="grpc", EXPORTER_OTLP_INSECURE=True).configure_metrics()
+        settings = _enabled_settings(EXPORTER_OTLP_PROTOCOL="grpc", EXPORTER_OTLP_INSECURE=True)
+        settings.configure_metrics().shutdown()
 
     grpc_exporter.assert_called_once_with(endpoint=OTLP_ENDPOINT, insecure=True)
 
@@ -86,7 +93,7 @@ def test_grpc_protocol_passes_the_insecure_flag() -> None:
 def test_http_protocol_uses_the_http_exporter_without_insecure() -> None:
     """The HTTP arm was the branch left uncovered when metrics were introduced."""
     with patch.object(settings_module, "HTTPMetricExporter") as http_exporter:
-        _enabled_settings(EXPORTER_OTLP_PROTOCOL="http").configure_metrics()
+        _enabled_settings(EXPORTER_OTLP_PROTOCOL="http").configure_metrics().shutdown()
 
     http_exporter.assert_called_once_with(endpoint=OTLP_ENDPOINT)
 
@@ -114,3 +121,20 @@ def test_the_resource_carries_all_three_service_attributes() -> None:
     assert resource.attributes["service.name"] == "api"
     assert resource.attributes["service.version"] == "0.0.1"
     assert resource.attributes["service.namespace"] == "swiss-ai-hub"
+
+
+def test_failed_validation_starts_no_exporter_thread() -> None:
+    """
+    Ordering guard. PeriodicExportingMetricReader starts a daemon thread in its constructor, so
+    validating after building it orphans that thread: nothing owns it, nothing can shut it down,
+    and it logs "Cannot call collect on a MetricReader until it is registered on a MeterProvider"
+    on every tick for the life of the process. Everything the reader needs must therefore be
+    validated before it is constructed.
+    """
+    threads_before = {id(thread) for thread in threading.enumerate()}
+
+    with pytest.raises(ValueError, match="OTEL_RESOURCE_SERVICE_NAME"):
+        _enabled_settings(RESOURCE_SERVICE_NAMESPACE=None).configure_metrics()
+
+    leaked = [thread.name for thread in threading.enumerate() if id(thread) not in threads_before]
+    assert leaked == []

--- a/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/tests/unit/test_open_telemetry_settings.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/tests/unit/test_open_telemetry_settings.py
@@ -1,15 +1,17 @@
+from typing import Any
 from unittest.mock import patch
 
 import pytest
 from opentelemetry import metrics
 from opentelemetry.sdk.metrics import MeterProvider
 
+from swiss_ai_hub.core.infrastructure.opentelemetry import open_telemetry_settings as settings_module
 from swiss_ai_hub.core.infrastructure.opentelemetry.open_telemetry_settings import OpenTelemetrySettings
 
 pytestmark = pytest.mark.unit
 
 
-def _enabled_settings(**overrides) -> OpenTelemetrySettings:
+def _enabled_settings(**overrides: Any) -> OpenTelemetrySettings:
     return OpenTelemetrySettings(
         **{
             "ENABLED": True,
@@ -65,3 +67,48 @@ def test_metrics_enabled_without_endpoint_fails_loudly() -> None:
 
     with pytest.raises(ValueError, match="OTEL_EXPORTER_OTLP_ENDPOINT"):
         settings.configure_metrics()
+
+
+def test_grpc_protocol_passes_the_insecure_flag() -> None:
+    """
+    The two exporter arms are asymmetric on purpose — only gRPC takes `insecure`, mirroring
+    configure_tracing(). Pinning it keeps a later "tidy-up" from passing it to the HTTP exporter,
+    which does not accept it.
+    """
+    with patch.object(settings_module, "GRPCMetricExporter") as grpc_exporter:
+        _enabled_settings(EXPORTER_OTLP_PROTOCOL="grpc", EXPORTER_OTLP_INSECURE=True).configure_metrics()
+
+    grpc_exporter.assert_called_once_with(endpoint="http://localhost:4317", insecure=True)
+
+
+def test_http_protocol_uses_the_http_exporter_without_insecure() -> None:
+    """The HTTP arm was the branch left uncovered when metrics were introduced."""
+    with patch.object(settings_module, "HTTPMetricExporter") as http_exporter:
+        _enabled_settings(EXPORTER_OTLP_PROTOCOL="http").configure_metrics()
+
+    http_exporter.assert_called_once_with(endpoint="http://localhost:4317")
+
+
+@pytest.mark.parametrize(
+    "missing_attribute",
+    ["RESOURCE_SERVICE_NAME", "RESOURCE_SERVICE_VERSION", "RESOURCE_SERVICE_NAMESPACE"],
+)
+def test_every_service_attribute_is_required(missing_attribute: str) -> None:
+    """
+    All three attributes gate the resource, not just the first one. Worth pinning now that a
+    single _build_resource() serves tracing, metrics and logging: a regression here would
+    silently ship unidentifiable telemetry from all three at once.
+    """
+    settings = _enabled_settings(**{missing_attribute: None})
+
+    with pytest.raises(ValueError, match="OTEL_RESOURCE_SERVICE_NAME"):
+        settings.configure_metrics()
+
+
+def test_the_resource_carries_all_three_service_attributes() -> None:
+    """Guards the extraction itself: the shared resource must still describe the service."""
+    resource = _enabled_settings()._build_resource()
+
+    assert resource.attributes["service.name"] == "api"
+    assert resource.attributes["service.version"] == "0.0.1"
+    assert resource.attributes["service.namespace"] == "swiss-ai-hub"

--- a/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/tests/unit/test_open_telemetry_settings.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/tests/unit/test_open_telemetry_settings.py
@@ -141,10 +141,11 @@ def test_failed_validation_starts_no_exporter_thread() -> None:
     on every tick for the life of the process. Everything the reader needs must therefore be
     validated before it is constructed.
     """
+    settings = _enabled_settings(RESOURCE_SERVICE_NAMESPACE=None)
     threads_before = {id(thread) for thread in threading.enumerate()}
 
     with pytest.raises(ValueError, match="OTEL_RESOURCE_SERVICE_NAME"):
-        _enabled_settings(RESOURCE_SERVICE_NAMESPACE=None).configure_metrics()
+        settings.configure_metrics()
 
     leaked = [thread.name for thread in threading.enumerate() if id(thread) not in threads_before]
     assert leaked == []


### PR DESCRIPTION
## Summary

Clears the SonarCloud issues #1734 introduced on Lib Core, and pays back the two things it left
behind. **No behaviour change** — the OTLP push path stays exactly as merged, per
[@denis-rodionov's decision](https://github.com/bbvch-ai/aihub-core/pull/1734#issuecomment-5342159265)
that a new metrics pipeline gets provisioned in the k8s otel-collector config feeding VictoriaMetrics.

### 1. The 4 new SonarCloud issues (`python:S1192`)

`configure_metrics()` was the **third** copy of the endpoint check, the service-attribute check and the
`Resource.create({...})` literal in `open_telemetry_settings.py` — exactly Sonar's default duplication
threshold of 3. Extracting `_build_resource()` collapses every one of them to a single occurrence:

| String literal | On `main` | Here |
| --- | --- | --- |
| `"OpenTelemetry is enabled but missing required service configuration. "` | 3 | 1 |
| `"Please set OTEL_RESOURCE_SERVICE_NAME, OTEL_RESOURCE_SERVICE_VERSION, "` | 3 | 1 |
| `"and OTEL_RESOURCE_SERVICE_NAMESPACE."` | 3 | 1 |
| `"service.name"` / `"service.version"` / `"service.namespace"` | 3 each | 1 each |

Six literals sit at the threshold on `main`; Sonar reported four, so it is not counting the three
`"service.*"` dict keys. Either way none of them survives — after this change no string literal of 10+
characters appears more than twice in the file.

I could not read the SonarCloud issue list directly (the API needs a token and returns empty
anonymously), so this is inferred from occurrence counts against `origin/main` rather than from the
issue keys. If the four turn out to be something else, say so and I will address those instead.

### 2. Coverage on new code: 89.5% → 100%

The uncovered branch was the `HTTPMetricExporter` arm of the grpc/http split. Added tests for both arms,
which also pins the deliberate asymmetry between them — only gRPC takes `insecure`, mirroring
`configure_tracing()`; the HTTP exporter does not accept it, so a later "tidy-up" that passes it to both
would break.

`pytest --cov-report=term-missing` now shows `configure_metrics` (lines 69-105) and `_build_resource`
(106-122) fully covered. The remaining uncovered lines are the pre-existing `configure_tracing` /
`configure_logging` bodies, untouched by #1734 and by this PR.

### 3. Env-var docs regeneration

`docs/.../9_environment_variables/index.en.md` is auto-generated and says *"Do not edit by hand — run
`make generate-env-docs`"*, which `make pr-ready` runs. #1734 added `OTEL_METRICS_ENABLED` without it, so
the table was missing the row. Regenerated — a one-line diff. Worth noting CI cannot catch this: the
`env-check` job runs `generate-compose` + `check-env` only.

## Also added

A parametrized test that each of the three service attributes is individually required. Worth pinning now
that one `_build_resource()` serves tracing, metrics and logging: a regression there would silently ship
unidentifiable telemetry from all three at once rather than from one.

## Test plan

- `packages/core`: **1261 passed** (up from 1259), 12 tests in the otel unit file (up from 6).
- Remaining failures are pre-existing and environmental — **21 failed / 15 errors, an identical count to
  `origin/main`**, verified by stashing this branch and re-running the same files there (Keycloak on
  :8080, Milvus, LiteLLM on :4000 not running locally).
- `ruff check` + `ruff format --check`: clean.
- No new dependencies, no `uv.lock` change, no compose change, no env-file change.

## Not in this PR

- The k8s-side metrics pipeline. That is the part that makes `OTEL_METRICS_ENABLED=true` actually reach
  VictoriaMetrics — without it, `filter/metrics_cardinality` still drops every metric the ASGI
  instrumentation emits (`http.server.duration`, `http.server.request.duration`,
  `http.server.active_requests`, `http.server.request.size`, `http.server.response.size` — the drop list
  is exhaustive of what the instrumentation can produce), and on k8s the metrics pipeline is not rendered
  at all while `OTEL_CLOUD_ENDPOINT` is `""`.
- The `OTEL_METRICS_ENABLED` comments in `.env.dev` / `.env.prod`. They are accurate for the push path, so
  nothing to change here; flagging only that a local hook blocks me from touching those files if anything
  is ever needed there.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>`
- [ ] Exactly one of `major` / `minor` / `patch` label applied
- [x] Tests added or updated where relevant

## Update: what I could and could not verify about the Sonar state

**New finding — `[Lib Core] SonarCloud Code Analysis` is red on `main`**, not just carrying 4 new issues.
On the merge commit `89c69738` the branch analysis reports `failure` for Lib Core. But `[Bot Core]` and
`[Web Core]` report `failure` on that same commit too, and #1734 touched neither package — so the red on
`main` is a gate condition on **overall** metrics (project-wide coverage or accumulated issues), not the
4 new issues, which passed the new-code gate on the PR itself. This PR addresses the new issues; it will
not by itself turn the `main` branch gate green, and that is a separate, larger piece of work.

**Also caught and fixed: this PR had introduced an S1192 of its own.** The two exporter-branch tests
asserted on the literal `"http://localhost:4317"`, which together with the fixture made it the third
occurrence in the test file — the exact threshold. Hoisted to a module-level `OTLP_ENDPOINT` constant
(commit `e7c9dcb7`). Both changed files now have no 10+ character string literal appearing more than
twice.

**What I could not verify.** The SonarCloud API rejects anonymous reads for these projects
(`{"errors":[{"msg":"Project doesn't exist"}]}` for both `project_status` and `issues/search`), and the
check runs carry `annotations_count=0`, so there is no route to the actual issue keys from here.
Everything above is derived from occurrence counting against `origin/main` plus the reported issue count.
**If you can paste the issue list from the SonarCloud UI** (rule key + file + line is enough), I will fix
whatever this inference missed rather than leaving it at four.

---

## Empirical verification against the local docker stack

Ran a test matrix against a real collector — same image as the stack
(`otel/opentelemetry-collector-contrib:0.154.0`), `filter/metrics_cardinality` copied verbatim from
`infra/configs/otel/otel-config.dev.yml`, and metrics pushed through this repo's own
`configure_metrics()`. Not inferred from reading config.

| TC | Question | Result |
| --- | --- | --- |
| TC1 | Does the flag produce a real `MeterProvider`? | **PASS** — off → `None`, on → `sdk.metrics.MeterProvider` |
| TC2 | What does the instrumentation actually emit? | `http.server.duration`, `http.server.active_requests`, `http.server.response.size`, `http.server.request.size` |
| TC3 | Are those in the collector's drop list? | **4/4 match** |
| TC4 | Do they reach an exporter? | **FAIL → now PASS** (see below) |
| TC5 | Is the pipeline itself alive? | **PASS** — a canary metric outside the drop list passes through |
| TC6 | Does this PR change metrics behaviour? | **PASS** — identical counts on this branch and on `origin/main` |
| TC7 | Would an unfiltered pipeline work? | **PASS** — 4/4 pass → the author's planned k8s pipeline is the right fix |

**TC4, measured.** Two pipelines fed the *same* OTLP payload, one with the repo's filter and one without:

```
debug/AFTER_FILTER   metrics=2     # 1 metric x 2 flushes — only the canary
debug/NO_FILTER      metrics=8     # 4 metrics x 2 flushes — everything
```

So `OTEL_METRICS_ENABLED=true` on `main` emits correctly and then loses **3 of 4** metrics inside the
collector. TC2+TC3 explain why: the drop list is exhaustive of what the ASGI instrumentation can produce.

### The fix in this PR (commit `d0ab9ad2`)

Removed `filter/metrics_cardinality` from the **dev** metrics pipeline only. That guard exists because
SigNoz bills per ingested series (issue 1496) — and dev's exporter is `debug`, i.e. stdout. Keeping it
there meant a developer enabling the flag saw nothing at all, with no way to tell a broken metrics setup
from a filtered one. That is precisely how #1734 merged without anyone noticing it produced no metrics.

Non-dev pipelines (`local`, `build`, `nightly`, `latest`) keep the filter — verified: 1 occurrence each,
dev 0. The paid backend stays protected and the SigNoz-bound pipeline is untouched, per
@denis-rodionov's instruction.

Re-ran TC4 against the **regenerated dev config**, metrics pipeline taken verbatim:

```
before:  metrics=2   (1 of 4 survived)
after :  metrics=8   (4 of 4 survived)
         aihub.canary.probe · http.server.active_requests · http.server.duration · http.server.response.size
```

Also verified a processor may be defined but unreferenced — the collector starts clean, so leaving
`filter/metrics_cardinality` defined in the dev config is valid.

### What this does NOT fix

**k8s still cannot receive these metrics**, and that cannot be fixed from this repo:

1. `helm/aihub/templates/otel-collector/` guards the whole metrics pipeline behind
   `OTEL_CLOUD_ENDPOINT`, which is `""` in `helm/aihub/values.yaml` and overridden nowhere — so on k8s
   there is no metrics pipeline at all, filtered or otherwise.
2. VictoriaMetrics scrapes; no OTLP receiver is wired into `vmsingle`.

Both are the additive pipeline @denis-rodionov said the k8s side would provision. TC7 confirms that
approach works: with the filter absent, all four metrics pass.

### Cardinality data point

Measured with routes registered the way `endpoints_discovery_service.py:94` does it — agent class
interpolated into the path, only `agent_id` a parameter — **~12 series per agent class** (49 series for 4
classes x 2 events x normal+stream). `http.target` carries the route *template*, so `agent_id` does not
multiply series; the class name does. Bounded by deployed classes, matching the concern raised on #1734.
Left alone here since @denis-rodionov is collapsing those into a generic bucket on the k8s side.

---

## Re-verified against the k8s requirements (code on this branch)

End-to-end this time: a real FastAPI app, real `FastAPIInstrumentor`, real OTLP push over gRPC, into a
collector configured the way the k8s side plans to — an additive metrics pipeline with **no**
`filter/metrics_cardinality`, standing in for VictoriaMetrics.

| TC | Requirement | Result |
| --- | --- | --- |
| **TC8** | Flag off must emit nothing (protects SigNoz on compose) | **PASS** — `NoOpMeterProvider`, **0** metrics reach the collector |
| **TC12** | Flag on must deliver over OTLP | **PASS** — 4 metrics arrive: `http.server.duration`, `.active_requests`, `.request.size`, `.response.size` |
| **TC12b** | Resource identity must be usable for per-service queries | **PASS** — `service.name=api`, `service.version=0.320.0`, `service.namespace=swiss-ai-hub` |
| **TC9** | Per-endpoint request count + latency + status code | **PASS** — see below |

**TC9 in detail.** `http.server.duration` carries exactly the three labels the requirement names, plus a
histogram:

```
-> http.method:      Str(POST)
-> http.status_code: Int(200)
-> http.target:      Str(/api/v1/classes/RagAgent/instances/{agent_id}/StartEvent)
Count: 3          <- request count
Buckets #0..#15   <- latency distribution
```

Counts matched the requests exactly (3 POSTs → `Count: 3`, 1 GET → `Count: 1`), and a 404 produced its own
`http.status_code: Int(404)` series, so status-code breakdown works. `http.target` holds the route
*template*, not the raw path, so path parameters like `agent_id` do not multiply series.

### Verdict: `aihub-core` side is ready. Two things still block k8s, both outside this repo.

**1. `api-env-configmap.yaml` has no `OTEL_METRICS_ENABLED`.** This is the one that surprised me. In
`helm/aihub/templates/api/api-env-configmap.yaml` the `{{- if .Values.api.otel.enabled }}` block sets five
variables:

```
OTEL_ENABLED, OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_PROTOCOL,
OTEL_RESOURCE_SERVICE_NAME, OTEL_RESOURCE_SERVICE_VERSION, OTEL_RESOURCE_SERVICE_NAMESPACE
```

`OTEL_METRICS_ENABLED` is not among them, so the Pydantic field falls back to its `False` default and
**k8s currently has no way to turn metrics on at all** — independent of the collector. One line in that
configmap fixes it.

**2. The metrics pipeline is still compiled out.**
`helm/aihub/templates/otel-collector/otel-collector-configmap.yaml` guards the metrics pipeline behind
`OTEL_CLOUD_ENDPOINT`, which is `""` in `helm/aihub/values.yaml` and overridden in no instance. That is the
additive pipeline @denis-rodionov described; TC7 and TC12 both confirm metrics flow once the filter is
absent.

Neither is fixable from `aihub-core`. What this branch guarantees is the app half: off means silent, on
means correctly-labelled OTLP.

---

## Confirmed with a real server, not a test client

Everything above used `TestClient` (in-process ASGI). Re-ran the decisive case against a real
`uvicorn` process driven through the real `ApiRunner.create_app()` path — so
`_configure_opentelemetry()` ran for real — with real HTTP requests over TCP via `curl`, exporting
over gRPC to a collector configured the way the k8s side will be (additive metrics pipeline, no
`filter/metrics_cardinality`). Only `lifespan` was disabled, which touches nothing in the metrics path.

**`OTEL_METRICS_ENABLED=true` → metrics are exported.** Arrived ~36s later on the reader's own
60s cycle, no manual flush:

```
http.server.duration · http.server.active_requests · http.server.response.size
service.name=api · service.version=0.320.0 · service.namespace=swiss-ai-hub
```

Labels and counts from the actual curl traffic (3 POSTs + one 404):

```
-> http.method: Str(POST)
-> http.status_code: Int(200)
-> http.target: Str(/api/v1/classes/RagAgent/instances/{agent_id}/StartEvent)
Count: 3                                    <- matches the 3 requests exactly

-> http.method: Str(GET)
-> http.status_code: Int(404)
Count: 2
```

So per-endpoint request count, latency buckets and status-code breakdown all arrive. Note the 404
datapoint carries no `http.target` — unmatched paths produce no route label, so junk URLs cannot inflate
cardinality.

**`OTEL_METRICS_ENABLED=false` → nothing is exported.** Same real server, restarted with the flag off,
5 real POSTs, 80s wait (more than one export cycle), against a collector started *after* the server so
nothing could leak in from the previous run:

```
http.server lines : 0
metric batches    : 0
```

`NoOpMeterProvider` is installed and no instruments exist to export. Disabling this on the compose side
carries no SigNoz cost — nothing leaves the process at all.

### Summary

| | flag off | flag on |
| --- | --- | --- |
| Provider | `NoOpMeterProvider` | `sdk.metrics.MeterProvider` |
| Metrics leaving the process | **0** | 3 instruments, correctly labelled |
| Suitable for | compose / SigNoz-billed deployments | k8s with the additive pipeline |

The app half is confirmed working end-to-end. The remaining work is the two k8s items noted above —
`OTEL_METRICS_ENABLED` in `api-env-configmap.yaml`, and the additive collector pipeline — both outside
this repo.

---

## Review finding: orphaned metric-reader thread — confirmed and fixed (`71685522`)

A reviewer spotted that the `_build_resource()` extraction reordered `configure_metrics()`: the
exporter and `PeriodicExportingMetricReader` were built **before** the service-attribute validation,
which had moved into `_build_resource()` and was only evaluated as the `MeterProvider` argument.
`PeriodicExportingMetricReader.__init__` starts a daemon thread, so a validation error after that
point orphaned it. Valid on every point — verified rather than assumed:

| Claim | How verified | Outcome |
| --- | --- | --- |
| Reader built before validation | Read the code: `_build_resource()` sat inside the `return` statement | confirmed |
| The constructor starts a thread | SDK source: `self._daemon_thread.start()` plus `os.register_at_fork` | confirmed |
| Orphan logs on every tick | Reproduced with `OTEL_METRIC_EXPORT_INTERVAL=1500`: `LEAKED THREADS: ['OtelPeriodicExportingMetricReader']` and repeating `Cannot call collect on a MetricReader until it is registered on a MeterProvider` | confirmed |
| `main` unaffected | Same script against `origin/main`: threads 1 → 1, no leak, no warning | confirmed |
| Tests leak reader threads | Counted inside a pytest session: **7** residual `OtelPeriodicExportingMetricReader` threads | confirmed |
| `configure_tracing` / `configure_logging` are fine | `_build_resource()` is the `TracerProvider` / `LoggerProvider` argument, evaluated before any exporter exists | confirmed |

**Fix.** `_build_resource()` is now called into a local before the exporter is constructed, restoring
`main`'s ordering, with a comment recording why the call cannot be inlined again.

**Regression guard.** `test_failed_validation_starts_no_exporter_thread` snapshots
`threading.enumerate()`, triggers the validation error, and asserts nothing new survives.

**Test hygiene.** The reviewer's count also exposed providers built successfully in tests and never
shut down. Every test that builds one now calls `provider.shutdown()`:

```
before fix:  7 residual OtelPeriodicExportingMetricReader threads
after  fix:  0
```

`packages/core`: **1290 passed**. The 8 remaining failures are the same pre-existing environmental
ones (auth handlers needing Keycloak, mem0 telemetry) already confirmed identical on `origin/main`.

---

## The 1 remaining New issue (`2832ac7f`)

The first CI run on this branch reported **1 New issue** on Lib Core (quality gate still passed;
coverage on new code 71.4%, duplication 0.0%). The SonarCloud API rejects anonymous reads for this
project and the check runs carry `annotations_count=0`, so again I could not read the issue key.

The clear candidate was in the tests I added: `configure_metrics()` is declared
`MeterProvider | None`, and two of the exporter-branch tests chained straight onto it —

```python
settings.configure_metrics().shutdown()                                   # grpc arm
_enabled_settings(EXPORTER_OTLP_PROTOCOL="http").configure_metrics().shutdown()   # http arm
```

which dereferences an Optional. Replaced both with a narrowing `_enabled_provider()` helper that
asserts non-None and returns `MeterProvider`, so a configuration regression surfaces as that
assertion rather than as an `AttributeError` on `None`. No `configure_metrics().<attr>` chain remains
in the file.

`test_both_flags_enabled_returns_a_real_meter_provider` deliberately keeps the direct call: its
`assert isinstance(provider, MeterProvider)` already narrows before `shutdown()`, and routing it
through the helper would have made the assertion tautological.

Re-verified after the change: 13 passed, ruff clean, no string literal repeated 3+ times, 0 residual
reader threads.

**Not yet confirmed by Sonar.** The rescan has not run on `2832ac7f` — the SonarCloud job waits on
`Test Modules (packages/agent)`, still in progress. If the count does not drop to 0, the issue is
something else and the issue list would settle it in seconds; happy to fix whatever it actually is.
