### PR TITLE
doc(swiss-ai-hub): Document the file generation capability

### DIFF
--- a/docs/arc42/decisions/2026_06_22_openwebui_code_execution_open_terminal.md
+++ b/docs/arc42/decisions/2026_06_22_openwebui_code_execution_open_terminal.md
@@ -27,6 +27,15 @@ Route OpenWebUI's code-execution path to a new **`open-terminal`** service:
 
 (the base already ships pandas, openpyxl, python-docx, weasyprint, matplotlib, xlsxwriter)
 
+> **Amendment 2026-08-28 — the baked-in inventory is larger than this decision recorded.** Verified against the running
+> `open-terminal-office:0.11.34` container, the base image also ships **`python-pptx`, `pypdf`, `Pillow`, `numpy`,
+> `scipy`, `lxml` and `PyYAML`, plus the `ffmpeg` and `pandoc` binaries**. This is not a change of decision — nothing
+> was added to the image — but the omission understated the capability: PPTX, video and audio generation were all
+> possible and undocumented. The user-facing format matrix in `docs/docs/2_platform/10_chat_ui/6_coding/index.en.md` now
+> records the verified set, and the sandbox has **no** diagram renderer (`cairosvg`, `mmdc`, `plantuml`, Graphviz,
+> Inkscape are all absent) and no Visio library, so `.vsdx` cannot be produced at all. Re-verify both when the base tag
+> is bumped.
+
 - **Isolation** — `OPEN_TERMINAL_MULTI_USER=true` for per-user home directories; attached to a **dedicated
   `code-sandbox` network only**, whose sole residents are the sandbox and its callers (`open-webui`; AI-Hub agents as a
   follow-up). Because Docker networks are bidirectional, keeping the sandbox off `backend` is what severs lateral reach

--- a/docs/arc42/decisions/2026_06_22_openwebui_code_execution_open_terminal.md
+++ b/docs/arc42/decisions/2026_06_22_openwebui_code_execution_open_terminal.md
@@ -31,10 +31,10 @@ Route OpenWebUI's code-execution path to a new **`open-terminal`** service:
 > `open-terminal-office:0.11.34` container, the base image also ships **`python-pptx`, `pypdf`, `Pillow`, `numpy`,
 > `scipy`, `lxml` and `PyYAML`, plus the `ffmpeg` and `pandoc` binaries**. This is not a change of decision — nothing
 > was added to the image — but the omission understated the capability: PPTX, video and audio generation were all
-> possible and undocumented. The user-facing format matrix in `docs/docs/2_platform/10_chat_ui/6_coding/index.en.md` now
-> records the verified set, and the sandbox has **no** diagram renderer (`cairosvg`, `mmdc`, `plantuml`, Graphviz,
-> Inkscape are all absent) and no Visio library, so `.vsdx` cannot be produced at all. Re-verify both when the base tag
-> is bumped.
+> possible and undocumented. The user-facing format matrix in
+> `docs/docs/2_platform/10_chat_ui/13_file_generation/index.en.md` records the verified set, and the sandbox has **no**
+> diagram renderer (`cairosvg`, `mmdc`, `plantuml`, Graphviz, Inkscape are all absent) and no Visio library, so `.vsdx`
+> cannot be produced at all. Re-verify both when the base tag is bumped.
 
 - **Isolation** — `OPEN_TERMINAL_MULTI_USER=true` for per-user home directories; attached to a **dedicated
   `code-sandbox` network only**, whose sole residents are the sandbox and its callers (`open-webui`; AI-Hub agents as a
@@ -43,9 +43,10 @@ Route OpenWebUI's code-execution path to a new **`open-terminal`** service:
   outbound internet); host port exposed only in `dev`/`local`/`build`.
 - **Wiring** — OpenWebUI connects via the Integrations env `TERMINAL_SERVER_CONNECTIONS` (bearer auth with
   `OPEN_TERMINAL_API_KEY`), replacing the Jupyter `CODE_EXECUTION_*` / `CODE_INTERPRETER_*` engine variables.
-- **Scope — plain LLM models only.** OpenWebUI orchestrates Open Terminal through native `execute_code` tool-calling;
-  the existing `/openai` proxy passes `tools`/`tool_calls` through transparently for plain models, and all LiteLLM
-  text-generation models declare `supports_function_calling: true`. Native function calling must be enabled per model.
+- **Scope — plain LLM models only.** OpenWebUI orchestrates Open Terminal through native `execute_code` tool-calling
+  (*corrected — see the amendment below*); the existing `/openai` proxy passes `tools`/`tool_calls` through
+  transparently for plain models, and all LiteLLM text-generation models declare `supports_function_calling: true`.
+  Native function calling must be enabled per model.
 - **AI-Hub agent chats are deferred.** Agent surfaces (the `aihub_pipeline.py` `Pipe` and the agent branch of the
   `/openai` proxy) own their own generation and do not expose OpenWebUI-orchestrated tool-calling, so Open Terminal does
   not engage for them. Supporting agents requires the OpenAI tool-calling handshake inside the agent framework and is
@@ -53,6 +54,16 @@ Route OpenWebUI's code-execution path to a new **`open-terminal`** service:
   separately)".
 - **Jupyter is retained** for now (its full removal is a follow-up once any remaining consumers migrate), but OpenWebUI
   no longer uses it.
+
+> **Amendment 2026-08-28 — the sandbox is not reached through `execute_code`.** The *Scope* bullet above names the wrong
+> mechanism. Verified against the OpenWebUI 0.9.5 source in the running container: the built-in `execute_code` tool
+> (`tools/builtin.py`) handles only the `pyodide` and `jupyter` engines and errors on anything else, and
+> `CODE_INTERPRETER_ENGINE` defaults to `pyodide` and is set in no compose file. Open Terminal is reached through the
+> **terminal-server integration** instead, which resolves the sandbox's OpenAPI operations into model-callable tools
+> (`run_command`, `write_file`, `display_file`, …) via `get_terminal_tools` in `utils/tools.py`, gated on a terminal
+> being selected in the chat and on the model's terminal capability. The rest of the bullet stands: native function
+> calling must still be enabled per model, because only then are those tools passed as real function definitions rather
+> than through OpenWebUI's single prompt-based tool-selection pass.
 
 ## Consequences
 

--- a/docs/docs/2_platform/10_chat_ui/13_file_generation/index.de.md
+++ b/docs/docs/2_platform/10_chat_ui/13_file_generation/index.de.md
@@ -1,0 +1,73 @@
+---
+title: Dateigenerierung
+source_sha: 73caf73bb3fd24736a4b68c9ec8375a9392a2b1c06a5608a3491e0e045d51ff3
+---
+
+# Dateigenerierung
+
+Bitten Sie ein Modell, eine Datei zu erzeugen — einen Report, ein Spreadsheet, ein Diagramm, eine Präsentation — und es
+schreibt diese Datei mit Python innerhalb der **Open Terminal**-Sandbox. Die fertige Datei erscheint im Files-Panel von
+OpenWebUI, wo sie heruntergeladen werden kann; nach dem Erstellen bestätigt das Modell den Dateinamen.
+
+Sie müssen dafür weder Code schreiben noch lesen. Beschreiben Sie das gewünschte Dokument und lassen Sie es vom Modell
+erzeugen.
+
+::: warning Voraussetzungen
+Die Dateigenerierung läuft über denselben Code-Ausführungspfad wie [Programmierung / Softwareentwicklung](../6_coding/)
+und erbt daher dessen Einschränkungen: Sie funktioniert nur mit **einfachen LLM-Modellen, die Function (Tool) Calling
+unterstützen**, **Native Function Calling muss** für das Modell **aktiviert sein** (Admin → Settings → Models → die
+Advanced Params des Modells), und **AI-Hub Agents werden noch nicht unterstützt**. Auf jener Seite finden Sie die
+Mechanik der Sandbox, das Isolationsmodell pro Benutzer und den Hinweis, dass generierte Dateien unbegrenzt aufbewahrt
+werden.
+:::
+
+::: tip Empfohlenes Modell — Workspace → Kimi-K2.6
+Wählen Sie **Kimi-K2.6** im Modell-Picker (unter **Workspace**), wenn das Modell eine Datei erzeugen soll.
+
+Die Dateigenerierung ist eine mehrstufige Tool-Calling-Schleife: Das Modell muss entscheiden, `execute_code` aufzurufen,
+korrektes Python schreiben, das Ergebnis zurücklesen und den Dateinamen melden. Die Zuverlässigkeit dieser Schleife
+variiert zwischen den Modellen deutlich stärker als die Liste der unterstützten Formate. Alle AI-Hub
+Text-Generation-Modelle deklarieren Function-Calling-Unterstützung, aber nicht alle vollziehen den Handshake in der
+Praxis — bei aktiviertem Open Terminal liefert `Qwen3.5-122B-A10B-FP8` eine leere Antwort. Siehe
+[ADR: Model Identity as a Platform-Injected System Prompt for Plain LLM Chats](/arc42/decisions/2026_08_14_model_identity_system_prompt_for_plain_llm_chats.md).
+
+**Native Function Calling** muss für das gewählte Modell dennoch aktiviert werden — es ist nicht standardmäßig aktiv.
+:::
+
+## Unterstützte Ausgabeformate
+
+Verifiziert gegen das Sandbox-Image `open-terminal-office:0.11.34`. „Kann generiert werden" bedeutet, dass die Sandbox
+die Datei schreiben und an das Files-Panel übergeben kann; es sagt nichts darüber aus, ob dasselbe Format als Upload
+wieder eingelesen werden kann.
+
+| Kategorie          | Dateiformate                                            | Kann generiert werden | Wie                                         |
+| ------------------ | ------------------------------------------------------- | --------------------- | ------------------------------------------- |
+| Textdokumente      | DOCX, RTF, TXT, Markdown (`.md`), HTML                  | Ja                    | `python-docx`, `pandoc`, Plain Text         |
+| Portable Dokumente | PDF                                                     | Ja                    | `reportlab`, `fpdf2`, `weasyprint`, `pypdf` |
+| Spreadsheets       | XLSX, XLS, CSV                                          | Ja                    | `openpyxl`, `xlsxwriter`, `pandas`          |
+| Präsentationen     | PPTX, PDF                                               | Ja                    | `python-pptx`, `pandoc`                     |
+| Bilder (Raster)    | PNG, JPG/JPEG, TIFF, WebP, BMP                          | Ja                    | `Pillow`, `matplotlib`                      |
+| Video              | MP4, WebM, MOV, GIF                                     | Ja                    | `ffmpeg` (H.264, VP9, GIF)                  |
+| Audio              | MP3, WAV, OGG, FLAC                                     | Ja                    | `ffmpeg` (LAME, PCM, Vorbis, FLAC)          |
+| Quellcode          | py, cs, java, ts, js, go, rs, cpp, sql, yaml, json, xml | Ja                    | Plain Text                                  |
+| Datenaustausch     | JSON, XML, YAML, CSV                                    | Ja                    | `json`, `lxml`, `PyYAML`, `pandas`          |
+| Knowledge Bases    | Markdown, HTML, Confluence Storage Format, MediaWiki    | Ja                    | `pandoc`, Plain Text/XML                    |
+| Diagramme (Source) | SVG, Draw.io (`.drawio`), Mermaid, PlantUML             | Nur Source            | Wird als Text geschrieben — siehe unten     |
+| Diagramme (Visio)  | Visio (`.vsdx`)                                         | Nein                  | Keine Library verfügbar — siehe unten       |
+
+## Bekannte Einschränkungen
+
+::: warning
+- **Diagramme werden als Source generiert, nicht als Bild.** SVG-, Draw.io-, Mermaid- und PlantUML-Dateien sind Text
+  oder XML, die Sandbox schreibt sie also problemlos — sie liefert dafür jedoch **keinen Renderer** mit (kein
+  `cairosvg`, `mmdc`, `plantuml`, Graphviz oder Inkscape) und kann sie daher nicht in eine Bilddatei umwandeln. Fragen
+  Sie stattdessen ein Rasterbild über `matplotlib` an, wenn Sie ein Bild und keine Source-Datei benötigen. Beachten Sie,
+  dass Mermaid *in einer Chat-Antwort* ein separater Pfad ist: Die Chat-Oberfläche rendert dieses inline als Diagramm —
+  deshalb kann eine Mermaid-Antwort gerendert aussehen, während eine Mermaid-**Datei** Source bleibt.
+- **Visio (`.vsdx`) kann nicht generiert werden.** Es gibt keine Visio-Library in der Sandbox und kein LibreOffice zum
+  Konvertieren. Fragen Sie stattdessen `.drawio`- oder SVG-Source an.
+- **Ein Format lesen ist nicht dasselbe wie es schreiben.** TIFF- und Visio-Dateien konnten während der Verifikation der
+  Capability nicht als Input in die Sandbox eingelesen werden, obwohl die TIFF-Generierung funktioniert.
+- **Die Formatliste ist an das Sandbox-Image gebunden.** Sie bezieht sich auf `open-terminal-office:0.11.34`. Ein
+  Anheben dieses Tags kann Libraries und damit Formate hinzufügen oder entfernen, ohne jede andere sichtbare Änderung.
+:::

