### PR TITLE
fix(swiss-ai-hub): Merge the model identity into the caller's system message

### DIFF
--- a/docs/arc42/decisions/2026_08_14_model_identity_system_prompt_for_plain_llm_chats.md
+++ b/docs/arc42/decisions/2026_08_14_model_identity_system_prompt_for_plain_llm_chats.md
@@ -85,12 +85,26 @@ It uses `str.format` brace interpolation, not Jinja, because `jinja2` is not a d
 substitution in this very file. Note that yamlfix strips blank lines inside the YAML block scalar, so the prompt reaches
 the model as consecutive lines; do not reintroduce them expecting them to survive.
 
-**2 — Injection happens in `OpenaiService._apply_model_identity`,** called from `chat_completion`. The message is
-**prepended**, satisfying Qwen3.5's constraint, and any caller-supplied system prompt is preserved after ours — so the
-caller still wins on task behaviour. Multiple leading system messages are already production behaviour on this stack
-(`extend_chat_history_with_user_memory` inserts after existing leading system messages), so no merging is needed. The
-display name is `model_name.rpartition("/")[2]`, which strips the capability prefix (`text-generation/Kimi-K2.6` →
-`Kimi-K2.6`) and leaves an unprefixed name untouched.
+**2 — Injection happens in `OpenaiService._apply_model_identity`,** called from `chat_completion`. The identity
+**leads the message list**, satisfying Qwen3.5's constraint, and any caller-supplied system prompt is preserved after
+ours — so the caller still wins on task behaviour. When the caller already sent a leading system message, the identity
+is **merged into it** (prefixed, separated by a blank line, other message fields kept) rather than added as a second
+system message. The display name is `model_name.rpartition("/")[2]`, which strips the capability prefix
+(`text-generation/Kimi-K2.6` → `Kimi-K2.6`) and leaves an unprefixed name untouched.
+
+> **Amendment 2026-08-20 — the merge replaces the original prepend.** As shipped, this decision prepended a *second*
+> system message and justified it with "multiple leading system messages are already production behaviour on this stack"
+> (`extend_chat_history_with_user_memory`). That claim does not hold for Qwen3.5 on Infomaniak: it rejects a payload
+> whose system message is not the first one — including a second system message at index 1 — and the streaming path
+> surfaces that 400 as an **empty response** with no error in the UI. The regression became visible when a user enabled
+> **Open Terminal**, because OpenWebUI injects the terminal server's `OPEN_TERMINAL_SYSTEM_PROMPT` as `messages[0]`
+> (`add_or_update_system_message`, `utils/middleware.py`), turning every subsequent chat turn into a two-system-message
+> payload. Verified against staging: with Open Terminal enabled, `gemma-4-31B-it`, `Ministral-3-14B` and `Kimi-K2.6`
+> answered normally while Qwen3.5 returned a zero-byte stream; Qwen3.5 failed identically **without** the terminal as
+> soon as any caller system message was present, and answered normally with none. Release `0.318` was unaffected because
+> the plain-model path did not inject anything yet. Any OpenWebUI feature that carries a system prompt is affected the
+> same way — workspace-model system prompts, `RAG_SYSTEM_CONTEXT`, direct tool servers — so the fix is the merge, not a
+> terminal-specific special case. Pinned by `TestASecondSystemMessageIsNeverEmitted`.
 
 The call site is pinned by `test_streaming_response_outlives_the_handler`, the suite's only happy path through
 `chat_completion`. Every other identity test either calls `_apply_model_identity` directly or asserts it did *not* run,
@@ -181,7 +195,9 @@ convention for no measured gain.
   this endpoint will reproduce #144 and must set their own system prompt. They own their message list, so they own the
   fix — and per Decision 3 we cannot tell them apart from the hub anyway.
 - **The endpoint is no longer a byte-for-byte passthrough.** Every plain-model caller receives a leading system message
-  it did not author.
+  it did not author — and when the caller sent one of its own, that message's own `content` is rewritten with our text
+  prefixed, so a caller inspecting what it sent versus what the model saw finds one modified message rather than an
+  extra one.
 - **The identity string is config-derived.** It comes from the LiteLLM `model_name`, so renaming a model in
   `litellm-config.yml.j2` silently changes what the model calls itself.
 - **The localization is nominal on this path.** Because the locale always resolves to `de` here, the fr/it translations

--- a/packages/api/playground/testing/tests/openai/test_openai_model_identity_unit_tests.py
+++ b/packages/api/playground/testing/tests/openai/test_openai_model_identity_unit_tests.py
@@ -67,16 +67,37 @@ class TestIdentitySystemMessage:
 
         assert request.messages[1:] == _CONTAMINATED_HISTORY
 
