### PR TITLE
fix(swiss-ai-hub): Keep system messages at the beginning of the LLM message list

### DIFF
--- a/packages/agent/swiss_ai_hub/agent/agents/expert_rag_agent/expert_rag_agent.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/expert_rag_agent/expert_rag_agent.py
@@ -682,8 +682,12 @@ class ExpertRAGAgent(Agent):
         context_content = t("agent.prompt.expert_context", expert_conversation=expert_conversation_text)
         await displayer.display_thought(f"Expert context: {context_content}")
 
+        # USER, not SYSTEM: limit_chat_history_with_context places context messages *after* the conversation
+        # turns, and strict providers (e.g. Qwen3.5 on Infomaniak) reject a 400 "System message must be at
+        # the beginning" for any system message past index 0. This matches the retrieval context message,
+        # which lib.prompt.rag.context_prompt already renders with role="user".
         context_message = ChatMessage(
-            role=MessageRole.SYSTEM,
+            role=MessageRole.USER,
             content=context_content,
         )
         return ExpertAnswerContextEvent(context_message=context_message)

--- a/packages/agent/swiss_ai_hub/agent/agents/few_shot_agent/few_shot_agent.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/few_shot_agent/few_shot_agent.py
@@ -17,6 +17,7 @@ from swiss_ai_hub.core.generative_ai import (
     condense_standalone_question,
     create_few_shot_messages,
     limit_chat_history,
+    merge_consecutive_messages,
 )
 from swiss_ai_hub.core.i18n import LocaleHandler
 
@@ -244,12 +245,18 @@ class FewShotAgent(Agent):
         system_prompt = ChatMessage(
             role=MessageRole.SYSTEM, content=agent_config.few_shot.system_prompt.in_locale(locale)
         )