--- a/docs/docs/2_platform/10_chat_ui/13_file_generation/index.de.md
+++ b/docs/docs/2_platform/10_chat_ui/13_file_generation/index.de.md
@@ -1,6 +1,6 @@
 ---
 title: Dateigenerierung
-source_sha: 04685dcb4afe8126fff35b4f1dbfd763a3664235062a1b6c0e3f936f79bac0f4
+source_sha: b8235feb8239dc872463b9fc7a3f7c8c5de4fa9fe26f01c95d769ef3917ff617
 ---
 
 # Dateigenerierung
@@ -27,10 +27,11 @@ Wählen Sie **Kimi-K2.6** im Modell-Picker (unter **Workspace**), wenn das Model
 
 Die Dateigenerierung ist eine mehrstufige Tool-Calling-Schleife: Das Modell muss korrektes Python schreiben, es mit
 `run_command` ausführen, das Ergebnis zurücklesen und die Datei dann mit `display_file` übergeben. Die Zuverlässigkeit
-dieser Schleife variiert zwischen den Modellen deutlich stärker als die Liste der unterstützten Formate. Alle AI-Hub
-Text-Generation-Modelle deklarieren Function-Calling-Unterstützung, aber nicht alle vollziehen den Handshake in der
-Praxis — bei aktiviertem Open Terminal liefert `Qwen3.5-122B-A10B-FP8` eine leere Antwort. Siehe
-[ADR: Model Identity as a Platform-Injected System Prompt for Plain LLM Chats](/arc42/decisions/2026_08_14_model_identity_system_prompt_for_plain_llm_chats.md).
+dieser Schleife variiert zwischen den Modellen deutlich stärker als die Liste der unterstützten Formate — alle AI-Hub
+Text-Generation-Modelle deklarieren Function-Calling-Unterstützung, aber diese Deklaration ist nicht dasselbe wie das
+Durchhalten eines mehrstufigen Aufbaus bis zur fertigen Datei. Kimi-K2.6 ist das Modell, gegen das die untenstehende
+Formatmatrix verifiziert wurde. Wenn ein anderes Modell antwortet, ohne eine Datei zu erzeugen, probieren Sie zuerst
+Kimi-K2.6, bevor Sie das Format als nicht unterstützt einstufen.
 
 **Native Function Calling** muss für das gewählte Modell dennoch aktiviert werden — es ist nicht standardmäßig aktiv.
 :::

--- a/docs/docs/2_platform/10_chat_ui/13_file_generation/index.de.md
+++ b/docs/docs/2_platform/10_chat_ui/13_file_generation/index.de.md
@@ -1,32 +1,33 @@
 ---
 title: Dateigenerierung
-source_sha: 73caf73bb3fd24736a4b68c9ec8375a9392a2b1c06a5608a3491e0e045d51ff3
+source_sha: 04685dcb4afe8126fff35b4f1dbfd763a3664235062a1b6c0e3f936f79bac0f4
 ---
 
 # Dateigenerierung
 
 Bitten Sie ein Modell, eine Datei zu erzeugen — einen Report, ein Spreadsheet, ein Diagramm, eine Präsentation — und es
-schreibt diese Datei mit Python innerhalb der **Open Terminal**-Sandbox. Die fertige Datei erscheint im Files-Panel von
-OpenWebUI, wo sie heruntergeladen werden kann; nach dem Erstellen bestätigt das Modell den Dateinamen.
+schreibt diese Datei mit Python innerhalb der **Open Terminal**-Sandbox. Anschließend öffnet es die fertige Datei in
+Ihrem File-Viewer und bestätigt den Dateinamen; die Datei bleibt zudem über den File-Browser des Terminal-Panels
+erreichbar.
 
 Sie müssen dafür weder Code schreiben noch lesen. Beschreiben Sie das gewünschte Dokument und lassen Sie es vom Modell
 erzeugen.
 
 ::: warning Voraussetzungen
-Die Dateigenerierung läuft über denselben Code-Ausführungspfad wie [Programmierung / Softwareentwicklung](../6_coding/)
-und erbt daher dessen Einschränkungen: Sie funktioniert nur mit **einfachen LLM-Modellen, die Function (Tool) Calling
-unterstützen**, **Native Function Calling muss** für das Modell **aktiviert sein** (Admin → Settings → Models → die
-Advanced Params des Modells), und **AI-Hub Agents werden noch nicht unterstützt**. Auf jener Seite finden Sie die
-Mechanik der Sandbox, das Isolationsmodell pro Benutzer und den Hinweis, dass generierte Dateien unbegrenzt aufbewahrt
-werden.
+Die Dateigenerierung läuft über denselben Pfad wie [Programmierung / Softwareentwicklung](../6_coding/) und erbt daher
+dessen Einschränkungen: ein **einfaches LLM-Modell** (kein AI-Hub Agent — diese werden noch nicht unterstützt), mit
+dafür **aktiviertem Native Function Calling** (Admin → Settings → Models → die Advanced Params des Modells), und ein im
+Chat **ausgewähltes Terminal**. Ohne Native Function Calling kann das Modell die mehrstufige Schleife nicht ausführen,
+die der Aufbau einer Datei erfordert. Auf jener Seite finden Sie die Mechanik der Sandbox, das Isolationsmodell pro
+Benutzer und den Hinweis, dass generierte Dateien unbegrenzt aufbewahrt werden.
 :::
 
 ::: tip Empfohlenes Modell — Workspace → Kimi-K2.6
 Wählen Sie **Kimi-K2.6** im Modell-Picker (unter **Workspace**), wenn das Modell eine Datei erzeugen soll.
 
-Die Dateigenerierung ist eine mehrstufige Tool-Calling-Schleife: Das Modell muss entscheiden, `execute_code` aufzurufen,
-korrektes Python schreiben, das Ergebnis zurücklesen und den Dateinamen melden. Die Zuverlässigkeit dieser Schleife
-variiert zwischen den Modellen deutlich stärker als die Liste der unterstützten Formate. Alle AI-Hub
+Die Dateigenerierung ist eine mehrstufige Tool-Calling-Schleife: Das Modell muss korrektes Python schreiben, es mit
+`run_command` ausführen, das Ergebnis zurücklesen und die Datei dann mit `display_file` übergeben. Die Zuverlässigkeit
+dieser Schleife variiert zwischen den Modellen deutlich stärker als die Liste der unterstützten Formate. Alle AI-Hub
 Text-Generation-Modelle deklarieren Function-Calling-Unterstützung, aber nicht alle vollziehen den Handshake in der
 Praxis — bei aktiviertem Open Terminal liefert `Qwen3.5-122B-A10B-FP8` eine leere Antwort. Siehe
 [ADR: Model Identity as a Platform-Injected System Prompt for Plain LLM Chats](/arc42/decisions/2026_08_14_model_identity_system_prompt_for_plain_llm_chats.md).
@@ -36,24 +37,25 @@ Praxis — bei aktiviertem Open Terminal liefert `Qwen3.5-122B-A10B-FP8` eine le
 
 ## Unterstützte Ausgabeformate
 
-Verifiziert gegen das Sandbox-Image `open-terminal-office:0.11.34`. „Kann generiert werden" bedeutet, dass die Sandbox
-die Datei schreiben und an das Files-Panel übergeben kann; es sagt nichts darüber aus, ob dasselbe Format als Upload
-wieder eingelesen werden kann.
+Was Sie anfragen können. Verifiziert gegen das Sandbox-Image `open-terminal-office:0.11.34` — „Ja" bedeutet, Sie
+erhalten eine echte, funktionierende Datei; „Nur Source" bedeutet, Sie erhalten den Textquellcode des Diagramms statt
+eines Bildes; „Nein" bedeutet, es ist nicht möglich. Dies sagt nichts darüber aus, ob dasselbe Format als Upload wieder
+eingelesen werden kann.
 
-| Kategorie          | Dateiformate                                            | Kann generiert werden | Wie                                         |
-| ------------------ | ------------------------------------------------------- | --------------------- | ------------------------------------------- |
-| Textdokumente      | DOCX, RTF, TXT, Markdown (`.md`), HTML                  | Ja                    | `python-docx`, `pandoc`, Plain Text         |
-| Portable Dokumente | PDF                                                     | Ja                    | `reportlab`, `fpdf2`, `weasyprint`, `pypdf` |
-| Spreadsheets       | XLSX, XLS, CSV                                          | Ja                    | `openpyxl`, `xlsxwriter`, `pandas`          |
-| Präsentationen     | PPTX, PDF                                               | Ja                    | `python-pptx`, `pandoc`                     |
-| Bilder (Raster)    | PNG, JPG/JPEG, TIFF, WebP, BMP                          | Ja                    | `Pillow`, `matplotlib`                      |
-| Video              | MP4, WebM, MOV, GIF                                     | Ja                    | `ffmpeg` (H.264, VP9, GIF)                  |
-| Audio              | MP3, WAV, OGG, FLAC                                     | Ja                    | `ffmpeg` (LAME, PCM, Vorbis, FLAC)          |
-| Quellcode          | py, cs, java, ts, js, go, rs, cpp, sql, yaml, json, xml | Ja                    | Plain Text                                  |
-| Datenaustausch     | JSON, XML, YAML, CSV                                    | Ja                    | `json`, `lxml`, `PyYAML`, `pandas`          |
-| Knowledge Bases    | Markdown, HTML, Confluence Storage Format, MediaWiki    | Ja                    | `pandoc`, Plain Text/XML                    |
-| Diagramme (Source) | SVG, Draw.io (`.drawio`), Mermaid, PlantUML             | Nur Source            | Wird als Text geschrieben — siehe unten     |
-| Diagramme (Visio)  | Visio (`.vsdx`)                                         | Nein                  | Keine Library verfügbar — siehe unten       |
+| Kategorie          | Dateiformate                                            | Kann generiert werden |
+| ------------------ | ------------------------------------------------------- | --------------------- |
+| Textdokumente      | DOCX, RTF, TXT, Markdown (`.md`), HTML                  | Ja                    |
+| Portable Dokumente | PDF                                                     | Ja                    |
+| Spreadsheets       | XLSX, XLS, CSV                                          | Ja                    |
+| Präsentationen     | PPTX, PDF                                               | Ja                    |
+| Bilder (Raster)    | PNG, JPG/JPEG, TIFF, WebP, BMP                          | Ja                    |
+| Video              | MP4, WebM, MOV, GIF                                     | Ja                    |
+| Audio              | MP3, WAV, OGG, FLAC                                     | Ja                    |
+| Quellcode          | py, cs, java, ts, js, go, rs, cpp, sql, yaml, json, xml | Ja                    |
+| Datenaustausch     | JSON, XML, YAML, CSV                                    | Ja                    |
+| Knowledge Bases    | Markdown, HTML, Confluence Storage Format, MediaWiki    | Ja                    |
+| Diagramme (Source) | SVG, Draw.io (`.drawio`), Mermaid, PlantUML             | Nur Source            |
+| Diagramme (Visio)  | Visio (`.vsdx`)                                         | Nein                  |
 
 ## Bekannte Einschränkungen
 

