### PR TITLE
fix(swiss-ai-hub): Stop resolving the UserAgent pseudo-class as an agent

### DIFF
--- a/packages/api/swiss_ai_hub/api/routes/thread/thread_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/thread/thread_service.py
@@ -355,10 +355,16 @@ class ThreadService:
 
             display_agg.update_from_run_data(run_data)
 
-            # Attempt to fetch the agent that started the run using the cached method
+            # Attempt to fetch the agent that started the run using the cached method.
+            # Both are None for a run with no qualifying control StartEvent (the aggregation
+            # projects them from an empty `start_event_info`), which is not an agent to look up.
             start_agent_class = run_data.get("start_agent_class")
             start_agent_id = run_data.get("start_agent_id")
-            run_agent_dto = ThreadService._fetch_minimal_agent_dto(start_agent_class, start_agent_id, t)
+            run_agent_dto = (
+                ThreadService._fetch_minimal_agent_dto(start_agent_class, start_agent_id, t)
+                if start_agent_class and start_agent_id
+                else None
+            )
 
             if run_agent_dto:
                 try:

--- a/packages/core/swiss_ai_hub/core/distributor/external_agent_event_distributor.py
+++ b/packages/core/swiss_ai_hub/core/distributor/external_agent_event_distributor.py
@@ -137,7 +137,7 @@ class ExternalAgentEventDistributor:
         logger.debug(f"Handling display event for thread {external_event.thread_id}")
         topic_manager = AgentTopicManager()
         subject = topic_manager.get_subject_for_specific_event_in_agent(
-            agent_class="UserAgent",
+            agent_class=AgentTopicManager.USER_AGENT_CLASS,
             agent_id=user.id,
             thread_id=external_event.thread_id,
             display_id=external_event.display_id,

--- a/packages/core/swiss_ai_hub/core/persistence/messaging/entities/persisted_agent_event_entity.py
+++ b/packages/core/swiss_ai_hub/core/persistence/messaging/entities/persisted_agent_event_entity.py
@@ -354,7 +354,7 @@ class PersistedAgentEventEntity(Document):
                             "agent_id": "$agent_id",
                             "event_time": "$event_time",
                             "is_start": {"$in": ["StartEvent", "$event_parents"]},
-                            "is_not_user": {"$ne": ["$agent_class", "UserAgent"]},
+                            "is_not_user": {"$ne": ["$agent_class", AgentTopicManager.USER_AGENT_CLASS]},
                             "is_control": {"$eq": ["$event_type", AgentTopicManager.CONTROL_EVENT]},
                         }
                     },
@@ -388,6 +388,16 @@ class PersistedAgentEventEntity(Document):
                                 "as": "event",
                                 "cond": {"$and": ["$$event.is_start", "$$event.is_not_user", "$$event.is_control"]},
                             }
+                        }
+                    },
+                    # The user's own events carry the UserAgent pseudo-class, which no
+                    # AgentClassEntity backs. Callers resolve these entries against the agent
+                    # catalog, so drop it here as `start_event_info` already does.
+                    "participating_agents_in_run": {
+                        "$filter": {
+                            "input": "$participating_agents_in_run",
+                            "as": "agent",
+                            "cond": {"$ne": ["$$agent.agent_class", AgentTopicManager.USER_AGENT_CLASS]},
                         }
                     },
                 }

