### PR TITLE
fix(swiss-ai-hub): Remove strange text after image generation in OWUI

### DIFF
--- a/packages/api/swiss_ai_hub/api/routes/openai/openai_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/openai/openai_service.py
@@ -22,6 +22,7 @@ from starlette.responses import StreamingResponse
 from swiss_ai_hub.core.auth import AccessChecker
 from swiss_ai_hub.core.auth.identity.user_identity import UserIdentity
 from swiss_ai_hub.core.auth.usage import ResourceType, UsageLimits
+from swiss_ai_hub.core.displayers import ToolCallStreamScrubber
 from swiss_ai_hub.core.distributor import ExternalAgentEventDistributor
 from swiss_ai_hub.core.events.agent.control.exception.exception_event import ExceptionEvent
 from swiss_ai_hub.core.events.agent.control.stop.stop_event import StopEvent
@@ -276,10 +277,14 @@ class OpenaiService:
                 either — Starlette 1.1.0 raises ``ClientDisconnect`` out of ``stream_response`` on
                 ASGI spec >= 2.4 and never reaches its ``background`` call.
                 """
+                scrubber = ToolCallStreamScrubber()
                 async with response:
                     async for chunk in response:
+                        OpenaiService._scrub_tool_call_markup(chunk, scrubber)
                         yield f"data: {chunk.model_dump_json()}\n\n"
                         await asyncio.sleep(0)
+                    if trailing := scrubber.flush():
+                        yield OpenaiService._build_chunk_sse(content=trailing, model=model_name)
 
             return StreamingResponse(
                 stream_chat_completion(),
@@ -512,6 +517,17 @@ class OpenaiService:
         if full_answer and full_answer.startswith(streamed):
             return full_answer[len(streamed) :]
         return "" if streamed else full_answer
+
+    @staticmethod
+    def _scrub_tool_call_markup(chunk: ChatCompletionChunk, scrubber: ToolCallStreamScrubber) -> None:
+        """Keep a tool call the model rendered into ``content`` out of the answer text.
+
+        Only ``content`` is touched — a real tool call arrives in ``delta.tool_calls`` and is
+        forwarded untouched, so native function calling in the client is unaffected.
+        """
+        for choice in chunk.choices:
+            if choice.delta.content is not None:
+                choice.delta.content = scrubber.feed(choice.delta.content)
 
     @staticmethod
     def _build_chunk_sse(*, content: str, model: str, finish_reason: str | None = None) -> str:

--- a/packages/core/swiss_ai_hub/core/displayers/__init__.py
+++ b/packages/core/swiss_ai_hub/core/displayers/__init__.py
@@ -1,5 +1,9 @@
 from swiss_ai_hub.core.displayers.event_displayer import EventDisplayer
+from swiss_ai_hub.core.displayers.parser.tool_call_markup import ToolCallMarkup
+from swiss_ai_hub.core.displayers.parser.tool_call_stream_scrubber import ToolCallStreamScrubber
 
 __all__ = [
     "EventDisplayer",
+    "ToolCallMarkup",
+    "ToolCallStreamScrubber",
 ]

--- a/packages/core/swiss_ai_hub/core/displayers/parser/tag_parser.py
+++ b/packages/core/swiss_ai_hub/core/displayers/parser/tag_parser.py
@@ -1,35 +1,48 @@
 import logging
 from collections.abc import Iterator
 
+from swiss_ai_hub.core.displayers.parser.tool_call_markup import ToolCallMarkup
 from swiss_ai_hub.core.displayers.stream.content_type import ContentType
 
 logger = logging.getLogger(__name__)
 
 
 class TagParser:
-    """Internal parser for handling thinking tags in streamed content."""
+    """Internal parser splitting streamed content into the answer and what must stay out of it.
+
+    Reasoning spans and tool-call markup are both routed to ``THINKING``: the collapsed block keeps
+    a misbehaving model diagnosable, where dropping the span outright would leave nothing to read.
+    """
 
     THINK_OPEN = "<think>"
     THINK_CLOSE = "</think>"
 
     def __init__(self):
         self.pending = ""
-        self.in_thinking = False
+        self.awaiting_close: str | None = None
+
+    @property
+    def in_thinking(self) -> bool:
+        return self.awaiting_close is not None
+
+    @property
+    def _spans(self) -> tuple[tuple[str, str], ...]:
+        return ((self.THINK_OPEN, self.THINK_CLOSE), *ToolCallMarkup.SPANS)
 
     def process_content(self, content: str) -> Iterator[tuple[ContentType, str]]:
         """Process content and yield parsed characters with their type."""
         self.pending += content
 
         while self.pending:
-            if self.pending.startswith(self.THINK_OPEN):
-                self.in_thinking = True
-                self.pending = self.pending[len(self.THINK_OPEN) :]
-                yield (ContentType.THINKING, "")  # Signal state change
-
-            elif self.pending.startswith(self.THINK_CLOSE):
-                self.in_thinking = False
-                self.pending = self.pending[len(self.THINK_CLOSE) :]
+            if closing := self._closed_span():
+                self.pending = self.pending[len(closing) :]
+                self.awaiting_close = None
                 yield (ContentType.REGULAR, "")  # Signal state change
+
+            elif opened := self._opened_span():
+                self.pending = self.pending[len(opened[0]) :]
+                self.awaiting_close = opened[1]
+                yield (ContentType.THINKING, "")  # Signal state change
 
             elif self._might_be_incomplete_tag():
                 # Wait for more content
@@ -52,12 +65,32 @@ class TagParser:
 
         self.pending = ""
 
+    def _opened_span(self) -> tuple[str, str] | None:
+        """The span starting at the head of pending, if any. Spans do not nest."""
+        if self.awaiting_close:
+            return None
+        return next((span for span in self._spans if self.pending.startswith(span[0])), None)
+
+    def _closed_span(self) -> str | None:
+        """A close delimiter at the head of pending.
+
+        A bare ``</think>`` closes too: some chat templates pre-fill the opening tag, so the model
+        only ever emits the closing one.
+        """
+        if self.awaiting_close:
+            return self.awaiting_close if self.pending.startswith(self.awaiting_close) else None
+        return self.THINK_CLOSE if self.pending.startswith(self.THINK_CLOSE) else None
+
     def _might_be_incomplete_tag(self) -> bool:
         """Check if pending content might be an incomplete tag."""
         if not self.pending.startswith("<"):
             return False
 
-        max_tag_len = max(len(self.THINK_OPEN), len(self.THINK_CLOSE))
-        return len(self.pending) < max_tag_len and (
-            self.THINK_OPEN.startswith(self.pending) or self.THINK_CLOSE.startswith(self.pending)
+        candidates = (
+            (self.awaiting_close,)
+            if self.awaiting_close
+            else (self.THINK_CLOSE, *(opening for opening, _ in self._spans))
+        )
+        return any(
+            len(self.pending) < len(candidate) and candidate.startswith(self.pending) for candidate in candidates
         )

--- a/packages/core/swiss_ai_hub/core/displayers/parser/tests/unit/test_tool_call_markup.py
+++ b/packages/core/swiss_ai_hub/core/displayers/parser/tests/unit/test_tool_call_markup.py
@@ -1,0 +1,107 @@
+import pytest
+
+from swiss_ai_hub.core.displayers.parser.tool_call_markup import ToolCallMarkup
+from swiss_ai_hub.core.displayers.parser.tool_call_stream_scrubber import ToolCallStreamScrubber
+
+# Kimi's native tool-call tokens, reaching content because the serving layer never parsed them.
+KIMI = (
+    "<|tool_calls_section_begin|><|tool_call_begin|>functions.generate_image:3"
+    '<|tool_call_argument_begin|>{"prompt": "A vast, deep blue ocean"}'
+    "<|tool_call_end|><|tool_calls_section_end|>"
+)
+
+HERMES = '<tool_call>{"name": "generate_image", "arguments": {"prompt": "An ocean"}}</tool_call>'
+
+# A captured gemma-4-31B-it response: a tool call imitated from training data, with no tool offered.
+REACT = (
+    "{\n"
+    '  "action": "dalle.text2im",\n'
+    '  "action_input": "{ \\"prompt\\": \\"A cozy, modern living room.\\" }",\n'
+    '  "thought": "The user wants an image of a sofa in a living room."\n'
+    "}"
+)
+
+
+class TestOpensReactObject:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            REACT,
+            '{"action":"x"}',
+            '  {\n\t"action"  :  "x" }',
+        ],
+    )
+    def test_recognizes_react_objects(self, text: str) -> None:
+        assert ToolCallMarkup.opens_react_object(text)
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            'The `action_input` field is a JSON string. Set "action" to the tool name.',
+            '{"actionType": "create"}',
+            'Here is an example:\n{"action": "run"}',
+            '{"name": "generate_image"}',
+            "",
+        ],
+    )
+    def test_leaves_everything_else_alone(self, text: str) -> None:
+        assert not ToolCallMarkup.opens_react_object(text)
+
+
+class TestMayOpenReactObject:
+    @pytest.mark.parametrize("text", ["", "{", '{\n  "act', '{"action"'])
+    def test_viable_prefixes_are_withheld(self, text: str) -> None:
+        assert ToolCallMarkup.may_open_react_object(text)
+
+    @pytest.mark.parametrize("text", ["Hello", '{"name"', "The image", "{}"])
+    def test_ruled_out_prefixes_flow_immediately(self, text: str) -> None:
+        assert not ToolCallMarkup.may_open_react_object(text)
+
+
+class TestStrip:
+    def test_removes_kimi_span(self) -> None:
+        assert ToolCallMarkup.strip(f"Here you go.{KIMI}") == "Here you go."
+
+    def test_removes_hermes_span(self) -> None:
+        assert ToolCallMarkup.strip(f"Here you go.{HERMES}") == "Here you go."
+
+    def test_blanks_a_whole_message_react_object(self) -> None:
+        assert ToolCallMarkup.strip(REACT) == ""
+
+    def test_unterminated_span_runs_to_the_end(self) -> None:
+        assert ToolCallMarkup.strip("Wait.<|tool_calls_section_begin|>truncated...") == "Wait."
+
+    def test_prose_survives_untouched(self) -> None:
+        prose = 'The `action_input` field is a JSON string. Set "action" to the tool name.'
+        assert ToolCallMarkup.strip(prose) == prose
+
+
+class TestToolCallStreamScrubber:
+    @staticmethod
+    def _run(text: str, size: int = 7) -> str:
+        """Feed in small chunks so every delimiter straddles a chunk boundary."""
+        scrubber = ToolCallStreamScrubber()
+        forwarded = "".join(scrubber.feed(text[i : i + size]) for i in range(0, len(text), size))
+        return forwarded + scrubber.flush()
+
+    @pytest.mark.parametrize("markup", [KIMI, HERMES, REACT])
+    def test_markup_never_reaches_the_client(self, markup: str) -> None:
+        assert self._run(markup) == ""
+
+    def test_prose_around_a_span_is_preserved(self) -> None:
+        assert self._run(f"Before. {KIMI} After.") == "Before.  After."
+
+    @pytest.mark.parametrize(
+        "prose",
+        [
+            "The image you requested has been generated and is shown above.",
+            'The `action_input` field is a JSON string. Set "action" to the tool name.',
+            "<think>Reasoning stays, the client renders it.</think>Here is your answer.",
+            '{"name": "generate_image", "size": "1024x1024"} is the payload.',
+        ],
+    )
+    def test_ordinary_content_passes_through_unchanged(self, prose: str) -> None:
+        assert self._run(prose) == prose
+
+    def test_single_character_chunks(self) -> None:
+        assert self._run(f"Hi.{HERMES}", size=1) == "Hi."

--- a/packages/core/swiss_ai_hub/core/displayers/parser/tool_call_markup.py
+++ b/packages/core/swiss_ai_hub/core/displayers/parser/tool_call_markup.py
@@ -1,0 +1,57 @@
+import re
+from typing import ClassVar
+
+
+class ToolCallMarkup:
+    """A tool call a model rendered into its answer instead of returning it in ``tool_calls``.
+
+    Two sources, one symptom. A serving stack with no parser for a model's native tool-call tokens
+    passes them through as text; and a model imitates a tool-calling transcript it saw in training
+    when a prompt reads like one, even with no tool on offer. Nothing executes either, so there is
+    no intent to recover: it is only text, and it belongs anywhere except the answer.
+    """
+
+    SPANS: ClassVar[tuple[tuple[str, str], ...]] = (
+        ("<|tool_calls_section_begin|>", "<|tool_calls_section_end|>"),
+        ("<tool_call>", "</tool_call>"),
+    )
+
+    _REACT_OPENING: ClassVar[str] = '{"action":'
+
+    @staticmethod
+    def _compact(text: str) -> str:
+        return "".join(text.split())
+
+    @staticmethod
+    def opens_react_object(text: str) -> bool:
+        """Whether the message *starts* as a ReAct tool-call object.
+
+        Anchored at the start so prose discussing ``action_input`` survives, and matched on the
+        opening alone so a response cut short is suppressed just the same. The trailing colon keeps
+        a legitimate ``{"actionType": ...}`` out.
+        """
+        return ToolCallMarkup._compact(text).startswith(ToolCallMarkup._REACT_OPENING)
+
+    @staticmethod
+    def may_open_react_object(text: str) -> bool:
+        """Whether ``text`` is still a viable prefix, so a streaming caller keeps withholding it."""
+        return ToolCallMarkup._REACT_OPENING.startswith(ToolCallMarkup._compact(text))
+
+    @staticmethod
+    def strip(text: str) -> str:
+        """Remove markup that must never reach the answer, leaving surrounding prose intact.
+
+        An unterminated span runs to the end of the text: the closing token is what the models at
+        issue drop most often, and half a tool call is no more presentable than a whole one.
+        """
+        if ToolCallMarkup.opens_react_object(text):
+            return ""
+
+        for opening, closing in ToolCallMarkup.SPANS:
+            text = re.sub(
+                f"{re.escape(opening)}.*?(?:{re.escape(closing)}|$)",
+                "",
+                text,
+                flags=re.DOTALL,
+            )
+        return text

--- a/packages/core/swiss_ai_hub/core/displayers/parser/tool_call_stream_scrubber.py
+++ b/packages/core/swiss_ai_hub/core/displayers/parser/tool_call_stream_scrubber.py
@@ -1,0 +1,89 @@
+from swiss_ai_hub.core.displayers.parser.tool_call_markup import ToolCallMarkup
+
+
+class ToolCallStreamScrubber:
+    """Removes tool-call markup from a relayed text stream.
+
+    The agent path reclassifies the markup as reasoning, which needs display events; a plain relay
+    has none, so here it is dropped instead. Reasoning tags are deliberately left alone — on that
+    path the client renders them itself.
+    """
+
+    def __init__(self):
+        self._pending = ""
+        self._awaiting_close: str | None = None
+        self._withheld = ""
+        self._deciding = True
+        self._suppressing = False
+
+    def feed(self, delta: str) -> str:
+        """The part of ``delta`` safe to forward now; markup and still-undecided text are held back."""
+        released = self._release(delta)
+        if released is None:
+            return ""
+
+        self._pending += released
+        return self._drain(final=False)
+
+    def flush(self) -> str:
+        """Whatever was held back and turned out to be safe, once the stream has ended."""
+        if self._suppressing:
+            return ""
+
+        self._pending += self._release_withheld()
+        return self._drain(final=True)
+
+    def _release(self, delta: str) -> str | None:
+        if self._suppressing:
+            return None
+        if not self._deciding:
+            return delta
+
+        self._withheld += delta
+        if ToolCallMarkup.opens_react_object(self._withheld):
+            self._suppressing = True
+            return None
+        if ToolCallMarkup.may_open_react_object(self._withheld):
+            return None
+
+        return self._release_withheld()
+
+    def _release_withheld(self) -> str:
+        self._deciding = False
+        released, self._withheld = self._withheld, ""
+        return released
+
+    def _drain(self, final: bool) -> str:
+        forwarded: list[str] = []
+
+        while self._pending:
+            if self._awaiting_close:
+                if self._pending.startswith(self._awaiting_close):
+                    self._pending = self._pending[len(self._awaiting_close) :]
+                    self._awaiting_close = None
+                    continue
+                if not final and self._might_complete(self._awaiting_close):
+                    break
+                self._pending = self._pending[1:]
+                continue
+
+            if opened := self._opened_span():
+                self._pending = self._pending[len(opened[0]) :]
+                self._awaiting_close = opened[1]
+                continue
+
+            if not final and any(self._might_complete(opening) for opening, _ in ToolCallMarkup.SPANS):
+                break
+
+            forwarded.append(self._pending[0])
+            self._pending = self._pending[1:]
+
+        if final:
+            self._pending = ""
+        return "".join(forwarded)
+
+    def _opened_span(self) -> tuple[str, str] | None:
+        return next((span for span in ToolCallMarkup.SPANS if self._pending.startswith(span[0])), None)
+
+    def _might_complete(self, delimiter: str) -> bool:
+        return len(self._pending) < len(delimiter) and delimiter.startswith(self._pending)

--- a/packages/core/swiss_ai_hub/core/displayers/stream/stream_processor.py
+++ b/packages/core/swiss_ai_hub/core/displayers/stream/stream_processor.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 from swiss_ai_hub.core.displayers.buffer.stream_buffer import StreamBuffer
 from swiss_ai_hub.core.displayers.parser.tag_parser import TagParser
+from swiss_ai_hub.core.displayers.parser.tool_call_markup import ToolCallMarkup
 from swiss_ai_hub.core.displayers.stream.content_type import ContentType
 
 if TYPE_CHECKING:
@@ -18,20 +19,61 @@ class StreamProcessor:
         self.regular_buffer = StreamBuffer()
         self.thinking_buffer = StreamBuffer()
         self.aggregate = ""
+        self.withheld = ""
+        self.deciding = True
+        self.suppressing = False
 
     async def process_chunk(self, chunk_content: str) -> None:
         """Process a single chunk of streamed content."""
         self.aggregate += chunk_content
-        for content_type, char in self.parser.process_content(chunk_content):
+        released = self._release(chunk_content)
+        if released is None:
+            return
+
+        for content_type, char in self.parser.process_content(released):
             await self._handle_character(content_type, char)
 
     async def finalize(self) -> str:
-        """Flush remaining content and return aggregate."""
+        """Flush remaining content and return the aggregate the user was actually shown."""
+        if self.suppressing:
+            await self.displayer.display_thought(self.aggregate)
+            return ""
+
+        for content_type, char in self.parser.process_content(self._release_withheld()):
+            await self._handle_character(content_type, char)
+
         for content_type, char in self.parser.flush_remaining():
             await self._handle_character(content_type, char)
 
         await self._flush_buffers()
-        return self.aggregate
+        return ToolCallMarkup.strip(self.aggregate)
+
+    def _release(self, chunk_content: str) -> str | None:
+        """Withhold the opening of a stream until a whole-message ReAct object is ruled in or out.
+
+        A ReAct object carries no opening delimiter to switch on, so the decision needs the first
+        few characters — bounded by the length of ``{"action":``. Anything else starts flowing
+        immediately; a match never reaches the answer at all.
+        """
+        if self.suppressing:
+            return None
+        if not self.deciding:
+            return chunk_content
+
+        self.withheld += chunk_content
+        if ToolCallMarkup.opens_react_object(self.withheld):
+            self.suppressing = True
+            return None
+        if ToolCallMarkup.may_open_react_object(self.withheld):
+            return None
+
+        return self._release_withheld()
+
+    def _release_withheld(self) -> str:
+        """Hand back whatever the gate was holding — a stream can also end while still undecided."""
+        self.deciding = False
+        released, self.withheld = self.withheld, ""
+        return released
 
     async def _handle_character(self, content_type: ContentType, char: str) -> None:
         """Handle a single character based on its type."""

--- a/packages/core/swiss_ai_hub/core/displayers/tests/unit/test_stream_processor_tool_call_markup.py
+++ b/packages/core/swiss_ai_hub/core/displayers/tests/unit/test_stream_processor_tool_call_markup.py
@@ -1,0 +1,120 @@
+import pytest
+
+from swiss_ai_hub.core.displayers.stream.stream_processor import StreamProcessor
+
+# Kimi's native tool-call tokens, reaching content because the serving layer never parsed them.
+KIMI = (
+    "<|tool_calls_section_begin|><|tool_call_begin|>functions.generate_image:3"
+    '<|tool_call_argument_begin|>{"prompt": "A vast, deep blue ocean"}'
+    "<|tool_call_end|><|tool_calls_section_end|>"
+)
+
+# A captured LLMWrappingAgent stream on gemma-4-31B-it, chunked as it actually arrived: every chunk
+# of the answer is markup, so nothing is left once it is suppressed.
+SOFA_RUN = [
+    "{\n",
+    '  "action": "dalle.',
+    'text2im",\n',
+    '  "action_input": "{ \\"prompt\\": \\"A cozy, modern living room featuring a sofa as the centerpiece.',
+    " The room should have warm lighting, a soft rug, a coffee table, and some indoor plants.",
+    " High resolution, photorealistic style.",
+    '\\" }",\n',
+    '  "thought": "The user wants an image of a sofa in a living room.',
+    " I will generate a photorealistic image of a cozy modern living room.",
+    '"\n',
+    "}",
+]
+
+
+class StubDisplayer:
+    def __init__(self):
+        self.chunks: list[str] = []
+        self.thoughts: list[str] = []
+
+    async def display_chunk(self, content: str, model_name: str) -> None:
+        self.chunks.append(content)
+
+    async def display_thought(self, thought: str) -> None:
+        self.thoughts.append(thought)
+
+
+async def _stream(chunks: list[str]) -> tuple[StubDisplayer, str]:
+    displayer = StubDisplayer()
+    processor = StreamProcessor(displayer, "text-generation/gemma-4-31B-it")
+    for chunk in chunks:
+        await processor.process_chunk(chunk)
+    return displayer, await processor.finalize()
+
+
+def _split(text: str, size: int = 7) -> list[str]:
+    """Split small enough that the decision straddles chunk boundaries, as a real stream does."""
+    return [text[i : i + size] for i in range(0, len(text), size)]
+
+
+@pytest.mark.asyncio
+async def test_react_object_never_reaches_the_answer() -> None:
+    displayer, aggregate = await _stream(SOFA_RUN)
+
+    assert displayer.chunks == []
+    assert aggregate == ""
+    assert '"action": "dalle.text2im"' in "".join(displayer.thoughts)
+
+
+@pytest.mark.asyncio
+async def test_kimi_span_never_reaches_the_answer() -> None:
+    displayer, aggregate = await _stream(_split(KIMI))
+
+    assert "".join(displayer.chunks) == ""
+    assert "<|tool_call" not in aggregate
+
+
+@pytest.mark.asyncio
+async def test_prose_around_a_span_still_answers() -> None:
+    displayer, aggregate = await _stream(_split(f"Here is your image.{KIMI}"))
+
+    assert "".join(displayer.chunks) == "Here is your image."
+    assert aggregate == "Here is your image."
+
+
+@pytest.mark.asyncio
+async def test_bare_closing_think_tag_is_still_consumed() -> None:
+    """Some chat templates pre-fill ``<think>``, so the model emits only the closing tag."""
+    displayer, _ = await _stream(_split("Reasoning here.</think>The real answer."))
+
+    assert "".join(displayer.chunks) == "Reasoning here.The real answer."
+
+
+@pytest.mark.asyncio
+async def test_reasoning_tags_are_unaffected() -> None:
+    displayer, _ = await _stream(_split("<think>I should describe an ocean.</think>Vast and blue."))
+
+    assert "".join(displayer.chunks) == "Vast and blue."
+    assert "".join(displayer.thoughts) == "I should describe an ocean."
+
+
+@pytest.mark.asyncio
+async def test_prose_mentioning_tool_call_keys_survives() -> None:
+    prose = 'The `action_input` field is a JSON string. Set "action" to the tool name.'
+    displayer, aggregate = await _stream(_split(prose))
+
+    assert "".join(displayer.chunks) == prose
+    assert aggregate == prose
+
+
+@pytest.mark.asyncio
+async def test_answer_that_merely_starts_with_a_brace_still_streams() -> None:
+    """The gate withholds only while ``{"action":`` is still possible, never longer."""
+    snippet = '{"name": "generate_image", "size": "1024x1024"} is the payload.'
+    displayer, aggregate = await _stream(_split(snippet))
+
+    assert "".join(displayer.chunks) == snippet
+    assert aggregate == snippet
+
+
+@pytest.mark.asyncio
+async def test_a_well_behaved_caption_is_untouched() -> None:
+    caption = "The image you requested has been generated and is shown above."
+    displayer, aggregate = await _stream(["The image ", "you requested has been ", "generated and is shown above."])
+
+    assert "".join(displayer.chunks) == caption
+    assert aggregate == caption


### PR DESCRIPTION
## Summary

When OpenWebUI generates an image, it prepends a system message to the user's chat turn telling the model to say the image is ready. Some models answer that prompt with a tool call rendered as plain text instead of a sentence, and it was displayed verbatim as the assistant's answer. This keeps that markup out of the answer on both the agent path and the plain-model path.

This is a temporary fix until we have more control with native image generation. Until then, this just hides the json fields after OWUI generation.

closes bbvch-ai/aihub-core-private#65

https://github.com/user-attachments/assets/ccedfd63-c06c-48e2-88d3-26a401c400c8


## Changes

- **`ToolCallMarkup`** (new) — recognises the three forms this arrives in, matched on the literal text and never on the model: special-token delimited (`<|tool_calls_section_begin|> … <|tool_calls_section_end|>`), XML-tag delimited (`<tool_call> … </tool_call>`), and a bare JSON object opening the message (`{"action": ..., "action_input": ...}`). These are wire formats shared across model families, not properties of any one model — the case reported here was `gemma-4-31B-it` emitting the third form.

- **`TagParser`** — generalised from one hardcoded `<think>` pair to a list of spans, so tool-call markup is routed to the thinking channel mid-stream. It lands in the collapsed reasoning block rather than being dropped, so a misbehaving model stays diagnosable.
- **`StreamProcessor`** — a ReAct object has no opening delimiter to switch on, so the head of the stream is withheld until `{"action":` is ruled in or out. The returned aggregate is stripped too, otherwise the blob reaches the user a second time via the API's final-content backstop and persists into chat history.
- **`ToolCallStreamScrubber`** (new) + **`OpenaiService`** — the plain-model chat is relayed as SSE with no display events to route markup into, so there it is removed instead. Only `delta.content` is touched; `delta.tool_calls` is forwarded untouched, so native function calling — including OpenWebUI's own image generation — is unaffected.

### Notes for reviewers

- **No tool intent is recovered, deliberately.** `dalle.text2im` exists nowhere in the stack — nothing offered it, nothing would execute it. The model is imitating a tool-calling transcript from training data. It is only text.
- The image itself is produced by OpenWebUI *before* this LLM call, so suppressing the caption cannot break image generation.

## Test plan

- [ ] `make test` in `packages/core` — 1470 passed
- [ ] `make test` in `packages/api` — 559 passed (1 pre-existing failure, `test_get_user_with_valid_token`, which also fails on clean `main`; caused by `keycloak-config` crash-looping locally)
- [ ] **Differential over real data** — replayed all 214 persisted agent responses through the old and new pipeline: **207 byte-identical, 7 changed**, and all 7 are the tool-call blobs. No unexpected changes across markdown-heavy RAG answers, code explanations, and German responses.
- [ ] New unit tests cover all three markup shapes plus controls: prose mentioning `action_input` survives, `<think>` handling is unchanged, a bare `</think>` is still consumed, an answer legitimately starting with `{` still streams, and native `tool_calls` pass through untouched.
- [ ] Manual: "sofa in a living room" against an LLM-wrapping agent with image generation enabled — image renders, no JSON blob, blob visible in the collapsed Thought block.
