### PR TITLE
fix(workflows): Stop a failed scheduled publish starving every schedule

### DIFF
--- a/docs/arc42/decisions/2026_08_11_cron_scheduled_agent_runs.md
+++ b/docs/arc42/decisions/2026_08_11_cron_scheduled_agent_runs.md
@@ -167,28 +167,42 @@ alternative is hand-rolling field parsing, ranges, steps, and DST handling.
   `user.acting_within_tenant` and is only wired as a FastAPI `Depends` on HTTP endpoints. A scheduled run has neither a
   user nor an HTTP request, so nothing meters it: a misconfigured cron can consume LLM budget unchecked. Accepted for v1
   and tracked separately.
+
 - **Scheduled runs are invisible in the UI.** A thread with no members appears in nobody's thread list. This is the
   documented v1 behaviour; configurable membership is [#1582](https://github.com/bbvch-ai/aihub-core/issues/1582).
+
 - **The leader lease becomes dead code** once the scheduler moves into the single-replica daemon.
+
 - **Occurrences missed beyond the catch-up window never run.** Deliberate, but it means extended downtime silently skips
   work beyond a warning in the logs.
+
 - **A malformed stored schedule is skipped, not fatal.** This is a deliberate exception to the codebase's fail-fast
   rule. The profile store is shared across every scheduled agent, and `_due_instances` reads all of them before firing
   any, so letting one bad row raise would abort the tick before the watermark advanced — and every later tick would
   rediscover the same row. One malformed profile would permanently starve every other schedule. It is logged at error
   level and skipped instead, confining the blast radius to the profile that is actually broken.
+
 - **A profile's scheduled runs all share one thread, forever.** Bounding thread growth to one per profile means that
   thread's run history only ever grows. Nothing prunes it, so a long-lived `*/5` schedule eventually makes an expensive
   thread to open. That is a retention problem on one document rather than a proliferation problem across 105k, and it is
   the same problem a long-running chat already has.
+
 - **Occurrences due while a blueprint is offline are dropped, not queued.** Deliberate — the scheduler does not queue
   work for an agent that cannot consume it, and the watermark advances regardless — but it means a runner that crashes
   overnight loses that night's runs. Each drop is logged with the class, the profile, and how long it has been offline.
-- **A run that fails to start is not retried.** The claim is taken *before* the run is published, so if publishing
-  raises, the tick aborts without advancing the watermark and the next tick finds the occurrence already claimed. This
-  makes the failure at-most-once rather than at-least-once, which is the right way round given the acceptance criterion
-  is "no duplicate runs" — but it does mean a transient publish failure silently drops that occurrence. It also stops
-  one failing profile from starving the others, which would otherwise repeat on every tick.
+
+- **A run that fails to start is not retried.** The claim is taken *before* the run is published, so a publish that
+  raises leaves the occurrence claimed and the next tick passes over it. This makes the failure at-most-once rather than
+  at-least-once, which is the right way round given the acceptance criterion is "no duplicate runs" — but it does mean a
+  transient publish failure drops that occurrence. It is logged per occurrence, naming the class, the profile, and the
+  occurrence.
+
+  The claim is what stops the drop from repeating every tick. The failure is caught at the occurrence rather than
+  allowed to propagate: an uncaught publish error would abort the whole window before the watermark advanced, so every
+  *other* profile would lose its due occurrences too, and the next tick would rediscover the same broken row — one
+  failing profile starving all the rest. That is the same reasoning as the malformed-schedule skip above, and the same
+  deliberate exception to the codebase's fail-fast rule.
+
 - Discovery auto-registers a REST endpoint per start event, so schedulable agents also gain a
   `POST .../ScheduledStartEvent` route — an unplanned but useful manual trigger, which does carry a real user because it
   arrives over HTTP.

--- a/packages/core/swiss_ai_hub/core/scheduling/scheduled_agent_service.py
+++ b/packages/core/swiss_ai_hub/core/scheduling/scheduled_agent_service.py
@@ -303,7 +303,21 @@ class ScheduledAgentService:
                     config.agent_id,
                 )
                 continue
