### PR TITLE
fix(ui): Show the release version on promoted Helm deployments

### DIFF
--- a/packages/web/composables/app/useAppVersion.ts
+++ b/packages/web/composables/app/useAppVersion.ts
@@ -3,18 +3,29 @@ import { minutesToMilliseconds } from 'date-fns'
 
 // Surfaces the running version of both services. The UI service version is baked
 // into the static bundle at build time (runtimeConfig.public.appVersion); the API
-// version is read from the health endpoint, which reports the channel tag (e.g.
-// `latest`) the running image was pulled as. When both match a single number is
+// version is read from the health endpoint. When both agree a single number is
 // shown, otherwise both are shown as `UI / API`.
 //
-// A release is promoted onto the `latest` channel by retagging the exact `-rc.N`
-// build that was tested, so the baked version keeps its release-candidate suffix
-// (e.g. `v0.317.0-rc.3`) even though the artifact IS the final release. Strip that
-// suffix only on the `latest` channel, so a promoted build shows its release
-// version (`v0.317.0`). On any other channel the build is genuinely a candidate or
-// rolling build, so keep the suffix to stay identifiable.
+// A release is promoted by retagging the exact `-rc.N` build that was tested, so
+// the baked UI version keeps its release-candidate suffix (e.g. `v0.317.0-rc.3`)
+// even though the artifact IS the final release. A container cannot read its own
+// image tag, so the release has to be inferred from what the API reports, and the
+// two deployment flavours report it differently: docker-compose pins the channel
+// tag (`latest`), while Helm pins an exact `vX.Y.Z` per instance and leaves the
+// API on its package metadata (`0.319.0`). Both are release signals; on either
+// one the suffix is dropped so a promoted build shows its release version.
+//
+// Versions are compared with the leading `v` normalised away, because one side is
+// a git tag (`v0.319.0`) and the other Python package metadata (`0.319.0`) — the
+// same version, and rendering it as `UI / API` would read as skew.
+//
+// Every other case is genuinely a candidate or a rolling build (another channel
+// such as `staging`, an API pinned to an explicit `-rc.N`, a nightly), so the
+// suffix stays to keep the build identifiable.
 const RELEASE_CHANNEL = 'latest'
-const toReleaseVersion = (version: string): string => version.replace(/-rc\.\d+$/, '')
+const RC_SUFFIX = /-rc\.\d+$/
+const toReleaseVersion = (version: string): string => version.replace(RC_SUFFIX, '')
+const toComparable = (version: string): string => version.replace(/^v/, '')
 
 export const useAppVersion = defineQuery(() => {
   const bakedUiVersion = useRuntimeConfig().public.appVersion as string
@@ -28,13 +39,21 @@ export const useAppVersion = defineQuery(() => {
     },
   })
 
+  // An API version that still carries `-rc.N` can never equal the stripped UI
+  // version, so a candidate deployment fails this check without a separate guard.
+  const isReleaseDeployment = computed(() => {
+    const api = apiVersion.value
+    if (!api) return false
+    return api === RELEASE_CHANNEL || toComparable(api) === toComparable(toReleaseVersion(bakedUiVersion))
+  })
+
   const uiVersion = computed(() =>
-    apiVersion.value === RELEASE_CHANNEL ? toReleaseVersion(bakedUiVersion) : bakedUiVersion,
+    isReleaseDeployment.value ? toReleaseVersion(bakedUiVersion) : bakedUiVersion,
   )
 
   const versionDisplay = computed(() => {
     const api = apiVersion.value
-    if (!api || api === uiVersion.value) return uiVersion.value
+    if (!api || toComparable(api) === toComparable(uiVersion.value)) return uiVersion.value
     return `${uiVersion.value} / ${api}`
   })
 


### PR DESCRIPTION
Closes #1787

`useAppVersion` stripped the `-rc.N` suffix from the baked UI version only when the API reported the literal channel tag `latest` — a docker-compose concept. Helm pins an exact `vX.Y.Z` per instance and leaves the API on its package metadata, so the condition never matched and a promoted release kept showing the release candidate it was retagged from (`v0.319.0-rc.4 / 0.319.0` instead of `v0.319.0`).

## What changed

`packages/web/composables/app/useAppVersion.ts` only.

- **Second release signal.** Alongside the `latest` channel tag, an API reporting a flat release version equal to the UI's release base now counts as a release, and the suffix is dropped. No extra guard is needed to exclude candidates: an API version that still carries `-rc.N` can never equal the stripped UI version.
- **Leading `v` normalised for comparison.** One side is a git tag (`v0.319.0`), the other Python package metadata (`0.319.0`) — the same version, previously rendered as skew.
- **Every non-release case keeps its suffix**: another channel such as `staging`, an API pinned to an explicit `-rc.N`, and nightly builds (`v<core>-nightly.<height>` is untouched by the `-rc.\d+$` regex).

## Verification

`packages/web` has no test runner (`make test` is a no-op there), so the logic was verified against the full truth table out-of-band. Every accepted-when criterion of #1787 is covered:

| Case | baked UI | API `/health` | Display |
| --- | --- | --- | --- |
| Helm promoted release | `v0.319.0-rc.4` | `0.319.0` | `v0.319.0` |
| Compose `latest` channel | `v0.317.0-rc.3` | `latest` | `v0.317.0 / latest` |
| Compose `staging` channel | `v0.319.0-rc.4` | `staging` | `v0.319.0-rc.4 / staging` |
| API pinned to explicit rc | `v0.319.0-rc.4` | `v0.319.0-rc.4` | `v0.319.0-rc.4` |
| API pinned to explicit rc, flat | `v0.319.0-rc.4` | `0.319.0-rc.4` | `v0.319.0-rc.4` |
| Nightly | `v0.320.0-nightly.42` | `nightly` | `v0.320.0-nightly.42 / nightly` |
| Genuine skew | `v0.319.0-rc.4` | `0.318.0` | `v0.319.0-rc.4 / 0.318.0` |
| Dev stack | `0.319.0` | `dev` | `0.319.0 / dev` |
| API unreachable | `v0.319.0-rc.4` | — | `v0.319.0-rc.4` |

ESLint passes. No OpenAPI change, so no SDK regeneration. No ADR: no new dependency, framework, or pattern.

## Known trade-off

On Helm, an instance pinned to `v0.319.0-rc.4` will now show `v0.319.0`. `cut-release.yml` bumps only `main` to the next minor while the release branch stays on the cut line, so an rc image and its promoted release carry identical package metadata (`0.319.0`) — the two cases are indistinguishable from inside the container. #1787 declares this out of scope and resolves the ambiguity in favour of releases, because `aihub-k8s` has only ever pinned flat releases.