-        context = [
-            *system_messages,
-            system_prompt,
-            *few_shot_messages,
-            event.condensed_chat_message,
-        ]
+        # Only one leading system message may survive: strict providers (e.g. Qwen3.5 on Infomaniak) reject a
+        # 400 "System message must be at the beginning" for any system message past index 0, and the chat
+        # client's own system prompt (OpenWebUI model prompt, bot PathEntity.system_message) would push ours
+        # to index 1.
+        context = merge_consecutive_messages(
+            [
+                *system_messages,
+                system_prompt,
+                *few_shot_messages,
+                event.condensed_chat_message,
+            ]
+        )
         return FewShotEvent(
             few_shot_examples=few_shot_messages,
             system_prompt=system_prompt,

--- a/packages/agent/swiss_ai_hub/agent/agents/few_shot_agent/tests/test_few_shot_system_message_ordering.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/few_shot_agent/tests/test_few_shot_system_message_ordering.py
@@ -1,0 +1,72 @@
+"""
+Regression guard for the 400 "System message must be at the beginning" from strict providers
+(e.g. Qwen3.5 on Infomaniak): the agent's own few-shot system prompt used to land at index 1
+whenever the chat client supplied its own system message (OpenWebUI model prompt, bot
+PathEntity.system_message).
+
+Pure unit test — create_few_shot_examples touches no infrastructure.
+"""
+
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from swiss_ai_hub.core.events.agent import LimitChatHistoryEvent, UserMessageEvent
+from swiss_ai_hub.core.generative_ai import FewShotExample, LLMConfig
+from swiss_ai_hub.core.i18n import LocaleString
+from swiss_ai_hub.core.testing import async_test
+from swiss_ai_hub.core.testing.auth_utils import fake_user
+
+from swiss_ai_hub.agent.agents.few_shot_agent.events.few_shot_standalone_question_condenser_event import (
+    FewShotStandaloneQuestionCondenserEvent,
+)
+from swiss_ai_hub.agent.agents.few_shot_agent.few_shot_agent import FewShotAgent
+from swiss_ai_hub.agent.agents.few_shot_agent.few_shot_agent_config import FewShotAgentConfig
+from swiss_ai_hub.agent.steps.prompting.few_shot_step.few_shot_step_config import FewShotStepConfig
+
+
+def _config() -> FewShotAgentConfig:
+    return FewShotAgentConfig(
+        agent_id="system_message_ordering_test",
+        name=LocaleString(en="Test FewShot"),
+        description=LocaleString(en="A test few-shot agent."),
+        llm=LLMConfig(model_name="text-generation/gemma-4-31B-it"),
+        few_shot=FewShotStepConfig(
+            few_shot_examples=[FewShotExample(user=LocaleString(en="hi"), agent=LocaleString(en="hello"))],
+            system_prompt=LocaleString(en="Respond briefly."),
+        ),
+    )
+
+
+async def _build_context(chat_history: list[ChatMessage]) -> list[ChatMessage]:
+    event = await FewShotAgent().create_few_shot_examples(
+        event=FewShotStandaloneQuestionCondenserEvent(
+            condensed_chat_message=ChatMessage(role=MessageRole.USER, content="What is Fight Club about?")
+        ),
+        start_event=UserMessageEvent(messages=chat_history, user=fake_user(), locale="en"),
+        chat_history_event=LimitChatHistoryEvent(limited_history=chat_history),
+        agent_config=_config(),
+    )
+    return event.full_context
+
+
+@async_test
+async def test_client_system_prompt_does_not_displace_the_agent_system_prompt():
+    context = await _build_context(
+        [
+            ChatMessage(role=MessageRole.SYSTEM, content="You are a helpful assistant."),
+            ChatMessage(role=MessageRole.USER, content="Tell me about Fight Club"),
+        ]
+    )
+
+    system_indices = [index for index, message in enumerate(context) if message.role == MessageRole.SYSTEM]
+    assert system_indices == [0], f"system messages must collapse into index 0, got {system_indices}"
+    assert "You are a helpful assistant." in context[0].content
+    assert "Respond briefly." in context[0].content
+
+
+@async_test
+async def test_agent_system_prompt_leads_when_client_sends_none():
+    context = await _build_context([ChatMessage(role=MessageRole.USER, content="Tell me about Fight Club")])
+
+    system_indices = [index for index, message in enumerate(context) if message.role == MessageRole.SYSTEM]
+    assert system_indices == [0]
+    assert context[0].content == "Respond briefly."
+    assert context[-1].role == MessageRole.USER

--- a/packages/agent/swiss_ai_hub/agent/agents/llm_wrapping_agent/llm_wrapping_agent.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/llm_wrapping_agent/llm_wrapping_agent.py
@@ -9,7 +9,7 @@ from swiss_ai_hub.core.events.agent import (
     NotAMetaQuestionEvent,
     UserMessageEvent,
 )
-from swiss_ai_hub.core.generative_ai import limit_chat_history
+from swiss_ai_hub.core.generative_ai import limit_chat_history, merge_consecutive_messages
 from swiss_ai_hub.core.i18n import LocaleHandler
 
 from swiss_ai_hub.agent.agents.agent import Agent
@@ -134,11 +134,17 @@ class LLMWrappingAgent(Agent):
         system_messages = [msg for msg in event.messages if msg.role == MessageRole.SYSTEM]
         system_prompt = ChatMessage(role=MessageRole.SYSTEM, content=agent_config.system_prompt.in_locale(locale))
         regular_messages = [msg for msg in event.messages if msg.role != MessageRole.SYSTEM]
-        chat_history = [
-            *system_messages,
-            system_prompt,
-            *regular_messages,
-        ]
+        # Only one leading system message may survive: strict providers (e.g. Qwen3.5 on Infomaniak) reject a
+        # 400 "System message must be at the beginning" for any system message past index 0, and the chat
+        # client's own system prompt (OpenWebUI model prompt, bot PathEntity.system_message) would push ours
+        # to index 1. Merge before limiting so the token budget reflects what is actually sent.
+        chat_history = merge_consecutive_messages(
+            [
+                *system_messages,
+                system_prompt,
+                *regular_messages,
+            ]
+        )
         limited_chat_history = limit_chat_history(
             chat_history=chat_history,
             number_of_input_tokens=agent_config.number_of_input_tokens,

--- a/packages/agent/swiss_ai_hub/agent/agents/llm_wrapping_agent/tests/test_llm_wrapping_system_message_ordering.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/llm_wrapping_agent/tests/test_llm_wrapping_system_message_ordering.py
@@ -1,0 +1,60 @@
+"""
+Regression guard for the 400 "System message must be at the beginning" from strict providers
+(e.g. Qwen3.5 on Infomaniak): the agent's own system prompt used to land at index 1 whenever the
+chat client supplied its own system message (OpenWebUI model prompt, bot PathEntity.system_message).
+
+Pure unit test — limit_chat_history_step touches no infrastructure.
+"""
+
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from swiss_ai_hub.core.events.agent import NotAMetaQuestionEvent, UserMessageEvent
+from swiss_ai_hub.core.generative_ai import LLMConfig
+from swiss_ai_hub.core.i18n import LocaleString
+from swiss_ai_hub.core.testing import async_test
+from swiss_ai_hub.core.testing.auth_utils import fake_user
+
+from swiss_ai_hub.agent.agents.llm_wrapping_agent.llm_wrapping_agent import LLMWrappingAgent
+from swiss_ai_hub.agent.agents.llm_wrapping_agent.llm_wrapping_agent_config import LLMWrappingAgentConfig
+
+
+def _config() -> LLMWrappingAgentConfig:
+    return LLMWrappingAgentConfig(
+        agent_id="system_message_ordering_test",
+        name=LocaleString(en="Test LLM Wrapper"),
+        description=LocaleString(en="A test llm wrapping agent."),
+        system_prompt=LocaleString(en="Respond briefly."),
+        llm=LLMConfig(model_name="text-generation/gemma-4-31B-it"),
+    )
+
+
+async def _limited_history(chat_history: list[ChatMessage]) -> list[ChatMessage]:
+    event = await LLMWrappingAgent().limit_chat_history_step(
+        event=UserMessageEvent(messages=chat_history, user=fake_user(), locale="en"),
+        agent_config=_config(),
+        _clear=NotAMetaQuestionEvent(reasoning="forced normal"),
+    )
+    return event.limited_history
+
+
+@async_test
+async def test_client_system_prompt_does_not_displace_the_agent_system_prompt():
+    history = await _limited_history(
+        [
+            ChatMessage(role=MessageRole.SYSTEM, content="You are a helpful assistant."),
+            ChatMessage(role=MessageRole.USER, content="Tell me about Fight Club"),
+        ]
+    )
+
+    system_indices = [index for index, message in enumerate(history) if message.role == MessageRole.SYSTEM]
+    assert system_indices == [0], f"system messages must collapse into index 0, got {system_indices}"
+    assert "You are a helpful assistant." in history[0].content
+    assert "Respond briefly." in history[0].content
+
+
+@async_test
+async def test_agent_system_prompt_leads_when_client_sends_none():
+    history = await _limited_history([ChatMessage(role=MessageRole.USER, content="Tell me about Fight Club")])
+
+    system_indices = [index for index, message in enumerate(history) if message.role == MessageRole.SYSTEM]
+    assert system_indices == [0]
+    assert history[0].content == "Respond briefly."


### PR DESCRIPTION
Cherry-picks #1742 from `release/0.319` back to `main` (`git cherry-pick -x 1347c1d`).

The original fix was merged into the release branch only; this forward-ports it so `main` does not regress.

## What it does

Strict providers (e.g. Qwen3.5 on Infomaniak) return a 400 `System message must be at the beginning` for any system message past index 0.

- `FewShotAgent` and `LLMWrappingAgent` both prepended the agent's own system prompt *after* the chat client's one (OpenWebUI model prompt, bot `PathEntity.system_message`), putting theirs at index 1. Both now collapse them with `merge_consecutive_messages`, as `RAGAgent` and the meta-question path already do.
- `ExpertRAGAgent` built its expert-answer context as a `SYSTEM` message, and `limit_chat_history_with_context` places context messages *after* the conversation turns. It now uses role `USER`, matching the retrieval context message that `lib.prompt.rag.context_prompt` already renders with `role="user"`.

## Cherry-pick notes

- Applied cleanly, no conflicts; rebased onto current `main` (which meanwhile picked up #1746, touching `packages/api` only — no overlap).
- `merge_consecutive_messages` is already exported from `swiss_ai_hub.core.generative_ai` on `main`.

## Test plan

- [x] The 4 tests added by #1742 pass (`test_few_shot_system_message_ordering.py`, `test_llm_wrapping_system_message_ordering.py`).
- [x] Full `packages/agent` suite: 376 passed, 3 skipped.
- [x] Compared against a `main` baseline run (372 passed) — no new failures.

One run showed `test_validate_the_fewshotagent_workflow` failing; it is a pre-existing flake in a live-LLM BDD test (calls `gemma-4-31B-it` through LiteLLM with `delay_before_stop=120`). It passed 12/12 standalone and in a repeat full-suite run, and is unrelated to this change.