### PR TITLE
fix(deploy): Set Keycloak accessTokenLifespan to 1 hour

### DIFF
--- a/docs/arc42/decisions/2026_06_11_keycloak_sso_session_lifespans.md
+++ b/docs/arc42/decisions/2026_06_11_keycloak_sso_session_lifespans.md
@@ -87,7 +87,28 @@ forcing a credential re-verification at least monthly.
 - Sessions already expired before the rollout cannot be revived; users see one final forced login after the change is
   deployed.
 
+## Addendum (2026-08-20): access token lifespan
+
+The original decision scoped itself to the two SSO **session** timers and left `accessTokenLifespan` on Keycloak's
+default of 300 seconds — never an explicit choice, simply the value nobody set. Every environment therefore ran on a
+5-minute access token, which forced the admin SPA into a refresh-token grant roughly every 3 minutes
+(`accessTokenExpiringNotificationTimeInSeconds: 120` in `packages/web/plugins/oidc-client.ts`) and broke any consumer
+holding a Keycloak JWT without a refresh loop.
+
+**`accessTokenLifespan` is now set explicitly to 1 hour (3600 seconds)**, defined alongside the session timers in the
+`keycloak:` block of `infra/deployment/compose-config.yml` and rolled out through the same two mechanisms: the bootstrap
+realm import for fresh installs, and a conditional `kcadm` default-migration in the entrypoint (guarded on the value
+still being exactly `300`) for existing deployments.
+
+The security trade-off differs from the session timers. A JWT is validated statelessly against JWKS in
+`KeycloakAuthHandler` with no per-request revocation check, so the access token lifespan — not the session timer — is
+the real bound on how long a logged-out, disabled, or role-revoked user keeps API access. One hour is the accepted
+window; it is also the staleness bound on the `roles` and `tenants` claims that drive sysadmin status and tenant
+membership sync.
+
 ### Related Decisions
 
 - `2026_04_07_active_tenant_as_keycloak_user_attribute.md` — active tenant persisted in Keycloak, restored after login
 - `2025_12_28_keycloak_as_identity_broker.md` — Keycloak as sole OIDC provider
+- `2026_02_19_parent_app_owns_auth_state_for_iframe_services.md` — the post-iframe-logout grace window this lifespan
+  determines

--- a/docs/docs/6_code_deep_dive/2_keycloak_configuration/index.en.md
+++ b/docs/docs/6_code_deep_dive/2_keycloak_configuration/index.en.md
@@ -23,10 +23,10 @@ the session-lifespan migration via `kcadm`; it no longer reconciles clients, flo
 
 ### What lives in each lifecycle
 
-| Lifecycle     | Realm objects                                                                                                                                                                                                                    |
-| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Bootstrap** | Realm-level settings (login theme, brute-force protection, session lifespans, SMTP), the user-profile component, the startup **tenant group** seed, the **superuser** seed, and the **identity providers** (Azure AD + mappers). |
-| **Managed**   | Realm **roles**, **client scopes**, **clients**, custom **authentication flows** (incl. the Langfuse sysadmin gate and its `browserFlow` binding), and the `aihub-api-service` **service account**.                              |
+| Lifecycle     | Realm objects                                                                                                                                                                                                                              |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Bootstrap** | Realm-level settings (login theme, brute-force protection, token and session lifespans, SMTP), the user-profile component, the startup **tenant group** seed, the **superuser** seed, and the **identity providers** (Azure AD + mappers). |
+| **Managed**   | Realm **roles**, **client scopes**, **clients**, custom **authentication flows** (incl. the Langfuse sysadmin gate and its `browserFlow` binding), and the `aihub-api-service` **service account**.                                        |
 
 ::: tip Rule of thumb
 If you change something in `bootstrap/` and need it on an existing deployment, you must apply it manually (admin
@@ -129,7 +129,7 @@ What this means in practice when upgrading AI-Hub:
 - **Bootstrap** changes (realm settings, the tenant-group seed, the superuser, **identity providers**) do **not** reach
   an already-initialized realm. Apply them in the Keycloak admin console, or re-seed by resetting the realm database.
   Conversely, this is exactly why operator edits to those objects (e.g. rotating an Azure client secret in the console,
-  tuning session lifespans) survive upgrades.
+  tuning token or session lifespans) survive upgrades.
 
 The Langfuse sysadmin gate follows the managed path (its flows live in `managed/40-auth-flows.json.j2`); details in
 [Langfuse Sysadmin Gate](1_langfuse_sysadmin_gate/).

