### PR TITLE
fix(swiss-ai-hub): Offload blocking event queries off the API event loop

### DIFF
--- a/packages/api/playground/testing/tests/event/test_event_timeseries_offload_api.py
+++ b/packages/api/playground/testing/tests/event/test_event_timeseries_offload_api.py
@@ -1,0 +1,58 @@
+import threading
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+from asgi_lifespan import LifespanManager
+from httpx import ASGITransport, AsyncClient
+from swiss_ai_hub.core.persistence.messaging.entities.persisted_agent_event_entity import Resolution
+from swiss_ai_hub.core.testing.auth_utils import TestAuthHandler
+
+from swiss_ai_hub.api.routes.event.event_controller import EventController
+from swiss_ai_hub.api.runners.api_test_runner import ApiTestRunner
+
+BASE_URL = "http://test"
+TIMESERIES_ENDPOINT = "/api/v1/active/events/agents/timeseries/365d"
+
+ENTITY_TIMESERIES = (
+    "swiss_ai_hub.core.persistence.messaging.entities.persisted_agent_event_entity"
+    ".PersistedAgentEventEntity.get_event_timeseries"
+)
+
+
+def _empty_timeseries_recording_its_thread(recorded: list[int]):
+    """Stands in for the aggregation, recording which thread it ran on."""
+
+    def fake(**_kwargs):
+        recorded.append(threading.get_ident())
+        now = datetime.now(UTC)
+        return [], now, now, Resolution.ONE_WEEK
+
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_timeseries_aggregation_does_not_run_on_the_event_loop():
+    """The synchronous aggregation must be offloaded, or it stalls every concurrent request.
+
+    Regression guard for aihub-core-private#186: run on the event loop, an unfiltered aggregation
+    froze the loop for minutes, which pushed concurrent token-validation calls to Keycloak past
+    their timeout and failed valid logins with 500s. Asserting the thread rather than timing the
+    request keeps this deterministic.
+    """
+    recorded: list[int] = []
+
+    runner = ApiTestRunner()
+    runner.mount(EventController(auth=TestAuthHandler()).get_agent_event_timeseries())
+    app = runner.create_app()
+
+    with patch(ENTITY_TIMESERIES, side_effect=_empty_timeseries_recording_its_thread(recorded)):
+        async with LifespanManager(app) as lifespan:
+            async with AsyncClient(transport=ASGITransport(app=lifespan.app), base_url=BASE_URL) as client:
+                response = await client.get(TIMESERIES_ENDPOINT)
+
+    assert response.status_code == 200, response.text
+    assert recorded, "the aggregation was never called"
+    assert recorded[0] != threading.get_ident(), (
+        "get_event_timeseries ran on the event loop thread; it must be offloaded via asyncio.to_thread"
+    )

--- a/packages/api/playground/testing/tests/event/test_event_timeseries_offload_api.py
+++ b/packages/api/playground/testing/tests/event/test_event_timeseries_offload_api.py
@@ -1,11 +1,13 @@
 import threading
 from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import patch
 
 import pytest
 from asgi_lifespan import LifespanManager
 from httpx import ASGITransport, AsyncClient
 from swiss_ai_hub.core.persistence.messaging.entities.persisted_agent_event_entity import Resolution
+from swiss_ai_hub.core.persistence.messaging.entities.types.event_bucket import EventBucket
 from swiss_ai_hub.core.testing.auth_utils import TestAuthHandler
 
 from swiss_ai_hub.api.routes.event.event_controller import EventController
@@ -20,39 +22,33 @@ ENTITY_TIMESERIES = (
 )
 
 
-def _empty_timeseries_recording_its_thread(recorded: list[int]):
-    """Stands in for the aggregation, recording which thread it ran on."""
-
-    def fake(**_kwargs):
-        recorded.append(threading.get_ident())
-        now = datetime.now(UTC)
-        return [], now, now, Resolution.ONE_WEEK
-
-    return fake
-
-
 @pytest.mark.asyncio
-async def test_timeseries_aggregation_does_not_run_on_the_event_loop():
+async def test_timeseries_aggregation_does_not_run_on_the_event_loop() -> None:
     """The synchronous aggregation must be offloaded, or it stalls every concurrent request.
 
     Regression guard for aihub-core-private#186: run on the event loop, an unfiltered aggregation
     froze the loop for minutes, which pushed concurrent token-validation calls to Keycloak past
-    their timeout and failed valid logins with 500s. Asserting the thread rather than timing the
-    request keeps this deterministic.
+    their timeout and failed valid logins with 500s. Asserting which thread ran the query rather
+    than timing the request keeps this deterministic.
     """