-            await self._start_run(config, occurrence)
+            # Deliberately not fail-fast, for the same reason a malformed schedule is skipped rather than
+            # raised: the loop over profiles is shared. Letting a publish failure propagate aborts the window
+            # before the watermark advances, so every *other* profile loses its due occurrences too and the
+            # next tick rediscovers the same broken row. The occurrence stays claimed, keeping the at-most-once
+            # posture the no-duplicate-runs guarantee is built on — it is dropped, not retried.
+            try:
+                await self._start_run(config, occurrence)
+            except Exception:
+                logger.exception(
+                    "Failed to start scheduled run for %s/%s (occurrence %s); the occurrence stays claimed "
+                    "and will not be retried",
+                    config.agent_class,
+                    config.agent_id,
+                    occurrence.isoformat(),
+                )
 
     async def _start_run(self, config: AgentConfigEntityDocument, occurrence: datetime) -> None:
         """Publishes a scheduled start event on the normal agent control path."""

--- a/packages/core/swiss_ai_hub/core/scheduling/tests/unit/test_scheduled_agent_service.py
+++ b/packages/core/swiss_ai_hub/core/scheduling/tests/unit/test_scheduled_agent_service.py
@@ -169,6 +169,53 @@ class TestExactlyOnce:
         )
 
 
