### PR TITLE
fix(tracing): Stop the cloud trace exporter dropping whole batches

### DIFF
--- a/infra/configs/otel/otel-config.build.gpu.yml
+++ b/infra/configs/otel/otel-config.build.gpu.yml
@@ -97,15 +97,23 @@ processors:
         - attributes["openinference.span.kind"] == nil
   # A rejected OTLP request is a PERMANENT error, so the exporter drops the whole batch
   # without retrying — every span in it is lost, including the small ones that rode along.
-  # The size comes from OpenInference LLM spans carrying full prompts and completions, and
-  # embedding vectors. Langfuse is the consumer that needs those verbatim and it has its own
-  # pipeline, so drop the payload keys on the cloud path and truncate whatever is left as a
-  # backstop against the next unbounded attribute. This also keeps prompts and completions
-  # from leaving the deployment for a third-party backend at all.
+  # The size comes from OpenInference spans carrying payload verbatim: LLM prompts and
+  # completions, embedding vectors, and the retrieved chunk text on retriever and reranker
+  # spans — a reranker span flattens every input AND output document, each with its full
+  # content. Langfuse is the consumer that needs those verbatim and it has its own pipeline,
+  # so drop the payload keys on the cloud path and truncate whatever is left as a backstop
+  # against the next unbounded attribute.
+  #
+  # truncate_all bounds each attribute, not the span, so deleting the document keys is what
+  # actually caps a retriever: retrieve_k goes to 100 in the agent form, and 100 documents
+  # left at 2048 each rebuild a span far past the ~100 KB average that broke the batch.
+  #
+  # This also keeps prompts, completions and internal document text from leaving the
+  # deployment for a third-party backend at all.
   transform/cloud_span_size:
     error_mode: ignore
     trace_statements:
-      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings)")
+      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings|retrieval[.]documents|reranker[.](input|output)_documents|reranker[.]query)")
       - truncate_all(span.attributes, 2048)
       - truncate_all(resource.attributes, 2048)
 

--- a/infra/configs/otel/otel-config.build.gpu.yml
+++ b/infra/configs/otel/otel-config.build.gpu.yml
@@ -41,6 +41,11 @@ processors:
   # per-stage scaling (1000 on nightly, 2000 on latest) is gone: a cap the batch never reaches is
   # not a cap. The collector enforces send_batch_max_size >= send_batch_size, so raising throughput
   # again means raising both, and re-measuring. Only the timeout still varies by stage.
+  #
+  # Measured again on staging (2026-08): the real backend limit is 16 MiB, not 4, and 500 is
+  # still not low enough — requests of 500, 159 and 143 spans were all rejected with
+  # ResourceExhausted "larger than max 16777216", which puts the average span above 100 KB.
+  # Batch size is the wrong lever for a span that large; the cloud path bounds span size instead.
   batch:
     send_batch_size: 500
     send_batch_max_size: 500
@@ -90,6 +95,19 @@ processors:
     traces:
       span:
         - attributes["openinference.span.kind"] == nil
+  # A rejected OTLP request is a PERMANENT error, so the exporter drops the whole batch
+  # without retrying — every span in it is lost, including the small ones that rode along.
+  # The size comes from OpenInference LLM spans carrying full prompts and completions, and
+  # embedding vectors. Langfuse is the consumer that needs those verbatim and it has its own
+  # pipeline, so drop the payload keys on the cloud path and truncate whatever is left as a
+  # backstop against the next unbounded attribute. This also keeps prompts and completions
+  # from leaving the deployment for a third-party backend at all.
+  transform/cloud_span_size:
+    error_mode: ignore
+    trace_statements:
+      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings)")
+      - truncate_all(span.attributes, 2048)
+      - truncate_all(resource.attributes, 2048)
 
   # Backstop (issue 1496): drop unbounded, high-cardinality HTTP server metrics
   # (side-effect of FastAPI/ASGI auto-instrumentation) before they reach the paid
@@ -151,7 +169,11 @@ service:
     # Send traces to cloud backend
     traces/cloud:
       receivers: [otlp]
-      processors: [filter/noise, resource/deployment, batch]
+      processors:
+        - filter/noise
+        - transform/cloud_span_size
+        - resource/deployment
+        - batch
       exporters: [otlp/cloud]
 
     # Send metrics to cloud backend

--- a/infra/configs/otel/otel-config.build.yml
+++ b/infra/configs/otel/otel-config.build.yml
@@ -97,15 +97,23 @@ processors:
         - attributes["openinference.span.kind"] == nil
   # A rejected OTLP request is a PERMANENT error, so the exporter drops the whole batch
   # without retrying — every span in it is lost, including the small ones that rode along.