-    recorded: list[int] = []
+    ran_on_thread: list[int] = []
+
+    def fake_aggregation(**_kwargs: Any) -> tuple[list[EventBucket], datetime, datetime, Resolution]:
+        ran_on_thread.append(threading.get_ident())
+        now = datetime.now(UTC)
+        return [], now, now, Resolution.ONE_WEEK
 
     runner = ApiTestRunner()
     runner.mount(EventController(auth=TestAuthHandler()).get_agent_event_timeseries())
     app = runner.create_app()
 
-    with patch(ENTITY_TIMESERIES, side_effect=_empty_timeseries_recording_its_thread(recorded)):
+    with patch(ENTITY_TIMESERIES, side_effect=fake_aggregation):
         async with LifespanManager(app) as lifespan:
             async with AsyncClient(transport=ASGITransport(app=lifespan.app), base_url=BASE_URL) as client:
                 response = await client.get(TIMESERIES_ENDPOINT)
 
     assert response.status_code == 200, response.text
-    assert recorded, "the aggregation was never called"
-    assert recorded[0] != threading.get_ident(), (
+    assert ran_on_thread, "the aggregation was never called"
+    assert ran_on_thread[0] != threading.get_ident(), (
         "get_event_timeseries ran on the event loop thread; it must be offloaded via asyncio.to_thread"
     )

--- a/packages/api/swiss_ai_hub/api/routes/event/event_controller.py
+++ b/packages/api/swiss_ai_hub/api/routes/event/event_controller.py
@@ -71,9 +71,8 @@ class EventController(TenantScopedController):
                     detail=NO_THREAD_ACCESS_DETAIL,
                 )
 
-            # Offloaded: reads every display event of the thread and deserialises each one, so its
-            # cost grows with conversation length. Run on the event loop it stalls every other
-            # request — including the Keycloak calls in token validation, which then time out.
+            # Offloaded: reads and deserialises every display event in the thread, so its cost grows
+            # with conversation length. On the event loop that stalls every concurrent request.
             return await asyncio.to_thread(
                 EventService.get_events_in_thread,
                 locale=t.locale,
@@ -172,9 +171,8 @@ class EventController(TenantScopedController):
                     )
 
             # Offloaded: an unfiltered range aggregates the whole agent_events collection, which took
-            # minutes in production (see aihub-core-private#186). Run on the event loop it stalled
-            # every concurrent request's token validation past its Keycloak timeout, so valid logins
-            # failed with 500s. Slow here is acceptable; blocking the loop is not.
+            # minutes in production and, on the event loop, pushed concurrent token validation past
+            # its Keycloak timeout — failing valid logins with 500s (aihub-core-private#186).
             return await asyncio.to_thread(
                 EventService.get_event_timeseries,
                 time_range,

--- a/packages/api/swiss_ai_hub/api/routes/event/event_controller.py
+++ b/packages/api/swiss_ai_hub/api/routes/event/event_controller.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Annotated, Self
 
@@ -70,7 +71,11 @@ class EventController(TenantScopedController):
                     detail=NO_THREAD_ACCESS_DETAIL,
                 )
 