--- a/docs/docs/2_platform/10_chat_ui/13_file_generation/index.en.md
+++ b/docs/docs/2_platform/10_chat_ui/13_file_generation/index.en.md
@@ -1,0 +1,68 @@
+---
+title: File generation
+---
+
+# File generation
+
+Ask a model to produce a file — a report, a spreadsheet, a chart, a slide deck — and it writes that file inside the
+**Open Terminal** sandbox using Python. The finished file appears in OpenWebUI's Files panel, where it can be
+downloaded; after creating it the model confirms the filename.
+
+You do not need to write or read any code to use this. Describe the document you want and let the model produce it.
+
+::: warning Requirements
+File generation runs on the same code-execution path as [Coding / Software Development](../6_coding/), so it inherits
+that path's constraints: it works only with **plain LLM models that support function (tool) calling**, **Native Function
+Calling must be enabled** for the model (Admin → Settings → Models → the model's advanced params), and **AI-Hub agents
+are not supported yet**. See that page for the sandbox mechanics, the per-user isolation model, and the fact that
+generated files are kept indefinitely.
+:::
+
+::: tip Recommended model — Workspace → Kimi-K2.6
+Select **Kimi-K2.6** in the model picker (under **Workspace**) when you want the model to produce a file.
+
+File generation is a multi-step tool-calling loop: the model has to decide to call `execute_code`, write correct Python,
+read the result back and report the filename. Reliability on that loop varies far more between models than the list of
+supported formats does. All AI-Hub text-generation models declare function-calling support, but not all of them complete
+the handshake in practice — with Open Terminal enabled, `Qwen3.5-122B-A10B-FP8` returns an empty response. See
+[ADR: Model Identity as a Platform-Injected System Prompt for Plain LLM Chats](/arc42/decisions/2026_08_14_model_identity_system_prompt_for_plain_llm_chats.md).
+
+**Native Function Calling** still has to be switched on for the chosen model — it is not enabled by default.
+:::
+
+## Supported output formats
+
+Verified against the `open-terminal-office:0.11.34` sandbox image. "Can be generated" means the sandbox can write the
+file and hand it to the Files panel; it says nothing about whether the same format can be read back in as an upload.
+
+| Category           | File formats                                            | Can be generated | How                                         |
+| ------------------ | ------------------------------------------------------- | ---------------- | ------------------------------------------- |
+| Text documents     | DOCX, RTF, TXT, Markdown (`.md`), HTML                  | Yes              | `python-docx`, `pandoc`, plain text         |
+| Portable documents | PDF                                                     | Yes              | `reportlab`, `fpdf2`, `weasyprint`, `pypdf` |
+| Spreadsheets       | XLSX, XLS, CSV                                          | Yes              | `openpyxl`, `xlsxwriter`, `pandas`          |
+| Presentations      | PPTX, PDF                                               | Yes              | `python-pptx`, `pandoc`                     |
+| Images (raster)    | PNG, JPG/JPEG, TIFF, WebP, BMP                          | Yes              | `Pillow`, `matplotlib`                      |
+| Video              | MP4, WebM, MOV, GIF                                     | Yes              | `ffmpeg` (H.264, VP9, GIF)                  |
+| Audio              | MP3, WAV, OGG, FLAC                                     | Yes              | `ffmpeg` (LAME, PCM, Vorbis, FLAC)          |
+| Source code        | py, cs, java, ts, js, go, rs, cpp, sql, yaml, json, xml | Yes              | Plain text                                  |
+| Data exchange      | JSON, XML, YAML, CSV                                    | Yes              | `json`, `lxml`, `PyYAML`, `pandas`          |
+| Knowledge bases    | Markdown, HTML, Confluence storage format, MediaWiki    | Yes              | `pandoc`, plain text/XML                    |
+| Diagrams (source)  | SVG, Draw.io (`.drawio`), Mermaid, PlantUML             | Source only      | Written as text — see below                 |
+| Diagrams (Visio)   | Visio (`.vsdx`)                                         | No               | No library available — see below            |
+
+## Known limitations
+
+::: warning
+- **Diagrams are generated as source, not as pictures.** SVG, Draw.io, Mermaid and PlantUML files are text or XML, so
+  the sandbox writes them without trouble — but it ships **no renderer** for them (no `cairosvg`, `mmdc`, `plantuml`,
+  Graphviz or Inkscape), so it cannot turn them into an image file. Ask for a raster image via `matplotlib` instead when
+  you need a picture rather than a source file. Note that Mermaid returned *in a chat response* is a separate path: the
+  chat UI renders that inline as a diagram, which is why a Mermaid answer can look rendered while a Mermaid **file**
+  stays source.
+- **Visio (`.vsdx`) cannot be generated.** There is no Visio library in the sandbox and no LibreOffice to convert
+  through. Ask for `.drawio` or SVG source instead.
+- **Reading a format is not the same as writing it.** TIFF and Visio files could not be read back into the sandbox as
+  input during capability testing, even though TIFF generation works.
+- **The format list is tied to the sandbox image.** It reflects `open-terminal-office:0.11.34`. Bumping that tag can add
+  or remove libraries, and therefore formats, without any other visible change.
+:::

--- a/docs/docs/2_platform/10_chat_ui/13_file_generation/index.en.md
+++ b/docs/docs/2_platform/10_chat_ui/13_file_generation/index.en.md
@@ -5,8 +5,8 @@ title: File generation
 # File generation
 
 Ask a model to produce a file — a report, a spreadsheet, a chart, a slide deck — and it writes that file inside the
-**Open Terminal** sandbox using Python. The finished file appears in OpenWebUI's Files panel, where it can be
-downloaded; after creating it the model confirms the filename.
+**Open Terminal** sandbox using Python. It then opens the finished file in your file viewer and confirms the filename;
+the file also stays reachable through the terminal panel's file browser.
 
 You do not need to write or read any code to use this. Describe the document you want and let the model produce it.
 
@@ -21,10 +21,11 @@ generated files are kept indefinitely.
 ::: tip Recommended model — Workspace → Kimi-K2.6
 Select **Kimi-K2.6** in the model picker (under **Workspace**) when you want the model to produce a file.
 
-File generation is a multi-step tool-calling loop: the model has to decide to call `execute_code`, write correct Python,
-read the result back and report the filename. Reliability on that loop varies far more between models than the list of
-supported formats does. All AI-Hub text-generation models declare function-calling support, but not all of them complete
-the handshake in practice — with Open Terminal enabled, `Qwen3.5-122B-A10B-FP8` returns an empty response. See
+File generation is a multi-step tool-calling loop: the model has to write correct Python, run it with `run_command`,
+read the result back, and then hand the file over with `display_file`. Reliability on that loop varies far more between
+models than the list of supported formats does. All AI-Hub text-generation models declare function-calling support, but
+not all of them complete the handshake in practice — with Open Terminal enabled, `Qwen3.5-122B-A10B-FP8` returns an
+empty response. See
 [ADR: Model Identity as a Platform-Injected System Prompt for Plain LLM Chats](/arc42/decisions/2026_08_14_model_identity_system_prompt_for_plain_llm_chats.md).
 
 **Native Function Calling** still has to be switched on for the chosen model — it is not enabled by default.
@@ -32,23 +33,24 @@ the handshake in practice — with Open Terminal enabled, `Qwen3.5-122B-A10B-FP8
 
 ## Supported output formats
 
-Verified against the `open-terminal-office:0.11.34` sandbox image. "Can be generated" means the sandbox can write the
-file and hand it to the Files panel; it says nothing about whether the same format can be read back in as an upload.
+What you can ask for. Verified against the `open-terminal-office:0.11.34` sandbox image — "Yes" means you get a real,
+working file; "Source only" means you get the diagram's text source rather than a picture; "No" means it cannot be done.
+This says nothing about whether the same format can be read back in as an upload.
 
-| Category           | File formats                                            | Can be generated | How                                         |
-| ------------------ | ------------------------------------------------------- | ---------------- | ------------------------------------------- |
-| Text documents     | DOCX, RTF, TXT, Markdown (`.md`), HTML                  | Yes              | `python-docx`, `pandoc`, plain text         |
-| Portable documents | PDF                                                     | Yes              | `reportlab`, `fpdf2`, `weasyprint`, `pypdf` |
-| Spreadsheets       | XLSX, XLS, CSV                                          | Yes              | `openpyxl`, `xlsxwriter`, `pandas`          |
-| Presentations      | PPTX, PDF                                               | Yes              | `python-pptx`, `pandoc`                     |
-| Images (raster)    | PNG, JPG/JPEG, TIFF, WebP, BMP                          | Yes              | `Pillow`, `matplotlib`                      |
-| Video              | MP4, WebM, MOV, GIF                                     | Yes              | `ffmpeg` (H.264, VP9, GIF)                  |
-| Audio              | MP3, WAV, OGG, FLAC                                     | Yes              | `ffmpeg` (LAME, PCM, Vorbis, FLAC)          |
-| Source code        | py, cs, java, ts, js, go, rs, cpp, sql, yaml, json, xml | Yes              | Plain text                                  |
-| Data exchange      | JSON, XML, YAML, CSV                                    | Yes              | `json`, `lxml`, `PyYAML`, `pandas`          |
-| Knowledge bases    | Markdown, HTML, Confluence storage format, MediaWiki    | Yes              | `pandoc`, plain text/XML                    |
-| Diagrams (source)  | SVG, Draw.io (`.drawio`), Mermaid, PlantUML             | Source only      | Written as text — see below                 |
-| Diagrams (Visio)   | Visio (`.vsdx`)                                         | No               | No library available — see below            |
+| Category           | File formats                                            | Can be generated |
+| ------------------ | ------------------------------------------------------- | ---------------- |
+| Text documents     | DOCX, RTF, TXT, Markdown (`.md`), HTML                  | Yes              |
+| Portable documents | PDF                                                     | Yes              |
+| Spreadsheets       | XLSX, XLS, CSV                                          | Yes              |
+| Presentations      | PPTX, PDF                                               | Yes              |
+| Images (raster)    | PNG, JPG/JPEG, TIFF, WebP, BMP                          | Yes              |
+| Video              | MP4, WebM, MOV, GIF                                     | Yes              |
+| Audio              | MP3, WAV, OGG, FLAC                                     | Yes              |
+| Source code        | py, cs, java, ts, js, go, rs, cpp, sql, yaml, json, xml | Yes              |
+| Data exchange      | JSON, XML, YAML, CSV                                    | Yes              |
+| Knowledge bases    | Markdown, HTML, Confluence storage format, MediaWiki    | Yes              |
+| Diagrams (source)  | SVG, Draw.io (`.drawio`), Mermaid, PlantUML             | Source only      |
+| Diagrams (Visio)   | Visio (`.vsdx`)                                         | No               |
 
 ## Known limitations
 

--- a/docs/docs/2_platform/10_chat_ui/13_file_generation/index.en.md
+++ b/docs/docs/2_platform/10_chat_ui/13_file_generation/index.en.md
@@ -13,9 +13,10 @@ You do not need to write or read any code to use this. Describe the document you
 ::: warning Requirements
 File generation runs on the same code-execution path as [Coding / Software Development](../6_coding/), so it inherits
 that path's constraints: it works only with **plain LLM models that support function (tool) calling**, **Native Function
-Calling must be enabled** for the model (Admin → Settings → Models → the model's advanced params), and **AI-Hub agents
-are not supported yet**. See that page for the sandbox mechanics, the per-user isolation model, and the fact that
-generated files are kept indefinitely.
+Calling must be enabled** for the model (Admin → Settings → Models → the model's advanced params), **a terminal has to
+be selected in the chat** — the sandbox tools are resolved only then — and **AI-Hub agents are not supported yet**. See
+that page for the sandbox mechanics, the per-user isolation model, and the fact that generated files are kept
+indefinitely.
 :::
 
 ::: tip Recommended model — Workspace → Kimi-K2.6
@@ -23,10 +24,10 @@ Select **Kimi-K2.6** in the model picker (under **Workspace**) when you want the
 
 File generation is a multi-step tool-calling loop: the model has to write correct Python, run it with `run_command`,
 read the result back, and then hand the file over with `display_file`. Reliability on that loop varies far more between
-models than the list of supported formats does. All AI-Hub text-generation models declare function-calling support, but
-not all of them complete the handshake in practice — with Open Terminal enabled, `Qwen3.5-122B-A10B-FP8` returns an
-empty response. See
-[ADR: Model Identity as a Platform-Injected System Prompt for Plain LLM Chats](/arc42/decisions/2026_08_14_model_identity_system_prompt_for_plain_llm_chats.md).
+models than the list of supported formats does — every AI-Hub text-generation model declares function-calling support,
+but declaring it is not the same as carrying a multi-step build through to a finished file. Kimi-K2.6 is the model the
+format matrix below was verified against. If another model answers without producing a file, try Kimi-K2.6 before
+concluding that the format is unsupported.
 
 **Native Function Calling** still has to be switched on for the chosen model — it is not enabled by default.
 :::

--- a/docs/docs/2_platform/10_chat_ui/1_feature_overview/index.de.md
+++ b/docs/docs/2_platform/10_chat_ui/1_feature_overview/index.de.md
@@ -1,6 +1,6 @@
 ---
 title: Funktionsübersicht
-source_sha: 372f92552bca6a8de6b631b7437cd9b9cb5943fdf219709ad021529d1683074a
+source_sha: 03a5e3828888ed3da08f3082dbed452b3f351f06d54e11faa81f062468170305
 ---
 
 # Funktionsübersicht
@@ -121,6 +121,10 @@ Erscheinungsbild der Oberfläche an persönliche Vorlieben und die Umgebungsbele
 Für unterstützte Modelle und Konfigurationen kann die Oberfläche Code-Snippets ausführen, was interaktive
 Programmierhilfe, rechnerische Problemlösung und Algorithmus-Prototyping innerhalb von Konversationskontexten
 ermöglicht.
+
+Derselbe Ausführungspfad erlaubt es Modellen, Dateien zu erzeugen — Reports, Spreadsheets, Präsentationen, Diagramme,
+Audio und Video —, die zum Download im Files-Panel erscheinen. Dies erfordert keinen Code seitens des Benutzers; siehe
+[Dateigenerierung](../13_file_generation/) für die unterstützten Formate und das empfohlene Modell.
 
 Die Unterstützung für Mermaid-Diagramme ermöglicht KI-generierte Visualisierungen – Flussdiagramme, Sequenzdiagramme,
 Zustandsautomaten – die direkt in Konversationen gerendert werden. Dies unterstützt Systemdesign, Prozessdokumentation

--- a/docs/docs/2_platform/10_chat_ui/1_feature_overview/index.de.md
+++ b/docs/docs/2_platform/10_chat_ui/1_feature_overview/index.de.md
@@ -1,6 +1,6 @@
 ---
 title: Funktionsübersicht
-source_sha: 03a5e3828888ed3da08f3082dbed452b3f351f06d54e11faa81f062468170305
+source_sha: b5796d38068692ac98735b4e07a4551d0b26b65f8bb986d40f88588c4a022ac2
 ---
 
 # Funktionsübersicht
@@ -122,9 +122,9 @@ Für unterstützte Modelle und Konfigurationen kann die Oberfläche Code-Snippet
 Programmierhilfe, rechnerische Problemlösung und Algorithmus-Prototyping innerhalb von Konversationskontexten
 ermöglicht.
 
-Derselbe Ausführungspfad erlaubt es Modellen, Dateien zu erzeugen — Reports, Spreadsheets, Präsentationen, Diagramme,
-Audio und Video —, die zum Download im Files-Panel erscheinen. Dies erfordert keinen Code seitens des Benutzers; siehe
-[Dateigenerierung](../13_file_generation/) für die unterstützten Formate und das empfohlene Modell.
+Dieselbe Sandbox erlaubt es Modellen, Dateien zu erzeugen — Reports, Spreadsheets, Präsentationen, Diagramme, Audio und
+Video —, die das Modell anschließend im File-Viewer des Benutzers öffnet. Dies erfordert keinen Code seitens des
+Benutzers; siehe [Dateigenerierung](../13_file_generation/) für die unterstützten Formate und das empfohlene Modell.
 
 Die Unterstützung für Mermaid-Diagramme ermöglicht KI-generierte Visualisierungen – Flussdiagramme, Sequenzdiagramme,
 Zustandsautomaten – die direkt in Konversationen gerendert werden. Dies unterstützt Systemdesign, Prozessdokumentation

--- a/docs/docs/2_platform/10_chat_ui/1_feature_overview/index.en.md
+++ b/docs/docs/2_platform/10_chat_ui/1_feature_overview/index.en.md
@@ -109,6 +109,10 @@ appearance to personal preferences and environmental lighting.
 For supported models and configurations, the interface can execute code snippets, enabling interactive programming
 assistance, computational problem solving, and algorithm prototyping within conversational contexts.
 
+The same execution path lets models produce files — reports, spreadsheets, slide decks, charts, audio and video — which
+appear in the Files panel for download. This needs no code from the user; see [File generation](../13_file_generation/)
+for the supported formats and the recommended model.
+
 Mermaid diagram support enables AI-generated visualizations - flowcharts, sequence diagrams, state machines - rendered
 directly within conversations. This supports systems design, process documentation, and visual explanation.
 

--- a/docs/docs/2_platform/10_chat_ui/1_feature_overview/index.en.md
+++ b/docs/docs/2_platform/10_chat_ui/1_feature_overview/index.en.md
@@ -109,9 +109,9 @@ appearance to personal preferences and environmental lighting.
 For supported models and configurations, the interface can execute code snippets, enabling interactive programming
 assistance, computational problem solving, and algorithm prototyping within conversational contexts.
 
-The same execution path lets models produce files — reports, spreadsheets, slide decks, charts, audio and video — which
-appear in the Files panel for download. This needs no code from the user; see [File generation](../13_file_generation/)
-for the supported formats and the recommended model.
+The same sandbox lets models produce files — reports, spreadsheets, slide decks, charts, audio and video — which the
+model then opens in the user's file viewer. This needs no code from the user; see
+[File generation](../13_file_generation/) for the supported formats and the recommended model.
 
 Mermaid diagram support enables AI-generated visualizations - flowcharts, sequence diagrams, state machines - rendered
 directly within conversations. This supports systems design, process documentation, and visual explanation.

--- a/docs/docs/2_platform/10_chat_ui/6_coding/index.de.md
+++ b/docs/docs/2_platform/10_chat_ui/6_coding/index.de.md
@@ -1,6 +1,6 @@
 ---
 title: Programmierung / Softwareentwicklung
-source_sha: 820147cd3e9470b283394b49091768f7aa09f69401f0825ab70497b59e3a6831
+source_sha: 9a40633fb3368d39acf2c3e882fca3ac64a683df7ef4be946a083569cca6af00
 ---
 
 # Programmierung / Softwareentwicklung
@@ -8,13 +8,19 @@ source_sha: 820147cd3e9470b283394b49091768f7aa09f69401f0825ab70497b59e3a6831
 OpenWebUI integriert **Open Terminal** — eine gesandboxte Linux-Umgebung mit Python 3.12, gängigen Dokumenten-Libraries
 (pandas, openpyxl, xlsxwriter, python-docx, python-pptx, reportlab, fpdf2, weasyprint, pypdf, matplotlib, Pillow, numpy,
 scipy, lxml, PyYAML) sowie den Command-Line Tools `ffmpeg` und `pandoc`. Der Code läuft in einer isolierten Umgebung pro
-Benutzer; während der Ausführung erstellte Dateien erscheinen im Files-Panel von OpenWebUI zum Download.
+Benutzer, und zwar im Home-Verzeichnis dieses Benutzers innerhalb der Sandbox.
 
 ::: warning Voraussetzungen & aktuelle Einschränkungen
-- **Nur einfache LLM-Modelle.** Die Code-Ausführung wird durch das native `execute_code`-Tool von OpenWebUI gesteuert
-  und funktioniert daher nur mit einfachen Chat-Modellen, die **Function (Tool) Calling unterstützen**, und **Native
-  Function Calling muss** für das Modell **aktiviert sein** (Admin → Settings → Models → die Advanced Params des
-  Modells). Modelle ohne Function-Calling-Unterstützung können die Sandbox nicht auslösen.
+- **Nur einfache LLM-Modelle, mit aktiviertem Native Function Calling.** OpenWebUI stellt dem Modell die Sandbox als
+  eine Reihe von Tools bereit (`run_command`, `write_file`, `display_file` und weitere), die aus der
+  Terminal-Server-Integration aufgelöst werden — nicht über das eingebaute `execute_code`-Tool. **Native Function
+  Calling muss** für das Modell **aktiviert sein** (Admin → Settings → Models → die Advanced Params des Modells): Erst
+  dann werden diese Tools dem Modell als echte Function-Definitionen übergeben, was es ihm erlaubt, einen Schritt
+  auszuführen, das Ergebnis zu lesen und fortzufahren. Beim Standardwert fällt OpenWebUI auf einen einzelnen
+  prompt-basierten Tool-Auswahldurchlauf zurück, was für einen mehrstufigen Aufbau nicht ausreicht. Modelle ohne
+  Function-Calling-Unterstützung können die Sandbox überhaupt nicht ansteuern.
+- **Das Terminal muss für die Konversation aktiv sein.** Die Tools werden nur aufgelöst, wenn im Chat ein Terminal
+  ausgewählt ist.
 - **AI-Hub Agents werden noch nicht unterstützt.** Agent-Chats steuern ihre eigene Generierung und stellen den
   Tool-Calling-Handshake von OpenWebUI nicht bereit, weshalb die Code-Ausführung für sie **nicht** aktiv wird. Dies ist
   ein geplanter Follow-up.
@@ -37,12 +43,15 @@ Mit dem „Run"-Button kann der Code direkt im Chat getestet werden.
 
 ![Code with Run Button](../../../../media/open_webui/code_with_run_button.jpeg)
 
-::: tip Zwei Ausführungspfade
-**Modellgesteuerte Ausführung** — bei der das Modell entscheidet, Code auszuführen, um eine Antwort zu berechnen oder
-eine Datei zu erzeugen — läuft in der **Open Terminal**-Sandbox (serverseitig, mit den oben genannten
-Dokumenten-Libraries; generierte Dateien erscheinen im Files-Panel). Der manuelle **„Run"-Button** an einem Code-Block
-nutzt die eingebaute **Pyodide**-Engine von OpenWebUI (In-Browser-WebAssembly), die leichtgewichtig ist, aber auf ihre
-mitgelieferten Packages beschränkt bleibt und keine Dateien auf dem Server schreibt.
+::: tip Zwei Ausführungspfade — nur einer kann eine Datei erzeugen
+**Modellgesteuerte Ausführung**, bei der das Modell die Tools der Sandbox selbst aufruft, läuft serverseitig in **Open
+Terminal** mit den oben genannten Libraries, im Home-Verzeichnis des jeweiligen Benutzers. Dies ist der einzige Pfad,
+der eine herunterladbare Datei erzeugen kann.
+
+Der manuelle **„Run"-Button** an einem Code-Block — und das eingebaute `execute_code`-Tool von OpenWebUI, dessen
+`CODE_INTERPRETER_ENGINE` standardmäßig auf `pyodide` steht — nutzen stattdessen die **Pyodide**-Engine:
+In-Browser-WebAssembly, leichtgewichtig, auf die mitgelieferten Packages beschränkt und **nicht in der Lage, Dateien auf
+dem Server zu schreiben**. Diagramme kommen auf diesem Pfad als Inline-Bilder zurück, nicht als Dateien.
 :::
 
 Nach der Ausführung gibt das Code-Snippet das Ergebnis unterhalb der Zelle aus.
@@ -65,9 +74,10 @@ Wenn der Code ausgeführt wurde, wird das Ergebnis ausgegeben.
 
 ## Generierte Dateien
 
-Während der Code-Ausführung geschriebene Dateien (Reports, Spreadsheets, Diagramme usw.) erscheinen automatisch im
-Files-Panel von OpenWebUI, wo Benutzer sie herunterladen können. Nach dem Erstellen einer Datei bestätigt das Modell den
-Dateinamen.
+Während der Code-Ausführung geschriebene Dateien (Reports, Spreadsheets, Diagramme usw.) werden im Home-Verzeichnis des
+jeweiligen Benutzers innerhalb der Sandbox erstellt (`/home/<user>`). Das Modell übergibt eine fertige Datei mit
+`display_file`, wodurch sie im File-Viewer des Benutzers geöffnet wird; die Dateien bleiben zudem über den File-Browser
+des Terminal-Panels erreichbar.
 
 Das Erzeugen von Dokumenten ist eine eigenständige Capability und erfordert kein Schreiben von Code. Siehe
 [Dateigenerierung](../13_file_generation/) für das empfohlene Modell, die verifizierte Liste der Ausgabeformate und die

--- a/docs/docs/2_platform/10_chat_ui/6_coding/index.de.md
+++ b/docs/docs/2_platform/10_chat_ui/6_coding/index.de.md
@@ -1,6 +1,6 @@
 ---
 title: Programmierung / Softwareentwicklung
-source_sha: fed56eac7b0aec32c6b93eb4e57ce6b808c2c2cb2689ef97487591d21100d0b8
+source_sha: 820147cd3e9470b283394b49091768f7aa09f69401f0825ab70497b59e3a6831
 ---
 
 # Programmierung / Softwareentwicklung
@@ -63,60 +63,15 @@ Wenn der Code ausgeführt wurde, wird das Ergebnis ausgegeben.
 
 ![Code Execution Output](../../../../media/open_webui/code_execution_output.jpeg)
 
-## Dateigenerierung
+## Generierte Dateien
 
 Während der Code-Ausführung geschriebene Dateien (Reports, Spreadsheets, Diagramme usw.) erscheinen automatisch im
 Files-Panel von OpenWebUI, wo Benutzer sie herunterladen können. Nach dem Erstellen einer Datei bestätigt das Modell den
 Dateinamen.
 
-::: tip Empfohlenes Modell — Workspace → Kimi-K2.6
-Wählen Sie **Kimi-K2.6** im Modell-Picker (unter **Workspace**), wenn das Modell eine Datei erzeugen soll.
-
-Die Dateigenerierung ist eine mehrstufige Tool-Calling-Schleife: Das Modell muss entscheiden, `execute_code` aufzurufen,
-korrektes Python schreiben, das Ergebnis zurücklesen und den Dateinamen melden. Die Zuverlässigkeit dieser Schleife
-variiert zwischen den Modellen deutlich stärker als die Liste der unterstützten Formate. Alle AI-Hub
-Text-Generation-Modelle deklarieren Function-Calling-Unterstützung, aber nicht alle vollziehen den Handshake in der
-Praxis — bei aktiviertem Open Terminal liefert `Qwen3.5-122B-A10B-FP8` eine leere Antwort. Siehe
-[ADR: Model Identity as a Platform-Injected System Prompt for Plain LLM Chats](/arc42/decisions/2026_08_14_model_identity_system_prompt_for_plain_llm_chats.md).
-
-**Native Function Calling** muss für das gewählte Modell dennoch aktiviert werden — es ist nicht standardmäßig aktiv.
-:::
-
-### Unterstützte Ausgabeformate
-
-Verifiziert gegen das Sandbox-Image `open-terminal-office:0.11.34`. „Kann generiert werden" bedeutet, dass die Sandbox
-die Datei schreiben und an das Files-Panel übergeben kann; es sagt nichts darüber aus, ob dasselbe Format als Upload
-wieder eingelesen werden kann.
-
-| Kategorie          | Dateiformate                                            | Kann generiert werden | Wie                                         |
-| ------------------ | ------------------------------------------------------- | --------------------- | ------------------------------------------- |
-| Textdokumente      | DOCX, RTF, TXT, Markdown (`.md`), HTML                  | Ja                    | `python-docx`, `pandoc`, Plain Text         |
-| Portable Dokumente | PDF                                                     | Ja                    | `reportlab`, `fpdf2`, `weasyprint`, `pypdf` |
-| Spreadsheets       | XLSX, XLS, CSV                                          | Ja                    | `openpyxl`, `xlsxwriter`, `pandas`          |
-| Präsentationen     | PPTX, PDF                                               | Ja                    | `python-pptx`, `pandoc`                     |
-| Bilder (Raster)    | PNG, JPG/JPEG, TIFF, WebP, BMP                          | Ja                    | `Pillow`, `matplotlib`                      |
-| Video              | MP4, WebM, MOV, GIF                                     | Ja                    | `ffmpeg` (H.264, VP9, GIF)                  |
-| Audio              | MP3, WAV, OGG, FLAC                                     | Ja                    | `ffmpeg` (LAME, PCM, Vorbis, FLAC)          |
-| Quellcode          | py, cs, java, ts, js, go, rs, cpp, sql, yaml, json, xml | Ja                    | Plain Text                                  |
-| Datenaustausch     | JSON, XML, YAML, CSV                                    | Ja                    | `json`, `lxml`, `PyYAML`, `pandas`          |
-| Knowledge Bases    | Markdown, HTML, Confluence Storage Format, MediaWiki    | Ja                    | `pandoc`, Plain Text/XML                    |
-| Diagramme (Source) | SVG, Draw.io (`.drawio`), Mermaid, PlantUML             | Nur Source            | Wird als Text geschrieben — siehe unten     |
-| Diagramme (Visio)  | Visio (`.vsdx`)                                         | Nein                  | Keine Library verfügbar — siehe unten       |
-
-### Bekannte Einschränkungen
-
-::: warning
-- **Diagramme werden als Source generiert, nicht als Bild.** SVG-, Draw.io-, Mermaid- und PlantUML-Dateien sind Text
-  oder XML, die Sandbox schreibt sie also problemlos — sie liefert dafür jedoch **keinen Renderer** mit (kein
-  `cairosvg`, `mmdc`, `plantuml`, Graphviz oder Inkscape). Fragen Sie stattdessen ein Rasterbild über `matplotlib` an,
-  wenn Sie ein Bild und keine Source-Datei benötigen.
-- **Visio (`.vsdx`) kann nicht generiert werden.** Es gibt keine Visio-Library in der Sandbox und kein LibreOffice zum
-  Konvertieren. Fragen Sie stattdessen `.drawio`- oder SVG-Source an.
-- **Ein Format lesen ist nicht dasselbe wie es schreiben.** TIFF- und Visio-Dateien konnten während der Verifikation der
-  Capability nicht als Input in die Sandbox eingelesen werden, obwohl die TIFF-Generierung funktioniert.
-- **Die Formatliste ist an das Sandbox-Image gebunden.** Sie bezieht sich auf `open-terminal-office:0.11.34`. Ein
-  Anheben dieses Tags kann Libraries und damit Formate hinzufügen oder entfernen, ohne jede andere sichtbare Änderung.
-:::
+Das Erzeugen von Dokumenten ist eine eigenständige Capability und erfordert kein Schreiben von Code. Siehe
+[Dateigenerierung](../13_file_generation/) für das empfohlene Modell, die verifizierte Liste der Ausgabeformate und die
+dafür geltenden Einschränkungen.
 
 ## Isolation und Einschränkungen
 

--- a/docs/docs/2_platform/10_chat_ui/6_coding/index.de.md
+++ b/docs/docs/2_platform/10_chat_ui/6_coding/index.de.md
@@ -1,26 +1,49 @@
 ---
 title: Programmierung / Softwareentwicklung
-source_sha: 7d2350bab17cc800c6d66787e8f18d9c8eb4eacc587f787c84730f4c68ee9d92
+source_sha: fed56eac7b0aec32c6b93eb4e57ce6b808c2c2cb2689ef97487591d21100d0b8
 ---
 
 # Programmierung / Softwareentwicklung
 
-Wenn es darum geht, mit Hilfe eines Modells zu programmieren, gibt es zwei Hauptwege, dies zu tun.
+OpenWebUI integriert **Open Terminal** — eine gesandboxte Linux-Umgebung mit Python 3.12, gängigen Dokumenten-Libraries
+(pandas, openpyxl, xlsxwriter, python-docx, python-pptx, reportlab, fpdf2, weasyprint, pypdf, matplotlib, Pillow, numpy,
+scipy, lxml, PyYAML) sowie den Command-Line Tools `ffmpeg` und `pandoc`. Der Code läuft in einer isolierten Umgebung pro
+Benutzer; während der Ausführung erstellte Dateien erscheinen im Files-Panel von OpenWebUI zum Download.
 
-1. Entweder schreibt das Modell den Code, was durch die Erwähnung der "Pydiode environment", die zur Ausführung des
-   Codes verwendet wird, angedeutet werden kann. Dies gibt dem Modell den Hinweis, dass der Benutzer mit Code arbeiten
-   möchte und wird versuchen, die Anfrage durch das Schreiben von Code zu beantworten.
-2. Alternativ kann der Chat auch verwendet werden, um bestehenden Code auszuführen und weiterzuentwickeln.
+::: warning Voraussetzungen & aktuelle Einschränkungen
+- **Nur einfache LLM-Modelle.** Die Code-Ausführung wird durch das native `execute_code`-Tool von OpenWebUI gesteuert
+  und funktioniert daher nur mit einfachen Chat-Modellen, die **Function (Tool) Calling unterstützen**, und **Native
+  Function Calling muss** für das Modell **aktiviert sein** (Admin → Settings → Models → die Advanced Params des
+  Modells). Modelle ohne Function-Calling-Unterstützung können die Sandbox nicht auslösen.
+- **AI-Hub Agents werden noch nicht unterstützt.** Agent-Chats steuern ihre eigene Generierung und stellen den
+  Tool-Calling-Handshake von OpenWebUI nicht bereit, weshalb die Code-Ausführung für sie **nicht** aktiv wird. Dies ist
+  ein geplanter Follow-up.
+:::
+
+Es gibt zwei Hauptwege, die Code-Ausführung zu nutzen.
+
+1. Bitten Sie das Modell, Code zu schreiben und auszuführen. Die Nennung eines konkreten Ziels (z. B. „ein Diagramm
+   erstellen", „diese Daten verarbeiten") gibt dem Modell den Kontext, um Python-Code zu generieren und auszuführen, der
+   das Ergebnis direkt im Chat erzeugt.
+2. Stellen Sie bestehenden Code bereit und bitten Sie das Modell, ihn auszuführen oder zu verbessern.
 
 ## Programmierung mit dem LLM
 
-Geben Sie einen Prompt ein, der die "Pydiode environment" erwähnt, um Code zu generieren.
+Geben Sie einen Prompt ein, der die „Pydiode environment" erwähnt, um Code zu generieren.
 
 ![Prompt Pydiode Environment](../../../../media/open_webui/prompt_pydiode_environment.jpeg)
 
-Mit dem "Run"-Button kann der Code direkt im Chat getestet werden.
+Mit dem „Run"-Button kann der Code direkt im Chat getestet werden.
 
 ![Code with Run Button](../../../../media/open_webui/code_with_run_button.jpeg)
+
+::: tip Zwei Ausführungspfade
+**Modellgesteuerte Ausführung** — bei der das Modell entscheidet, Code auszuführen, um eine Antwort zu berechnen oder
+eine Datei zu erzeugen — läuft in der **Open Terminal**-Sandbox (serverseitig, mit den oben genannten
+Dokumenten-Libraries; generierte Dateien erscheinen im Files-Panel). Der manuelle **„Run"-Button** an einem Code-Block
+nutzt die eingebaute **Pyodide**-Engine von OpenWebUI (In-Browser-WebAssembly), die leichtgewichtig ist, aber auf ihre
+mitgelieferten Packages beschränkt bleibt und keine Dateien auf dem Server schreibt.
+:::
 
 Nach der Ausführung gibt das Code-Snippet das Ergebnis unterhalb der Zelle aus.
 
@@ -28,7 +51,7 @@ Nach der Ausführung gibt das Code-Snippet das Ergebnis unterhalb der Zelle aus.
 
 ## Ausführen von bestehendem Code
 
-Wählen Sie "Code Interpreter".
+Wählen Sie „Code Interpreter".
 
 ![Select Code Interpreter](../../../../media/open_webui/select_code_interpreter.jpeg)
 
@@ -39,3 +62,77 @@ Fassen Sie den Code in Backticks ein, um ihn als auszuführenden Code zu kennzei
 Wenn der Code ausgeführt wurde, wird das Ergebnis ausgegeben.
 
 ![Code Execution Output](../../../../media/open_webui/code_execution_output.jpeg)
+
+## Dateigenerierung
+
+Während der Code-Ausführung geschriebene Dateien (Reports, Spreadsheets, Diagramme usw.) erscheinen automatisch im
+Files-Panel von OpenWebUI, wo Benutzer sie herunterladen können. Nach dem Erstellen einer Datei bestätigt das Modell den
+Dateinamen.
+
+::: tip Empfohlenes Modell — Workspace → Kimi-K2.6
+Wählen Sie **Kimi-K2.6** im Modell-Picker (unter **Workspace**), wenn das Modell eine Datei erzeugen soll.
+
+Die Dateigenerierung ist eine mehrstufige Tool-Calling-Schleife: Das Modell muss entscheiden, `execute_code` aufzurufen,
+korrektes Python schreiben, das Ergebnis zurücklesen und den Dateinamen melden. Die Zuverlässigkeit dieser Schleife
+variiert zwischen den Modellen deutlich stärker als die Liste der unterstützten Formate. Alle AI-Hub
+Text-Generation-Modelle deklarieren Function-Calling-Unterstützung, aber nicht alle vollziehen den Handshake in der
+Praxis — bei aktiviertem Open Terminal liefert `Qwen3.5-122B-A10B-FP8` eine leere Antwort. Siehe
+[ADR: Model Identity as a Platform-Injected System Prompt for Plain LLM Chats](/arc42/decisions/2026_08_14_model_identity_system_prompt_for_plain_llm_chats.md).
+
+**Native Function Calling** muss für das gewählte Modell dennoch aktiviert werden — es ist nicht standardmäßig aktiv.
+:::
+
+### Unterstützte Ausgabeformate
+
+Verifiziert gegen das Sandbox-Image `open-terminal-office:0.11.34`. „Kann generiert werden" bedeutet, dass die Sandbox
+die Datei schreiben und an das Files-Panel übergeben kann; es sagt nichts darüber aus, ob dasselbe Format als Upload
+wieder eingelesen werden kann.
+
+| Kategorie          | Dateiformate                                            | Kann generiert werden | Wie                                         |
+| ------------------ | ------------------------------------------------------- | --------------------- | ------------------------------------------- |
+| Textdokumente      | DOCX, RTF, TXT, Markdown (`.md`), HTML                  | Ja                    | `python-docx`, `pandoc`, Plain Text         |
+| Portable Dokumente | PDF                                                     | Ja                    | `reportlab`, `fpdf2`, `weasyprint`, `pypdf` |
+| Spreadsheets       | XLSX, XLS, CSV                                          | Ja                    | `openpyxl`, `xlsxwriter`, `pandas`          |
+| Präsentationen     | PPTX, PDF                                               | Ja                    | `python-pptx`, `pandoc`                     |
+| Bilder (Raster)    | PNG, JPG/JPEG, TIFF, WebP, BMP                          | Ja                    | `Pillow`, `matplotlib`                      |
+| Video              | MP4, WebM, MOV, GIF                                     | Ja                    | `ffmpeg` (H.264, VP9, GIF)                  |
+| Audio              | MP3, WAV, OGG, FLAC                                     | Ja                    | `ffmpeg` (LAME, PCM, Vorbis, FLAC)          |
+| Quellcode          | py, cs, java, ts, js, go, rs, cpp, sql, yaml, json, xml | Ja                    | Plain Text                                  |
+| Datenaustausch     | JSON, XML, YAML, CSV                                    | Ja                    | `json`, `lxml`, `PyYAML`, `pandas`          |
+| Knowledge Bases    | Markdown, HTML, Confluence Storage Format, MediaWiki    | Ja                    | `pandoc`, Plain Text/XML                    |
+| Diagramme (Source) | SVG, Draw.io (`.drawio`), Mermaid, PlantUML             | Nur Source            | Wird als Text geschrieben — siehe unten     |
+| Diagramme (Visio)  | Visio (`.vsdx`)                                         | Nein                  | Keine Library verfügbar — siehe unten       |
+
+### Bekannte Einschränkungen
+
+::: warning
+- **Diagramme werden als Source generiert, nicht als Bild.** SVG-, Draw.io-, Mermaid- und PlantUML-Dateien sind Text
+  oder XML, die Sandbox schreibt sie also problemlos — sie liefert dafür jedoch **keinen Renderer** mit (kein
+  `cairosvg`, `mmdc`, `plantuml`, Graphviz oder Inkscape). Fragen Sie stattdessen ein Rasterbild über `matplotlib` an,
+  wenn Sie ein Bild und keine Source-Datei benötigen.
+- **Visio (`.vsdx`) kann nicht generiert werden.** Es gibt keine Visio-Library in der Sandbox und kein LibreOffice zum
+  Konvertieren. Fragen Sie stattdessen `.drawio`- oder SVG-Source an.
+- **Ein Format lesen ist nicht dasselbe wie es schreiben.** TIFF- und Visio-Dateien konnten während der Verifikation der
+  Capability nicht als Input in die Sandbox eingelesen werden, obwohl die TIFF-Generierung funktioniert.
+- **Die Formatliste ist an das Sandbox-Image gebunden.** Sie bezieht sich auf `open-terminal-office:0.11.34`. Ein
+  Anheben dieses Tags kann Libraries und damit Formate hinzufügen oder entfernen, ohne jede andere sichtbare Änderung.
+:::
+
+## Isolation und Einschränkungen
+
+::: warning Geteilter Container, Isolation pro Benutzer
+Open Terminal läuft in **einem einzigen geteilten Container** mit aktiviertem `OPEN_TERMINAL_MULTI_USER`: Jeder Benutzer
+erhält einen separaten Linux-Account und ein eigenes Home-Verzeichnis (`/home/<user>`), und die
+Standard-Dateisystemberechtigungen halten die Dateien eines Benutzers vor anderen privat. Dies ist **Isolation pro
+Benutzer innerhalb eines Containers**, kein Container-pro-Benutzer-Modell — alle Benutzer teilen denselben Kernel, CPU,
+Memory, `/tmp` und die Prozessliste. Es eignet sich für kleine, vertrauenswürdige Gruppen; es ist **keine** harte
+Multi-Tenant-Sicherheitsgrenze. Betrachten Sie die Sandbox als Komfort für Mitarbeitende, nicht als Barriere zwischen
+sich gegenseitig nicht vertrauenden Parteien.
+:::
+
+::: tip Gespeicherte Dateien wachsen über die Zeit
+Die generierten Dateien jedes Benutzers persistieren auf dem Host (das `/home`-Volume von `open-terminal`) und werden
+**nicht** automatisch aufgeräumt — es gibt derzeit keine Retention- oder Quota-Policy. Der Speicherbedarf wächst mit der
+Nutzung; Betreiber sollten das Volume überwachen und alte Benutzerdaten manuell entfernen, bis ein automatisches
+Cleanup/TTL hinzugefügt wird.
+:::

--- a/docs/docs/2_platform/10_chat_ui/6_coding/index.en.md
+++ b/docs/docs/2_platform/10_chat_ui/6_coding/index.en.md
@@ -59,57 +59,14 @@ When the code has run through the result is printed out.
 
 ![Code Execution Output](../../../../media/open_webui/code_execution_output.jpeg)
 
-## File generation
+## Generated files
 
 Files written during code execution (reports, spreadsheets, charts, etc.) automatically appear in OpenWebUI's Files
 panel, where users can download them. After creating a file the model will confirm the filename.
 
-::: tip Recommended model — Workspace → Kimi-K2.6
-Select **Kimi-K2.6** in the model picker (under **Workspace**) when you want the model to produce a file.
-
-File generation is a multi-step tool-calling loop: the model has to decide to call `execute_code`, write correct Python,
-read the result back and report the filename. Reliability on that loop varies far more between models than the list of
-supported formats does. All AI-Hub text-generation models declare function-calling support, but not all of them complete
-the handshake in practice — with Open Terminal enabled, `Qwen3.5-122B-A10B-FP8` returns an empty response. See
-[ADR: Model Identity as a Platform-Injected System Prompt for Plain LLM Chats](/arc42/decisions/2026_08_14_model_identity_system_prompt_for_plain_llm_chats.md).
-
-**Native Function Calling** still has to be switched on for the chosen model — it is not enabled by default.
-:::
-
-### Supported output formats
-
-Verified against the `open-terminal-office:0.11.34` sandbox image. "Can be generated" means the sandbox can write the
-file and hand it to the Files panel; it says nothing about whether the same format can be read back in as an upload.
-
-| Category           | File formats                                            | Can be generated | How                                         |
-| ------------------ | ------------------------------------------------------- | ---------------- | ------------------------------------------- |
-| Text documents     | DOCX, RTF, TXT, Markdown (`.md`), HTML                  | Yes              | `python-docx`, `pandoc`, plain text         |
-| Portable documents | PDF                                                     | Yes              | `reportlab`, `fpdf2`, `weasyprint`, `pypdf` |
-| Spreadsheets       | XLSX, XLS, CSV                                          | Yes              | `openpyxl`, `xlsxwriter`, `pandas`          |
-| Presentations      | PPTX, PDF                                               | Yes              | `python-pptx`, `pandoc`                     |
-| Images (raster)    | PNG, JPG/JPEG, TIFF, WebP, BMP                          | Yes              | `Pillow`, `matplotlib`                      |
-| Video              | MP4, WebM, MOV, GIF                                     | Yes              | `ffmpeg` (H.264, VP9, GIF)                  |
-| Audio              | MP3, WAV, OGG, FLAC                                     | Yes              | `ffmpeg` (LAME, PCM, Vorbis, FLAC)          |
-| Source code        | py, cs, java, ts, js, go, rs, cpp, sql, yaml, json, xml | Yes              | Plain text                                  |
-| Data exchange      | JSON, XML, YAML, CSV                                    | Yes              | `json`, `lxml`, `PyYAML`, `pandas`          |
-| Knowledge bases    | Markdown, HTML, Confluence storage format, MediaWiki    | Yes              | `pandoc`, plain text/XML                    |
-| Diagrams (source)  | SVG, Draw.io (`.drawio`), Mermaid, PlantUML             | Source only      | Written as text — see below                 |
-| Diagrams (Visio)   | Visio (`.vsdx`)                                         | No               | No library available — see below            |
-
-### Known limitations
-
-::: warning
-- **Diagrams are generated as source, not as pictures.** SVG, Draw.io, Mermaid and PlantUML files are text or XML, so
-  the sandbox writes them without trouble — but it ships **no renderer** for them (no `cairosvg`, `mmdc`, `plantuml`,
-  Graphviz or Inkscape). Ask for a raster image via `matplotlib` instead when you need a picture rather than a source
-  file.
-- **Visio (`.vsdx`) cannot be generated.** There is no Visio library in the sandbox and no LibreOffice to convert
-  through. Ask for `.drawio` or SVG source instead.
-- **Reading a format is not the same as writing it.** TIFF and Visio files could not be read back into the sandbox as
-  input during capability testing, even though TIFF generation works.
-- **The format list is tied to the sandbox image.** It reflects `open-terminal-office:0.11.34`. Bumping that tag can add
-  or remove libraries, and therefore formats, without any other visible change.
-:::
+Producing documents is a capability in its own right and does not require writing any code. See
+[File generation](../13_file_generation/) for the recommended model, the verified list of output formats, and the
+limitations that apply to them.
 
 ## Isolation and limitations
 

--- a/docs/docs/2_platform/10_chat_ui/6_coding/index.en.md
+++ b/docs/docs/2_platform/10_chat_ui/6_coding/index.en.md
@@ -4,9 +4,10 @@ title: Coding / Software Development
 
 # Coding / Software Development
 
-OpenWebUI integrates with **Open Terminal** — a sandboxed Linux environment with Python and common document libraries
-(pandas, openpyxl, python-docx, reportlab, fpdf2, weasyprint, matplotlib, xlsxwriter). Code runs in an isolated per-user
-environment; files created during execution appear in OpenWebUI's Files panel for download.
+OpenWebUI integrates with **Open Terminal** — a sandboxed Linux environment with Python 3.12, common document libraries
+(pandas, openpyxl, xlsxwriter, python-docx, python-pptx, reportlab, fpdf2, weasyprint, pypdf, matplotlib, Pillow, numpy,
+scipy, lxml, PyYAML) and the `ffmpeg` and `pandoc` command-line tools. Code runs in an isolated per-user environment;
+files created during execution appear in OpenWebUI's Files panel for download.
 
 ::: warning Requirements & current limitations
 - **Plain LLM models only.** Code execution is driven by OpenWebUI's native `execute_code` tool, so it works only with
@@ -58,10 +59,57 @@ When the code has run through the result is printed out.
 
 ![Code Execution Output](../../../../media/open_webui/code_execution_output.jpeg)
 
-## Generated files
+## File generation
 
 Files written during code execution (reports, spreadsheets, charts, etc.) automatically appear in OpenWebUI's Files
 panel, where users can download them. After creating a file the model will confirm the filename.
+
+::: tip Recommended model — Workspace → Kimi-K2.6
+Select **Kimi-K2.6** in the model picker (under **Workspace**) when you want the model to produce a file.
+
+File generation is a multi-step tool-calling loop: the model has to decide to call `execute_code`, write correct Python,
+read the result back and report the filename. Reliability on that loop varies far more between models than the list of
+supported formats does. All AI-Hub text-generation models declare function-calling support, but not all of them complete
+the handshake in practice — with Open Terminal enabled, `Qwen3.5-122B-A10B-FP8` returns an empty response. See
+[ADR: Model Identity as a Platform-Injected System Prompt for Plain LLM Chats](/arc42/decisions/2026_08_14_model_identity_system_prompt_for_plain_llm_chats.md).
+
+**Native Function Calling** still has to be switched on for the chosen model — it is not enabled by default.
+:::
+
+### Supported output formats
+
+Verified against the `open-terminal-office:0.11.34` sandbox image. "Can be generated" means the sandbox can write the
+file and hand it to the Files panel; it says nothing about whether the same format can be read back in as an upload.
+
+| Category           | File formats                                            | Can be generated | How                                         |
+| ------------------ | ------------------------------------------------------- | ---------------- | ------------------------------------------- |
+| Text documents     | DOCX, RTF, TXT, Markdown (`.md`), HTML                  | Yes              | `python-docx`, `pandoc`, plain text         |
+| Portable documents | PDF                                                     | Yes              | `reportlab`, `fpdf2`, `weasyprint`, `pypdf` |
+| Spreadsheets       | XLSX, XLS, CSV                                          | Yes              | `openpyxl`, `xlsxwriter`, `pandas`          |
+| Presentations      | PPTX, PDF                                               | Yes              | `python-pptx`, `pandoc`                     |
+| Images (raster)    | PNG, JPG/JPEG, TIFF, WebP, BMP                          | Yes              | `Pillow`, `matplotlib`                      |
+| Video              | MP4, WebM, MOV, GIF                                     | Yes              | `ffmpeg` (H.264, VP9, GIF)                  |
+| Audio              | MP3, WAV, OGG, FLAC                                     | Yes              | `ffmpeg` (LAME, PCM, Vorbis, FLAC)          |
+| Source code        | py, cs, java, ts, js, go, rs, cpp, sql, yaml, json, xml | Yes              | Plain text                                  |
+| Data exchange      | JSON, XML, YAML, CSV                                    | Yes              | `json`, `lxml`, `PyYAML`, `pandas`          |
+| Knowledge bases    | Markdown, HTML, Confluence storage format, MediaWiki    | Yes              | `pandoc`, plain text/XML                    |
+| Diagrams (source)  | SVG, Draw.io (`.drawio`), Mermaid, PlantUML             | Source only      | Written as text — see below                 |
+| Diagrams (Visio)   | Visio (`.vsdx`)                                         | No               | No library available — see below            |
+
+### Known limitations
+
+::: warning
+- **Diagrams are generated as source, not as pictures.** SVG, Draw.io, Mermaid and PlantUML files are text or XML, so
+  the sandbox writes them without trouble — but it ships **no renderer** for them (no `cairosvg`, `mmdc`, `plantuml`,
+  Graphviz or Inkscape). Ask for a raster image via `matplotlib` instead when you need a picture rather than a source
+  file.
+- **Visio (`.vsdx`) cannot be generated.** There is no Visio library in the sandbox and no LibreOffice to convert
+  through. Ask for `.drawio` or SVG source instead.
+- **Reading a format is not the same as writing it.** TIFF and Visio files could not be read back into the sandbox as
+  input during capability testing, even though TIFF generation works.
+- **The format list is tied to the sandbox image.** It reflects `open-terminal-office:0.11.34`. Bumping that tag can add
+  or remove libraries, and therefore formats, without any other visible change.
+:::
 
 ## Isolation and limitations
 

--- a/docs/docs/2_platform/10_chat_ui/6_coding/index.en.md
+++ b/docs/docs/2_platform/10_chat_ui/6_coding/index.en.md
@@ -6,14 +6,19 @@ title: Coding / Software Development
 
 OpenWebUI integrates with **Open Terminal** — a sandboxed Linux environment with Python 3.12, common document libraries
 (pandas, openpyxl, xlsxwriter, python-docx, python-pptx, reportlab, fpdf2, weasyprint, pypdf, matplotlib, Pillow, numpy,
-scipy, lxml, PyYAML) and the `ffmpeg` and `pandoc` command-line tools. Code runs in an isolated per-user environment;
-files created during execution appear in OpenWebUI's Files panel for download.
+scipy, lxml, PyYAML) and the `ffmpeg` and `pandoc` command-line tools. Code runs in an isolated per-user environment, in
+that user's own home directory inside the sandbox.
 
 ::: warning Requirements & current limitations
-- **Plain LLM models only.** Code execution is driven by OpenWebUI's native `execute_code` tool, so it works only with
-  plain chat models that **support function (tool) calling**, and **Native Function Calling must be enabled** for the
-  model (Admin → Settings → Models → the model's advanced params). Models without function-calling support cannot
-  trigger the sandbox.
+- **Plain LLM models only, with Native Function Calling enabled.** OpenWebUI exposes the sandbox to the model as a set
+  of tools (`run_command`, `write_file`, `display_file` and so on) resolved from its terminal-server integration — not
+  through the built-in `execute_code` tool. **Native Function Calling must be enabled** for the model (Admin → Settings
+  → Models → the model's advanced params): only then are those tools handed to the model as real function definitions,
+  which is what lets it run a step, read the result and continue. Left at the default, OpenWebUI falls back to a single
+  prompt-based tool-selection pass, which is not enough for a multi-step build. Models without function-calling support
+  cannot drive the sandbox at all.
+- **The terminal has to be active for the conversation.** The tools are resolved only when a terminal is selected in the
+  chat.
 - **AI-Hub agents are not supported yet.** Agent chats own their own generation and do not expose OpenWebUI's
   tool-calling handshake, so code execution does **not** engage for them. This is a planned follow-up.
 :::
@@ -34,11 +39,14 @@ Using the "Run" button the code can be tested directly inside the chat.
 
 ![Code with Run Button](../../../../media/open_webui/code_with_run_button.jpeg)
 
-::: tip Two execution paths
-**Model-driven execution** — where the model decides to run code to compute an answer or produce a file — runs in the
-**Open Terminal** sandbox (server-side, with the document libraries above; generated files appear in the Files panel).
-The manual **"Run" button** on a code block uses OpenWebUI's built-in **Pyodide** engine (in-browser WebAssembly), which
-is lightweight but limited to its bundled packages and does not write files to the server.
+::: tip Two execution paths — only one of them can produce a file
+**Model-driven execution**, where the model calls the sandbox's tools itself, runs server-side in **Open Terminal** with
+the libraries above, inside the user's own home directory. This is the only path that can produce a downloadable file.
+
+The manual **"Run" button** on a code block — and OpenWebUI's built-in `execute_code` tool, whose
+`CODE_INTERPRETER_ENGINE` defaults to `pyodide` — both use the **Pyodide** engine instead: in-browser WebAssembly, which
+is lightweight, limited to its bundled packages, and **cannot write files to the server**. Charts come back as inline
+images on that path, not as files.
 :::
 
 After running the code snippet prints the result below the cell.
@@ -61,8 +69,9 @@ When the code has run through the result is printed out.
 
 ## Generated files
 
-Files written during code execution (reports, spreadsheets, charts, etc.) automatically appear in OpenWebUI's Files
-panel, where users can download them. After creating a file the model will confirm the filename.
+Files written during code execution (reports, spreadsheets, charts, etc.) are created in the user's own home directory
+inside the sandbox (`/home/<user>`). The model surfaces a finished file by calling `display_file`, which opens it in the
+user's file viewer; the files also stay reachable through the terminal panel's own file browser.
 
 Producing documents is a capability in its own right and does not require writing any code. See
 [File generation](../13_file_generation/) for the recommended model, the verified list of output formats, and the

--- a/infra/deployment/CLAUDE.md
+++ b/infra/deployment/CLAUDE.md
@@ -150,12 +150,15 @@ continues to build locally so developers test Dockerfile edits without round-tri
 ### Publishing the open-terminal image
 
 The open-terminal image is project-managed. It extends `ghcr.io/open-webui/open-terminal:0.11.34` with additional Python
-libraries (reportlab, fpdf2 — the base already ships pandas/openpyxl/python-docx/weasyprint/matplotlib/xlsxwriter) and
-is published manually via `make -C infra/deployment build-and-push-open-terminal-image` (requires
-`docker login ghcr.io`). Re-publish whenever:
+libraries (reportlab, fpdf2 — the base already ships pandas/openpyxl/xlsxwriter/python-docx/python-pptx/weasyprint/
+pypdf/matplotlib/Pillow/numpy/scipy/lxml/PyYAML plus the ffmpeg and pandoc binaries) and is published manually via
+`make -C infra/deployment build-and-push-open-terminal-image` (requires `docker login ghcr.io`). Re-publish whenever:
 
 - The upstream `open-terminal` base tag in `docker/open-terminal/Dockerfile` needs bumping
 - A new Python library dependency must be baked into the image
+
+The baked-in inventory decides which file formats the sandbox can produce for end users, so re-verify the format matrix
+in `docs/docs/2_platform/10_chat_ui/6_coding/index.en.md` whenever the base tag moves.
 
 After publishing, all stages pull the new image automatically via `docker compose pull`. See ADR:
 `docs/arc42/decisions/2026_06_22_openwebui_code_execution_open_terminal.md`.

--- a/infra/deployment/CLAUDE.md
+++ b/infra/deployment/CLAUDE.md
@@ -158,7 +158,7 @@ pypdf/matplotlib/Pillow/numpy/scipy/lxml/PyYAML plus the ffmpeg and pandoc binar
 - A new Python library dependency must be baked into the image
 
 The baked-in inventory decides which file formats the sandbox can produce for end users, so re-verify the format matrix
-in `docs/docs/2_platform/10_chat_ui/6_coding/index.en.md` whenever the base tag moves.
+in `docs/docs/2_platform/10_chat_ui/13_file_generation/index.en.md` whenever the base tag moves.
 
 After publishing, all stages pull the new image automatically via `docker compose pull`. See ADR:
 `docs/arc42/decisions/2026_06_22_openwebui_code_execution_open_terminal.md`.

--- a/infra/deployment/docker/open-terminal/Dockerfile
+++ b/infra/deployment/docker/open-terminal/Dockerfile
@@ -2,8 +2,13 @@
 #
 # OpenWebUI routes its code-execution path to this sandbox (the native execute_code
 # tool, via TERMINAL_SERVER_CONNECTIONS on the open-webui service). The base image
-# already ships Python with pandas, openpyxl, python-docx, weasyprint, matplotlib
-# and xlsxwriter — only reportlab and fpdf2 are missing, so we add just those.
+# already ships Python 3.12 with pandas, openpyxl, xlsxwriter, python-docx,
+# python-pptx, weasyprint, pypdf, matplotlib, Pillow, numpy, scipy, lxml and PyYAML,
+# plus the ffmpeg and pandoc binaries — only reportlab and fpdf2 are missing, so we
+# add just those. That inventory is what the user-facing format matrix in
+# docs/docs/2_platform/10_chat_ui/6_coding is verified against: re-verify it there
+# when bumping the base tag below, because it decides which file formats the
+# sandbox can actually produce.
 # Everything installs from binary wheels at build time, so the running container
 # needs NO outbound internet (it stays network-isolated on `code-sandbox`).
 #

--- a/infra/deployment/docker/open-terminal/Dockerfile
+++ b/infra/deployment/docker/open-terminal/Dockerfile
@@ -1,13 +1,15 @@
 # Custom Open Terminal image: pinned upstream sandbox + the two missing file libs.
 #
-# OpenWebUI routes its code-execution path to this sandbox (the native execute_code
-# tool, via TERMINAL_SERVER_CONNECTIONS on the open-webui service). The base image
+# OpenWebUI reaches this sandbox through its terminal-server integration
+# (TERMINAL_SERVER_CONNECTIONS on the open-webui service), which resolves the sandbox's
+# OpenAPI operations into model-callable tools — NOT through the built-in execute_code
+# tool, which only handles the pyodide and jupyter engines. The base image
 # already ships Python 3.12 with pandas, openpyxl, xlsxwriter, python-docx,
 # python-pptx, weasyprint, pypdf, matplotlib, Pillow, numpy, scipy, lxml and PyYAML,
 # plus the ffmpeg and pandoc binaries — only reportlab and fpdf2 are missing, so we
 # add just those. That inventory is what the user-facing format matrix in
-# docs/docs/2_platform/10_chat_ui/6_coding is verified against: re-verify it there
-# when bumping the base tag below, because it decides which file formats the
+# docs/docs/2_platform/10_chat_ui/13_file_generation is verified against: re-verify it
+# there when bumping the base tag below, because it decides which file formats the
 # sandbox can actually produce.
 # Everything installs from binary wheels at build time, so the running container
 # needs NO outbound internet (it stays network-isolated on `code-sandbox`).


### PR DESCRIPTION
## Summary

Documents the file-generation capability on the docs site — closes #1700. Adds a new **File generation** page with a
verified format matrix and the recommended model (Workspace → `Kimi-K2.6`), and corrects the mechanism description on
the Coding page, which turned out to be wrong.

## Changes

**New user-facing page** — `docs/docs/2_platform/10_chat_ui/13_file_generation/`

- Verified output-format matrix answering one question: what file types can I ask for. `Yes` / `Source only` / `No`.
- Recommends **Workspace → Kimi-K2.6**, with the reason: file generation is a multi-step tool-calling loop, and that is
  where models differ. `Qwen3.5-122B-A10B-FP8` returns an empty response with Open Terminal enabled.
- Known-limitations block: `.vsdx` cannot be generated at all; SVG / Draw.io / Mermaid / PlantUML are written as source
  only (the sandbox has no rasteriser); the matrix is pinned to sandbox image `open-terminal-office:0.11.34`.

It lives on its own page rather than under *Coding / Software Development* because `10_chat_ui` is organised by user
task, and asking for a DOCX report is a business-user task that merely runs on the code sandbox. `6_coding` keeps the
sandbox mechanics and the two cross-link; `1_feature_overview` links to it too.

**Mechanism corrections** — two claims on `6_coding`, inherited from the earlier Open Terminal migration, were wrong.
Verified against the OpenWebUI 0.9.5 source in the running container:

- ~~"driven by OpenWebUI's native `execute_code` tool"~~ — that builtin handles only the `pyodide` and `jupyter`
  engines and errors on anything else, and `CODE_INTERPRETER_ENGINE` defaults to `pyodide` and is set in no compose
  file. Open Terminal is reached through the **terminal-server integration**, which turns the sandbox's 12 OpenAPI
  operations into model-callable tools (`run_command`, `write_file`, `display_file`, …).
- ~~"files appear in OpenWebUI's Files panel"~~ — that path only inlines base64 PNGs as markdown images and has no
  document handoff. Files are written to the user's sandbox home and surfaced when the model calls `display_file`. The
  Open Terminal ADR already said this correctly; the page contradicted it.

The *Native Function Calling* requirement survives, but for the real reason: with native FC the terminal tools are
passed as genuine function definitions, otherwise OpenWebUI falls back to a single prompt-based tool-selection pass,
which cannot carry a multi-step build.

**Corrected library inventory** — the Dockerfile comment claimed the base image ships six libraries and that "only
reportlab and fpdf2 are missing". It also ships `python-pptx`, `pypdf`, `Pillow`, `numpy`, `scipy`, `lxml` and `PyYAML`
plus the `ffmpeg` and `pandoc` binaries — so PPTX, video and audio generation were already possible and undocumented.
Fixed in the Dockerfile comment, `infra/deployment/CLAUDE.md`, and as a dated amendment to the Open Terminal ADR. No
image rebuild; the `0.11.34` tag is untouched.

## Test plan

Every format claim was verified by generating a real file inside the running `open-terminal` container, not taken from
the issue's table:

- DOCX, PPTX, XLSX (openpyxl + xlsxwriter), CSV, PDF (reportlab, fpdf2, weasyprint), and PNG/JPEG/**TIFF**/WebP/BMP via
  Pillow.
- MP4, WebM, MOV, GIF, MP3, WAV, OGG, FLAC via `ffmpeg` 7.1.3 — encoders and muxers confirmed present.
- RTF, MediaWiki, DOCX and PPTX via `pandoc` 3.1.11.1.
- Confirmed **absent**: `vsdx`, `cairosvg`, `mmdc`, `plantuml`, `java`, `dot`, `inkscape`, LibreOffice — which is what
  the `.vsdx` and "source only" rows record. Test files cleaned up afterwards.

Docs build: `pnpm run docs:build:ci` passes. Both locales render with a 3-column, 12-row table and all container blocks;
the ADR link resolves to a real page in `dist` (worth checking explicitly, since `ignoreDeadLinks: true` means the build
will not flag a broken link).

`make test` covers only the five Python packages — none are touched, so it has nothing to say about this change and was
not run.

## Reviewer notes

- **`.vsdx` disagrees with the issue.** @ThongMai92's table marks Visio as generatable; I could not reproduce that and
  documented it as unsupported. Worth confirming how it was tested.
- **German pages are hand-written**, with matching `source_sha`. The `llm` CLI is not installed and `translate-docs.sh`
  takes no path filter, so running it would have rewritten 18 unrelated stale translations. Stale count went 19 → 18.
- **Sidebar position.** `13_` sorts last, so *File generation* sits after the three meta pages. Mitigated with links
  from `1_feature_overview` and `6_coding`. Moving it to `7_` would renumber six directories and change six live URLs —
  happy to do it if reviewers prefer that.
- **No screenshot** of the model picker; that needs an authenticated session. Easy follow-up.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>` (see
  [CONTRIBUTING.md](https://github.com/bbvch-ai/aihub-core/blob/main/CONTRIBUTING.md))
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [x] CLA signed — post this exact comment on the PR if the bot hasn't prompted you yet:
  `I have read the CONTRIBUTOR_AGREEMENT and I hereby sign the CLA`
  ([read the agreement](https://github.com/bbvch-ai/aihub-core/blob/main/CONTRIBUTOR_AGREEMENT.md))
- [x] Tests added or updated where relevant — n/a, documentation only