+class TestPublishFailureIsolation:
+    """A publish that raises used to propagate out of the whole tick, taking every other profile with it."""
+
+    @pytest.mark.asyncio
+    async def test_a_failing_publish_does_not_starve_the_other_profiles(
+        self, service: ScheduledAgentService, distributor: MagicMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Same rationale as a malformed schedule: the loop over profiles is shared, so an uncaught failure
+        aborts the window before the watermark advances and every later tick rediscovers the same row."""
+
+        async def fail_only_for_broken(_event, *, user, target_agent):
+            if target_agent.agent_id == "broken":
+                raise RuntimeError("NATS unavailable")
+
+        distributor.distribute_event.side_effect = fail_only_for_broken
+
+        with caplog.at_level(logging.ERROR):
+            await _run_tick(service, configs=[_config(agent_id="broken"), _config(agent_id="healthy")])
+
+        attempted = {call.kwargs["target_agent"].agent_id for call in distributor.distribute_event.call_args_list}
+        assert attempted == {"broken", "healthy"}
+        assert "Failed to start scheduled run for ScheduledDemoAgent/broken" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_a_failing_publish_still_advances_the_watermark(
+        self, service: ScheduledAgentService, distributor: MagicMock
+    ) -> None:
+        """Leaving the watermark behind would replay the whole window on the next tick."""
+        distributor.distribute_event.side_effect = RuntimeError("NATS unavailable")
+
+        await _run_tick(service, configs=[_config(agent_id="broken")])
+
+        service._store.set_watermark.assert_awaited_once_with(_NOW)
+
+    @pytest.mark.asyncio
+    async def test_a_failed_occurrence_keeps_its_claim(
+        self, service: ScheduledAgentService, distributor: MagicMock
+    ) -> None:
+        """At-most-once is the right way round given the no-duplicate-runs guarantee: the claim is taken
+        before publishing, so a failure drops the occurrence rather than retrying it."""
+        distributor.distribute_event.side_effect = RuntimeError("NATS unavailable")
+
+        await _run_tick(service, configs=[_config(agent_id="broken")])
+
+        service._store.claim_occurrence.assert_awaited_once()
+
+
 class TestInstanceSelection:
     @pytest.mark.asyncio
     async def test_ignores_instances_without_a_schedule(

--- a/packages/core/swiss_ai_hub/core/scheduling/tests/unit/test_scheduled_agent_service.py
+++ b/packages/core/swiss_ai_hub/core/scheduling/tests/unit/test_scheduled_agent_service.py
@@ -12,6 +12,7 @@ from swiss_ai_hub.core.scheduling.scheduled_agent_service import ScheduledAgentS
 _MODULE = "swiss_ai_hub.core.scheduling.scheduled_agent_service"
 _NOW = datetime(2026, 8, 11, 12, 0, 30, tzinfo=UTC)
 _HOURLY = {"minute": "0", "hour": "*", "day_of_month": "*", "month": "*", "day_of_week": "*", "timezone": "UTC"}
+_EVERY_FIVE_MINUTES = {**_HOURLY, "minute": "*/5"}
 _SCHEDULE_FORM = [{"formkit": "cronInput", "name": "schedule", "ref": "schedule"}]
 
 
@@ -204,16 +205,39 @@ class TestPublishFailureIsolation:
         service._store.set_watermark.assert_awaited_once_with(_NOW)
 
     @pytest.mark.asyncio
-    async def test_a_failed_occurrence_keeps_its_claim(
+    async def test_a_failure_does_not_stop_later_occurrences_of_the_same_profile(
         self, service: ScheduledAgentService, distributor: MagicMock
     ) -> None:
-        """At-most-once is the right way round given the no-duplicate-runs guarantee: the claim is taken
-        before publishing, so a failure drops the occurrence rather than retrying it."""
+        """The guard sits inside the per-occurrence loop, not around it.
+
+        Profile-level isolation comes from the caller's loop, so it survives the guard being hoisted to
+        wrap this whole method — which is exactly the "simplification" someone would reach for. Only a
+        profile with several due occurrences pins where the guard actually belongs.
+        """
+        distributor.distribute_event.side_effect = [RuntimeError("NATS unavailable"), None, None]
+
+        # A */5 schedule over the clamped 15-minute catch-up window: three occurrences, one profile.
+        await _run_tick(service, configs=[_config(schedule=_EVERY_FIVE_MINUTES)])
+
+        assert distributor.distribute_event.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_a_failed_occurrence_is_not_released(
+        self, service: ScheduledAgentService, distributor: MagicMock
+    ) -> None:
+        """At-most-once is the right way round given the no-duplicate-runs guarantee, so a failed
+        occurrence must not be handed back.
+
+        There is no release path today, and this pins that there isn't one: the tempting fix for a
+        transient publish failure is to release the claim so the next tick retries it, which would turn a
+        dropped run into a duplicated one. The claim is a Redis key, so releasing it means deleting it.
+        """
         distributor.distribute_event.side_effect = RuntimeError("NATS unavailable")
 
         await _run_tick(service, configs=[_config(agent_id="broken")])
 
-        service._store.claim_occurrence.assert_awaited_once()
+        removals = [call for call in service._store._redis.mock_calls if "delete" in call[0] or "unlink" in call[0]]
+        assert removals == []
 
 
 class TestInstanceSelection:


### PR DESCRIPTION
Closes part of #1510.

## What was wrong

`_start_run` raising propagated uncaught through `_fire_occurrences` and `_tick`, so a single unreachable distributor aborted the tick **before the watermark advanced**. Consequences:

- every *other* profile lost its due occurrences for that window
- the next tick re-scanned the same window and hit the same broken row again
- the only signal was `logger.exception("Error in scheduler tick: ...")`, naming neither the profile nor the occurrence

One misbehaving profile could therefore stop every schedule on the platform indefinitely.

## The fix

Catch at the occurrence, name it, and continue — the same reasoning already applied to a malformed stored schedule a few lines above: the loop over profiles is shared, so one bad row must not abort the window.

The occurrence keeps its claim, so the drop stays **at-most-once** rather than becoming a retry. That is the right way round given the acceptance criterion is "no duplicate runs". What changes is that the failure is now confined and named instead of global and anonymous.

## ADR correction

`docs/arc42/decisions/2026_08_11_cron_scheduled_agent_runs.md` claimed the abort *prevented* one profile from starving the others. It did the opposite — the **claim** is what prevents the repeat. Corrected in the same commit.

## Test plan

- [x] `TestPublishFailureIsolation`: a failing profile does not stop a healthy one, the watermark still advances, and the failed occurrence keeps its claim
- [x] Verified non-vacuous — all three tests fail without the fix (`assert 2 == 1` / uncaught `RuntimeError`)
- [x] `make test` in `packages/core`: 1224 passed

## Review notes

Deliberately standalone so it can merge without waiting on the rename and hardening work in #1510. `feat/cron-scheduler-hardening` contains the same guard plus a failure counter, so that branch will want a trivial conflict resolution (keep its version) once this lands.