-    def test_orders_a_client_system_prompt_after_ours(self):
-        """A caller's own system prompt must survive and stay later in the list, so it still wins on task
-        behaviour while the platform identity is merely the default."""
-        client_prompt = {"role": "system", "content": "You only answer in haiku."}
-        request = _hub_request([client_prompt, *_CONTAMINATED_HISTORY])
+    def test_merges_a_client_system_prompt_into_the_leading_system_message(self):
+        """A caller's own system prompt must survive and stay after ours, so it still wins on task behaviour
+        while the platform identity is merely the default — but inside the *same* message. A second system
+        message is what broke Open Terminal on Qwen3.5 (see `TestASecondSystemMessageIsNeverEmitted`)."""
+        request = _hub_request([{"role": "system", "content": "You only answer in haiku."}, *_CONTAMINATED_HISTORY])
 
         OpenaiService._apply_model_identity(request, _QWEN, _en())
 
-        assert _roles(request) == ["system", "system", "user", "assistant", "user"]
-        assert request.messages[1] == client_prompt
+        assert _roles(request) == ["system", "user", "assistant", "user"]
+        assert "Qwen3.5-122B-A10B-FP8" in request.messages[0]["content"]
+        assert request.messages[0]["content"].endswith("You only answer in haiku.")
+        assert request.messages[1:] == _CONTAMINATED_HISTORY
+
+    def test_merges_into_a_system_message_whose_content_is_a_part_list(self):
+        """OpenWebUI sends multimodal-style content part lists on some paths, so the merge must not assume a
+        plain string and must not drop the caller's parts."""
+        client_part = {"type": "text", "text": "You only answer in haiku."}
+        request = _hub_request([{"role": "system", "content": [client_part]}, *_CONTAMINATED_HISTORY])
+
+        OpenaiService._apply_model_identity(request, _QWEN, _en())
+
+        assert _roles(request) == ["system", "user", "assistant", "user"]
+        assert "Qwen3.5-122B-A10B-FP8" in request.messages[0]["content"][0]["text"]
+        assert request.messages[0]["content"][1] == client_part
+
+    def test_keeps_the_other_fields_of_a_client_system_message(self):
+        request = _hub_request([{"role": "system", "content": "Be terse.", "name": "policy"}])
+
+        OpenaiService._apply_model_identity(request, _QWEN, _en())
+
+        assert request.messages[0]["name"] == "policy"
 
     def test_tolerates_a_request_without_messages(self):
         request = _hub_request([])
@@ -93,6 +114,39 @@ class TestIdentitySystemMessage:
         template = LocaleHandler(locale=locale).t_object(_IDENTITY_KEY, locale=locale)
 
         assert "{model_name}" in template
+
+
+class TestASecondSystemMessageIsNeverEmitted:
+    """Regression from PR #1729: enabling Open Terminal made Qwen3.5 answer nothing at all. OpenWebUI injects
+    the terminal server's `OPEN_TERMINAL_SYSTEM_PROMPT` as `messages[0]`, this endpoint then prepended a
+    second system message,
+    and Infomaniak's Qwen3.5 rejects that payload with `400 - System message must be at the beginning` — a
+    failure the streaming path surfaces as an empty response. Reproduced live against staging: gemma,
+    Ministral and Kimi answered with the terminal enabled, Qwen returned a zero-byte stream, and Qwen also
+    failed without the terminal as soon as any caller system message was present."""
+
+    _OPEN_TERMINAL_PROMPT = "You have access to a sandboxed Linux computer with Python."
+
+    def test_a_terminal_enabled_payload_carries_exactly_one_system_message(self):
+        request = _hub_request(
+            [
+                {"role": "system", "content": self._OPEN_TERMINAL_PROMPT},
+                {"role": "user", "content": "create a chart of these numbers"},
+            ]
+        )
+
+        OpenaiService._apply_model_identity(request, _QWEN, _en())
+
+        assert _roles(request).count("system") == 1
+        assert self._OPEN_TERMINAL_PROMPT in request.messages[0]["content"]
+
+    def test_no_system_message_follows_a_user_or_assistant_turn(self):
+        request = _hub_request([{"role": "system", "content": self._OPEN_TERMINAL_PROMPT}, *_CONTAMINATED_HISTORY])
+
+        OpenaiService._apply_model_identity(request, _QWEN, _en())
+
+        assert _roles(request).index("system") == 0
+        assert "system" not in _roles(request)[1:]
 
 
 class TestEveryPlainModelRequestGetsAnIdentity:

--- a/packages/api/swiss_ai_hub/api/routes/openai/openai_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/openai/openai_service.py
@@ -165,12 +165,30 @@ class OpenaiService:
         looping on the conflict until it exhausts its output budget. Applies to every plain-model request:
         OpenWebUI reaches this endpoint through its own OpenAI connection, whose payload is indistinguishable
         from an external SDK client's, so there is nothing to gate on. Leads the list because Qwen3.5 rejects
-        a system message that follows any user or assistant turn. See ADR 2026_08_14."""
+        a system message that follows any user or assistant turn — which is also why a caller's own system
+        message is merged into this one instead of being left as a second one. See ADR 2026_08_14."""
         identity = t("lib.prompt.model.identity_system_message").format(model_name=model_name.rpartition("/")[2])