-            return EventService.get_events_in_thread(
+            # Offloaded: reads every display event of the thread and deserialises each one, so its
+            # cost grows with conversation length. Run on the event loop it stalls every other
+            # request — including the Keycloak calls in token validation, which then time out.
+            return await asyncio.to_thread(
+                EventService.get_events_in_thread,
                 locale=t.locale,
                 thread_id=str_to_object_id(thread_id),
                 display_id=str_to_object_id(display_id) if display_id else None,
@@ -166,8 +171,17 @@ class EventController(TenantScopedController):
                         detail=NO_THREAD_ACCESS_DETAIL,
                     )
 
-            return EventService.get_event_timeseries(
-                time_range, agent_id=agent_id, agent_class=agent_class, event_name=event_name, thread_id=thread_id
+            # Offloaded: an unfiltered range aggregates the whole agent_events collection, which took
+            # minutes in production (see aihub-core-private#186). Run on the event loop it stalled
+            # every concurrent request's token validation past its Keycloak timeout, so valid logins
+            # failed with 500s. Slow here is acceptable; blocking the loop is not.
+            return await asyncio.to_thread(
+                EventService.get_event_timeseries,
+                time_range,
+                agent_id=agent_id,
+                agent_class=agent_class,
+                event_name=event_name,
+                thread_id=thread_id,
             )
 
         return self


### PR DESCRIPTION
## Summary

Sysadmin logins were failing with `500 Authentication error`, and retrying never recovered
(bbvch-ai/aihub-core-private#186). Keycloak was healthy — the API's event loop was blocked for
minutes by a synchronous MongoDB aggregation running on it, which pushed concurrent token
validation past its Keycloak timeout. This offloads the two blocking event queries with
`asyncio.to_thread`.

## Changes

- `event_controller.py` — `get_agent_event_timeseries` and `get_agent_events_in_thread` now run
  their synchronous `EventService` calls via `asyncio.to_thread` instead of on the event loop.
- New regression test asserting the aggregation does not execute on the event loop thread.

Dropping `async` from the handlers (the simpler fix for a fully synchronous body) is not an
option here: both `await ThreadService.get_thread_by_id`.

## Root cause

From trace `953ec8732203856d034eddb017e21a8e` on `v0.319.0-rc.3`:

| Span | Duration | Result |
| --- | --- | --- |
| `GET /{tenant_id}/events/agents/timeseries/{time_range}` | 3.33 m | 401 |
| `KeycloakAdminService.get_user_tenant_ids` | ms | **200** |
| `KeycloakAdminService.get_active_tenant_id` | 3.16 m | error |
| `GET keycloak:8080/admin/realms/aihub/users/…` | 3.15 m | `httpx.WriteTimeout` |

The first Keycloak admin call returned 200 in milliseconds on the same shared client, so Keycloak
was fine. python-keycloak defaults to `timeout=60`, yet the GET ran **189 s** — `anyio.fail_after`
can only overshoot 3× if the task was never scheduled to observe its own deadline. That is the
event loop being starved, not a network fault.

`EventService.get_event_timeseries` was called without `await` from an `async def` handler. An
unfiltered range aggregates the whole `agent_events` collection (the `$group` keyed on `event_id`
cannot use an index, and there is no tenant filter), and `useBasicEventStatistics.ts` fires seven
of these concurrently per dashboard load. Once the loop froze, every concurrent request's token
validation overran its Keycloak deadline; the blanket `except Exception` in `KeycloakAuthHandler`
turned that into a 500. Each retry reloaded the dashboard and re-triggered it.

The event-route code is unchanged since 0.318 — this was data volume crossing a threshold, which
is also why it could not be reproduced locally.

## Scope

This **contains the outage; it does not make the query faster.** The chart is still slow, but a
slow analytics query no longer takes authentication down with it. Deliberately deferred:

1. The timeseries aggregation cost, and its missing tenant filter.
2. Per-replica event duplication — `nc_subscriber.py` subscribes with no queue group, so every API
   replica writes its own copy of every event. This is what forces the dedup `$group` stages and
   inflates the collection N×.
3. Thread-list N+1 — `thread_service.py` gathers over a page of `thread_response_from_entity`, each
   synchronously running `get_aggregated_run_statistics`. Same bug, hotter path.
4. Auth-path fragility — `ensure_active_tenant` makes two uncached Keycloak Admin round-trips on
   every authenticated request at a 60 s timeout, and turns any failure into a 500.

## Test plan

- [x] New regression test passes, and **fails against the unfixed controller** (verified by
  stashing the fix) — so it genuinely guards the invariant.
- [x] `packages/api` event tests: 4 passed.
- [x] Full `packages/api` suite: 518 passed, 2 failed — both pre-existing local-environment gaps,
  verified by reproducing them identically on the untouched base (`ffmpeg` not installed;
  `test_get_user_with_valid_token` asserts a machine-specific name).
- [ ] **Not done:** load-based verification against a large seeded `agent_events` collection
  (concurrent request hangs pre-fix, returns immediately post-fix). The test proves the query runs
  off the loop thread; it does not prove the production symptom is gone under real volume.

## Note for reviewers

Targets `release/0.319`, not `main`, since the outage is on `v0.319.0-rc.3` and
`forward-port-check.yml` documents hotfixes landing on `release/*` and being cherry-picked forward.
**This needs a manual forward-port to `main`** — CI will post the reminder after merge.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>`
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [ ] CLA signed
- [x] Tests added or updated where relevant