--- a/docs/docs/6_code_deep_dive/2_keycloak_configuration/index.en.md
+++ b/docs/docs/6_code_deep_dive/2_keycloak_configuration/index.en.md
@@ -17,8 +17,8 @@ whether an edit reaches an *already-running* deployment on the next AI-Hub upgra
 | **Managed**   | `keycloak/managed/`   | Every container start — by the one-shot `keycloak-config` service ([keycloak-config-cli](https://github.com/adorsys/keycloak-config-cli)) over the admin API | **Yes.** File wins, including deletions; admin-console drift on these objects is reverted on the next restart.                                                                                  |
 
 `keycloak-entrypoint.sh.j2` orchestrates the first-start import (env-var substitution + `--import-realm`) and applies
-the session-lifespan migration via `kcadm`; it no longer reconciles clients, flows, or identity providers — that is the
-`keycloak-config` service's job. The decision and mechanics are recorded in ADR
+the token- and session-lifespan migration via `kcadm`; it no longer reconciles clients, flows, or identity providers —
+that is the `keycloak-config` service's job. The decision and mechanics are recorded in ADR
 `2026_06_12_declarative_keycloak_realm_reconciliation`.
 
 ### What lives in each lifecycle

--- a/infra/configs/keycloak/aihub-realm.build.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.build.gpu.json
@@ -13,6 +13,7 @@
   "rememberMe": true,
   "ssoSessionIdleTimeout": 432000,
   "ssoSessionMaxLifespan": 2592000,
+  "accessTokenLifespan": 3600,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,

--- a/infra/configs/keycloak/aihub-realm.build.json
+++ b/infra/configs/keycloak/aihub-realm.build.json
@@ -13,6 +13,7 @@
   "rememberMe": true,
   "ssoSessionIdleTimeout": 432000,
   "ssoSessionMaxLifespan": 2592000,
+  "accessTokenLifespan": 3600,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,

--- a/infra/configs/keycloak/aihub-realm.dev.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.dev.gpu.json
@@ -13,6 +13,7 @@
   "rememberMe": true,
   "ssoSessionIdleTimeout": 432000,
   "ssoSessionMaxLifespan": 2592000,
+  "accessTokenLifespan": 3600,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,

--- a/infra/configs/keycloak/aihub-realm.dev.json
+++ b/infra/configs/keycloak/aihub-realm.dev.json
@@ -13,6 +13,7 @@
   "rememberMe": true,
   "ssoSessionIdleTimeout": 432000,
   "ssoSessionMaxLifespan": 2592000,
+  "accessTokenLifespan": 3600,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,

--- a/infra/configs/keycloak/aihub-realm.latest.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.latest.gpu.json
@@ -13,6 +13,7 @@
   "rememberMe": true,
   "ssoSessionIdleTimeout": 432000,
   "ssoSessionMaxLifespan": 2592000,
+  "accessTokenLifespan": 3600,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,

--- a/infra/configs/keycloak/aihub-realm.latest.json
+++ b/infra/configs/keycloak/aihub-realm.latest.json
@@ -13,6 +13,7 @@
   "rememberMe": true,
   "ssoSessionIdleTimeout": 432000,
   "ssoSessionMaxLifespan": 2592000,
+  "accessTokenLifespan": 3600,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,

--- a/infra/configs/keycloak/aihub-realm.local.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.local.gpu.json
@@ -13,6 +13,7 @@
   "rememberMe": true,
   "ssoSessionIdleTimeout": 432000,
   "ssoSessionMaxLifespan": 2592000,
+  "accessTokenLifespan": 3600,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,

--- a/infra/configs/keycloak/aihub-realm.local.json
+++ b/infra/configs/keycloak/aihub-realm.local.json
@@ -13,6 +13,7 @@
   "rememberMe": true,
   "ssoSessionIdleTimeout": 432000,
   "ssoSessionMaxLifespan": 2592000,
+  "accessTokenLifespan": 3600,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,

--- a/infra/configs/keycloak/aihub-realm.nightly.gpu.json
+++ b/infra/configs/keycloak/aihub-realm.nightly.gpu.json
@@ -13,6 +13,7 @@
   "rememberMe": true,
   "ssoSessionIdleTimeout": 432000,
   "ssoSessionMaxLifespan": 2592000,
+  "accessTokenLifespan": 3600,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,

--- a/infra/configs/keycloak/aihub-realm.nightly.json
+++ b/infra/configs/keycloak/aihub-realm.nightly.json
@@ -13,6 +13,7 @@
   "rememberMe": true,
   "ssoSessionIdleTimeout": 432000,
   "ssoSessionMaxLifespan": 2592000,
+  "accessTokenLifespan": 3600,
   "verifyEmail": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,

--- a/infra/configs/keycloak/keycloak-entrypoint.sh
+++ b/infra/configs/keycloak/keycloak-entrypoint.sh
@@ -23,10 +23,11 @@
 #   one-shot service (keycloak-config in docker-compose) — not by this script.
 #   This includes the Langfuse sysadmin gate (custom browser flow, deny
 #   sub-flows, marker client scope, and the realm browserFlow binding).
-# - Realm session lifespans: Applied via kcadm update after startup, but only
-#   while a lifespan still holds the Keycloak default (30 min idle / 10 h max) —
-#   the first-start-only realm import never propagates them to existing
-#   deployments, while operator overrides made in the admin console must survive.
+# - Realm token and session lifespans: Applied via kcadm update after startup,
+#   but only while a lifespan still holds the Keycloak default (30 min idle /
+#   10 h max / 5 min access token) — the first-start-only realm import never
+#   propagates them to existing deployments, while operator overrides made in
+#   the admin console must survive.
 
 set -euo pipefail
 
@@ -49,12 +50,12 @@ bash_envsubst /opt/keycloak/data/import-templates/aihub-realm.json \
 
 KCADM=/opt/keycloak/bin/kcadm.sh
 
-# Post-startup configuration applied on every start: realm session lifespans
-# via kcadm (the realm import only runs on first start, so existing deployments
-# would otherwise never pick up lifespan changes and stay on Keycloak defaults
-# of 30 min idle / 10 h max). Each lifespan is only written while it still
-# holds the Keycloak default — values customized by operators in the admin
-# console are left untouched.
+# Post-startup configuration applied on every start: realm token and session
+# lifespans via kcadm (the realm import only runs on first start, so existing
+# deployments would otherwise never pick up lifespan changes and stay on
+# Keycloak defaults of 30 min idle / 10 h max / 5 min access token). Each
+# lifespan is only written while it still holds the Keycloak default — values
+# customized by operators in the admin console are left untouched.
 (
   echo "Waiting for Keycloak to be ready before applying post-startup configuration..."
   until $KCADM config credentials \
@@ -66,7 +67,7 @@ KCADM=/opt/keycloak/bin/kcadm.sh
   done
 
   current_lifespans=$($KCADM get realms/aihub \
-    --fields ssoSessionIdleTimeout,ssoSessionMaxLifespan 2> /dev/null)
+    --fields ssoSessionIdleTimeout,ssoSessionMaxLifespan,accessTokenLifespan 2> /dev/null)
   lifespan_updates=()
   if [[ "$current_lifespans" =~ \"ssoSessionIdleTimeout\"[[:space:]]*:[[:space:]]*1800([^0-9]|$) ]]; then
     lifespan_updates+=(-s ssoSessionIdleTimeout=432000)
@@ -74,12 +75,15 @@ KCADM=/opt/keycloak/bin/kcadm.sh
   if [[ "$current_lifespans" =~ \"ssoSessionMaxLifespan\"[[:space:]]*:[[:space:]]*36000([^0-9]|$) ]]; then
     lifespan_updates+=(-s ssoSessionMaxLifespan=2592000)
   fi
+  if [[ "$current_lifespans" =~ \"accessTokenLifespan\"[[:space:]]*:[[:space:]]*300([^0-9]|$) ]]; then
+    lifespan_updates+=(-s accessTokenLifespan=3600)
+  fi
   if [ ${#lifespan_updates[@]} -gt 0 ]; then
     $KCADM update realms/aihub "${lifespan_updates[@]}" \
-      && echo "Realm session lifespans applied successfully." \
-      || echo "ERROR: Failed to apply realm session lifespans."
+      && echo "Realm token and session lifespans applied successfully." \
+      || echo "ERROR: Failed to apply realm token and session lifespans."
   else
-    echo "Realm session lifespans differ from Keycloak defaults; leaving unchanged."
+    echo "Realm token and session lifespans differ from Keycloak defaults; leaving unchanged."
   fi
 ) &
 

--- a/infra/deployment/CLAUDE.md
+++ b/infra/deployment/CLAUDE.md
@@ -216,10 +216,10 @@ The realm config lives in standalone JSON templates under `templates/configs/key
 `2026_06_12_declarative_keycloak_realm_reconciliation`):
 
 - **`bootstrap/`** — applied via `--import-realm` on **first start only**, never reconciled: realm-level settings
-  (themes, brute force, session lifespans, SMTP), the user-profile component, the startup tenant group seed, the
-  superuser seed, and the **identity providers** (Azure Entra ID + its mappers). Operator changes to these in the admin
-  console survive restarts — and updating identity-provider config on an already-initialized deployment requires the
-  admin console (or a fresh realm DB), since they do not reconcile automatically.
+  (themes, brute force, token and session lifespans, SMTP), the user-profile component, the startup tenant group seed,
+  the superuser seed, and the **identity providers** (Azure Entra ID + its mappers). Operator changes to these in the
+  admin console survive restarts — and updating identity-provider config on an already-initialized deployment requires
+  the admin console (or a fresh realm DB), since they do not reconcile automatically.
 - **`managed/`** — reconciled on **every stack start** by the one-shot `keycloak-config` service
   (adorsys/keycloak-config-cli): realm roles, client scopes, clients, custom auth flows, and the `aihub-api-service`
   service account. **File wins**: admin-console edits to these objects are overwritten, and objects removed from config

--- a/infra/deployment/compose-config.yml
+++ b/infra/deployment/compose-config.yml
@@ -162,12 +162,14 @@ notifications:
   title_prefix: Swiss AI Hub Pipeline
   min_interval_seconds: 30
 # -------------------------------------------------------------------
-# Keycloak realm session lifespans (seconds), shared by the merged
-# aihub-realm.{stage}.json (first-start import) and
+# Keycloak realm token and session lifespans (seconds), shared by the
+# merged aihub-realm.{stage}.json (first-start import) and
 # keycloak-entrypoint.sh.j2 (kcadm update on every start, so existing
 # deployments converge without re-importing the realm).
 # Keycloak defaults (30 min idle / 10 h max) force daily re-logins.
+# The 5 min access token default forces a silent renew every ~3 min.
 # -------------------------------------------------------------------
 keycloak:
   sso_session_idle_timeout: 432000  # 5 days
   sso_session_max_lifespan: 2592000  # 30 days
+  access_token_lifespan: 3600  # 1 hour

--- a/infra/deployment/templates/configs/keycloak-entrypoint.sh.j2
+++ b/infra/deployment/templates/configs/keycloak-entrypoint.sh.j2
@@ -23,10 +23,11 @@
 #   one-shot service (keycloak-config in docker-compose) — not by this script.
 #   This includes the Langfuse sysadmin gate (custom browser flow, deny
 #   sub-flows, marker client scope, and the realm browserFlow binding).
-# - Realm session lifespans: Applied via kcadm update after startup, but only
-#   while a lifespan still holds the Keycloak default (30 min idle / 10 h max) —
-#   the first-start-only realm import never propagates them to existing
-#   deployments, while operator overrides made in the admin console must survive.
+# - Realm token and session lifespans: Applied via kcadm update after startup,
+#   but only while a lifespan still holds the Keycloak default (30 min idle /
+#   10 h max / 5 min access token) — the first-start-only realm import never
+#   propagates them to existing deployments, while operator overrides made in
+#   the admin console must survive.
 
 set -euo pipefail
 
@@ -49,12 +50,12 @@ bash_envsubst /opt/keycloak/data/import-templates/aihub-realm.json \
 
 KCADM=/opt/keycloak/bin/kcadm.sh
 
-# Post-startup configuration applied on every start: realm session lifespans
-# via kcadm (the realm import only runs on first start, so existing deployments
-# would otherwise never pick up lifespan changes and stay on Keycloak defaults
-# of 30 min idle / 10 h max). Each lifespan is only written while it still
-# holds the Keycloak default — values customized by operators in the admin
-# console are left untouched.
+# Post-startup configuration applied on every start: realm token and session
+# lifespans via kcadm (the realm import only runs on first start, so existing
+# deployments would otherwise never pick up lifespan changes and stay on
+# Keycloak defaults of 30 min idle / 10 h max / 5 min access token). Each
+# lifespan is only written while it still holds the Keycloak default — values
+# customized by operators in the admin console are left untouched.
 (
   echo "Waiting for Keycloak to be ready before applying post-startup configuration..."
   until $KCADM config credentials \
@@ -66,7 +67,7 @@ KCADM=/opt/keycloak/bin/kcadm.sh
   done
 
   current_lifespans=$($KCADM get realms/aihub \
-    --fields ssoSessionIdleTimeout,ssoSessionMaxLifespan 2> /dev/null)
+    --fields ssoSessionIdleTimeout,ssoSessionMaxLifespan,accessTokenLifespan 2> /dev/null)
   lifespan_updates=()
   if [[ "$current_lifespans" =~ \"ssoSessionIdleTimeout\"[[:space:]]*:[[:space:]]*1800([^0-9]|$) ]]; then
     lifespan_updates+=(-s ssoSessionIdleTimeout={{ keycloak.sso_session_idle_timeout }})
@@ -74,12 +75,15 @@ KCADM=/opt/keycloak/bin/kcadm.sh
   if [[ "$current_lifespans" =~ \"ssoSessionMaxLifespan\"[[:space:]]*:[[:space:]]*36000([^0-9]|$) ]]; then
     lifespan_updates+=(-s ssoSessionMaxLifespan={{ keycloak.sso_session_max_lifespan }})
   fi
+  if [[ "$current_lifespans" =~ \"accessTokenLifespan\"[[:space:]]*:[[:space:]]*300([^0-9]|$) ]]; then
+    lifespan_updates+=(-s accessTokenLifespan={{ keycloak.access_token_lifespan }})
+  fi
   if [ {% raw %}${#lifespan_updates[@]}{% endraw %} -gt 0 ]; then
     $KCADM update realms/aihub "${lifespan_updates[@]}" \
-      && echo "Realm session lifespans applied successfully." \
-      || echo "ERROR: Failed to apply realm session lifespans."
+      && echo "Realm token and session lifespans applied successfully." \
+      || echo "ERROR: Failed to apply realm token and session lifespans."
   else
-    echo "Realm session lifespans differ from Keycloak defaults; leaving unchanged."
+    echo "Realm token and session lifespans differ from Keycloak defaults; leaving unchanged."
   fi
 ) &
 

--- a/infra/deployment/templates/configs/keycloak/bootstrap/realm-settings.json.j2
+++ b/infra/deployment/templates/configs/keycloak/bootstrap/realm-settings.json.j2
@@ -6,8 +6,8 @@
    BOOTSTRAP-ONLY: applied via --import-realm on first start, never reconciled.
    Realm-level settings stay bootstrap-only so operator overrides made in the
    admin console (e.g. session lifespans per ADR 2026_06_11, SMTP) survive.
-   Session lifespan changes still reach existing deployments via the kcadm
-   default-migration in keycloak-entrypoint.sh.
+   Token and session lifespan changes still reach existing deployments via the
+   kcadm default-migration in keycloak-entrypoint.sh.
 -#}
 {
   "realm": "aihub",
@@ -24,6 +24,7 @@
   "rememberMe": true,
   "ssoSessionIdleTimeout": {{ keycloak.sso_session_idle_timeout }},
   "ssoSessionMaxLifespan": {{ keycloak.sso_session_max_lifespan }},
+  "accessTokenLifespan": {{ keycloak.access_token_lifespan }},
   "verifyEmail": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,


### PR DESCRIPTION
## Summary

`accessTokenLifespan` was never set on the `aihub` realm, so every environment silently ran on Keycloak's 5-minute
default. That forced the admin SPA into a refresh-token grant roughly every 3 minutes
(`accessTokenExpiringNotificationTimeInSeconds: 120`) and broke any consumer holding a Keycloak JWT without its own
refresh loop. This sets it explicitly to **1 hour (3600s)**, alongside the two SSO session timers already defined in
`compose-config.yml`.

Requirement: bbvch-ai/aihub-core-private#205

## Changes

- **`infra/deployment/compose-config.yml`** — new `keycloak.access_token_lifespan: 3600`, the single source of truth
  next to the existing `sso_session_*` values.
- **`templates/configs/keycloak/bootstrap/realm-settings.json.j2`** — renders `accessTokenLifespan` into the
  first-start realm import, so fresh installs are correct from boot.
- **`templates/configs/keycloak-entrypoint.sh.j2`** — third conditional `kcadm` default-migration, guarded on the
  value still being exactly `300`, so existing deployments converge on their next Keycloak container recreation
  without a realm re-import. Operator overrides made in the admin console are left untouched.
- **`infra/configs/keycloak/*`** — regenerated artifacts (10 realm JSONs across all stage/GPU variants + the
  entrypoint) via `make generate-compose`.
- **Docs** — addendum to ADR `2026_06_11_keycloak_sso_session_lifespans` recording the decision and its security
  trade-off; wording fixes in the Keycloak configuration deep-dive and `infra/deployment/CLAUDE.md` to cover token
  lifespans, not just session lifespans.

### Security trade-off worth reviewer attention

JWTs are validated statelessly against JWKS in `KeycloakAuthHandler` with no per-request revocation check. The access
token lifespan — not the session timer — is therefore the real bound on how long a logged-out, disabled, or
role-revoked user keeps API access. This widens that window from 5 minutes to 1 hour, and is likewise the staleness
bound on the `roles` and `tenants` claims that drive sysadmin status and tenant-membership sync. One hour is the
accepted window; the reasoning is recorded in the ADR addendum.

## Test plan

Verified against the local dev stack:

- [x] **A real issued token lives 1 hour.** Password grant on realm `aihub` via the built-in `admin-cli` client
  returns `expires_in: 3600`, and the JWT itself carries `exp - iat = 3600`. `refresh_expires_in` came back at
  `432000`, matching `ssoSessionIdleTimeout`.
- [x] **Realm state correct** — `kcadm get realms/aihub` reports `accessTokenLifespan: 3600` alongside
  `ssoSessionIdleTimeout: 432000` / `ssoSessionMaxLifespan: 2592000`.
- [x] **No conflicting shorter timer** — `clientSessionIdleTimeout` and `clientSessionMaxLifespan` are both `0`
  (inheriting the 5d/30d SSO values), so a 1h token cannot outlive its client session.
  `accessTokenLifespanForImplicitFlow` stays at 900 and is off the path (the SPA is auth-code + PKCE).
- [x] **No client-level override** — every client in the realm has empty `attributes`, so `aihub-frontend` inherits
  the realm value rather than shadowing it.
- [x] **Guard regex unit-tested in isolation** — fires on `300` (with trailing comma, as a last field, and at
  end-of-string); correctly does *not* fire on `3600`, `3000`, `30000`, or `900`.
- [x] **All 10 regenerated realm JSONs** parse and carry identical `3600 / 432000 / 2592000`.
- [x] **`bash -n` clean** on the entrypoint, and the generated `.sh` matches its `.j2` template exactly (only the
  `{% raw %}` escape differs).
- [x] **`make generate-compose` is a no-op** on every keycloak and compose file — templates and committed artifacts
  are in sync.
- [x] **ADR claims checked against code** — `KeycloakAuthHandler` is indeed stateless JWKS validation with no
  revocation check, and the `roles` → `is_sys_admin` / `tenants` → `_sync_tenant_memberships` paths are as described.

**Not covered:** the dev realm was already migrated to `3600`, so the `300 → 3600` transition was not re-exercised
against a live realm — only the guard logic driving it. A true first-run test needs a fresh realm database.

No Python changed, and no module or test reads any of the touched files, so no test scope is affected.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>` (see
  [CONTRIBUTING.md](https://github.com/bbvch-ai/aihub-core/blob/main/CONTRIBUTING.md))
- [ ] Exactly one of `major` / `minor` / `patch` label applied — **`patch`**
- [ ] CLA signed — post this exact comment on the PR if the bot hasn't prompted you yet:
  `I have read the CONTRIBUTOR_AGREEMENT and I hereby sign the CLA`
  ([read the agreement](https://github.com/bbvch-ai/aihub-core/blob/main/CONTRIBUTOR_AGREEMENT.md))
- [x] Tests added or updated where relevant — n/a, config-only change with no Python surface