### PR TITLE
fix(tracing): Start the OTel collector before every service that exports to it

### DIFF
--- a/infra/configs/otel/otel-config.build.gpu.yml
+++ b/infra/configs/otel/otel-config.build.gpu.yml
@@ -50,12 +50,16 @@ processors:
   # quick-filters on resource[deployment.environment] and resource[host.name]; the SDK sets only
   # service.name/version/namespace, so both columns arrived empty for every span and log.
   #
-  # Values come from the deploying VM (aihub-playbook's env.j2 writes them into .env). The compose
-  # fallback to the stage name is load-bearing, not cosmetic: an EMPTY value makes this processor
-  # fail to build, and since nothing depends_on the collector that would silently drop all
-  # telemetry rather than just this attribute:
+  # Values come from the deploying VM (aihub-playbook's env.j2 writes them into the stage's
+  # environment file). The compose fallback to the stage name is load-bearing, not cosmetic: an
+  # EMPTY value makes this processor fail to build, and the collector then exits:
   #   failed to create "resource/deployment" processor: error with key "deployment.environment"
   #   ... Either field "value", "from_attribute", "from_context", or "default_value" must be specified
+  #
+  # That used to cost only telemetry. It no longer does: every service that exports OTLP now
+  # declares depends_on this collector (service_started), so a config error here holds up the app
+  # plane instead of quietly dropping spans. These fallbacks are the only thing keeping an unset
+  # variable on the VM from turning into a failed deploy.
   #
   # `upsert` so the VM's own identity wins over anything an app SDK may inconsistently send.
   resource/deployment:

--- a/infra/configs/otel/otel-config.build.yml
+++ b/infra/configs/otel/otel-config.build.yml
@@ -50,12 +50,16 @@ processors:
   # quick-filters on resource[deployment.environment] and resource[host.name]; the SDK sets only
   # service.name/version/namespace, so both columns arrived empty for every span and log.
   #
-  # Values come from the deploying VM (aihub-playbook's env.j2 writes them into .env). The compose
-  # fallback to the stage name is load-bearing, not cosmetic: an EMPTY value makes this processor
-  # fail to build, and since nothing depends_on the collector that would silently drop all
-  # telemetry rather than just this attribute:
+  # Values come from the deploying VM (aihub-playbook's env.j2 writes them into the stage's
+  # environment file). The compose fallback to the stage name is load-bearing, not cosmetic: an
+  # EMPTY value makes this processor fail to build, and the collector then exits:
   #   failed to create "resource/deployment" processor: error with key "deployment.environment"
   #   ... Either field "value", "from_attribute", "from_context", or "default_value" must be specified
+  #
+  # That used to cost only telemetry. It no longer does: every service that exports OTLP now
+  # declares depends_on this collector (service_started), so a config error here holds up the app
+  # plane instead of quietly dropping spans. These fallbacks are the only thing keeping an unset
+  # variable on the VM from turning into a failed deploy.
   #
   # `upsert` so the VM's own identity wins over anything an app SDK may inconsistently send.
   resource/deployment:

--- a/infra/configs/otel/otel-config.dev.gpu.yml
+++ b/infra/configs/otel/otel-config.dev.gpu.yml
@@ -50,12 +50,16 @@ processors:
   # quick-filters on resource[deployment.environment] and resource[host.name]; the SDK sets only
   # service.name/version/namespace, so both columns arrived empty for every span and log.
   #
-  # Values come from the deploying VM (aihub-playbook's env.j2 writes them into .env). The compose
-  # fallback to the stage name is load-bearing, not cosmetic: an EMPTY value makes this processor
-  # fail to build, and since nothing depends_on the collector that would silently drop all
-  # telemetry rather than just this attribute:
+  # Values come from the deploying VM (aihub-playbook's env.j2 writes them into the stage's
+  # environment file). The compose fallback to the stage name is load-bearing, not cosmetic: an
+  # EMPTY value makes this processor fail to build, and the collector then exits:
   #   failed to create "resource/deployment" processor: error with key "deployment.environment"
   #   ... Either field "value", "from_attribute", "from_context", or "default_value" must be specified
+  #
+  # That used to cost only telemetry. It no longer does: every service that exports OTLP now
+  # declares depends_on this collector (service_started), so a config error here holds up the app
+  # plane instead of quietly dropping spans. These fallbacks are the only thing keeping an unset
+  # variable on the VM from turning into a failed deploy.
   #
   # `upsert` so the VM's own identity wins over anything an app SDK may inconsistently send.
   resource/deployment:

--- a/infra/configs/otel/otel-config.dev.yml
+++ b/infra/configs/otel/otel-config.dev.yml
@@ -50,12 +50,16 @@ processors:
   # quick-filters on resource[deployment.environment] and resource[host.name]; the SDK sets only
   # service.name/version/namespace, so both columns arrived empty for every span and log.
   #
-  # Values come from the deploying VM (aihub-playbook's env.j2 writes them into .env). The compose
-  # fallback to the stage name is load-bearing, not cosmetic: an EMPTY value makes this processor
-  # fail to build, and since nothing depends_on the collector that would silently drop all
-  # telemetry rather than just this attribute:
+  # Values come from the deploying VM (aihub-playbook's env.j2 writes them into the stage's
+  # environment file). The compose fallback to the stage name is load-bearing, not cosmetic: an
+  # EMPTY value makes this processor fail to build, and the collector then exits:
   #   failed to create "resource/deployment" processor: error with key "deployment.environment"
   #   ... Either field "value", "from_attribute", "from_context", or "default_value" must be specified
+  #
+  # That used to cost only telemetry. It no longer does: every service that exports OTLP now
+  # declares depends_on this collector (service_started), so a config error here holds up the app
+  # plane instead of quietly dropping spans. These fallbacks are the only thing keeping an unset
+  # variable on the VM from turning into a failed deploy.
   #
   # `upsert` so the VM's own identity wins over anything an app SDK may inconsistently send.
   resource/deployment:

--- a/infra/configs/otel/otel-config.latest.gpu.yml
+++ b/infra/configs/otel/otel-config.latest.gpu.yml
@@ -50,12 +50,16 @@ processors:
   # quick-filters on resource[deployment.environment] and resource[host.name]; the SDK sets only
   # service.name/version/namespace, so both columns arrived empty for every span and log.
   #
-  # Values come from the deploying VM (aihub-playbook's env.j2 writes them into .env). The compose
-  # fallback to the stage name is load-bearing, not cosmetic: an EMPTY value makes this processor
-  # fail to build, and since nothing depends_on the collector that would silently drop all
-  # telemetry rather than just this attribute:
+  # Values come from the deploying VM (aihub-playbook's env.j2 writes them into the stage's
+  # environment file). The compose fallback to the stage name is load-bearing, not cosmetic: an
+  # EMPTY value makes this processor fail to build, and the collector then exits:
   #   failed to create "resource/deployment" processor: error with key "deployment.environment"
   #   ... Either field "value", "from_attribute", "from_context", or "default_value" must be specified
+  #
+  # That used to cost only telemetry. It no longer does: every service that exports OTLP now
+  # declares depends_on this collector (service_started), so a config error here holds up the app
+  # plane instead of quietly dropping spans. These fallbacks are the only thing keeping an unset
+  # variable on the VM from turning into a failed deploy.
   #
   # `upsert` so the VM's own identity wins over anything an app SDK may inconsistently send.
   resource/deployment:

--- a/infra/configs/otel/otel-config.latest.yml
+++ b/infra/configs/otel/otel-config.latest.yml
@@ -50,12 +50,16 @@ processors:
   # quick-filters on resource[deployment.environment] and resource[host.name]; the SDK sets only
   # service.name/version/namespace, so both columns arrived empty for every span and log.
   #
-  # Values come from the deploying VM (aihub-playbook's env.j2 writes them into .env). The compose
-  # fallback to the stage name is load-bearing, not cosmetic: an EMPTY value makes this processor
-  # fail to build, and since nothing depends_on the collector that would silently drop all
-  # telemetry rather than just this attribute:
+  # Values come from the deploying VM (aihub-playbook's env.j2 writes them into the stage's
+  # environment file). The compose fallback to the stage name is load-bearing, not cosmetic: an
+  # EMPTY value makes this processor fail to build, and the collector then exits:
   #   failed to create "resource/deployment" processor: error with key "deployment.environment"
   #   ... Either field "value", "from_attribute", "from_context", or "default_value" must be specified
+  #
+  # That used to cost only telemetry. It no longer does: every service that exports OTLP now
+  # declares depends_on this collector (service_started), so a config error here holds up the app
+  # plane instead of quietly dropping spans. These fallbacks are the only thing keeping an unset
+  # variable on the VM from turning into a failed deploy.
   #
   # `upsert` so the VM's own identity wins over anything an app SDK may inconsistently send.
   resource/deployment:

--- a/infra/configs/otel/otel-config.local.gpu.yml
+++ b/infra/configs/otel/otel-config.local.gpu.yml
@@ -50,12 +50,16 @@ processors:
   # quick-filters on resource[deployment.environment] and resource[host.name]; the SDK sets only
   # service.name/version/namespace, so both columns arrived empty for every span and log.
   #