-  # The size comes from OpenInference LLM spans carrying full prompts and completions, and
-  # embedding vectors. Langfuse is the consumer that needs those verbatim and it has its own
-  # pipeline, so drop the payload keys on the cloud path and truncate whatever is left as a
-  # backstop against the next unbounded attribute. This also keeps prompts and completions
-  # from leaving the deployment for a third-party backend at all.
+  # The size comes from OpenInference spans carrying payload verbatim: LLM prompts and
+  # completions, embedding vectors, and the retrieved chunk text on retriever and reranker
+  # spans — a reranker span flattens every input AND output document, each with its full
+  # content. Langfuse is the consumer that needs those verbatim and it has its own pipeline,
+  # so drop the payload keys on the cloud path and truncate whatever is left as a backstop
+  # against the next unbounded attribute.
+  #
+  # truncate_all bounds each attribute, not the span, so deleting the document keys is what
+  # actually caps a retriever: retrieve_k goes to 100 in the agent form, and 100 documents
+  # left at 2048 each rebuild a span far past the ~100 KB average that broke the batch.
+  #
+  # This also keeps prompts, completions and internal document text from leaving the
+  # deployment for a third-party backend at all.
   transform/cloud_span_size:
     error_mode: ignore
     trace_statements:
-      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings)")
+      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings|retrieval[.]documents|reranker[.](input|output)_documents|reranker[.]query)")
       - truncate_all(span.attributes, 2048)
       - truncate_all(resource.attributes, 2048)
 

--- a/infra/configs/otel/otel-config.build.yml
+++ b/infra/configs/otel/otel-config.build.yml
@@ -41,6 +41,11 @@ processors:
   # per-stage scaling (1000 on nightly, 2000 on latest) is gone: a cap the batch never reaches is
   # not a cap. The collector enforces send_batch_max_size >= send_batch_size, so raising throughput
   # again means raising both, and re-measuring. Only the timeout still varies by stage.
+  #
+  # Measured again on staging (2026-08): the real backend limit is 16 MiB, not 4, and 500 is
+  # still not low enough — requests of 500, 159 and 143 spans were all rejected with
+  # ResourceExhausted "larger than max 16777216", which puts the average span above 100 KB.
+  # Batch size is the wrong lever for a span that large; the cloud path bounds span size instead.
   batch:
     send_batch_size: 500
     send_batch_max_size: 500
@@ -90,6 +95,19 @@ processors:
     traces:
       span:
         - attributes["openinference.span.kind"] == nil
+  # A rejected OTLP request is a PERMANENT error, so the exporter drops the whole batch
+  # without retrying — every span in it is lost, including the small ones that rode along.
+  # The size comes from OpenInference LLM spans carrying full prompts and completions, and
+  # embedding vectors. Langfuse is the consumer that needs those verbatim and it has its own
+  # pipeline, so drop the payload keys on the cloud path and truncate whatever is left as a
+  # backstop against the next unbounded attribute. This also keeps prompts and completions
+  # from leaving the deployment for a third-party backend at all.
+  transform/cloud_span_size:
+    error_mode: ignore
+    trace_statements:
+      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings)")
+      - truncate_all(span.attributes, 2048)
+      - truncate_all(resource.attributes, 2048)
 
   # Backstop (issue 1496): drop unbounded, high-cardinality HTTP server metrics
   # (side-effect of FastAPI/ASGI auto-instrumentation) before they reach the paid
@@ -151,7 +169,11 @@ service:
     # Send traces to cloud backend
     traces/cloud:
       receivers: [otlp]
-      processors: [filter/noise, resource/deployment, batch]
+      processors:
+        - filter/noise
+        - transform/cloud_span_size
+        - resource/deployment
+        - batch
       exporters: [otlp/cloud]
 
     # Send metrics to cloud backend

--- a/infra/configs/otel/otel-config.dev.gpu.yml
+++ b/infra/configs/otel/otel-config.dev.gpu.yml
@@ -41,6 +41,11 @@ processors:
   # per-stage scaling (1000 on nightly, 2000 on latest) is gone: a cap the batch never reaches is
   # not a cap. The collector enforces send_batch_max_size >= send_batch_size, so raising throughput
   # again means raising both, and re-measuring. Only the timeout still varies by stage.
+  #
+  # Measured again on staging (2026-08): the real backend limit is 16 MiB, not 4, and 500 is
+  # still not low enough — requests of 500, 159 and 143 spans were all rejected with
+  # ResourceExhausted "larger than max 16777216", which puts the average span above 100 KB.
+  # Batch size is the wrong lever for a span that large; the cloud path bounds span size instead.
   batch:
     send_batch_size: 500
     send_batch_max_size: 500

--- a/infra/configs/otel/otel-config.dev.yml
+++ b/infra/configs/otel/otel-config.dev.yml
@@ -41,6 +41,11 @@ processors:
   # per-stage scaling (1000 on nightly, 2000 on latest) is gone: a cap the batch never reaches is
   # not a cap. The collector enforces send_batch_max_size >= send_batch_size, so raising throughput
   # again means raising both, and re-measuring. Only the timeout still varies by stage.
+  #
+  # Measured again on staging (2026-08): the real backend limit is 16 MiB, not 4, and 500 is
+  # still not low enough — requests of 500, 159 and 143 spans were all rejected with
+  # ResourceExhausted "larger than max 16777216", which puts the average span above 100 KB.
+  # Batch size is the wrong lever for a span that large; the cloud path bounds span size instead.
   batch:
     send_batch_size: 500
     send_batch_max_size: 500

--- a/infra/configs/otel/otel-config.latest.gpu.yml
+++ b/infra/configs/otel/otel-config.latest.gpu.yml
@@ -97,15 +97,23 @@ processors:
         - attributes["openinference.span.kind"] == nil
   # A rejected OTLP request is a PERMANENT error, so the exporter drops the whole batch
   # without retrying — every span in it is lost, including the small ones that rode along.
