### PR TITLE
fix(ui): Stop the agent configuration tab from freezing

### DIFF
--- a/packages/web/components/FormKit/AgentSelector.vue
+++ b/packages/web/components/FormKit/AgentSelector.vue
@@ -94,7 +94,6 @@
 </template>
 
 <script setup lang="ts">
-import { getAgentClasses, getAgentClassInstances } from '@core/sdk/client'
 import { capitalCase } from 'change-case'
 
 import type { AgentClassDto, FullAgentInstanceDto, LocaleString } from '@core/sdk/client'
@@ -147,7 +146,6 @@ interface AgentSelectorProps {
 
 const props = defineProps<AgentSelectorProps>()
 const { t, locale } = useI18n()
-const { tenantId } = useTenant()
 
 // Get custom props from context (FormKit passes them there, not as direct props)
 const startEvent = computed(() => props.context.startEvent)
@@ -155,27 +153,29 @@ const classPlaceholder = computed(() => props.context.classPlaceholder)
 const idPlaceholder = computed(() => props.context.idPlaceholder)
 const filter = computed(() => props.context.filter ?? true)
 
-// State
-const agentClasses = ref<AgentClassDto[]>([])
-const agentInstances = ref<FullAgentInstanceDto[]>([])
-const isLoading = ref(false)
-const isLoadingInstances = ref(false)
-
 // Get current value from context
 const currentValue = computed(() => props.context.value ?? null)
+
+// Shared cached queries rather than per-mount fetches: a form renders several of these and
+// re-renders remount them, which previously issued one request per mount. Instances follow the
+// selected class through the query key, so no imperative refetch on selection.
+const { agentClasses: fetchedClasses, agentClassesAreLoading: isLoading } = useAgentClasses()
+const agentClasses = computed<AgentClassDto[]>(() => fetchedClasses.value ?? [])
+
+const { agentInstances: fetchedInstances, agentInstancesAreLoading: isLoadingInstances }
+  = useAgentInstancesByClass(() => currentValue.value?.agent_class)
+const agentInstances = computed<FullAgentInstanceDto[]>(() => fetchedInstances.value ?? [])
 
 // Selected class (computed property that syncs with the form value)
 const selectedClass = computed({
   get: () => currentValue.value?.agent_class ?? null,
   set: (value: string | null) => {
     if (value) {
-      // When class changes, reset agent ID and fetch instances
+      // Resetting the id re-keys the instances query onto the new class.
       emitValue(value, '')
-      fetchInstances(value)
     }
     else {
       props.context.node.input(null)
-      agentInstances.value = []
     }
   },
 })
@@ -252,58 +252,10 @@ function getIdDisplayName(id: string): string {
   return option?.displayName ?? id
 }
 
-async function fetchClasses() {
-  isLoading.value = true
-  try {
-    const response = await getAgentClasses({
-      composable: '$fetch',
-      path: { tenant_id: tenantId.value! },
-    })
-    agentClasses.value = response
-  }
-  catch (error) {
-    console.error('Failed to fetch agent classes:', error)
-    agentClasses.value = []
-  }
-  finally {
-    isLoading.value = false
-  }
-}
-
-async function fetchInstances(agentClass: string) {
-  isLoadingInstances.value = true
-  try {
-    const response = await getAgentClassInstances({
-      composable: '$fetch',
-      path: { tenant_id: tenantId.value!, agent_class: agentClass },
-    })
-    agentInstances.value = response
-  }
-  catch (error) {
-    console.error(`Failed to fetch instances for class "${agentClass}":`, error)
-    agentInstances.value = []
-  }
-  finally {
-    isLoadingInstances.value = false
-  }
-}
-
-// Fetch classes on mount
-onMounted(() => {
-  fetchClasses()
-
-  // If there's already a selected class, fetch its instances
-  if (currentValue.value?.agent_class) {
-    fetchInstances(currentValue.value.agent_class)
-  }
-})
-
-// Refetch if startEvent changes
+// Clear the selection if a changed startEvent filter no longer admits the selected class.
 watch(startEvent, () => {
-  // Clear selection if current class no longer matches filter
   if (selectedClass.value && !filteredClassOptions.value.some(opt => opt.name === selectedClass.value)) {
     props.context.node.input(null)
-    agentInstances.value = []
   }
 })
 </script>

--- a/packages/web/components/FormKit/DynamicConfiguration.vue
+++ b/packages/web/components/FormKit/DynamicConfiguration.vue
@@ -13,9 +13,11 @@
       }"
       @submit="submitHandler"
     >