--- a/packages/core/swiss_ai_hub/core/persistence/messaging/entities/tests/unit/test_persisted_agent_event_entity.py
+++ b/packages/core/swiss_ai_hub/core/persistence/messaging/entities/tests/unit/test_persisted_agent_event_entity.py
@@ -32,10 +32,11 @@ def _persist_event(
     display_id: str = "disp",
     agent_id: str = "test",
     run_id: str = "run",
+    agent_class: str = "TestAgent",
 ) -> None:
     """Insert a minimal event. Only thread_id / event_id / event_parents / event_type drive classification."""
     PersistedAgentEventEntity(
-        agent_class="TestAgent",
+        agent_class=agent_class,
         agent_id=agent_id,
         thread_id=thread_id,
         display_id=display_id,
@@ -121,3 +122,39 @@ class TestThreadIdForDisplay:
         _persist_event("t_b", ["StartEvent"], "e2", display_id="d_b")
         assert PersistedAgentEventEntity.thread_id_for_display("d_a") == "t_a"
         assert PersistedAgentEventEntity.thread_id_for_display("d_b") == "t_b"
+
+
+class TestAggregatedRunStatistics:
+    def test_user_agent_is_not_a_participating_agent(self):
+        # A user's own display events are published under the UserAgent pseudo-class, which no
+        # AgentClassEntity backs — callers resolve participants against the agent catalog.
+        _persist_event("t_run", ["StartEvent"], "e1", agent_id="rag")
+        _persist_event(
+            "t_run",
+            ["ChunkEvent"],
+            "e2",
+            event_type=AgentTopicManager.DISPLAY_EVENT,
+            agent_class=AgentTopicManager.USER_AGENT_CLASS,
+            agent_id="user-uuid",
+        )
+
+        runs = PersistedAgentEventEntity.get_aggregated_run_statistics("t_run")
+
+        assert len(runs) == 1
+        participants = runs[0]["participating_agents_in_run"]
+        assert participants == [{"agent_class": "TestAgent", "agent_id": "rag"}]
+
+    def test_run_started_only_by_the_user_reports_no_start_agent(self):
+        _persist_event(
+            "t_user_only",
+            ["StartEvent"],
+            "e1",
+            agent_class=AgentTopicManager.USER_AGENT_CLASS,
+            agent_id="user-uuid",
+        )
+
+        runs = PersistedAgentEventEntity.get_aggregated_run_statistics("t_user_only")
+
+        assert len(runs) == 1
+        assert runs[0].get("start_agent_class") is None
+        assert runs[0]["participating_agents_in_run"] == []

--- a/packages/core/swiss_ai_hub/core/topic_managers/agents/agent_topic_manager.py
+++ b/packages/core/swiss_ai_hub/core/topic_managers/agents/agent_topic_manager.py
@@ -9,6 +9,10 @@ class AgentTopicManager(TopicManager):
     DISPLAY_EVENT: ClassVar[str] = "display_event"
     CONTROL_EVENT: ClassVar[str] = "control_event"
 
+    # Publisher identity for events a user emits themselves. No AgentClassEntity backs it, so
+    # anything resolving agent classes must skip it rather than look it up.
+    USER_AGENT_CLASS: ClassVar[str] = "UserAgent"
+
     def get_agent_config_rpc_subject(
         self,
         agent_class: Annotated[str, "Agent class identifier or '*' for wildcard"] = "*",


### PR DESCRIPTION
## Summary

Closes bbvch-ai/aihub-core-private#148

Every thread read logged a `fastapi.exceptions.HTTPException: 404: Agent class UserAgent not found.` traceback.
`UserAgent` is the pseudo-class a user's own display events are published under; no `AgentClassEntity` backs it, so
resolving it against the agent catalog always fails.

## Changes

- `get_aggregated_run_statistics` excluded `UserAgent` when picking a run's starting agent, but still collected it
  into `participating_agents_in_run`. It is now filtered out of the participants too, mirroring what
  `start_event_info` already did.
- `ThreadService._process_aggregated_runs` skips the agent lookup when a run has no qualifying control `StartEvent` —
  the projection reads `$start_event_info.agent_class`, so both the class and the id come back `null` and were being
  passed straight into the fetch. Second source of the same traceback, found while fixing the first.
- Names the pseudo-class as `AgentTopicManager.USER_AGENT_CLASS` so the publisher and the aggregation share one
  definition instead of two string literals.

Impact is log noise plus a silent gap: `_fetch_minimal_agent_dto` swallows the exception and returns `None`, and a run
whose starting agent fails to resolve is dropped from the thread's display statistics entirely. The `except Exception`
in that helper is left in place — with the two known sources gone, what it logs is now a genuine missing agent.

## Test plan

- Two regression tests added to `test_persisted_agent_event_entity.py`, covering both sources. Verified they fail
  against the unpatched aggregation and pass with it.
- `make test` in `packages/core`: 1223 passed.
- `make test` in `packages/api`: 518 passed, 3 failed — `test_audio_chunking`, `test_bearer_api`, `test_memory_api`.
  All three fail identically on clean `main`; pre-existing and unrelated to this change.
- Manual: open a thread with user chat messages and confirm the API log carries no `Agent class UserAgent not found.`
  traceback, and the participating-agents list is unchanged apart from the pseudo-agent being gone.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>`
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [x] CLA signed
- [x] Tests added or updated where relevant