-  # The size comes from OpenInference LLM spans carrying full prompts and completions, and
-  # embedding vectors. Langfuse is the consumer that needs those verbatim and it has its own
-  # pipeline, so drop the payload keys on the cloud path and truncate whatever is left as a
-  # backstop against the next unbounded attribute. This also keeps prompts and completions
-  # from leaving the deployment for a third-party backend at all.
+  # The size comes from OpenInference spans carrying payload verbatim: LLM prompts and
+  # completions, embedding vectors, and the retrieved chunk text on retriever and reranker
+  # spans — a reranker span flattens every input AND output document, each with its full
+  # content. Langfuse is the consumer that needs those verbatim and it has its own pipeline,
+  # so drop the payload keys on the cloud path and truncate whatever is left as a backstop
+  # against the next unbounded attribute.
+  #
+  # truncate_all bounds each attribute, not the span, so deleting the document keys is what
+  # actually caps a retriever: retrieve_k goes to 100 in the agent form, and 100 documents
+  # left at 2048 each rebuild a span far past the ~100 KB average that broke the batch.
+  #
+  # This also keeps prompts, completions and internal document text from leaving the
+  # deployment for a third-party backend at all.
   transform/cloud_span_size:
     error_mode: ignore
     trace_statements:
-      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings)")
+      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings|retrieval[.]documents|reranker[.](input|output)_documents|reranker[.]query)")
       - truncate_all(span.attributes, 2048)
       - truncate_all(resource.attributes, 2048)
 

--- a/infra/configs/otel/otel-config.latest.gpu.yml
+++ b/infra/configs/otel/otel-config.latest.gpu.yml
@@ -41,6 +41,11 @@ processors:
   # per-stage scaling (1000 on nightly, 2000 on latest) is gone: a cap the batch never reaches is
   # not a cap. The collector enforces send_batch_max_size >= send_batch_size, so raising throughput
   # again means raising both, and re-measuring. Only the timeout still varies by stage.
+  #
+  # Measured again on staging (2026-08): the real backend limit is 16 MiB, not 4, and 500 is
+  # still not low enough — requests of 500, 159 and 143 spans were all rejected with
+  # ResourceExhausted "larger than max 16777216", which puts the average span above 100 KB.
+  # Batch size is the wrong lever for a span that large; the cloud path bounds span size instead.
   batch:
     send_batch_size: 500
     send_batch_max_size: 500
@@ -90,6 +95,19 @@ processors:
     traces:
       span:
         - attributes["openinference.span.kind"] == nil
+  # A rejected OTLP request is a PERMANENT error, so the exporter drops the whole batch
+  # without retrying — every span in it is lost, including the small ones that rode along.
+  # The size comes from OpenInference LLM spans carrying full prompts and completions, and
+  # embedding vectors. Langfuse is the consumer that needs those verbatim and it has its own
+  # pipeline, so drop the payload keys on the cloud path and truncate whatever is left as a
+  # backstop against the next unbounded attribute. This also keeps prompts and completions
+  # from leaving the deployment for a third-party backend at all.
+  transform/cloud_span_size:
+    error_mode: ignore
+    trace_statements:
+      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings)")
+      - truncate_all(span.attributes, 2048)
+      - truncate_all(resource.attributes, 2048)
 
   # Backstop (issue 1496): drop unbounded, high-cardinality HTTP server metrics
   # (side-effect of FastAPI/ASGI auto-instrumentation) before they reach the paid
@@ -151,7 +169,11 @@ service:
     # Send traces to cloud backend
     traces/cloud:
       receivers: [otlp]
-      processors: [filter/noise, resource/deployment, batch]
+      processors:
+        - filter/noise
+        - transform/cloud_span_size
+        - resource/deployment
+        - batch
       exporters: [otlp/cloud]
 
     # Send metrics to cloud backend

--- a/infra/configs/otel/otel-config.latest.yml
+++ b/infra/configs/otel/otel-config.latest.yml
@@ -97,15 +97,23 @@ processors:
         - attributes["openinference.span.kind"] == nil
   # A rejected OTLP request is a PERMANENT error, so the exporter drops the whole batch
   # without retrying — every span in it is lost, including the small ones that rode along.
-  # The size comes from OpenInference LLM spans carrying full prompts and completions, and
-  # embedding vectors. Langfuse is the consumer that needs those verbatim and it has its own
-  # pipeline, so drop the payload keys on the cloud path and truncate whatever is left as a
-  # backstop against the next unbounded attribute. This also keeps prompts and completions
-  # from leaving the deployment for a third-party backend at all.
+  # The size comes from OpenInference spans carrying payload verbatim: LLM prompts and
+  # completions, embedding vectors, and the retrieved chunk text on retriever and reranker
+  # spans — a reranker span flattens every input AND output document, each with its full
+  # content. Langfuse is the consumer that needs those verbatim and it has its own pipeline,
+  # so drop the payload keys on the cloud path and truncate whatever is left as a backstop
+  # against the next unbounded attribute.
+  #
+  # truncate_all bounds each attribute, not the span, so deleting the document keys is what
+  # actually caps a retriever: retrieve_k goes to 100 in the agent form, and 100 documents
+  # left at 2048 each rebuild a span far past the ~100 KB average that broke the batch.
+  #
+  # This also keeps prompts, completions and internal document text from leaving the
+  # deployment for a third-party backend at all.
   transform/cloud_span_size:
     error_mode: ignore
     trace_statements:
-      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings)")
+      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings|retrieval[.]documents|reranker[.](input|output)_documents|reranker[.]query)")
       - truncate_all(span.attributes, 2048)
       - truncate_all(resource.attributes, 2048)
 

--- a/infra/configs/otel/otel-config.latest.yml
+++ b/infra/configs/otel/otel-config.latest.yml
@@ -41,6 +41,11 @@ processors:
   # per-stage scaling (1000 on nightly, 2000 on latest) is gone: a cap the batch never reaches is
   # not a cap. The collector enforces send_batch_max_size >= send_batch_size, so raising throughput
   # again means raising both, and re-measuring. Only the timeout still varies by stage.
+  #
+  # Measured again on staging (2026-08): the real backend limit is 16 MiB, not 4, and 500 is
+  # still not low enough — requests of 500, 159 and 143 spans were all rejected with
+  # ResourceExhausted "larger than max 16777216", which puts the average span above 100 KB.
+  # Batch size is the wrong lever for a span that large; the cloud path bounds span size instead.
   batch:
     send_batch_size: 500
     send_batch_max_size: 500
@@ -90,6 +95,19 @@ processors:
     traces:
       span:
         - attributes["openinference.span.kind"] == nil
+  # A rejected OTLP request is a PERMANENT error, so the exporter drops the whole batch
+  # without retrying — every span in it is lost, including the small ones that rode along.
+  # The size comes from OpenInference LLM spans carrying full prompts and completions, and
+  # embedding vectors. Langfuse is the consumer that needs those verbatim and it has its own
+  # pipeline, so drop the payload keys on the cloud path and truncate whatever is left as a
+  # backstop against the next unbounded attribute. This also keeps prompts and completions
+  # from leaving the deployment for a third-party backend at all.
+  transform/cloud_span_size:
+    error_mode: ignore
+    trace_statements:
+      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings)")
+      - truncate_all(span.attributes, 2048)
+      - truncate_all(resource.attributes, 2048)
 
   # Backstop (issue 1496): drop unbounded, high-cardinality HTTP server metrics
   # (side-effect of FastAPI/ASGI auto-instrumentation) before they reach the paid
@@ -151,7 +169,11 @@ service:
     # Send traces to cloud backend
     traces/cloud:
       receivers: [otlp]
-      processors: [filter/noise, resource/deployment, batch]
+      processors:
+        - filter/noise
+        - transform/cloud_span_size
+        - resource/deployment
+        - batch
       exporters: [otlp/cloud]
 
     # Send metrics to cloud backend

--- a/infra/configs/otel/otel-config.local.gpu.yml
+++ b/infra/configs/otel/otel-config.local.gpu.yml
@@ -97,15 +97,23 @@ processors:
         - attributes["openinference.span.kind"] == nil
   # A rejected OTLP request is a PERMANENT error, so the exporter drops the whole batch
   # without retrying — every span in it is lost, including the small ones that rode along.
-  # The size comes from OpenInference LLM spans carrying full prompts and completions, and
-  # embedding vectors. Langfuse is the consumer that needs those verbatim and it has its own
-  # pipeline, so drop the payload keys on the cloud path and truncate whatever is left as a
-  # backstop against the next unbounded attribute. This also keeps prompts and completions
-  # from leaving the deployment for a third-party backend at all.
+  # The size comes from OpenInference spans carrying payload verbatim: LLM prompts and
+  # completions, embedding vectors, and the retrieved chunk text on retriever and reranker
+  # spans — a reranker span flattens every input AND output document, each with its full
+  # content. Langfuse is the consumer that needs those verbatim and it has its own pipeline,
+  # so drop the payload keys on the cloud path and truncate whatever is left as a backstop
+  # against the next unbounded attribute.
+  #
+  # truncate_all bounds each attribute, not the span, so deleting the document keys is what
+  # actually caps a retriever: retrieve_k goes to 100 in the agent form, and 100 documents
+  # left at 2048 each rebuild a span far past the ~100 KB average that broke the batch.
+  #
+  # This also keeps prompts, completions and internal document text from leaving the
+  # deployment for a third-party backend at all.
   transform/cloud_span_size:
     error_mode: ignore
     trace_statements:
-      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings)")
+      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings|retrieval[.]documents|reranker[.](input|output)_documents|reranker[.]query)")
       - truncate_all(span.attributes, 2048)
       - truncate_all(resource.attributes, 2048)
 

--- a/infra/configs/otel/otel-config.local.gpu.yml
+++ b/infra/configs/otel/otel-config.local.gpu.yml
@@ -41,6 +41,11 @@ processors:
   # per-stage scaling (1000 on nightly, 2000 on latest) is gone: a cap the batch never reaches is
   # not a cap. The collector enforces send_batch_max_size >= send_batch_size, so raising throughput
   # again means raising both, and re-measuring. Only the timeout still varies by stage.