+      <!-- Pass `data` itself, not a spread copy: a fresh object on every parent render made
+           FormKitSchema re-render even when the schema was unchanged. -->
       <FormKitSchema
         :schema="schema"
-        :data="{ ...data }"
+        :data="data"
       />
 
       <!-- Render repeaters separately (not supported by FormKit standard) -->
@@ -74,6 +76,14 @@ function hydrate(raw: Record<string, unknown>): Record<string, unknown> {
 
 const data = ref<Record<string, unknown>>(hydrate(props.initialData || {}))
 
+// Substitution source for `$field` label variables, deliberately decoupled from `data`.
+// `schema` reads this while building labels, so anything it reads becomes a schema dependency:
+// reading the live `data` model made every FormKit commit rebuild the whole schema, which
+// recompiles FormKitSchema and remounts every input — each remount refetching select options and
+// re-committing values, so the cycle fed itself until the tab died. This snapshot changes only
+// when the form is seeded, so labels resolve against the loaded values without the feedback edge.
+const labelValues = shallowRef<Record<string, unknown>>({ ...data.value })
+
 // Seed from `initialData` only once. A save refetches the query, so `initialData` becomes a new
 // object; re-hydrating then would reassign `data`, which FormKit's `v-model` re-commits in a
 // slightly different shape and reassigns again — an infinite render loop that froze the tab.
@@ -83,6 +93,7 @@ watch(() => props.initialData, (newData) => {
   if (formSeeded) return
   if (newData && Object.keys(newData).length > 0) {
     data.value = hydrate(newData)
+    labelValues.value = { ...data.value }
     formSeeded = true
   }
 })
@@ -92,7 +103,7 @@ const emit = defineEmits<{
 }>()
 
 function createLabelPattern(): RegExp {
-  const keys = Object.keys(data.value)
+  const keys = Object.keys(labelValues.value)
   if (keys.length === 0) return /(?!)/ // Never matches
   return new RegExp(keys.map(key => `\\$${key}`).join('|'), 'g')
 }
@@ -101,7 +112,7 @@ function replaceLabelVariables(label: string): string {
   const pattern = createLabelPattern()
   return label.replace(pattern, (match: string) => {
     const key = match.substring(1)
-    return (data.value[key] as string) || match
+    return (labelValues.value[key] as string) || match
   })
 }
 

--- a/packages/web/components/FormKit/KnowledgeDatabaseSelector.vue
+++ b/packages/web/components/FormKit/KnowledgeDatabaseSelector.vue
@@ -25,7 +25,6 @@
 </template>
 
 <script setup lang="ts">
-import { getDatabases } from '@core/sdk/client'
 import { capitalCase } from 'change-case'
 
 import type { DatabaseDto } from '@core/sdk/client'
@@ -46,13 +45,14 @@ interface KnowledgeDatabaseSelectorProps {
 
 const props = defineProps<KnowledgeDatabaseSelectorProps>()
 const { t } = useI18n()
-const { tenantId } = useTenant()
 
 const placeholder = computed(() => props.context.placeholder)
 const filter = computed(() => props.context.filter ?? true)
 
-const databases = ref<DatabaseDto[]>([])
-const isLoading = ref(false)
+// Shared cached query rather than a per-mount fetch: a form renders several of these and
+// re-renders remount them, which previously issued one request per mount.
+const { databases: fetchedDatabases, databasesAreLoading: isLoading } = useDatabases()
+const databases = computed<DatabaseDto[]>(() => fetchedDatabases.value ?? [])
 
 const selectedDatabases = computed({
   get: () => props.context.value ?? [],
@@ -67,26 +67,4 @@ const databaseOptions = computed<DatabaseOption[]>(() =>
     displayName: db.display_name || capitalCase(db.name),
   })),
 )
-
-async function fetchDatabases() {
-  isLoading.value = true
-  try {
-    const response = await getDatabases({
-      composable: '$fetch',
-      path: { tenant_id: tenantId.value! },
-    })
-    databases.value = response
-  }
-  catch (error) {
-    console.error('Failed to fetch databases:', error)
-    databases.value = []
-  }
-  finally {
-    isLoading.value = false
-  }
-}
-
-onMounted(() => {
-  fetchDatabases()
-})
 </script>

--- a/packages/web/components/FormKit/ModelSelect.vue
+++ b/packages/web/components/FormKit/ModelSelect.vue
@@ -36,8 +36,6 @@
 </template>
 
 <script setup lang="ts">
-import { getLitellmModelsByMode } from '@core/sdk/client'
-
 import type { ModelDto } from '@core/sdk/client'
 
 interface ModelSelectProps {
@@ -64,10 +62,9 @@ const filter = computed(() => props.context.filter ?? true)
 const showClear = computed(() => props.context.showClear ?? false)
 
 const { t } = useI18n()
-const { tenantId } = useTenant()
 
-const models = ref<ModelDto[]>([])
-const isLoading = ref(false)
+const { models: fetchedModels, modelsAreLoading: isLoading } = useModelsByMode(mode)
+const models = computed<ModelDto[]>(() => fetchedModels.value ?? [])
 
 const selectedModel = computed({
   get: () => props.context.value ?? null,
@@ -80,32 +77,4 @@ function getModelIcon(modelName: string): string {
   const model = models.value.find(m => m.model_name === modelName)
   return model?.icon ?? 'meteor-icons:cpu'
 }
-
-async function fetchModels() {
-  isLoading.value = true
-  try {
-    const response = await getLitellmModelsByMode({
-      composable: '$fetch',
-      path: { tenant_id: tenantId.value!, mode: mode.value },
-    })
-    models.value = response
-  }
-  catch (error) {
-    console.error(`Failed to fetch models for mode "${mode.value}":`, error)
-    models.value = []
-  }
-  finally {
-    isLoading.value = false
-  }
-}
-
-// Fetch models on mount
-onMounted(() => {
-  fetchModels()
-})
-
-// Refetch if mode changes
-watch(mode, () => {
-  fetchModels()
-})
 </script>

--- a/packages/web/components/FormKit/TenantSelect.vue
+++ b/packages/web/components/FormKit/TenantSelect.vue
@@ -51,12 +51,17 @@ const selectedTenant = computed({
 
 // Pre-select the user's active tenant on a fresh field, while leaving an
 // already-configured value (editing an existing instance) untouched.
+// `preSelected` makes this idempotent: a commit re-renders the form, and re-emitting the same
+// value from a re-created input would commit again, driving the input/commit loop that froze
+// the configuration tab.
+let preSelected: string | null = null
+
 watch(
   [tenantId, () => props.context.value],
   ([active, current]) => {
-    if (!current && active) {
-      props.context.node.input(active)
-    }
+    if (current || !active || preSelected === active) return
+    preSelected = active
+    props.context.node.input(active)
   },
   { immediate: true },
 )

--- a/packages/web/components/FormKit/VectorStoreInput.vue
+++ b/packages/web/components/FormKit/VectorStoreInput.vue
@@ -96,7 +96,6 @@
 
 <script setup lang="ts">
 import ChipsInput from '@core/components/FormKit/ChipsInput.vue'
-import { getDatabases } from '@core/sdk/client'
 import { capitalCase } from 'change-case'
 
 import type { DatabaseDto } from '@core/sdk/client'
@@ -133,7 +132,6 @@ interface VectorStoreInputProps {
 
 const props = defineProps<VectorStoreInputProps>()
 const { t } = useI18n()
-const { tenantId } = useTenant()
 
 // Get custom props from context (FormKit passes them there, not as direct props)
 const databasePlaceholder = computed(() => props.context.databasePlaceholder)
@@ -141,9 +139,10 @@ const namespacePlaceholder = computed(() => props.context.namespacePlaceholder)
 const allowedFilterFieldsPlaceholder = computed(() => props.context.allowedFilterFieldsPlaceholder)
 const filter = computed(() => props.context.filter ?? true)
 
-// State
-const databases = ref<DatabaseDto[]>([])
-const isLoading = ref(false)
+// Shared cached query rather than a per-mount fetch: a form renders several of these and
+// re-renders remount them, which previously issued one request per mount.
+const { databases: fetchedDatabases, databasesAreLoading: isLoading } = useDatabases()
+const databases = computed<DatabaseDto[]>(() => fetchedDatabases.value ?? [])
 
 // Get current value from context
 const currentValue = computed(() => props.context.value ?? null)
@@ -222,27 +221,4 @@ function getDatabaseDisplayName(name: string): string {
   const option = databaseOptions.value.find(opt => opt.name === name)
   return option?.displayName ?? name
 }
-
-async function fetchDatabases() {
-  isLoading.value = true
-  try {
-    const response = await getDatabases({
-      composable: '$fetch',
-      path: { tenant_id: tenantId.value! },
-    })
-    databases.value = response
-  }
-  catch (error) {
-    console.error('Failed to fetch databases:', error)
-    databases.value = []
-  }
-  finally {
-    isLoading.value = false
-  }
-}
-
-// Fetch databases on mount
-onMounted(() => {
-  fetchDatabases()
-})
 </script>

--- a/packages/web/composables/agent/useAgentInstancesByClass.ts
+++ b/packages/web/composables/agent/useAgentInstancesByClass.ts
@@ -1,0 +1,34 @@
+import { type FullAgentInstanceDto, getAgentClassInstances } from '@core/sdk/client'
+import { minutesToMilliseconds } from 'date-fns'
+
+import type { MaybeRefOrGetter } from 'vue'
+
+/**
+ * Instances of an arbitrary agent class. Unlike `useAgentClassInstances`, the class comes from a
+ * caller-supplied value rather than the route, so this is a plain composable with a reactive key
+ * instead of a `defineQuery` singleton.
+ */
+export const useAgentInstancesByClass = (agentClass: MaybeRefOrGetter<string | null | undefined>) => {
+  const { tenantId } = useTenant()
+  const tenantReady = useTenantReady()
+
+  const { data: agentInstances, isPending: agentInstancesAreLoading } = useQuery<FullAgentInstanceDto[]>({
+    key: () => ['tenant', tenantId.value, 'agent-class-instances', toValue(agentClass) ?? ''],
+    staleTime: minutesToMilliseconds(5),
+    enabled: computed(() => tenantReady.value && !!toValue(agentClass)),
+    query: async () => {
+      return await getAgentClassInstances({
+        composable: '$fetch',
+        path: {
+          tenant_id: tenantId.value!,
+          agent_class: toValue(agentClass)!,
+        },
+      })
+    },
+  })
+
+  return {
+    agentInstances,
+    agentInstancesAreLoading,
+  }
+}

--- a/packages/web/composables/models/useModelsByMode.ts
+++ b/packages/web/composables/models/useModelsByMode.ts
@@ -1,0 +1,31 @@
+import { getLitellmModelsByMode, type ModelDto } from '@core/sdk/client'
+import { minutesToMilliseconds } from 'date-fns'
+
+import type { MaybeRefOrGetter } from 'vue'
+
+/**
+ * Models available for one LiteLLM mode. A plain composable rather than `defineQuery` because the
+ * key depends on a per-instance argument (see `useSingleModel`). The shared query cache is what
+ * matters here: a form renders several model fields and re-renders remount them, and an uncached
+ * per-mount fetch turned that into a request storm.
+ */
+export const useModelsByMode = (mode: MaybeRefOrGetter<string>) => {
+  const { tenantId } = useTenant()
+
+  const { data: models, isPending: modelsAreLoading } = useQuery<ModelDto[]>({
+    key: () => ['tenant', tenantId.value, 'models', 'mode', toValue(mode)],
+    staleTime: minutesToMilliseconds(5),
+    enabled: useTenantReady(),
+    query: async () => {
+      return await getLitellmModelsByMode({
+        composable: '$fetch',
+        path: { tenant_id: tenantId.value!, mode: toValue(mode) },
+      })
+    },
+  })
+
+  return {
+    models,
+    modelsAreLoading,
+  }
+}


### PR DESCRIPTION
## Summary

Closes bbvch-ai/aihub-core-private#188

The agent **Configuration** tab froze the browser tab on staging — reproducible for accounts with many tenant
memberships, not for single-tenant accounts. The schema was rebuilt from the live form model on every FormKit
commit, remounting every input in a self-feeding loop.

## Changes

- **Root cause.** `DynamicConfiguration.vue`'s `schema` computed read `data.value` through the `$field` label
  substitution, and `data` is the FormKit form's `v-model` — reassigned on every commit. So each commit invalidated
  the schema, which recompiles `FormKitSchema` and remounts every input, and the remounted inputs committed again.
  Labels now substitute from a snapshot taken when the form is seeded, so `schema` depends only on `props.form`.
  Behaviour change: `$field` labels resolve against the loaded values instead of updating live as the user types.
  The only consumer is the `Hire $name?` playground process form, where `name` is pre-filled context.
- Pass `data` to `FormKitSchema` instead of `{ ...data }` — a new object each render re-rendered it even when the
  schema was unchanged.
- `TenantSelect` no longer re-emits a value it already committed, so a re-created input cannot pump another commit.
- The four custom inputs that fetched on every mount (`ModelSelect`, `KnowledgeDatabaseSelector`, `VectorStoreInput`,
  `AgentSelector`) now use cached Pinia-Colada queries, so remounts hit the cache instead of the API. An agent config
  renders several model and knowledge fields, so each loop cycle previously issued a burst of requests — and each
  failure raised a 10s toast via the global `onResponseError`.
- Adds `useModelsByMode` and `useAgentInstancesByClass` for the two call sites whose key depends on a per-instance
  value (same shape as the existing `useSingleModel`); the other two reuse `useDatabases` and `useAgentClasses`.

Prior fixes #1537, #1539 and #1558 patched the `initialData` watcher but never touched the schema↔data edge.

## Test plan

`pnpm lint` clean. No automated coverage — `make test` is a no-op for `packages/web`, so this needs manual
verification before merge:

- [ ] Open the configuration tab of a RAG agent (org memory + several model fields) with DevTools open.
- [ ] **Network**: one `models/mode/*` and one `databases` request per distinct field, not a stream.
- [ ] **Console**: no `Maximum recursive updates exceeded`, no repeated `Failed to fetch models`.
- [ ] **Memory**: heap flat while the page sits idle.
- [ ] Nullable groups (`reranking_config`, `org_memory`) load with their Enable toggles in the saved state, and
      backend `if:` conditionals still show/hide correctly (covers the `:data` change).
- [ ] Typing in a field does not lose focus mid-keystroke; save round-trips the values.
- [ ] With an account that is a member of many tenants, the org-memory tenant picker lists them all without freezing.
- [ ] `AgentSelector`: changing the class repopulates the instance list, and changing a `startEvent` filter still
      clears a selection the filter no longer admits.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>`
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [ ] CLA signed
- [ ] Tests added or updated where relevant — no frontend test runner is configured