-  # Values come from the deploying VM (aihub-playbook's env.j2 writes them into .env). The compose
-  # fallback to the stage name is load-bearing, not cosmetic: an EMPTY value makes this processor
-  # fail to build, and since nothing depends_on the collector that would silently drop all
-  # telemetry rather than just this attribute:
+  # Values come from the deploying VM (aihub-playbook's env.j2 writes them into the stage's
+  # environment file). The compose fallback to the stage name is load-bearing, not cosmetic: an
+  # EMPTY value makes this processor fail to build, and the collector then exits:
   #   failed to create "resource/deployment" processor: error with key "deployment.environment"
   #   ... Either field "value", "from_attribute", "from_context", or "default_value" must be specified
+  #
+  # That used to cost only telemetry. It no longer does: every service that exports OTLP now
+  # declares depends_on this collector (service_started), so a config error here holds up the app
+  # plane instead of quietly dropping spans. These fallbacks are the only thing keeping an unset
+  # variable on the VM from turning into a failed deploy.
   #
   # `upsert` so the VM's own identity wins over anything an app SDK may inconsistently send.
   resource/deployment:

--- a/infra/configs/otel/otel-config.local.yml
+++ b/infra/configs/otel/otel-config.local.yml
@@ -50,12 +50,16 @@ processors:
   # quick-filters on resource[deployment.environment] and resource[host.name]; the SDK sets only
   # service.name/version/namespace, so both columns arrived empty for every span and log.
   #
-  # Values come from the deploying VM (aihub-playbook's env.j2 writes them into .env). The compose
-  # fallback to the stage name is load-bearing, not cosmetic: an EMPTY value makes this processor
-  # fail to build, and since nothing depends_on the collector that would silently drop all
-  # telemetry rather than just this attribute:
+  # Values come from the deploying VM (aihub-playbook's env.j2 writes them into the stage's
+  # environment file). The compose fallback to the stage name is load-bearing, not cosmetic: an
+  # EMPTY value makes this processor fail to build, and the collector then exits:
   #   failed to create "resource/deployment" processor: error with key "deployment.environment"
   #   ... Either field "value", "from_attribute", "from_context", or "default_value" must be specified
+  #
+  # That used to cost only telemetry. It no longer does: every service that exports OTLP now
+  # declares depends_on this collector (service_started), so a config error here holds up the app
+  # plane instead of quietly dropping spans. These fallbacks are the only thing keeping an unset
+  # variable on the VM from turning into a failed deploy.
   #
   # `upsert` so the VM's own identity wins over anything an app SDK may inconsistently send.
   resource/deployment:

--- a/infra/configs/otel/otel-config.nightly.gpu.yml
+++ b/infra/configs/otel/otel-config.nightly.gpu.yml
@@ -50,12 +50,16 @@ processors:
   # quick-filters on resource[deployment.environment] and resource[host.name]; the SDK sets only
   # service.name/version/namespace, so both columns arrived empty for every span and log.
   #
-  # Values come from the deploying VM (aihub-playbook's env.j2 writes them into .env). The compose
-  # fallback to the stage name is load-bearing, not cosmetic: an EMPTY value makes this processor
-  # fail to build, and since nothing depends_on the collector that would silently drop all
-  # telemetry rather than just this attribute:
+  # Values come from the deploying VM (aihub-playbook's env.j2 writes them into the stage's
+  # environment file). The compose fallback to the stage name is load-bearing, not cosmetic: an
+  # EMPTY value makes this processor fail to build, and the collector then exits:
   #   failed to create "resource/deployment" processor: error with key "deployment.environment"
   #   ... Either field "value", "from_attribute", "from_context", or "default_value" must be specified
+  #
+  # That used to cost only telemetry. It no longer does: every service that exports OTLP now
+  # declares depends_on this collector (service_started), so a config error here holds up the app
+  # plane instead of quietly dropping spans. These fallbacks are the only thing keeping an unset
+  # variable on the VM from turning into a failed deploy.
   #
   # `upsert` so the VM's own identity wins over anything an app SDK may inconsistently send.
   resource/deployment:

--- a/infra/configs/otel/otel-config.nightly.yml
+++ b/infra/configs/otel/otel-config.nightly.yml
@@ -50,12 +50,16 @@ processors:
   # quick-filters on resource[deployment.environment] and resource[host.name]; the SDK sets only
   # service.name/version/namespace, so both columns arrived empty for every span and log.
   #
-  # Values come from the deploying VM (aihub-playbook's env.j2 writes them into .env). The compose
-  # fallback to the stage name is load-bearing, not cosmetic: an EMPTY value makes this processor
-  # fail to build, and since nothing depends_on the collector that would silently drop all
-  # telemetry rather than just this attribute:
+  # Values come from the deploying VM (aihub-playbook's env.j2 writes them into the stage's
+  # environment file). The compose fallback to the stage name is load-bearing, not cosmetic: an
+  # EMPTY value makes this processor fail to build, and the collector then exits:
   #   failed to create "resource/deployment" processor: error with key "deployment.environment"
   #   ... Either field "value", "from_attribute", "from_context", or "default_value" must be specified
+  #
+  # That used to cost only telemetry. It no longer does: every service that exports OTLP now
+  # declares depends_on this collector (service_started), so a config error here holds up the app
+  # plane instead of quietly dropping spans. These fallbacks are the only thing keeping an unset
+  # variable on the VM from turning into a failed deploy.
   #
   # `upsert` so the VM's own identity wins over anything an app SDK may inconsistently send.
   resource/deployment:

--- a/infra/deployment/CLAUDE.md
+++ b/infra/deployment/CLAUDE.md
@@ -276,10 +276,11 @@ the same level as ALTERNATIVE executions, or Keycloak ignores the alternatives a
 - Only external/override endpoints (for services running on the host outside Docker) use env vars
 - **`OTEL_DEPLOYMENT_ENVIRONMENT` / `OTEL_HOST_NAME` are the one sanctioned `${VAR:-default}`.** The
   collector's `resource/deployment` processor stamps them onto every pipeline, and an *empty* value
-  makes that processor fail to build — which exits the collector. Nothing `depends_on` the collector,
-  so an unset var would silently drop all telemetry rather than just one attribute. Values are
-  written per-VM into `.env` by `aihub-playbook`'s `env.j2`; the stage-name fallback exists so a
-  non-Ansible deploy still starts. Do not "fix" it by moving the default to `.env.prod`.
+  makes that processor fail to build — which exits the collector. Every service that exports OTLP
+  now declares `depends_on: otel-collector`, so an unset var no longer merely drops telemetry: it
+  holds up the app plane. Values are written per-VM into the stage's environment file by
+  `aihub-playbook`'s `env.j2`; the stage-name fallback is what keeps a non-Ansible deploy starting
+  at all. Do not "fix" it by moving the default to `.env.prod`.
 
 ### Which collector owns which signal
 

--- a/infra/deployment/templates/configs/otel-config.yml.j2
+++ b/infra/deployment/templates/configs/otel-config.yml.j2
@@ -58,12 +58,16 @@ processors:
   # quick-filters on resource[deployment.environment] and resource[host.name]; the SDK sets only
   # service.name/version/namespace, so both columns arrived empty for every span and log.
   #
-  # Values come from the deploying VM (aihub-playbook's env.j2 writes them into .env). The compose
-  # fallback to the stage name is load-bearing, not cosmetic: an EMPTY value makes this processor
-  # fail to build, and since nothing depends_on the collector that would silently drop all
-  # telemetry rather than just this attribute:
+  # Values come from the deploying VM (aihub-playbook's env.j2 writes them into the stage's
+  # environment file). The compose fallback to the stage name is load-bearing, not cosmetic: an
+  # EMPTY value makes this processor fail to build, and the collector then exits:
   #   failed to create "resource/deployment" processor: error with key "deployment.environment"
   #   ... Either field "value", "from_attribute", "from_context", or "default_value" must be specified
+  #
+  # That used to cost only telemetry. It no longer does: every service that exports OTLP now
+  # declares depends_on this collector (service_started), so a config error here holds up the app
+  # plane instead of quietly dropping spans. These fallbacks are the only thing keeping an unset
+  # variable on the VM from turning into a failed deploy.
   #
   # `upsert` so the VM's own identity wins over anything an app SDK may inconsistently send.
   resource/deployment:

--- a/infra/deployment/templates/docker-compose.yml.j2
+++ b/infra/deployment/templates/docker-compose.yml.j2
@@ -1840,6 +1840,8 @@ services:
       - ./configs/litellm/custom_callbacks.py:/app/custom_callbacks.py:ro
     command: --config /app/config.yml
     depends_on:
+      otel-collector:
+        condition: service_started
       postgres:
         condition: service_healthy
       presidio-analyzer:
@@ -2139,8 +2141,11 @@ services:
       - "13133:13133"
       - "55679:55679"
     {%- endif %}