-        chat_completion_request.messages = [
-            {"role": "system", "content": identity},
-            *(chat_completion_request.messages or []),
-        ]
+        messages = list(chat_completion_request.messages or [])
+
+        if messages and messages[0].get("role") == "system":
+            messages[0] = OpenaiService._prefixed_system_message(messages[0], identity)
+        else:
+            messages.insert(0, {"role": "system", "content": identity})
+
+        chat_completion_request.messages = messages
+
+    @staticmethod
+    def _prefixed_system_message(system_message: dict[str, Any], identity: str) -> dict[str, Any]:
+        """Puts the identity ahead of the caller's own system prompt inside a single system message, so the
+        caller still wins on task behaviour without the payload carrying a second system message. Qwen3.5 on
+        Infomaniak rejects the latter with `400 - System message must be at the beginning`, which reaches the
+        user as an empty response — see ADR 2026_06_29."""
+        content = system_message.get("content")
+        if isinstance(content, str):
+            merged: Any = f"{identity}\n\n{content}" if content else identity
+        else:
+            merged = [{"type": "text", "text": identity}, *(content or [])]
+        return {**system_message, "content": merged}
 
     @staticmethod
     @trace_fn


### PR DESCRIPTION
## Problem

With **Open Terminal** enabled, `Qwen3.5-122B-A10B-FP8` returns **no answer at all** — an empty assistant message, no error in the UI. Every other model answers normally. Release `0.318` was unaffected.

The trigger is not Open Terminal and not tool-calling: it is **two system messages in one payload**.

1. Enabling Open Terminal makes OpenWebUI inject the terminal server's `OPEN_TERMINAL_SYSTEM_PROMPT` as `messages[0]` (`add_or_update_system_message`, `utils/middleware.py`).
2. `OpenaiService._apply_model_identity` (added in #1729) then **prepended a second** system message, pushing the caller's one to index 1.
3. Infomaniak's Qwen3.5 serving rejects that with `400 - System message must be at the beginning` (already recorded in ADR `2026_06_29`). On the streaming path the 400 never reaches the user — the stream is simply empty.

## Evidence (reproduced against staging, `POST /api/chat/completions`)

| Model | Open Terminal | Caller system msg | Result |
| --- | --- | --- | --- |
| Qwen3.5-122B | off | – | 200, streams content |
| Qwen3.5-122B | **on** | injected by terminal | **200, 0-byte stream** |
| Qwen3.5-122B | off | one, added by hand | **0-byte stream** / **HTTP 500** with `stream: false` |
| gemma-4-31B-it | on | ✓ | 200, streams content |
| Ministral-3-14B | on | ✓ | 200, streams content |
| Kimi-K2.6 | on | ✓ | 200, streams content |

Two rows carry the diagnosis: Open Terminal is not necessary to break Qwen (any caller system message does it), and it does not break the other models. The successful Qwen call's reasoning trace echoes our identity prompt, confirming the injection is live on staging.

`release/0.318` did not inject anything on the plain-model path, so the terminal's prompt was the only system message and sat at index 0 — which is why it worked.

## Fix

`_apply_model_identity` now **merges** the identity into an existing leading system message (prefixed, blank-line separated, other message fields preserved) instead of adding a second one. The payload always carries exactly one system message at index 0. `_prefixed_system_message` handles both `str` content and content part lists, so OpenWebUI's multimodal-style payloads keep their parts.

The ADR intent is unchanged: the identity leads, the caller's own prompt follows and still wins on task behaviour — now inside the same message.

This is not Open-Terminal-specific: workspace-model system prompts, `RAG_SYSTEM_CONTEXT` and direct tool servers hit the same failure, and all are fixed by the merge.

## Tests

- `test_orders_a_client_system_prompt_after_ours` → `test_merges_a_client_system_prompt_into_the_leading_system_message`. The old test pinned exactly the behaviour that caused the bug, so it had to change.
- New: merge into content-part-list system messages; other message fields survive the merge.
- New `TestASecondSystemMessageIsNeverEmitted` — builds the payload Open Terminal produces and asserts one single system message at index 0, as a regression net.

`18 passed` for the identity suite; `19 passed` together with the streaming-lifetime suite that pins the call site. The 12 failures in the wider `tests/openai` folder are pre-existing (`RemoteProtocolError`, integration tests need the dev stack) — verified identical with the changes stashed.

## Docs

ADR `2026_08_14` Decision 2 rewritten around the merge, plus an **Amendment 2026-08-20** recording that its "multiple leading system messages are already production behaviour" claim does not hold for Qwen3.5 on Infomaniak, the regression mechanism, the staging verification matrix, and why `0.318` was unaffected. The passthrough trade-off is updated too.

## Not covered here

Qwen actually **invoking** the sandbox is a separate issue: the `aihub-model-text-generation-Qwen3.5-122B-A10B-FP8` preset carries no `params.function_calling: native`, so OpenWebUI uses the non-native tool-calling path, on top of the reasoning-model tool-call parser fragility from ADR `2026_06_29`. This PR restores the answer, not the tool call.

Verify after deploy: Qwen + Open Terminal enabled must stream content again.