+  #
+  # Measured again on staging (2026-08): the real backend limit is 16 MiB, not 4, and 500 is
+  # still not low enough — requests of 500, 159 and 143 spans were all rejected with
+  # ResourceExhausted "larger than max 16777216", which puts the average span above 100 KB.
+  # Batch size is the wrong lever for a span that large; the cloud path bounds span size instead.
   batch:
     send_batch_size: 500
     send_batch_max_size: 500
@@ -90,6 +95,19 @@ processors:
     traces:
       span:
         - attributes["openinference.span.kind"] == nil
+  # A rejected OTLP request is a PERMANENT error, so the exporter drops the whole batch
+  # without retrying — every span in it is lost, including the small ones that rode along.
+  # The size comes from OpenInference LLM spans carrying full prompts and completions, and
+  # embedding vectors. Langfuse is the consumer that needs those verbatim and it has its own
+  # pipeline, so drop the payload keys on the cloud path and truncate whatever is left as a
+  # backstop against the next unbounded attribute. This also keeps prompts and completions
+  # from leaving the deployment for a third-party backend at all.
+  transform/cloud_span_size:
+    error_mode: ignore
+    trace_statements:
+      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings)")
+      - truncate_all(span.attributes, 2048)
+      - truncate_all(resource.attributes, 2048)
 
   # Backstop (issue 1496): drop unbounded, high-cardinality HTTP server metrics
   # (side-effect of FastAPI/ASGI auto-instrumentation) before they reach the paid
@@ -151,7 +169,11 @@ service:
     # Send traces to cloud backend
     traces/cloud:
       receivers: [otlp]
-      processors: [filter/noise, resource/deployment, batch]
+      processors:
+        - filter/noise
+        - transform/cloud_span_size
+        - resource/deployment
+        - batch
       exporters: [otlp/cloud]
 
     # Send metrics to cloud backend

--- a/infra/configs/otel/otel-config.local.yml
+++ b/infra/configs/otel/otel-config.local.yml
@@ -97,15 +97,23 @@ processors:
         - attributes["openinference.span.kind"] == nil
   # A rejected OTLP request is a PERMANENT error, so the exporter drops the whole batch
   # without retrying — every span in it is lost, including the small ones that rode along.
-  # The size comes from OpenInference LLM spans carrying full prompts and completions, and
-  # embedding vectors. Langfuse is the consumer that needs those verbatim and it has its own
-  # pipeline, so drop the payload keys on the cloud path and truncate whatever is left as a
-  # backstop against the next unbounded attribute. This also keeps prompts and completions
-  # from leaving the deployment for a third-party backend at all.
+  # The size comes from OpenInference spans carrying payload verbatim: LLM prompts and
+  # completions, embedding vectors, and the retrieved chunk text on retriever and reranker
+  # spans — a reranker span flattens every input AND output document, each with its full
+  # content. Langfuse is the consumer that needs those verbatim and it has its own pipeline,
+  # so drop the payload keys on the cloud path and truncate whatever is left as a backstop
+  # against the next unbounded attribute.
+  #
+  # truncate_all bounds each attribute, not the span, so deleting the document keys is what
+  # actually caps a retriever: retrieve_k goes to 100 in the agent form, and 100 documents
+  # left at 2048 each rebuild a span far past the ~100 KB average that broke the batch.
+  #
+  # This also keeps prompts, completions and internal document text from leaving the
+  # deployment for a third-party backend at all.
   transform/cloud_span_size:
     error_mode: ignore
     trace_statements:
-      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings)")
+      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings|retrieval[.]documents|reranker[.](input|output)_documents|reranker[.]query)")
       - truncate_all(span.attributes, 2048)
       - truncate_all(resource.attributes, 2048)
 

--- a/infra/configs/otel/otel-config.local.yml
+++ b/infra/configs/otel/otel-config.local.yml
@@ -41,6 +41,11 @@ processors:
   # per-stage scaling (1000 on nightly, 2000 on latest) is gone: a cap the batch never reaches is
   # not a cap. The collector enforces send_batch_max_size >= send_batch_size, so raising throughput
   # again means raising both, and re-measuring. Only the timeout still varies by stage.
+  #
+  # Measured again on staging (2026-08): the real backend limit is 16 MiB, not 4, and 500 is
+  # still not low enough — requests of 500, 159 and 143 spans were all rejected with
+  # ResourceExhausted "larger than max 16777216", which puts the average span above 100 KB.
+  # Batch size is the wrong lever for a span that large; the cloud path bounds span size instead.
   batch:
     send_batch_size: 500
     send_batch_max_size: 500
@@ -90,6 +95,19 @@ processors:
     traces:
       span:
         - attributes["openinference.span.kind"] == nil
+  # A rejected OTLP request is a PERMANENT error, so the exporter drops the whole batch
+  # without retrying — every span in it is lost, including the small ones that rode along.
+  # The size comes from OpenInference LLM spans carrying full prompts and completions, and
+  # embedding vectors. Langfuse is the consumer that needs those verbatim and it has its own
+  # pipeline, so drop the payload keys on the cloud path and truncate whatever is left as a
+  # backstop against the next unbounded attribute. This also keeps prompts and completions
+  # from leaving the deployment for a third-party backend at all.
+  transform/cloud_span_size:
+    error_mode: ignore
+    trace_statements:
+      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings)")
+      - truncate_all(span.attributes, 2048)
+      - truncate_all(resource.attributes, 2048)
 
   # Backstop (issue 1496): drop unbounded, high-cardinality HTTP server metrics
   # (side-effect of FastAPI/ASGI auto-instrumentation) before they reach the paid