-    depends_on:
-      - langfuse-web
+    # Deliberately no depends_on: this must be the first thing listening on 4317. Every app SDK
+    # gives up after OTEL_EXPORTER_OTLP_TIMEOUT and DROPS the batch, so gating the collector behind
+    # langfuse-web (and through it postgres/clickhouse/seaweedfs health) costs the startup log of
+    # every service on a cold start. The otlphttp/langfuse exporter has retry_on_failure and needs
+    # no start-order guarantee — langfuse-web is up long before the first OpenInference trace.
     healthcheck:
       test: [ "NONE" ]
     labels:
@@ -2176,6 +2181,8 @@ services:
     volumes:
       - {{ global.volume_root }}/open-webui:/app/backend/data
     depends_on:
+      otel-collector:
+        condition: service_started
       postgres:
         condition: service_healthy
       seaweedfs-s3:
@@ -2798,6 +2805,8 @@ services:
     image: {{ global.registry_prefix }}{{ image_tags.api[stage] }}
     {%- endif %}
     depends_on:
+      otel-collector:
+        condition: service_started
       nats:
         condition: service_started
       traefik:
@@ -3080,6 +3089,8 @@ services:
     image: {{ global.registry_prefix }}{{ image_tags['sysadmin-api'][stage] }}
     {%- endif %}
     depends_on:
+      otel-collector:
+        condition: service_started
       traefik:
         condition: service_started
       ferretdb:
@@ -3279,6 +3290,9 @@ services:
     {%- else %}
     image: {{ global.registry_prefix }}{{ image_tags.llm_wrapping_agent[stage] }}
     {%- endif %}
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3352,6 +3366,9 @@ services:
     {%- else %}
     image: {{ global.registry_prefix }}{{ image_tags.rag_agent[stage] }}
     {%- endif %}
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3433,6 +3450,9 @@ services:
     {%- else %}
     image: {{ global.registry_prefix }}{{ image_tags.expert_rag_agent[stage] }}
     {%- endif %}
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3514,6 +3534,9 @@ services:
     {%- else %}
     image: {{ global.registry_prefix }}{{ image_tags.expert_asking_agent[stage] }}
     {%- endif %}
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3590,6 +3613,9 @@ services:
     {%- else %}
     image: {{ global.registry_prefix }}{{ image_tags.retrieval_agent[stage] }}
     {%- endif %}
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3663,6 +3689,9 @@ services:
     {%- else %}
     image: {{ global.registry_prefix }}{{ image_tags.few_shot_agent[stage] }}
     {%- endif %}
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3723,6 +3752,9 @@ services:
     {%- else %}
     image: {{ global.registry_prefix }}{{ image_tags.namespace_selection_agent[stage] }}
     {%- endif %}
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3783,6 +3815,9 @@ services:
     {%- else %}
     image: {{ global.registry_prefix }}{{ image_tags.memory_writer_agent[stage] }}
     {%- endif %}
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3851,6 +3886,9 @@ services:
     {%- else %}
     image: {{ global.registry_prefix }}{{ image_tags.imap_agent[stage] }}
     {%- endif %}
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3920,6 +3958,9 @@ services:
     {%- else %}
     image: {{ global.registry_prefix }}{{ image_tags.email_classification_agent[stage] }}
     {%- endif %}
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 

--- a/infra/docker-compose.build.gpu.yml
+++ b/infra/docker-compose.build.gpu.yml
@@ -1632,6 +1632,8 @@ services:
       - ./configs/litellm/custom_callbacks.py:/app/custom_callbacks.py:ro
     command: --config /app/config.yml
     depends_on:
+      otel-collector:
+        condition: service_started
       postgres:
         condition: service_healthy
       presidio-analyzer:
@@ -1902,8 +1904,16 @@ services:
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY}
       - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY}
     volumes: [./configs/otel/otel-config.build.gpu.yml:/etc/otel-config.yml]
-    ports: [4317:4317, 4318:4318, 13133:13133, 55679:55679]
-    depends_on: [langfuse-web]
+    ports:
+      - 4317:4317
+      - 4318:4318
+      - 13133:13133
+      - 55679:55679
+    # Deliberately no depends_on: this must be the first thing listening on 4317. Every app SDK
+    # gives up after OTEL_EXPORTER_OTLP_TIMEOUT and DROPS the batch, so gating the collector behind
+    # langfuse-web (and through it postgres/clickhouse/seaweedfs health) costs the startup log of
+    # every service on a cold start. The otlphttp/langfuse exporter has retry_on_failure and needs
+    # no start-order guarantee — langfuse-web is up long before the first OpenInference trace.
     healthcheck:
       test: [NONE]
     labels:
@@ -1935,6 +1945,8 @@ services:
     restart: always
     volumes: ['${VOLUME_ROOT:-./.docker-volumes}/open-webui:/app/backend/data']
     depends_on:
+      otel-collector:
+        condition: service_started
       postgres:
         condition: service_healthy
       seaweedfs-s3:
@@ -2476,6 +2488,8 @@ services:
       context: ..
       dockerfile: ./packages/api/Dockerfile
     depends_on:
+      otel-collector:
+        condition: service_started
       nats:
         condition: service_started
       traefik:
@@ -2732,6 +2746,8 @@ services:
       context: ..
       dockerfile: ./packages/sysadmin-api/Dockerfile
     depends_on:
+      otel-collector:
+        condition: service_started
       traefik:
         condition: service_started
       ferretdb:
@@ -2909,6 +2925,9 @@ services:
     build:
       context: ..
       dockerfile: ./packages/agent/app/llm_wrapping_agent/Dockerfile
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2975,6 +2994,9 @@ services:
     build:
       context: ..
       dockerfile: ./packages/agent/app/rag_agent/Dockerfile
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3049,6 +3071,9 @@ services:
     build:
       context: ..
       dockerfile: ./packages/agent/app/expert_rag_agent/Dockerfile
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3123,6 +3148,9 @@ services:
     build:
       context: ..
       dockerfile: ./packages/agent/app/expert_asking_agent/Dockerfile
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3192,6 +3220,9 @@ services:
     build:
       context: ..
       dockerfile: ./packages/agent/app/retrieval_agent/Dockerfile
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3258,6 +3289,9 @@ services:
     build:
       context: ..
       dockerfile: ./packages/agent/app/few_shot_agent/Dockerfile
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3311,6 +3345,9 @@ services:
     build:
       context: ..
       dockerfile: ./packages/agent/app/namespace_selection_agent/Dockerfile
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3364,6 +3401,9 @@ services:
     build:
       context: ..
       dockerfile: ./packages/agent/app/memory_writer_agent/Dockerfile
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3425,6 +3465,9 @@ services:
     build:
       context: ..
       dockerfile: ./packages/agent/app/imap_agent/Dockerfile
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3487,6 +3530,9 @@ services:
     build:
       context: ..
       dockerfile: ./packages/agent/app/email_classification_agent/Dockerfile
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 

--- a/infra/docker-compose.build.yml
+++ b/infra/docker-compose.build.yml
@@ -1449,6 +1449,8 @@ services:
       - ./configs/litellm/custom_callbacks.py:/app/custom_callbacks.py:ro
     command: --config /app/config.yml
     depends_on:
+      otel-collector:
+        condition: service_started
       postgres:
         condition: service_healthy
       presidio-analyzer:
@@ -1682,8 +1684,16 @@ services:
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY}
       - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY}
     volumes: [./configs/otel/otel-config.build.yml:/etc/otel-config.yml]
-    ports: [4317:4317, 4318:4318, 13133:13133, 55679:55679]
-    depends_on: [langfuse-web]
+    ports:
+      - 4317:4317
+      - 4318:4318
+      - 13133:13133
+      - 55679:55679
+    # Deliberately no depends_on: this must be the first thing listening on 4317. Every app SDK
+    # gives up after OTEL_EXPORTER_OTLP_TIMEOUT and DROPS the batch, so gating the collector behind
+    # langfuse-web (and through it postgres/clickhouse/seaweedfs health) costs the startup log of
+    # every service on a cold start. The otlphttp/langfuse exporter has retry_on_failure and needs
+    # no start-order guarantee — langfuse-web is up long before the first OpenInference trace.
     healthcheck:
       test: [NONE]
     labels:
@@ -1715,6 +1725,8 @@ services:
     restart: always
     volumes: ['${VOLUME_ROOT:-./.docker-volumes}/open-webui:/app/backend/data']
     depends_on:
+      otel-collector:
+        condition: service_started
       postgres:
         condition: service_healthy
       seaweedfs-s3:
@@ -2264,6 +2276,8 @@ services:
       context: ..
       dockerfile: ./packages/api/Dockerfile
     depends_on:
+      otel-collector:
+        condition: service_started
       nats:
         condition: service_started
       traefik:
@@ -2520,6 +2534,8 @@ services:
       context: ..
       dockerfile: ./packages/sysadmin-api/Dockerfile
     depends_on:
+      otel-collector:
+        condition: service_started
       traefik:
         condition: service_started
       ferretdb:
@@ -2697,6 +2713,9 @@ services:
     build:
       context: ..
       dockerfile: ./packages/agent/app/llm_wrapping_agent/Dockerfile
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2763,6 +2782,9 @@ services:
     build:
       context: ..
       dockerfile: ./packages/agent/app/rag_agent/Dockerfile
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2837,6 +2859,9 @@ services:
     build:
       context: ..
       dockerfile: ./packages/agent/app/expert_rag_agent/Dockerfile
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2911,6 +2936,9 @@ services:
     build:
       context: ..
       dockerfile: ./packages/agent/app/expert_asking_agent/Dockerfile
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2980,6 +3008,9 @@ services:
     build:
       context: ..
       dockerfile: ./packages/agent/app/retrieval_agent/Dockerfile
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3046,6 +3077,9 @@ services:
     build:
       context: ..
       dockerfile: ./packages/agent/app/few_shot_agent/Dockerfile
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3099,6 +3133,9 @@ services:
     build:
       context: ..
       dockerfile: ./packages/agent/app/namespace_selection_agent/Dockerfile
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3152,6 +3189,9 @@ services:
     build:
       context: ..
       dockerfile: ./packages/agent/app/memory_writer_agent/Dockerfile
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3213,6 +3253,9 @@ services:
     build:
       context: ..
       dockerfile: ./packages/agent/app/imap_agent/Dockerfile
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3275,6 +3318,9 @@ services:
     build:
       context: ..
       dockerfile: ./packages/agent/app/email_classification_agent/Dockerfile
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 

--- a/infra/docker-compose.dev.gpu.yml
+++ b/infra/docker-compose.dev.gpu.yml
@@ -1329,6 +1329,8 @@ services:
       - ./configs/litellm/custom_callbacks.py:/app/custom_callbacks.py:ro
     command: --config /app/config.yml
     depends_on:
+      otel-collector:
+        condition: service_started
       postgres:
         condition: service_healthy
       presidio-analyzer:
@@ -1590,8 +1592,16 @@ services:
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY}
       - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY}
     volumes: [./configs/otel/otel-config.dev.gpu.yml:/etc/otel-config.yml]
-    ports: [4317:4317, 4318:4318, 13133:13133, 55679:55679]
-    depends_on: [langfuse-web]
+    ports:
+      - 4317:4317
+      - 4318:4318
+      - 13133:13133
+      - 55679:55679
+    # Deliberately no depends_on: this must be the first thing listening on 4317. Every app SDK
+    # gives up after OTEL_EXPORTER_OTLP_TIMEOUT and DROPS the batch, so gating the collector behind
+    # langfuse-web (and through it postgres/clickhouse/seaweedfs health) costs the startup log of
+    # every service on a cold start. The otlphttp/langfuse exporter has retry_on_failure and needs
+    # no start-order guarantee — langfuse-web is up long before the first OpenInference trace.
     healthcheck:
       test: [NONE]
     labels:
@@ -1624,6 +1634,8 @@ services:
     network_mode: host
     volumes: ['${VOLUME_ROOT:-./.docker-volumes}/open-webui:/app/backend/data']
     depends_on:
+      otel-collector:
+        condition: service_started
       postgres:
         condition: service_healthy
       seaweedfs-s3:

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -1146,6 +1146,8 @@ services:
       - ./configs/litellm/custom_callbacks.py:/app/custom_callbacks.py:ro
     command: --config /app/config.yml
     depends_on:
+      otel-collector:
+        condition: service_started
       postgres:
         condition: service_healthy
       presidio-analyzer:
@@ -1370,8 +1372,16 @@ services:
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY}
       - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY}
     volumes: [./configs/otel/otel-config.dev.yml:/etc/otel-config.yml]
-    ports: [4317:4317, 4318:4318, 13133:13133, 55679:55679]
-    depends_on: [langfuse-web]
+    ports:
+      - 4317:4317
+      - 4318:4318
+      - 13133:13133
+      - 55679:55679
+    # Deliberately no depends_on: this must be the first thing listening on 4317. Every app SDK
+    # gives up after OTEL_EXPORTER_OTLP_TIMEOUT and DROPS the batch, so gating the collector behind
+    # langfuse-web (and through it postgres/clickhouse/seaweedfs health) costs the startup log of
+    # every service on a cold start. The otlphttp/langfuse exporter has retry_on_failure and needs
+    # no start-order guarantee — langfuse-web is up long before the first OpenInference trace.
     healthcheck:
       test: [NONE]
     labels:
@@ -1404,6 +1414,8 @@ services:
     network_mode: host
     volumes: ['${VOLUME_ROOT:-./.docker-volumes}/open-webui:/app/backend/data']
     depends_on:
+      otel-collector:
+        condition: service_started
       postgres:
         condition: service_healthy
       seaweedfs-s3:

--- a/infra/docker-compose.latest.gpu.yml
+++ b/infra/docker-compose.latest.gpu.yml
@@ -1596,6 +1596,8 @@ services:
       - ./configs/litellm/custom_callbacks.py:/app/custom_callbacks.py:ro
     command: --config /app/config.yml
     depends_on:
+      otel-collector:
+        condition: service_started
       postgres:
         condition: service_healthy
       presidio-analyzer:
@@ -1858,8 +1860,13 @@ services:
       - OTEL_HOST_NAME=${OTEL_HOST_NAME:-unset-latest}
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY}
       - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY}
-    volumes: [./configs/otel/otel-config.latest.gpu.yml:/etc/otel-config.yml]
-    depends_on: [langfuse-web]
+    volumes:
+      - ./configs/otel/otel-config.latest.gpu.yml:/etc/otel-config.yml
+    # Deliberately no depends_on: this must be the first thing listening on 4317. Every app SDK
+    # gives up after OTEL_EXPORTER_OTLP_TIMEOUT and DROPS the batch, so gating the collector behind
+    # langfuse-web (and through it postgres/clickhouse/seaweedfs health) costs the startup log of
+    # every service on a cold start. The otlphttp/langfuse exporter has retry_on_failure and needs
+    # no start-order guarantee — langfuse-web is up long before the first OpenInference trace.
     healthcheck:
       test: [NONE]
     labels:
@@ -1891,6 +1898,8 @@ services:
     restart: always
     volumes: ['${VOLUME_ROOT:-./.docker-volumes}/open-webui:/app/backend/data']
     depends_on:
+      otel-collector:
+        condition: service_started
       postgres:
         condition: service_healthy
       seaweedfs-s3:
@@ -2427,6 +2436,8 @@ services:
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/api:latest
     depends_on:
+      otel-collector:
+        condition: service_started
       nats:
         condition: service_started
       traefik:
@@ -2679,6 +2690,8 @@ services:
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/sysadmin-api:latest
     depends_on:
+      otel-collector:
+        condition: service_started
       traefik:
         condition: service_started
       ferretdb:
@@ -2852,6 +2865,9 @@ services:
     container_name: llm-wrapping-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/llm_wrapping_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2916,6 +2932,9 @@ services:
     container_name: rag-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/rag_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2988,6 +3007,9 @@ services:
     container_name: expert-rag-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/expert_rag_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3060,6 +3082,9 @@ services:
     container_name: expert-asking-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/expert_asking_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3127,6 +3152,9 @@ services:
     container_name: retrieval-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/retrieval_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3191,6 +3219,9 @@ services:
     container_name: few-shot-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/few_shot_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3242,6 +3273,9 @@ services:
     container_name: namespace-selection-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/namespace_selection_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3293,6 +3327,9 @@ services:
     container_name: memory-writer-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/memory_writer_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3352,6 +3389,9 @@ services:
     container_name: imap-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/imap_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3412,6 +3452,9 @@ services:
     container_name: email-classification-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/email_classification_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 

--- a/infra/docker-compose.latest.yml
+++ b/infra/docker-compose.latest.yml
@@ -1417,6 +1417,8 @@ services:
       - ./configs/litellm/custom_callbacks.py:/app/custom_callbacks.py:ro
     command: --config /app/config.yml
     depends_on:
+      otel-collector:
+        condition: service_started
       postgres:
         condition: service_healthy
       presidio-analyzer:
@@ -1644,8 +1646,13 @@ services:
       - OTEL_HOST_NAME=${OTEL_HOST_NAME:-unset-latest}
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY}
       - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY}
-    volumes: [./configs/otel/otel-config.latest.yml:/etc/otel-config.yml]
-    depends_on: [langfuse-web]
+    volumes:
+      - ./configs/otel/otel-config.latest.yml:/etc/otel-config.yml
+    # Deliberately no depends_on: this must be the first thing listening on 4317. Every app SDK
+    # gives up after OTEL_EXPORTER_OTLP_TIMEOUT and DROPS the batch, so gating the collector behind
+    # langfuse-web (and through it postgres/clickhouse/seaweedfs health) costs the startup log of
+    # every service on a cold start. The otlphttp/langfuse exporter has retry_on_failure and needs
+    # no start-order guarantee — langfuse-web is up long before the first OpenInference trace.
     healthcheck:
       test: [NONE]
     labels:
@@ -1677,6 +1684,8 @@ services:
     restart: always
     volumes: ['${VOLUME_ROOT:-./.docker-volumes}/open-webui:/app/backend/data']
     depends_on:
+      otel-collector:
+        condition: service_started
       postgres:
         condition: service_healthy
       seaweedfs-s3:
@@ -2221,6 +2230,8 @@ services:
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/api:latest
     depends_on:
+      otel-collector:
+        condition: service_started
       nats:
         condition: service_started
       traefik:
@@ -2473,6 +2484,8 @@ services:
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/sysadmin-api:latest
     depends_on:
+      otel-collector:
+        condition: service_started
       traefik:
         condition: service_started
       ferretdb:
@@ -2646,6 +2659,9 @@ services:
     container_name: llm-wrapping-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/llm_wrapping_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2710,6 +2726,9 @@ services:
     container_name: rag-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/rag_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2782,6 +2801,9 @@ services:
     container_name: expert-rag-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/expert_rag_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2854,6 +2876,9 @@ services:
     container_name: expert-asking-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/expert_asking_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2921,6 +2946,9 @@ services:
     container_name: retrieval-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/retrieval_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2985,6 +3013,9 @@ services:
     container_name: few-shot-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/few_shot_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3036,6 +3067,9 @@ services:
     container_name: namespace-selection-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/namespace_selection_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3087,6 +3121,9 @@ services:
     container_name: memory-writer-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/memory_writer_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3146,6 +3183,9 @@ services:
     container_name: imap-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/imap_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3206,6 +3246,9 @@ services:
     container_name: email-classification-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/email_classification_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 

--- a/infra/docker-compose.local.gpu.yml
+++ b/infra/docker-compose.local.gpu.yml
@@ -1625,6 +1625,8 @@ services:
       - ./configs/litellm/custom_callbacks.py:/app/custom_callbacks.py:ro
     command: --config /app/config.yml
     depends_on:
+      otel-collector:
+        condition: service_started
       postgres:
         condition: service_healthy
       presidio-analyzer:
@@ -1895,8 +1897,16 @@ services:
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY}
       - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY}
     volumes: [./configs/otel/otel-config.local.gpu.yml:/etc/otel-config.yml]
-    ports: [4317:4317, 4318:4318, 13133:13133, 55679:55679]
-    depends_on: [langfuse-web]
+    ports:
+      - 4317:4317
+      - 4318:4318
+      - 13133:13133
+      - 55679:55679
+    # Deliberately no depends_on: this must be the first thing listening on 4317. Every app SDK
+    # gives up after OTEL_EXPORTER_OTLP_TIMEOUT and DROPS the batch, so gating the collector behind
+    # langfuse-web (and through it postgres/clickhouse/seaweedfs health) costs the startup log of
+    # every service on a cold start. The otlphttp/langfuse exporter has retry_on_failure and needs
+    # no start-order guarantee — langfuse-web is up long before the first OpenInference trace.
     healthcheck:
       test: [NONE]
     labels:
@@ -1928,6 +1938,8 @@ services:
     restart: always
     volumes: ['${VOLUME_ROOT:-./.docker-volumes}/open-webui:/app/backend/data']
     depends_on:
+      otel-collector:
+        condition: service_started
       postgres:
         condition: service_healthy
       seaweedfs-s3:
@@ -2463,6 +2475,8 @@ services:
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/api:latest
     depends_on:
+      otel-collector:
+        condition: service_started
       nats:
         condition: service_started
       traefik:
@@ -2715,6 +2729,8 @@ services:
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/sysadmin-api:latest
     depends_on:
+      otel-collector:
+        condition: service_started
       traefik:
         condition: service_started
       ferretdb:
@@ -2888,6 +2904,9 @@ services:
     container_name: llm-wrapping-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/llm_wrapping_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2952,6 +2971,9 @@ services:
     container_name: rag-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/rag_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3024,6 +3046,9 @@ services:
     container_name: expert-rag-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/expert_rag_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3096,6 +3121,9 @@ services:
     container_name: expert-asking-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/expert_asking_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3163,6 +3191,9 @@ services:
     container_name: retrieval-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/retrieval_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3227,6 +3258,9 @@ services:
     container_name: few-shot-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/few_shot_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3278,6 +3312,9 @@ services:
     container_name: namespace-selection-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/namespace_selection_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3329,6 +3366,9 @@ services:
     container_name: memory-writer-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/memory_writer_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3388,6 +3428,9 @@ services:
     container_name: imap-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/imap_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3448,6 +3491,9 @@ services:
     container_name: email-classification-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/email_classification_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -1442,6 +1442,8 @@ services:
       - ./configs/litellm/custom_callbacks.py:/app/custom_callbacks.py:ro
     command: --config /app/config.yml
     depends_on:
+      otel-collector:
+        condition: service_started
       postgres:
         condition: service_healthy
       presidio-analyzer:
@@ -1675,8 +1677,16 @@ services:
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY}
       - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY}
     volumes: [./configs/otel/otel-config.local.yml:/etc/otel-config.yml]
-    ports: [4317:4317, 4318:4318, 13133:13133, 55679:55679]
-    depends_on: [langfuse-web]
+    ports:
+      - 4317:4317
+      - 4318:4318
+      - 13133:13133
+      - 55679:55679
+    # Deliberately no depends_on: this must be the first thing listening on 4317. Every app SDK
+    # gives up after OTEL_EXPORTER_OTLP_TIMEOUT and DROPS the batch, so gating the collector behind
+    # langfuse-web (and through it postgres/clickhouse/seaweedfs health) costs the startup log of
+    # every service on a cold start. The otlphttp/langfuse exporter has retry_on_failure and needs
+    # no start-order guarantee — langfuse-web is up long before the first OpenInference trace.
     healthcheck:
       test: [NONE]
     labels:
@@ -1708,6 +1718,8 @@ services:
     restart: always
     volumes: ['${VOLUME_ROOT:-./.docker-volumes}/open-webui:/app/backend/data']
     depends_on:
+      otel-collector:
+        condition: service_started
       postgres:
         condition: service_healthy
       seaweedfs-s3:
@@ -2251,6 +2263,8 @@ services:
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/api:latest
     depends_on:
+      otel-collector:
+        condition: service_started
       nats:
         condition: service_started
       traefik:
@@ -2503,6 +2517,8 @@ services:
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/sysadmin-api:latest
     depends_on:
+      otel-collector:
+        condition: service_started
       traefik:
         condition: service_started
       ferretdb:
@@ -2676,6 +2692,9 @@ services:
     container_name: llm-wrapping-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/llm_wrapping_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2740,6 +2759,9 @@ services:
     container_name: rag-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/rag_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2812,6 +2834,9 @@ services:
     container_name: expert-rag-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/expert_rag_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2884,6 +2909,9 @@ services:
     container_name: expert-asking-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/expert_asking_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2951,6 +2979,9 @@ services:
     container_name: retrieval-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/retrieval_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3015,6 +3046,9 @@ services:
     container_name: few-shot-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/few_shot_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3066,6 +3100,9 @@ services:
     container_name: namespace-selection-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/namespace_selection_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3117,6 +3154,9 @@ services:
     container_name: memory-writer-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/memory_writer_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3176,6 +3216,9 @@ services:
     container_name: imap-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/imap_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3236,6 +3279,9 @@ services:
     container_name: email-classification-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/email_classification_agent:latest
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 

--- a/infra/docker-compose.nightly.gpu.yml
+++ b/infra/docker-compose.nightly.gpu.yml
@@ -1596,6 +1596,8 @@ services:
       - ./configs/litellm/custom_callbacks.py:/app/custom_callbacks.py:ro
     command: --config /app/config.yml
     depends_on:
+      otel-collector:
+        condition: service_started
       postgres:
         condition: service_healthy
       presidio-analyzer:
@@ -1858,8 +1860,13 @@ services:
       - OTEL_HOST_NAME=${OTEL_HOST_NAME:-unset-nightly}
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY}
       - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY}
-    volumes: [./configs/otel/otel-config.nightly.gpu.yml:/etc/otel-config.yml]
-    depends_on: [langfuse-web]
+    volumes:
+      - ./configs/otel/otel-config.nightly.gpu.yml:/etc/otel-config.yml
+    # Deliberately no depends_on: this must be the first thing listening on 4317. Every app SDK
+    # gives up after OTEL_EXPORTER_OTLP_TIMEOUT and DROPS the batch, so gating the collector behind
+    # langfuse-web (and through it postgres/clickhouse/seaweedfs health) costs the startup log of
+    # every service on a cold start. The otlphttp/langfuse exporter has retry_on_failure and needs
+    # no start-order guarantee — langfuse-web is up long before the first OpenInference trace.
     healthcheck:
       test: [NONE]
     labels:
@@ -1891,6 +1898,8 @@ services:
     restart: always
     volumes: ['${VOLUME_ROOT:-./.docker-volumes}/open-webui:/app/backend/data']
     depends_on:
+      otel-collector:
+        condition: service_started
       postgres:
         condition: service_healthy
       seaweedfs-s3:
@@ -2427,6 +2436,8 @@ services:
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/api:nightly
     depends_on:
+      otel-collector:
+        condition: service_started
       nats:
         condition: service_started
       traefik:
@@ -2679,6 +2690,8 @@ services:
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/sysadmin-api:nightly
     depends_on:
+      otel-collector:
+        condition: service_started
       traefik:
         condition: service_started
       ferretdb:
@@ -2852,6 +2865,9 @@ services:
     container_name: llm-wrapping-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/llm_wrapping_agent:nightly
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2916,6 +2932,9 @@ services:
     container_name: rag-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/rag_agent:nightly
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2988,6 +3007,9 @@ services:
     container_name: expert-rag-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/expert_rag_agent:nightly
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3060,6 +3082,9 @@ services:
     container_name: expert-asking-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/expert_asking_agent:nightly
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3127,6 +3152,9 @@ services:
     container_name: retrieval-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/retrieval_agent:nightly
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3191,6 +3219,9 @@ services:
     container_name: few-shot-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/few_shot_agent:nightly
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3242,6 +3273,9 @@ services:
     container_name: namespace-selection-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/namespace_selection_agent:nightly
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3293,6 +3327,9 @@ services:
     container_name: memory-writer-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/memory_writer_agent:nightly
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3352,6 +3389,9 @@ services:
     container_name: imap-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/imap_agent:nightly
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3412,6 +3452,9 @@ services:
     container_name: email-classification-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/email_classification_agent:nightly
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 

--- a/infra/docker-compose.nightly.yml
+++ b/infra/docker-compose.nightly.yml
@@ -1417,6 +1417,8 @@ services:
       - ./configs/litellm/custom_callbacks.py:/app/custom_callbacks.py:ro
     command: --config /app/config.yml
     depends_on:
+      otel-collector:
+        condition: service_started
       postgres:
         condition: service_healthy
       presidio-analyzer:
@@ -1644,8 +1646,13 @@ services:
       - OTEL_HOST_NAME=${OTEL_HOST_NAME:-unset-nightly}
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY}
       - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY}
-    volumes: [./configs/otel/otel-config.nightly.yml:/etc/otel-config.yml]
-    depends_on: [langfuse-web]
+    volumes:
+      - ./configs/otel/otel-config.nightly.yml:/etc/otel-config.yml
+    # Deliberately no depends_on: this must be the first thing listening on 4317. Every app SDK
+    # gives up after OTEL_EXPORTER_OTLP_TIMEOUT and DROPS the batch, so gating the collector behind
+    # langfuse-web (and through it postgres/clickhouse/seaweedfs health) costs the startup log of
+    # every service on a cold start. The otlphttp/langfuse exporter has retry_on_failure and needs
+    # no start-order guarantee — langfuse-web is up long before the first OpenInference trace.
     healthcheck:
       test: [NONE]
     labels:
@@ -1677,6 +1684,8 @@ services:
     restart: always
     volumes: ['${VOLUME_ROOT:-./.docker-volumes}/open-webui:/app/backend/data']
     depends_on:
+      otel-collector:
+        condition: service_started
       postgres:
         condition: service_healthy
       seaweedfs-s3:
@@ -2221,6 +2230,8 @@ services:
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/api:nightly
     depends_on:
+      otel-collector:
+        condition: service_started
       nats:
         condition: service_started
       traefik:
@@ -2473,6 +2484,8 @@ services:
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/sysadmin-api:nightly
     depends_on:
+      otel-collector:
+        condition: service_started
       traefik:
         condition: service_started
       ferretdb:
@@ -2646,6 +2659,9 @@ services:
     container_name: llm-wrapping-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/llm_wrapping_agent:nightly
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2710,6 +2726,9 @@ services:
     container_name: rag-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/rag_agent:nightly
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2782,6 +2801,9 @@ services:
     container_name: expert-rag-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/expert_rag_agent:nightly
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2854,6 +2876,9 @@ services:
     container_name: expert-asking-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/expert_asking_agent:nightly
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2921,6 +2946,9 @@ services:
     container_name: retrieval-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/retrieval_agent:nightly
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -2985,6 +3013,9 @@ services:
     container_name: few-shot-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/few_shot_agent:nightly
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3036,6 +3067,9 @@ services:
     container_name: namespace-selection-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/namespace_selection_agent:nightly
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3087,6 +3121,9 @@ services:
     container_name: memory-writer-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/memory_writer_agent:nightly
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3146,6 +3183,9 @@ services:
     container_name: imap-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/imap_agent:nightly
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 
@@ -3206,6 +3246,9 @@ services:
     container_name: email-classification-agent
     restart: always
     image: ghcr.io/bbvch-ai/aihub-core/email_classification_agent:nightly
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
 

--- a/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/open_telemetry_settings.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/open_telemetry_settings.py
@@ -38,14 +38,25 @@ class OpenTelemetrySettings(EnvironmentSettings):
     METRICS_ENABLED: Annotated[
         bool, Field(description="Enable/disable OpenTelemetry request metrics (separate from tracing)")
     ] = False
-    # The SDK's 10s default is the whole retry budget, not a per-attempt timeout: the gRPC exporter
-    # sets deadline = now + timeout once, then abandons the batch as soon as the next backoff
+    # The SDK's 10s default is the whole retry budget, not a per-attempt timeout: the exporter sets
+    # deadline = now + timeout once, then abandons the batch as soon as the next backoff
     # (1s, 2s, 4s, 8s...) would overrun it — three attempts, ~7s, then "Failed to export ... error
     # code: StatusCode.UNAVAILABLE" and the records are gone. A collector restart takes longer than
     # that: on nightly.951 sysadmin-api came up 27.4s before the recreated collector and lost its
-    # startup log. 60s buys the ~31s the hardcoded _MAX_RETRYS=6 ladder can actually use, which
-    # covers a container recreate. Raising it further trades queue headroom for a backend that is
-    # slow rather than absent — the queue keeps filling while the export thread waits.
+    # startup log.
+    #
+    # 60s does NOT buy 60s of coverage: the hardcoded _MAX_RETRYS=6 ladder makes its last attempt
+    # at ~31s, so that is the real ceiling, and against the 27.4s measured on that deploy the
+    # margin is only ~4s. The depends_on chain in docker-compose is what actually removes the
+    # ordering gap — this value only has to survive an unplanned collector restart. Raising it
+    # further trades queue headroom for a backend that is slow rather than absent: the queue keeps
+    # filling while the export thread waits, and BatchLogRecordProcessor.shutdown() only joins the
+    # worker for 30s, so anything past that is unreachable on the shutdown path anyway.
+    #
+    # NOTE: with the OTEL_ prefix this field's variable is OTEL_EXPORTER_OTLP_TIMEOUT, the name the
+    # OTel spec reserves — and the spec measures it in MILLISECONDS. Python's SDK deviates and
+    # reads seconds, so the two agree here, but a value placed in shared deployment config would be
+    # read as 60ms by any non-Python OTLP client in the stack.
     EXPORTER_OTLP_TIMEOUT: Annotated[int, Field(description="Seconds an OTLP export may spend retrying")] = 60
     BLRP_MAX_QUEUE_SIZE: Annotated[int, Field(description="Log records buffered before new ones are dropped")] = 16384
     BLRP_MAX_EXPORT_BATCH_SIZE: Annotated[int, Field(description="Log records per OTLP export")] = 2048
@@ -193,21 +204,35 @@ class OpenTelemetrySettings(EnvironmentSettings):
         set_logger_provider(logger_provider)
 
         otel_handler = LoggingHandler(level=logging.NOTSET, logger_provider=logger_provider)
-        otel_handler.addFilter(OpenTelemetrySettings._is_not_queue_management_record)
+        otel_handler.addFilter(OpenTelemetrySettings._is_not_sdk_internal_record)
         OpenTelemetrySettings._attach_handler(logging.getLogger(), otel_handler)
         OpenTelemetrySettings._attach_to_server_loggers(otel_handler)
 
         return logger_provider
 
     @staticmethod