@@ -151,7 +169,11 @@ service:
     # Send traces to cloud backend
     traces/cloud:
       receivers: [otlp]
-      processors: [filter/noise, resource/deployment, batch]
+      processors:
+        - filter/noise
+        - transform/cloud_span_size
+        - resource/deployment
+        - batch
       exporters: [otlp/cloud]
 
     # Send metrics to cloud backend

--- a/infra/configs/otel/otel-config.nightly.gpu.yml
+++ b/infra/configs/otel/otel-config.nightly.gpu.yml
@@ -97,15 +97,23 @@ processors:
         - attributes["openinference.span.kind"] == nil
   # A rejected OTLP request is a PERMANENT error, so the exporter drops the whole batch
   # without retrying — every span in it is lost, including the small ones that rode along.
-  # The size comes from OpenInference LLM spans carrying full prompts and completions, and
-  # embedding vectors. Langfuse is the consumer that needs those verbatim and it has its own
-  # pipeline, so drop the payload keys on the cloud path and truncate whatever is left as a
-  # backstop against the next unbounded attribute. This also keeps prompts and completions
-  # from leaving the deployment for a third-party backend at all.
+  # The size comes from OpenInference spans carrying payload verbatim: LLM prompts and
+  # completions, embedding vectors, and the retrieved chunk text on retriever and reranker
+  # spans — a reranker span flattens every input AND output document, each with its full
+  # content. Langfuse is the consumer that needs those verbatim and it has its own pipeline,
+  # so drop the payload keys on the cloud path and truncate whatever is left as a backstop
+  # against the next unbounded attribute.
+  #
+  # truncate_all bounds each attribute, not the span, so deleting the document keys is what
+  # actually caps a retriever: retrieve_k goes to 100 in the agent form, and 100 documents
+  # left at 2048 each rebuild a span far past the ~100 KB average that broke the batch.
+  #
+  # This also keeps prompts, completions and internal document text from leaving the
+  # deployment for a third-party backend at all.
   transform/cloud_span_size:
     error_mode: ignore
     trace_statements:
-      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings)")
+      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings|retrieval[.]documents|reranker[.](input|output)_documents|reranker[.]query)")
       - truncate_all(span.attributes, 2048)
       - truncate_all(resource.attributes, 2048)
 

--- a/infra/configs/otel/otel-config.nightly.gpu.yml
+++ b/infra/configs/otel/otel-config.nightly.gpu.yml
@@ -41,6 +41,11 @@ processors:
   # per-stage scaling (1000 on nightly, 2000 on latest) is gone: a cap the batch never reaches is
   # not a cap. The collector enforces send_batch_max_size >= send_batch_size, so raising throughput
   # again means raising both, and re-measuring. Only the timeout still varies by stage.
+  #
+  # Measured again on staging (2026-08): the real backend limit is 16 MiB, not 4, and 500 is
+  # still not low enough — requests of 500, 159 and 143 spans were all rejected with
+  # ResourceExhausted "larger than max 16777216", which puts the average span above 100 KB.
+  # Batch size is the wrong lever for a span that large; the cloud path bounds span size instead.
   batch:
     send_batch_size: 500
     send_batch_max_size: 500
@@ -90,6 +95,19 @@ processors:
     traces:
       span:
         - attributes["openinference.span.kind"] == nil
+  # A rejected OTLP request is a PERMANENT error, so the exporter drops the whole batch
+  # without retrying — every span in it is lost, including the small ones that rode along.
+  # The size comes from OpenInference LLM spans carrying full prompts and completions, and
+  # embedding vectors. Langfuse is the consumer that needs those verbatim and it has its own
+  # pipeline, so drop the payload keys on the cloud path and truncate whatever is left as a
+  # backstop against the next unbounded attribute. This also keeps prompts and completions
+  # from leaving the deployment for a third-party backend at all.
+  transform/cloud_span_size:
+    error_mode: ignore
+    trace_statements:
+      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings)")
+      - truncate_all(span.attributes, 2048)
+      - truncate_all(resource.attributes, 2048)
 
   # Backstop (issue 1496): drop unbounded, high-cardinality HTTP server metrics
   # (side-effect of FastAPI/ASGI auto-instrumentation) before they reach the paid
@@ -151,7 +169,11 @@ service:
     # Send traces to cloud backend
     traces/cloud:
       receivers: [otlp]
-      processors: [filter/noise, resource/deployment, batch]
+      processors:
+        - filter/noise
+        - transform/cloud_span_size
+        - resource/deployment
+        - batch
       exporters: [otlp/cloud]
 
     # Send metrics to cloud backend

--- a/infra/configs/otel/otel-config.nightly.yml
+++ b/infra/configs/otel/otel-config.nightly.yml
@@ -97,15 +97,23 @@ processors:
         - attributes["openinference.span.kind"] == nil
   # A rejected OTLP request is a PERMANENT error, so the exporter drops the whole batch
   # without retrying — every span in it is lost, including the small ones that rode along.
-  # The size comes from OpenInference LLM spans carrying full prompts and completions, and
-  # embedding vectors. Langfuse is the consumer that needs those verbatim and it has its own
-  # pipeline, so drop the payload keys on the cloud path and truncate whatever is left as a
-  # backstop against the next unbounded attribute. This also keeps prompts and completions
-  # from leaving the deployment for a third-party backend at all.
+  # The size comes from OpenInference spans carrying payload verbatim: LLM prompts and
+  # completions, embedding vectors, and the retrieved chunk text on retriever and reranker
+  # spans — a reranker span flattens every input AND output document, each with its full
+  # content. Langfuse is the consumer that needs those verbatim and it has its own pipeline,
+  # so drop the payload keys on the cloud path and truncate whatever is left as a backstop
+  # against the next unbounded attribute.
+  #
+  # truncate_all bounds each attribute, not the span, so deleting the document keys is what
+  # actually caps a retriever: retrieve_k goes to 100 in the agent form, and 100 documents
+  # left at 2048 each rebuild a span far past the ~100 KB average that broke the batch.
+  #
+  # This also keeps prompts, completions and internal document text from leaving the
+  # deployment for a third-party backend at all.
   transform/cloud_span_size:
     error_mode: ignore
     trace_statements:
-      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings)")
+      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings|retrieval[.]documents|reranker[.](input|output)_documents|reranker[.]query)")
       - truncate_all(span.attributes, 2048)
       - truncate_all(resource.attributes, 2048)
 

--- a/infra/configs/otel/otel-config.nightly.yml
+++ b/infra/configs/otel/otel-config.nightly.yml
@@ -41,6 +41,11 @@ processors:
   # per-stage scaling (1000 on nightly, 2000 on latest) is gone: a cap the batch never reaches is
   # not a cap. The collector enforces send_batch_max_size >= send_batch_size, so raising throughput
   # again means raising both, and re-measuring. Only the timeout still varies by stage.
+  #
+  # Measured again on staging (2026-08): the real backend limit is 16 MiB, not 4, and 500 is
+  # still not low enough — requests of 500, 159 and 143 spans were all rejected with
+  # ResourceExhausted "larger than max 16777216", which puts the average span above 100 KB.
+  # Batch size is the wrong lever for a span that large; the cloud path bounds span size instead.
   batch:
     send_batch_size: 500
     send_batch_max_size: 500
@@ -90,6 +95,19 @@ processors:
     traces:
       span:
         - attributes["openinference.span.kind"] == nil
+  # A rejected OTLP request is a PERMANENT error, so the exporter drops the whole batch
+  # without retrying — every span in it is lost, including the small ones that rode along.
+  # The size comes from OpenInference LLM spans carrying full prompts and completions, and
+  # embedding vectors. Langfuse is the consumer that needs those verbatim and it has its own
+  # pipeline, so drop the payload keys on the cloud path and truncate whatever is left as a
+  # backstop against the next unbounded attribute. This also keeps prompts and completions
+  # from leaving the deployment for a third-party backend at all.
+  transform/cloud_span_size:
+    error_mode: ignore
+    trace_statements:
+      - delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings)")
+      - truncate_all(span.attributes, 2048)
+      - truncate_all(resource.attributes, 2048)
 
   # Backstop (issue 1496): drop unbounded, high-cardinality HTTP server metrics
   # (side-effect of FastAPI/ASGI auto-instrumentation) before they reach the paid
@@ -151,7 +169,11 @@ service:
     # Send traces to cloud backend
     traces/cloud:
       receivers: [otlp]
-      processors: [filter/noise, resource/deployment, batch]
+      processors:
+        - filter/noise
+        - transform/cloud_span_size
+        - resource/deployment
+        - batch
       exporters: [otlp/cloud]
 
     # Send metrics to cloud backend

--- a/infra/deployment/templates/configs/otel-config.yml.j2
+++ b/infra/deployment/templates/configs/otel-config.yml.j2
@@ -43,6 +43,11 @@ processors:
   # per-stage scaling (1000 on nightly, 2000 on latest) is gone: a cap the batch never reaches is
   # not a cap. The collector enforces send_batch_max_size >= send_batch_size, so raising throughput
   # again means raising both, and re-measuring. Only the timeout still varies by stage.
+  #
+  # Measured again on staging (2026-08): the real backend limit is 16 MiB, not 4, and 500 is
+  # still not low enough — requests of 500, 159 and 143 spans were all rejected with
+  # ResourceExhausted "larger than max 16777216", which puts the average span above 100 KB.
+  # Batch size is the wrong lever for a span that large; the cloud path bounds span size instead.
   batch:
     send_batch_size: 500
     send_batch_max_size: 500
@@ -97,6 +102,22 @@ processors:
     traces:
       span:
         - 'attributes["openinference.span.kind"] == nil'
+
+{%- if stage != 'dev' %}
+  # A rejected OTLP request is a PERMANENT error, so the exporter drops the whole batch
+  # without retrying — every span in it is lost, including the small ones that rode along.
+  # The size comes from OpenInference LLM spans carrying full prompts and completions, and
+  # embedding vectors. Langfuse is the consumer that needs those verbatim and it has its own
+  # pipeline, so drop the payload keys on the cloud path and truncate whatever is left as a
+  # backstop against the next unbounded attribute. This also keeps prompts and completions
+  # from leaving the deployment for a third-party backend at all.
+  transform/cloud_span_size:
+    error_mode: ignore
+    trace_statements:
+      - 'delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings)")'
+      - truncate_all(span.attributes, 2048)
+      - truncate_all(resource.attributes, 2048)
+{%- endif %}
 
   # Backstop (issue 1496): drop unbounded, high-cardinality HTTP server metrics
   # (side-effect of FastAPI/ASGI auto-instrumentation) before they reach the paid