-    def _is_not_queue_management_record(record: logging.LogRecord) -> bool:
+    def _is_not_sdk_internal_record(record: logging.LogRecord) -> bool:
         """
-        The SDK reports a full queue with `_logger.warning("Queue full, dropping logs.")` from
-        inside BatchLogRecordProcessor.emit(), on the calling thread. With the handler on the root
-        logger that warning re-enters emit(), finds the queue still full, warns again — unbounded
-        recursion until the logging call dies in handleError(). Exporter self-reports
-        ("Failed to export logs to ...") are deliberately NOT filtered: they are emitted on the
-        export worker thread, cannot recurse, and are the only signal that telemetry was lost.
+        Keeps the OTLP handler off its own SDK's diagnostics, so reporting a problem with log
+        export cannot itself go through log export.
+
+        The case that motivates it: BatchLogRecordProcessor reports a full queue with
+        `_logger.warning("Queue full, dropping %s.")` on the *calling* thread, so with the handler
+        on the root logger that warning re-enters on_emit(). The SDK already breaks the loop —
+        _shared_internal attaches its own DuplicateFilter for exactly this ("prevent endlessly
+        logging the same log in cases where logging itself is failing"), which caps the nesting at
+        depth 2 — but that is an internal of a floating `>=1.39.1` pin, and re-entering the export
+        path to report that the export path is full is pointless work regardless.
+
+        Scope is the whole `opentelemetry.sdk.` tree, not just the queue warning, because the
+        emitting module has already moved once (_logs._internal.export -> _shared_internal) and a
+        prefix survives that. The cost is that SDK-side diagnostics (ended-span writes, instrument
+        name conflicts, resource detector errors) no longer reach the backend; they still reach
+        whatever console handlers sit on the root logger.
+
+        Exporter self-reports ("Failed to export logs to ...") are deliberately NOT filtered: they
+        are emitted on the export worker thread, cannot re-enter, and are the only signal in the
+        backend that telemetry was lost.
         """
         return not record.name.startswith("opentelemetry.sdk.")
 

--- a/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/open_telemetry_settings.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/open_telemetry_settings.py
@@ -38,6 +38,15 @@ class OpenTelemetrySettings(EnvironmentSettings):
     METRICS_ENABLED: Annotated[
         bool, Field(description="Enable/disable OpenTelemetry request metrics (separate from tracing)")
     ] = False
+    # The SDK's 10s default is the whole retry budget, not a per-attempt timeout: the gRPC exporter
+    # sets deadline = now + timeout once, then abandons the batch as soon as the next backoff
+    # (1s, 2s, 4s, 8s...) would overrun it — three attempts, ~7s, then "Failed to export ... error
+    # code: StatusCode.UNAVAILABLE" and the records are gone. A collector restart takes longer than
+    # that: on nightly.951 sysadmin-api came up 27.4s before the recreated collector and lost its
+    # startup log. 60s buys the ~31s the hardcoded _MAX_RETRYS=6 ladder can actually use, which
+    # covers a container recreate. Raising it further trades queue headroom for a backend that is
+    # slow rather than absent — the queue keeps filling while the export thread waits.
+    EXPORTER_OTLP_TIMEOUT: Annotated[int, Field(description="Seconds an OTLP export may spend retrying")] = 60
     BLRP_MAX_QUEUE_SIZE: Annotated[int, Field(description="Log records buffered before new ones are dropped")] = 16384
     BLRP_MAX_EXPORT_BATCH_SIZE: Annotated[int, Field(description="Log records per OTLP export")] = 2048
     RESOURCE_SERVICE_NAME: Annotated[str | None, Field(description="Resource service name")] = None
@@ -64,9 +73,13 @@ class OpenTelemetrySettings(EnvironmentSettings):
         tracer_provider = TracerProvider(resource=self._build_resource(), span_limits=span_limits)
 
         if self.EXPORTER_OTLP_PROTOCOL == "grpc":
-            otlp_exporter = GRPCSpanExporter(endpoint=self.EXPORTER_OTLP_ENDPOINT, insecure=self.EXPORTER_OTLP_INSECURE)
+            otlp_exporter = GRPCSpanExporter(
+                endpoint=self.EXPORTER_OTLP_ENDPOINT,
+                insecure=self.EXPORTER_OTLP_INSECURE,
+                timeout=self.EXPORTER_OTLP_TIMEOUT,
+            )
         else:
-            otlp_exporter = HTTPSpanExporter(endpoint=self.EXPORTER_OTLP_ENDPOINT)
+            otlp_exporter = HTTPSpanExporter(endpoint=self.EXPORTER_OTLP_ENDPOINT, timeout=self.EXPORTER_OTLP_TIMEOUT)
 
         span_processor = BatchSpanProcessor(otlp_exporter)
         tracer_provider.add_span_processor(span_processor)
@@ -110,10 +123,12 @@ class OpenTelemetrySettings(EnvironmentSettings):
 
         if self.EXPORTER_OTLP_PROTOCOL == "grpc":
             otlp_exporter = GRPCMetricExporter(
-                endpoint=self.EXPORTER_OTLP_ENDPOINT, insecure=self.EXPORTER_OTLP_INSECURE
+                endpoint=self.EXPORTER_OTLP_ENDPOINT,
+                insecure=self.EXPORTER_OTLP_INSECURE,
+                timeout=self.EXPORTER_OTLP_TIMEOUT,
             )
         else:
-            otlp_exporter = HTTPMetricExporter(endpoint=self.EXPORTER_OTLP_ENDPOINT)
+            otlp_exporter = HTTPMetricExporter(endpoint=self.EXPORTER_OTLP_ENDPOINT, timeout=self.EXPORTER_OTLP_TIMEOUT)
 
         metric_reader = PeriodicExportingMetricReader(otlp_exporter)
         return MeterProvider(resource=resource, metric_readers=[metric_reader])
@@ -151,10 +166,14 @@ class OpenTelemetrySettings(EnvironmentSettings):
 
         if self.EXPORTER_OTLP_PROTOCOL == "grpc":
             otlp_log_exporter = GRPCLogExporter(
-                endpoint=self.EXPORTER_OTLP_ENDPOINT, insecure=self.EXPORTER_OTLP_INSECURE
+                endpoint=self.EXPORTER_OTLP_ENDPOINT,
+                insecure=self.EXPORTER_OTLP_INSECURE,
+                timeout=self.EXPORTER_OTLP_TIMEOUT,
             )
         else:
-            otlp_log_exporter = HTTPLogExporter(endpoint=self.EXPORTER_OTLP_ENDPOINT)
+            otlp_log_exporter = HTTPLogExporter(
+                endpoint=self.EXPORTER_OTLP_ENDPOINT, timeout=self.EXPORTER_OTLP_TIMEOUT
+            )
 
         # The SDK defaults (2048 queued, 512 per export) silently discard records once the queue is
         # full, and nothing logs the discard — so a burst looks like a complete log in the backend
@@ -174,10 +193,23 @@ class OpenTelemetrySettings(EnvironmentSettings):
         set_logger_provider(logger_provider)
 
         otel_handler = LoggingHandler(level=logging.NOTSET, logger_provider=logger_provider)
+        otel_handler.addFilter(OpenTelemetrySettings._is_not_queue_management_record)
         OpenTelemetrySettings._attach_handler(logging.getLogger(), otel_handler)
         OpenTelemetrySettings._attach_to_server_loggers(otel_handler)
 
         return logger_provider
+
+    @staticmethod
+    def _is_not_queue_management_record(record: logging.LogRecord) -> bool:
+        """
+        The SDK reports a full queue with `_logger.warning("Queue full, dropping logs.")` from
+        inside BatchLogRecordProcessor.emit(), on the calling thread. With the handler on the root
+        logger that warning re-enters emit(), finds the queue still full, warns again — unbounded
+        recursion until the logging call dies in handleError(). Exporter self-reports
+        ("Failed to export logs to ...") are deliberately NOT filtered: they are emitted on the
+        export worker thread, cannot recurse, and are the only signal that telemetry was lost.
+        """
+        return not record.name.startswith("opentelemetry.sdk.")
 
     @staticmethod
     def _attach_to_server_loggers(handler: LoggingHandler) -> None:

--- a/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/tests/unit/test_open_telemetry_settings.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/tests/unit/test_open_telemetry_settings.py
@@ -1,3 +1,4 @@
+import logging
 import threading
 from typing import Any
 from unittest.mock import patch
@@ -12,6 +13,7 @@ from swiss_ai_hub.core.infrastructure.opentelemetry.open_telemetry_settings impo
 pytestmark = pytest.mark.unit
 
 OTLP_ENDPOINT = "http://localhost:4317"
+OTLP_TIMEOUT = 60
 
 
 def _enabled_settings(**overrides: Any) -> OpenTelemetrySettings:
@@ -38,6 +40,10 @@ def _enabled_provider(**overrides: Any) -> MeterProvider:
 
     assert provider is not None
     return provider
+
+
+def _log_record(logger_name: str) -> logging.LogRecord:
+    return logging.LogRecord(logger_name, logging.WARNING, __file__, 1, "msg", None, None)
 
 
 def test_metrics_are_off_by_default() -> None:
@@ -97,7 +103,7 @@ def test_grpc_protocol_passes_the_insecure_flag() -> None:
     with patch.object(settings_module, "GRPCMetricExporter") as grpc_exporter:
         _enabled_provider(EXPORTER_OTLP_PROTOCOL="grpc", EXPORTER_OTLP_INSECURE=True).shutdown()
 
-    grpc_exporter.assert_called_once_with(endpoint=OTLP_ENDPOINT, insecure=True)
+    grpc_exporter.assert_called_once_with(endpoint=OTLP_ENDPOINT, insecure=True, timeout=OTLP_TIMEOUT)
 
 
 def test_http_protocol_uses_the_http_exporter_without_insecure() -> None:
@@ -105,7 +111,31 @@ def test_http_protocol_uses_the_http_exporter_without_insecure() -> None:
     with patch.object(settings_module, "HTTPMetricExporter") as http_exporter:
         _enabled_provider(EXPORTER_OTLP_PROTOCOL="http").shutdown()
 
-    http_exporter.assert_called_once_with(endpoint=OTLP_ENDPOINT)
+    http_exporter.assert_called_once_with(endpoint=OTLP_ENDPOINT, timeout=OTLP_TIMEOUT)
+
+
+def test_the_export_retry_window_outlives_a_collector_restart() -> None:
+    """
+    Regression guard for the nightly.951 log loss. The SDK's 10s default is the entire retry
+    budget, so any collector gap longer than ~7s drops the batch — and a container recreate is
+    measured in tens of seconds (27.4s on that deploy). Lowering this back towards the default
+    silently reintroduces the data loss, hence the pin.
+    """
+    assert OpenTelemetrySettings.model_fields["EXPORTER_OTLP_TIMEOUT"].default == OTLP_TIMEOUT
+
+
+def test_the_sdk_queue_warning_never_re_enters_the_export_path() -> None:
+    """
+    "Queue full, dropping logs." is emitted from inside BatchLogRecordProcessor.emit() on the
+    calling thread, so routing it back through the root handler recurses until the logging call
+    fails. Exporter self-reports run on the export worker thread and must keep flowing — they are
+    the only evidence in the backend that telemetry was lost.
+    """
+    is_exported = OpenTelemetrySettings._is_not_queue_management_record
+
+    assert not is_exported(_log_record("opentelemetry.sdk._shared_internal"))
+    assert is_exported(_log_record("opentelemetry.exporter.otlp.proto.grpc.exporter"))
+    assert is_exported(_log_record("swiss_ai_hub.core.routes.health"))
 
 
 @pytest.mark.parametrize(

--- a/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/tests/unit/test_open_telemetry_settings.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/opentelemetry/tests/unit/test_open_telemetry_settings.py
@@ -114,7 +114,7 @@ def test_http_protocol_uses_the_http_exporter_without_insecure() -> None:
     http_exporter.assert_called_once_with(endpoint=OTLP_ENDPOINT, timeout=OTLP_TIMEOUT)
 
 
-def test_the_export_retry_window_outlives_a_collector_restart() -> None:
+def test_the_export_timeout_default_covers_a_container_recreate() -> None:
     """
     Regression guard for the nightly.951 log loss. The SDK's 10s default is the entire retry
     budget, so any collector gap longer than ~7s drops the batch — and a container recreate is
@@ -124,16 +124,29 @@ def test_the_export_retry_window_outlives_a_collector_restart() -> None:
     assert OpenTelemetrySettings.model_fields["EXPORTER_OTLP_TIMEOUT"].default == OTLP_TIMEOUT
 
 
-def test_the_sdk_queue_warning_never_re_enters_the_export_path() -> None:
+def test_the_retry_ladder_fits_inside_the_configured_timeout() -> None:
     """
-    "Queue full, dropping logs." is emitted from inside BatchLogRecordProcessor.emit() on the
-    calling thread, so routing it back through the root handler recurses until the logging call
-    fails. Exporter self-reports run on the export worker thread and must keep flowing — they are
-    the only evidence in the backend that telemetry was lost.
+    The timeout is a budget the backoff ladder spends, not a per-attempt limit: the exporter
+    abandons the batch once the next backoff would overrun `deadline = start + timeout`. A budget
+    that cuts the ladder short wastes the remaining attempts, so pin the relationship rather than
+    just the number — the last of the six attempts starts at 1+2+4+8+16 = 31s.
     """
-    is_exported = OpenTelemetrySettings._is_not_queue_management_record
+    ladder_end_seconds = sum(2**attempt for attempt in range(5))
+
+    assert ladder_end_seconds < OpenTelemetrySettings.model_fields["EXPORTER_OTLP_TIMEOUT"].default
+
+
+def test_the_otlp_handler_ignores_sdk_internal_records() -> None:
+    """
+    "Queue full, dropping logs." is emitted from inside BatchLogRecordProcessor on the calling
+    thread, so routing it back through the root handler re-enters the export path. Exporter
+    self-reports run on the export worker thread and must keep flowing — they are the only
+    evidence in the backend that telemetry was lost.
+    """
+    is_exported = OpenTelemetrySettings._is_not_sdk_internal_record
 
     assert not is_exported(_log_record("opentelemetry.sdk._shared_internal"))
+    assert not is_exported(_log_record("opentelemetry.sdk.trace"))
     assert is_exported(_log_record("opentelemetry.exporter.otlp.proto.grpc.exporter"))
     assert is_exported(_log_record("swiss_ai_hub.core.routes.health"))
 


### PR DESCRIPTION
## Problem

`sysadmin-api` on nightly reported, once, at 04:37:05.633Z:

```
Failed to export logs to otel-collector:4317, error code: StatusCode.UNAVAILABLE
```

That message means a whole batch of log records was **dropped**, not delayed. Container timings from the VM:

| Time (UTC, 2026-08-24) | Event | Δ from app start |
| --- | --- | --- |
| 03:42 | #1741 merges, adding `OTEL_DEPLOYMENT_ENVIRONMENT` / `OTEL_HOST_NAME` to the collector — its service definition changes | |
| 04:36:40.164 | `sysadmin-api` (nightly.951) starts and logs immediately | 0s |
| 04:37:05.633 | export deadline exhausted → `ERROR`, batch discarded | +25.5s |
| 04:37:07.574 | `otel-collector` finishes being recreated | +27.4s |

`langfuse-web` and `clickhouse` were still the containers started on 2026-07-16, so this was a partial redeploy: compose recreated exactly the two services whose definitions had changed, and it started the app **27.4s before** the collector because nothing constrained that order.

Two independent causes:

1. **No start-order constraint.** No service declared a dependency on `otel-collector`, so compose had no reason to bring it up first — while the collector itself was gated behind `langfuse-web` → postgres/clickhouse/seaweedfs health, the slowest chain in the stack.
2. **The retry window is far shorter than it looks.** `OTEL_EXPORTER_OTLP_TIMEOUT` defaults to 10s and is the *entire* retry budget, not a per-attempt timeout: the gRPC exporter sets `deadline = now + timeout` once, then abandons the batch as soon as the next backoff (1s, 2s, 4s, 8s…) would overrun it. That is ~3 attempts over ~7s — the hardcoded `_MAX_RETRYS = 6` is never reached. A container recreate is an order of magnitude longer.

## Changes

- **`otel-collector` loses its `depends_on: langfuse-web`.** It must be the first thing listening on 4317. The `otlphttp/langfuse` exporter has `retry_on_failure` and needs no start-order guarantee — `langfuse-web` is up long before the first OpenInference trace.
- **Every service that exports OTLP now waits for the collector** (`condition: service_started`; 14 services — litellm, open-webui, api, sysadmin-api and the 10 agents). `service_started` rather than `service_healthy` because the collector image is distroless and cannot run an in-container healthcheck — hence the existing `test: [ "NONE" ]` plus the label-based external probe. It binds 4317 within a second of starting. Compose does not recreate dependents when a dependency changes (that is what `--always-recreate-deps` is for), so this does not turn a collector-only change into a full-stack bounce.
- **`OTEL_EXPORTER_OTLP_TIMEOUT` defaults to 60s** and is now passed to all six exporters (traces/metrics/logs × gRPC/HTTP), which previously took the SDK default. 60s buys the ~31s the retry ladder can actually use — enough to outlive a container recreate. Overridable per service as before.
- **The SDK's queue-full warning no longer re-enters the export path.** `BatchLogRecordProcessor.emit()` reports a full queue with `_logger.warning("Queue full, dropping logs.")` on the *calling* thread; with the handler on the root logger that warning re-enters `emit()`, finds the queue still full, warns again — unbounded recursion until the logging call dies in `handleError()`. Records from `opentelemetry.sdk.*` are now filtered out of the OTLP handler.

Deliberately **not** filtered: `opentelemetry.exporter.*` self-reports. They are emitted on the export worker thread, cannot recurse, and are the only evidence in the backend that telemetry was lost — this investigation started from one of them. Worth a second opinion if reviewers would rather have the whole `opentelemetry.` tree filtered for safety.

## Verification

- `uv run pytest swiss_ai_hub/core/infrastructure/opentelemetry` — 24 passed. Two existing exporter-argument assertions updated for the new `timeout=` kwarg; two tests added (retry-window pin, filter behaviour).
- All 10 generated compose files parsed and checked for dangling / cyclic `depends_on`: 14 `otel-collector` waiters per production stage, 2 in dev (api and agents run locally there), no dangling references, collector has no dependencies.
- The wider `packages/core` suite: 1232 passed, 46 failed, 66 errors. The Docker dev stack is down on this machine, so everything DB-backed fails on `localhost:27017` connection refused. Two full runs an hour apart produced identical pass/fail counts, no telemetry test appears among the failures, and every failure sampled was a mongo connection error — but this is not a green baseline, so treat CI as the authority on the rest of the suite.