@@ -184,7 +205,7 @@ service:
     # Send traces to cloud backend
     traces/cloud:
       receivers: [otlp]
-      processors: [filter/noise, resource/deployment, batch]
+      processors: [filter/noise, transform/cloud_span_size, resource/deployment, batch]
       exporters: [otlp/cloud]
 
     # Send metrics to cloud backend

--- a/infra/deployment/templates/configs/otel-config.yml.j2
+++ b/infra/deployment/templates/configs/otel-config.yml.j2
@@ -106,15 +106,23 @@ processors:
 {%- if stage != 'dev' %}
   # A rejected OTLP request is a PERMANENT error, so the exporter drops the whole batch
   # without retrying — every span in it is lost, including the small ones that rode along.
-  # The size comes from OpenInference LLM spans carrying full prompts and completions, and
-  # embedding vectors. Langfuse is the consumer that needs those verbatim and it has its own
-  # pipeline, so drop the payload keys on the cloud path and truncate whatever is left as a
-  # backstop against the next unbounded attribute. This also keeps prompts and completions
-  # from leaving the deployment for a third-party backend at all.
+  # The size comes from OpenInference spans carrying payload verbatim: LLM prompts and
+  # completions, embedding vectors, and the retrieved chunk text on retriever and reranker
+  # spans — a reranker span flattens every input AND output document, each with its full
+  # content. Langfuse is the consumer that needs those verbatim and it has its own pipeline,
+  # so drop the payload keys on the cloud path and truncate whatever is left as a backstop
+  # against the next unbounded attribute.
+  #
+  # truncate_all bounds each attribute, not the span, so deleting the document keys is what
+  # actually caps a retriever: retrieve_k goes to 100 in the agent form, and 100 documents
+  # left at 2048 each rebuild a span far past the ~100 KB average that broke the batch.
+  #
+  # This also keeps prompts, completions and internal document text from leaving the
+  # deployment for a third-party backend at all.
   transform/cloud_span_size:
     error_mode: ignore
     trace_statements:
-      - 'delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings)")'
+      - 'delete_matching_keys(span.attributes, "^(llm[.](input|output)_messages|llm[.]prompt_template|input[.]value|output[.]value|embedding[.]embeddings|retrieval[.]documents|reranker[.](input|output)_documents|reranker[.]query)")'
       - truncate_all(span.attributes, 2048)
       - truncate_all(resource.attributes, 2048)
 {%- endif %}


### PR DESCRIPTION
## Problem

`otlp/cloud` on staging is permanently dropping traces, continuously:

```
error  Exporting failed. Dropping data.
  otelcol.component.id: otlp/cloud   otelcol.signal: traces
  error: not retryable error: Permanent error: rpc error: code = ResourceExhausted
         desc = grpc: received message after decompression larger than max 16777216
  dropped_items: 500
```

`Permanent` means no retry: the whole request is discarded, so every span in the batch is lost, including small unrelated ones that happened to be batched with a large one.

The existing `batch` comment documents a measurement against a stand-in collector capped at gRPC's default 4 MiB, and picked `send_batch_size: 500` from it. Both numbers are wrong against the real backend:

- the actual limit is **16 MiB**, not 4
- requests of **159** and **143** spans failed identically, which puts the average span **above 100 KB**

So `send_batch_size` is the wrong lever — 143 spans already break the limit, and any cap low enough would throttle normal traffic.

## Cause

`traces/langfuse` filters on `openinference.span.kind == nil`, but `traces/cloud` has no equivalent filter, so OpenInference LLM spans carry full prompts, completions and embedding vectors down **both** paths. Langfuse is the consumer that actually needs them verbatim.

## Fix

Bound span size on the cloud path only — `traces/langfuse` is untouched, so Langfuse keeps full fidelity:

- `delete_matching_keys` removes the payload attributes (`llm.input_messages.*`, `llm.output_messages.*`, `llm.prompt_template*`, `input.value`, `output.value`, `embedding.embeddings*`)
- `truncate_all(..., 2048)` as a backstop against the next unbounded attribute
- `openinference.span.kind`, `llm.model_name` and the rest of the span survive, so SigNoz still sees the LLM span and its timing

Defined only for stages that have a `traces/cloud` pipeline (everything except `dev`).

Side effect worth noting: prompts and completions stop leaving the deployment for a third-party backend.

## Verification

Against the real `otel/opentelemetry-collector-contrib:0.154.0`:

- `validate` passes on all **10** generated configs (5 stages x gpu/non-gpu)
- functional test — a span with 5 KB `llm.input_messages.0.message.content`, `input.value` and `embedding.embeddings.0.vector`, plus a 3000-char `http.url`, came out with those three keys **removed** and `http.url` cut to **exactly 2048**, while `openinference.span.kind` and `llm.model_name` were preserved

No Python scope changed, so `make test` has nothing to run for this.
