### PR TITLE
fix(dagster): Keep one source_observation run in flight and make it cheap

### DIFF
--- a/.claude/skills/dagster-pipelines/SKILL.md
+++ b/.claude/skills/dagster-pipelines/SKILL.md
@@ -387,6 +387,12 @@ def replace_partition_keys(context, partition_name, keys, max_partitions):
 
 **Partition key = document URI** (e.g., `s3://bucket/path/to/doc.pdf`).
 
+**Truncation is signalled, not silent**: additions and deletions are capped at `max_partitions` per run. When the cap
+bites, `replace_partition_keys` logs a warning and tags its own run with `PARTITIONS_TRUNCATED_TAG` — a run cannot write
+its sensor's cursor, so non-convergence travels back as a run tag. The NATS sensor re-arms on an unhandled tag and
+records the run id it answered, chaining observations until one truncates nothing. An upload larger than
+`max_partitions` therefore still ends up fully observed.
+
 ### DataVersionsByPartition
 
 Observable assets return content hashes per partition to trigger downstream:
@@ -471,6 +477,14 @@ sensor = nats_document_uploaded_sensor(
 
 **Flow**: Document uploaded via API sends `SourceUpdatedEvent` to NATS. Sensor triggers `observe_job`. Observable asset
 detects new partition. Downstream assets with `AutomationCondition.eager()` auto-materialize.
+
+**Single-flight**: an observation scans the whole bucket, so the sensor never requests a second one while one is queued
+or running — a burst of uploads yields one run, not one per tick. It drains the entire JetStream backlog each tick,
+holds events for a 30 s debounce, and derives run keys from the highest stream sequence plus a re-arm counter so
+Dagster's own deduplication is a second line of defence. Events that arrive *during* a run arm exactly one follow-up,
+because a running observation may already have listed the bucket before those files landed. The guard is scoped per job
+name, so a manually launched run suppresses the sensor too. `run_after_success_sensor` applies the same guard to the
+chained remove job, keyed on the observing run id.
 
 ### Schedules
 

--- a/.claude/skills/debug-pipeline/SKILL.md
+++ b/.claude/skills/debug-pipeline/SKILL.md
@@ -131,9 +131,14 @@ Use the error information from Step 1 to match against these known patterns.
 
 - Read: `packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/nats_document_uploaded_sensor.py`
 - Is NATS reachable? Check `NATS_ENDPOINT` env var
-- Is the JetStream stream created? (poller creates it on first run)
+- Is the JetStream stream created? (poller creates it on first run) — events published *before* the stream exists are
+  dropped, since JetStream has nowhere to store them
 - Are `SourceUpdatedEvent` messages being published?
 - Check consumer name uniqueness
+- `skipped: Observation run <id> is already in flight` is **normal**, not a fault — the sensor deliberately keeps one
+  observation at a time and re-arms afterwards. Likewise `Debouncing N pending event(s)` means a burst is being
+  collected (30 s). Read the sensor's cursor in the Dagster UI to see `pending_events` / `followup_armed`; if a run
+  seems missing, check whether its `dagster/run_key` was deduplicated
 
 ### Embedding Failures
 

--- a/packages/pipeline/CLAUDE.md
+++ b/packages/pipeline/CLAUDE.md
@@ -295,6 +295,17 @@ Four triggering mechanisms work together:
   compares the whole corpus, so one already in flight covers the observation that just succeeded, and the request is
   keyed on the observing run id so retries deduplicate.
 
+**Run priority**: `observe_source_job` and `materialize_asset_job` tag their runs
+`dagster/priority: "10"` (`ORCHESTRATION_RUN_PRIORITY` in `jobs/factory.py`). `QueuedRunCoordinator` sorts the whole
+queue by that tag before trimming to the dequeue batch, but every run defaults to `0` — which collapses the sort into
+plain FIFO and lets a bulk upload strand an observation behind the hundreds of per-document ingestion runs it just
+authorized. Observation and removal are cheap and gate everything downstream, so they jump the backlog. This is
+ordering only, not reserved capacity: no slot is ever held idle, and ingestion still uses every slot when nothing
+else is waiting. Dagster cannot preempt a *running* run, so the wait is bounded by one ingestion run rather than by
+zero. Only the sensor daemon and the scheduler apply a job's `run_tags`, so runs launched through
+`DagsterGraphQLClient` (or any caller that passes its own tags) land at priority 0 — the sensor, chaining sensor and
+daily schedule paths, which is every automated launch, all carry it.
+
 **Partition-set convergence**: `replace_partition_keys` caps additions and deletions at `max_partitions` (default 1000).
 When it truncates, it logs a warning and tags its own run with `PARTITIONS_TRUNCATED_TAG` — a run cannot write its
 sensor's cursor, so the fact that the partition set has not converged travels back as a run tag. The NATS sensor re-arms

--- a/packages/pipeline/CLAUDE.md
+++ b/packages/pipeline/CLAUDE.md
@@ -43,7 +43,13 @@ packages/pipeline/                        # SDK framework
 │   ├── sensors/
 │   │   ├── factory.py                     # default_automation_sensor (auto-materialization)
 │   │   ├── run_after_success_sensor.py    # Chain a job after another job's successful run
-│   │   └── nats/nats_document_uploaded_sensor.py  # NATS event-driven triggers
+│   │   ├── single_flight_run_guard.py     # "Is a run of this job already queued or running?"
+│   │   └── nats/
+│   │       ├── nats_document_uploaded_sensor.py  # NATS event-driven triggers
+│   │       ├── consumed_event_batch.py           # Drains the JetStream backlog, defers acks
+│   │       ├── observation_sensor_cursor.py      # Sensor state carried between ticks
+│   │       ├── observation_run_decider.py        # Pure request-or-wait decision
+│   │       └── observation_run_history.py        # Run-tag lookups the cursor cannot hold
 │   ├── schedules/factory.py               # daily_schedule_at, default_daily_materialize_schedule
 │   ├── jobs/factory.py                    # observe_source_job, materialize_asset_job, materialize_all_job
 │   ├── executors/factory.py               # default_process_executor (in-process)
@@ -198,6 +204,14 @@ assets.
 **Data lake hierarchy** (cloud-agnostic abstraction):
 
 - `AbstractDataLakeClient` → `S3DataLakeClient`, `AzureDataLakeClient` (list, get, delete file operations)
+  - **Observation cost is per directory, not per object.** `get_all_files()` answers only "which files exist and has any
+    changed", which `list_objects_v2` already covers — so it issues no per-object `head_object`, and resolves
+    `get_or_create_namespace_for_directory` once per directory rather than per file. The lookup also *registers* the
+    `NamespaceEntity` the knowledge UI and namespace-selection agent read, so the first file of each directory still
+    reaches it. The download path (`create_data_lake_file_from_uri`, `create_data_lake_files_from_uris`) keeps the head
+    because it needs the object's user metadata and content type — it just no longer fetches it twice. `list_objects_v2`
+    and `head_object` return the same ETag and modification time, so the `DataVersion` is identical either way; that
+    equivalence is pinned by tests, because a divergence would re-parse and re-embed the whole corpus.
 - `AbstractDataLakeClientResource` → typed `ConfigurableResource` wrappers for Dagster DI
 - `AbstractDataLakeFileSystemResource` → `s3fs`/`adlfs` wrappers for streaming reads
 
@@ -265,12 +279,27 @@ Four triggering mechanisms work together:
   changes. Enabled by `default_automation_sensor(assets, minimum_interval_seconds=60)`.
 - **NATS sensor**: `nats_document_uploaded_sensor` — polls JetStream for `SourceUpdatedEvent` via
   `PipelineInstanceTopicManager`. Triggers observe job when documents are uploaded externally (e.g., via API).
+  **Single-flight**: an observation scans the whole bucket, so the sensor never requests a second one while one is
+  queued or running (`SingleFlightRunGuard`, scoped per job name — a manually launched run suppresses it too). It does
+  not cancel or queue runs; the second request is simply never made. Events seen during a run arm exactly one follow-up
+  via the sensor cursor (`ObservationSensorCursor`), because a running observation may already have listed the bucket
+  before those files landed. A 30 s debounce (`DEBOUNCE_SECONDS`) collects a burst into one request, and the whole
+  JetStream backlog drains per tick rather than one fetch of ten. Run keys are derived from the highest stream sequence
+  plus a re-arm counter, so Dagster's own run-key deduplication acts as a second line of defence.
 - **Daily schedules**: `daily_schedule_at(job, hour, minute)` — cron-based observation for sources that don't push
   events.
 - **Run-status chaining**: `run_after_success_sensor(monitored_job=..., triggered_job=...)` — fires `triggered_job`
   after `monitored_job` succeeds. Used to order observe → remove jobs, since Dagster forbids mixing observable source
   assets with regular assets in a single `define_asset_job` selection. All `default_*_definitions()` builders wire this
-  automatically; the remove job no longer has its own schedule.
+  automatically; the remove job no longer has its own schedule. Single-flight applies here too: the removal also
+  compares the whole corpus, so one already in flight covers the observation that just succeeded, and the request is
+  keyed on the observing run id so retries deduplicate.
+
+**Partition-set convergence**: `replace_partition_keys` caps additions and deletions at `max_partitions` (default 1000).
+When it truncates, it logs a warning and tags its own run with `PARTITIONS_TRUNCATED_TAG` — a run cannot write its
+sensor's cursor, so the fact that the partition set has not converged travels back as a run tag. The NATS sensor re-arms
+on an unhandled truncation tag and records the run id it answered, chaining observations until one truncates nothing.
+Without this, single-flight would trade the run storm for partially observed batches above 1000 files.
 
 ## Run-Failure Notifications
 

--- a/packages/pipeline/swiss_ai_hub/pipeline/io/s3_data_lake_io_manager.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/io/s3_data_lake_io_manager.py
@@ -5,7 +5,7 @@ import s3fs
 from dagster import ConfigurableIOManager, InputContext, OutputContext, ResourceDependency
 from swiss_ai_hub.core.generative_ai.utils.path_utils import decode_partition_key
 
-from swiss_ai_hub.pipeline.resources.data_lake.s3.s3_data_lake_client import S3DataLakeClient
+from swiss_ai_hub.pipeline.resources.data_lake.s3.s3_data_lake_client import S3_PROTOCOL_PREFIX, S3DataLakeClient
 from swiss_ai_hub.pipeline.types.data_lake_file import DataLakeFile
 
 
@@ -105,7 +105,7 @@ class S3DataLakeIOManager(ConfigurableIOManager):
                 context.log.error(f"No content found for file {data_lake_file.uri}. Cannot write to S3.")
                 raise ValueError(f"No content to write for file {data_lake_file.uri}.")
 
-            path = data_lake_file.uri.removeprefix("s3://").lstrip("/")
+            path = data_lake_file.uri.removeprefix(S3_PROTOCOL_PREFIX).lstrip("/")
 
             # Split into bucket and key
             parts = path.split("/", 1)
@@ -116,7 +116,7 @@ class S3DataLakeIOManager(ConfigurableIOManager):
             bucket_name = parts[0]
             object_key = parts[1]
 
-            context.log.info(f"Writing file to S3: s3://{bucket_name}/{object_key}")
+            context.log.info(f"Writing file to S3: {S3_PROTOCOL_PREFIX}{bucket_name}/{object_key}")
 
             encoded_metadata = self._encode_metadata(data_lake_file.metadata)
 
@@ -133,7 +133,7 @@ class S3DataLakeIOManager(ConfigurableIOManager):
             # Write the content to S3 with metadata using put_object
             self.data_lake_client.raw_client.put_object(**put_params)
 
-            context.log.info(f"Successfully wrote file s3://{bucket_name}/{object_key} to S3.")
+            context.log.info(f"Successfully wrote file {S3_PROTOCOL_PREFIX}{bucket_name}/{object_key} to S3.")
 
     def load_input(self, context: InputContext) -> DataLakeFile | list[DataLakeFile]:
         if context.has_partition_key:
@@ -171,13 +171,13 @@ class S3DataLakeIOManager(ConfigurableIOManager):
         return data_lake_files
 
     def _to_full_uri(self, uri: str) -> str:
-        return uri if uri.startswith("s3://") else self.data_lake_client.build_uri(uri)
+        return uri if uri.startswith(S3_PROTOCOL_PREFIX) else self.data_lake_client.build_uri(uri)
 
     def _load_data_lake_file_from_uri(self, context: InputContext, uri: str) -> DataLakeFile:
         """Load a DataLakeFile directly using the partition key as an S3 URI."""
         context.log.info(f"Loading DataLakeFile from URI: {uri}")
 
-        if not uri.startswith("s3://"):
+        if not uri.startswith(S3_PROTOCOL_PREFIX):
             uri = self.data_lake_client.build_uri(uri)
             context.log.info(f"Constructed full S3 URI: {uri}")
 

--- a/packages/pipeline/swiss_ai_hub/pipeline/io/s3_data_lake_io_manager.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/io/s3_data_lake_io_manager.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from urllib.parse import quote, unquote
 
 import s3fs
@@ -144,15 +145,33 @@ class S3DataLakeIOManager(ConfigurableIOManager):
             partitions_def = upstream_output.asset_partitions_def
             if partitions_def is not None:
                 all_partition_keys = partitions_def.get_partition_keys(dynamic_partitions_store=context.instance)
-                data_lake_files = []
-                for partition_key in all_partition_keys:
-                    uri = decode_partition_key(partition_key) if self.encode_partition_keys else partition_key
-                    data_lake_file = self._load_data_lake_file_from_uri(context, uri)
-                    data_lake_files.append(data_lake_file)
-                return data_lake_files
+                return self._load_data_lake_files_from_partition_keys(context, all_partition_keys)
             else:
                 context.log.error("No partition definition found for the upstream asset.")
                 raise ValueError("Cannot load data without partition information.")
+
+    def _load_data_lake_files_from_partition_keys(
+        self, context: InputContext, partition_keys: Sequence[str]
+    ) -> list[DataLakeFile]:
+        """Loads every partition in one go so namespaces resolve once per directory.
+
+        This is the whole-corpus load the removal job performs after every observation, where a
+        per-file namespace lookup costs as much as it did in the observation itself.
+        """
+        uris = [
+            self._to_full_uri(decode_partition_key(partition_key) if self.encode_partition_keys else partition_key)
+            for partition_key in partition_keys
+        ]
+        context.log.info(f"Loading {len(uris)} DataLakeFile(s) from partition keys")
+
+        data_lake_files = self.data_lake_client.create_data_lake_files_from_uris(uris)
+        for data_lake_file in data_lake_files:
+            data_lake_file.metadata = self._decode_metadata(data_lake_file.metadata)
+
+        return data_lake_files
+
+    def _to_full_uri(self, uri: str) -> str:
+        return uri if uri.startswith("s3://") else self.data_lake_client.build_uri(uri)
 
     def _load_data_lake_file_from_uri(self, context: InputContext, uri: str) -> DataLakeFile:
         """Load a DataLakeFile directly using the partition key as an S3 URI."""

--- a/packages/pipeline/swiss_ai_hub/pipeline/io/tests/test_s3_data_lake_io_manager.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/io/tests/test_s3_data_lake_io_manager.py
@@ -28,6 +28,9 @@ def _make_s3_client() -> MagicMock:
     mock.create_data_lake_file_from_uri.return_value = _make_data_lake_file(
         "simple.txt", "docs", "s3://bucket/docs/simple.txt", content_type="text/plain", hash="def456"
     )
+    mock.create_data_lake_files_from_uris.side_effect = lambda uris: [
+        _make_data_lake_file(uri.rsplit("/", 1)[-1], "docs", uri) for uri in uris
+    ]
 
     mock.build_uri.side_effect = lambda path: f"s3://bucket/{path}"
 
@@ -108,7 +111,7 @@ class TestLoadInputEncoded:
 
         assert len(result) == 1
         assert result[0].name == "report, Q1.pdf"
-        s3_client.create_data_lake_file_from_uri.assert_called_once_with("s3://bucket/docs/report, Q1.pdf")
+        s3_client.create_data_lake_files_from_uris.assert_called_once_with(["s3://bucket/docs/report, Q1.pdf"])
 
     def test_non_partitioned_without_encoding_loads_each_key(self) -> None:
         s3_client = _make_s3_client()
@@ -133,4 +136,4 @@ class TestLoadInputEncoded:
 
         assert len(result) == 1
         assert result[0].name == "simple.txt"
-        s3_client.create_data_lake_file_from_uri.assert_called_once_with("s3://bucket/docs/simple.txt")
+        s3_client.create_data_lake_files_from_uris.assert_called_once_with(["s3://bucket/docs/simple.txt"])

--- a/packages/pipeline/swiss_ai_hub/pipeline/jobs/factory.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/jobs/factory.py
@@ -1,4 +1,12 @@
 from dagster import AssetSelection, JobDefinition, RunConfig, define_asset_job, observable_source_asset
+from dagster._core.storage.tags import PRIORITY_TAG
+
+# Observation and removal are cheap steps whose results authorize the per-document ingestion runs,
+# so they must not queue behind them. Every run defaults to priority 0, which collapses
+# QueuedRunCoordinator's priority sort into plain FIFO; a bulk upload then leaves an observation
+# waiting behind hundreds of already-queued ingestion runs. The sort spans the whole queue rather
+# than one page, so this jumps the backlog outright without reserving any capacity.
+ORCHESTRATION_RUN_PRIORITY = {PRIORITY_TAG: "10"}
 
 
 def materialize_all_job(namespace_name: str, config: RunConfig | None = None) -> JobDefinition:
@@ -30,6 +38,7 @@ def observe_source_job(
         name=f"{source_location_name}_{job_name}",
         config=config,
         description=job_description,
+        run_tags=ORCHESTRATION_RUN_PRIORITY,
     )
 
 
@@ -46,4 +55,5 @@ def materialize_asset_job(
         selection=asset_selection,
         config=config,
         description=description or "A job to materialize the selected assets.",
+        run_tags=ORCHESTRATION_RUN_PRIORITY,
     )

--- a/packages/pipeline/swiss_ai_hub/pipeline/jobs/tests/test_factory.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/jobs/tests/test_factory.py
@@ -1,0 +1,28 @@
+from dagster import AssetKey, AssetSelection, DataVersion, observable_source_asset
+from dagster._core.storage.tags import PRIORITY_TAG
+
+from swiss_ai_hub.pipeline.jobs.factory import materialize_asset_job, observe_source_job
+
+
+@observable_source_asset(name="a_source")
+def _source() -> DataVersion:
+    return DataVersion("v1")
+
+
+class TestOrchestrationRunPriority:
+    """The queue is priority-ordered but every run defaults to 0, so without an explicit tag these
+    jobs land behind every per-document ingestion run a bulk upload queues."""
+
+    def test_observation_runs_outrank_the_default(self) -> None:
+        job = observe_source_job(observable_asset=_source, source_location_name="bucket")
+
+        assert int(job.run_tags[PRIORITY_TAG]) > 0
+
+    def test_removal_runs_outrank_the_default(self) -> None:
+        job = materialize_asset_job(
+            source_location_name="bucket",
+            job_name="remove_documents",
+            asset_selection=AssetSelection.keys(AssetKey(["removed"])),
+        )
+
+        assert int(job.run_tags[PRIORITY_TAG]) > 0

--- a/packages/pipeline/swiss_ai_hub/pipeline/resources/data_lake/s3/s3_data_lake_client.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/resources/data_lake/s3/s3_data_lake_client.py
@@ -52,8 +52,13 @@ class S3DataLakeClient(AbstractDataLakeClient):
     def get_all_files(self) -> list[DataLakeFile]:
         """
         Retrieve all files from the specified directory, excluding figures.
+
+        Answers only "which files exist and has any changed", which ``list_objects_v2`` already
+        covers: no per-object ``head_object``, and one namespace lookup per directory rather than
+        per file. Cost therefore scales with directories, not with objects in the bucket.
         """
         data_lake_files: list[DataLakeFile] = []
+        namespace_cache: dict[str, str] = {}
 
         paginator = self._client.get_paginator("list_objects_v2")
         page_iterator = paginator.paginate(
@@ -80,17 +85,44 @@ class S3DataLakeClient(AbstractDataLakeClient):
                     continue
 
                 document_uri = self.build_uri(key)
-                data_lake_file = self._create_data_lake_file_from_s3_object(document_uri, obj, key)
+                data_lake_file = self._create_data_lake_file_from_s3_object(
+                    document_uri,
+                    obj,
+                    key,
+                    namespace=self._resolve_namespace(document_uri, namespace_cache),
+                )
                 data_lake_files.append(data_lake_file)
 
         return data_lake_files
+
+    def _resolve_namespace(self, document_uri: str, namespace_cache: dict[str, str] | None = None) -> str:
+        """Namespace varies only per directory, but the lookup also *registers* directories the
+        knowledge UI and namespace-selection agent read, so the first file of each directory must
+        still reach it — caching per directory keeps that side effect and drops the rest."""
+        directory_name = document_uri.split("/")[3]  # s3://bucket/directory_name/...
+        if namespace_cache is None:
+            return get_or_create_namespace_for_directory(self.container_name, directory_name)
+        if directory_name not in namespace_cache:
+            namespace_cache[directory_name] = get_or_create_namespace_for_directory(self.container_name, directory_name)
+        return namespace_cache[directory_name]
 
     def get_file_metadata(self, file_path: str) -> dict:
         """Get file metadata using S3 client"""
         response = self._client.head_object(Bucket=self.container_name, Key=file_path)
         return response.get("Metadata", {})
 
-    def create_data_lake_file_from_uri(self, document_uri: str) -> DataLakeFile:
+    def create_data_lake_files_from_uris(self, document_uris: list[str]) -> list[DataLakeFile]:
+        """Batch sibling of ``create_data_lake_file_from_uri`` that resolves each namespace once.
+
+        The removal job loads every partition at once, so a per-file namespace lookup there costs
+        as much as it did in the observation.
+        """
+        namespace_cache: dict[str, str] = {}
+        return [self.create_data_lake_file_from_uri(document_uri, namespace_cache) for document_uri in document_uris]
+
+    def create_data_lake_file_from_uri(
+        self, document_uri: str, namespace_cache: dict[str, str] | None = None
+    ) -> DataLakeFile:
         """Create a DataLakeFile from S3 URI by fetching object metadata."""
         if not document_uri.startswith(S3_PROTOCOL_PREFIX):
             if document_uri.startswith(f"{self.container_name}/"):
@@ -123,32 +155,42 @@ class S3DataLakeClient(AbstractDataLakeClient):
             "ETag": head_response.get("ETag", "").strip('"'),
         }
 
-        return self._create_data_lake_file_from_s3_object(document_uri, s3_object, key)
+        return self._create_data_lake_file_from_s3_object(
+            document_uri,
+            s3_object,
+            key,
+            namespace=self._resolve_namespace(document_uri, namespace_cache),
+            head_response=head_response,
+        )
 
-    def _create_data_lake_file_from_s3_object(self, document_uri: str, s3_object: dict, key: str) -> DataLakeFile:
+    def _create_data_lake_file_from_s3_object(
+        self,
+        document_uri: str,
+        s3_object: dict,
+        key: str,
+        namespace: str,
+        head_response: dict | None = None,
+    ) -> DataLakeFile:
         """
         Create a DataLakeFile from S3 object metadata.
 
-        This method constructs a DataLakeFile object from S3 object metadata,
-        handling content type detection, hash conversion, and timestamp processing.
+        ``head_response`` carries the object's user metadata and content type, which only the
+        download path needs; callers that already hold one pass it in rather than fetching it
+        again, and callers that never read those fields pass None to skip the request entirely.
+        ``list_objects_v2`` reports the same ETag, size and modification time either way, so the
+        DataVersion is identical on both paths.
         """
-        uri_parts = document_uri.split("/")
-        directory_name = uri_parts[3]  # s3://bucket/directory_name/...
-        namespace = get_or_create_namespace_for_directory(self.container_name, directory_name)
         filename = key.split("/")[-1]
 
         _, extension = os.path.splitext(filename)
         file_type = extension.lower()[1:] if extension else "unknown"
 
-        try:
-            head_response = self._client.head_object(Bucket=self.container_name, Key=key)
+        if head_response is not None:
             content_type = head_response.get("ContentType", "application/octet-stream")
             etag = head_response.get("ETag", "").strip('"')  # Remove quotes from ETag
             metadata = head_response.get("Metadata", {})
             last_modified = head_response.get("LastModified")
-        except (ClientError, NoCredentialsError, BotoCoreError) as e:
-            # Fallback if head_object fails - use data from list operation
-            logger.warning(f"Could not fetch detailed metadata for {key}, using fallback values: {e}")
+        else:
             content_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
             etag = s3_object.get("ETag", "").strip('"')
             metadata = {}

--- a/packages/pipeline/swiss_ai_hub/pipeline/resources/data_lake/s3/tests/test_s3_data_lake_client.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/resources/data_lake/s3/tests/test_s3_data_lake_client.py
@@ -11,6 +11,8 @@ NAMESPACE_PATCH_TARGET = (
     "swiss_ai_hub.pipeline.resources.data_lake.s3.s3_data_lake_client.get_or_create_namespace_for_directory"
 )
 
+LAST_MODIFIED = datetime(2026, 7, 24, tzinfo=UTC)
+
 
 def _make_s3_client(etag: str) -> MagicMock:
     mock = MagicMock()
@@ -18,7 +20,7 @@ def _make_s3_client(etag: str) -> MagicMock:
         "ContentType": "application/pdf",
         "ETag": f'"{etag}"',
         "Metadata": {},
-        "LastModified": datetime(2026, 7, 24, tzinfo=UTC),
+        "LastModified": LAST_MODIFIED,
         "ContentLength": 9_000_000,
     }
     return mock
@@ -28,51 +30,81 @@ def _make_s3_object(key: str, etag: str) -> dict:
     return {
         "Key": key,
         "Size": 9_000_000,
-        "LastModified": datetime(2026, 7, 24, tzinfo=UTC),
+        "LastModified": LAST_MODIFIED,
         "ETag": f'"{etag}"',
     }
 
 
+def _paginating(s3_client: MagicMock, keys_with_etags: list[tuple[str, str]]) -> MagicMock:
+    s3_client.get_paginator.return_value.paginate.return_value = [
+        {"Contents": [_make_s3_object(key, etag) for key, etag in keys_with_etags]}
+    ]
+    return s3_client
+
+
 class TestCreateDataLakeFileFromS3Object:
-    @patch(NAMESPACE_PATCH_TARGET, return_value="docs")
-    def test_chunked_etag_is_kept_verbatim(self, _namespace: MagicMock) -> None:
+    def test_chunked_etag_is_kept_verbatim(self) -> None:
         client = S3DataLakeClient(container_name="bucket", s3_client=_make_s3_client(CHUNKED_ETAG))
 
         data_lake_file = client._create_data_lake_file_from_s3_object(
-            "s3://bucket/docs/large.pdf", _make_s3_object("docs/large.pdf", CHUNKED_ETAG), "docs/large.pdf"
+            "s3://bucket/docs/large.pdf",
+            _make_s3_object("docs/large.pdf", CHUNKED_ETAG),
+            "docs/large.pdf",
+            namespace="docs",
         )
 
         assert data_lake_file.hash == CHUNKED_ETAG
 
-    @patch(NAMESPACE_PATCH_TARGET, return_value="docs")
-    def test_plain_md5_etag_stays_base64_encoded(self, _namespace: MagicMock) -> None:
+    def test_plain_md5_etag_stays_base64_encoded(self) -> None:
         client = S3DataLakeClient(container_name="bucket", s3_client=_make_s3_client(PLAIN_MD5_ETAG))
 
         data_lake_file = client._create_data_lake_file_from_s3_object(
-            "s3://bucket/docs/small.pdf", _make_s3_object("docs/small.pdf", PLAIN_MD5_ETAG), "docs/small.pdf"
+            "s3://bucket/docs/small.pdf",
+            _make_s3_object("docs/small.pdf", PLAIN_MD5_ETAG),
+            "docs/small.pdf",
+            namespace="docs",
         )
 
         assert data_lake_file.hash == base64.b64encode(bytes.fromhex(PLAIN_MD5_ETAG)).decode("utf-8")
 
 
+class TestDataVersionParity:
+    """The DataVersion is ``f"{updated}-{hash}"``. If either half differed between the listing and
+    the head, the first observation after deploy would mark every partition changed and re-parse
+    and re-embed the entire corpus."""
+
+    def _both_paths(self, etag: str) -> tuple[tuple[str, int], tuple[str, int]]:
+        s3_client = _make_s3_client(etag)
+        client = S3DataLakeClient(container_name="bucket", s3_client=s3_client)
+        s3_object = _make_s3_object("docs/file.pdf", etag)
+        head_response = s3_client.head_object(Bucket="bucket", Key="docs/file.pdf")
+
+        from_head = client._create_data_lake_file_from_s3_object(
+            "s3://bucket/docs/file.pdf", s3_object, "docs/file.pdf", namespace="docs", head_response=head_response
+        )
+        from_listing = client._create_data_lake_file_from_s3_object(
+            "s3://bucket/docs/file.pdf", s3_object, "docs/file.pdf", namespace="docs"
+        )
+        return (from_head.hash, from_head.updated), (from_listing.hash, from_listing.updated)
+
+    def test_plain_md5_branch_is_identical_on_both_paths(self) -> None:
+        from_head, from_listing = self._both_paths(PLAIN_MD5_ETAG)
+
+        assert from_head == from_listing
+
+    def test_chunked_branch_is_identical_on_both_paths(self) -> None:
+        from_head, from_listing = self._both_paths(CHUNKED_ETAG)
+
+        assert from_head == from_listing
+
+
 class TestGetAllFiles:
     @patch(NAMESPACE_PATCH_TARGET, return_value="docs")
     def test_mixed_etag_formats_all_enumerate(self, _namespace: MagicMock) -> None:
-        s3_client = _make_s3_client(PLAIN_MD5_ETAG)
-        s3_client.get_paginator.return_value.paginate.return_value = [
-            {
-                "Contents": [
-                    _make_s3_object("docs/small.pdf", PLAIN_MD5_ETAG),
-                    _make_s3_object("docs/large.pdf", CHUNKED_ETAG),
-                ]
-            }
-        ]
-        s3_client.head_object.side_effect = lambda Bucket, Key: {  # noqa: N803
-            "ContentType": "application/pdf",
-            "ETag": f'"{CHUNKED_ETAG if "large" in Key else PLAIN_MD5_ETAG}"',
-            "Metadata": {},
-            "LastModified": datetime(2026, 7, 24, tzinfo=UTC),
-        }
+        s3_client = _paginating(
+            _make_s3_client(PLAIN_MD5_ETAG),
+            [("docs/small.pdf", PLAIN_MD5_ETAG), ("docs/large.pdf", CHUNKED_ETAG)],
+        )
 
         client = S3DataLakeClient(container_name="bucket", s3_client=s3_client)
 
@@ -82,3 +114,84 @@ class TestGetAllFiles:
             base64.b64encode(bytes.fromhex(PLAIN_MD5_ETAG)).decode("utf-8"),
             CHUNKED_ETAG,
         ]
+
+    @patch(NAMESPACE_PATCH_TARGET, return_value="docs")
+    def test_does_not_head_each_object(self, _namespace: MagicMock) -> None:
+        """``list_objects_v2`` already carries size, ETag and modification time, and the
+        observation reads nothing else."""
+        s3_client = _paginating(
+            _make_s3_client(PLAIN_MD5_ETAG),
+            [(f"docs/file{index}.pdf", PLAIN_MD5_ETAG) for index in range(25)],
+        )
+        client = S3DataLakeClient(container_name="bucket", s3_client=s3_client)
+        s3_client.head_object.reset_mock()
+
+        client.get_all_files()
+
+        s3_client.head_object.assert_not_called()
+
+    @patch(NAMESPACE_PATCH_TARGET, return_value="docs")
+    def test_namespace_is_resolved_once_per_directory(self, namespace: MagicMock) -> None:
+        s3_client = _paginating(
+            _make_s3_client(PLAIN_MD5_ETAG),
+            [(f"docs/file{index}.pdf", PLAIN_MD5_ETAG) for index in range(25)],
+        )
+        client = S3DataLakeClient(container_name="bucket", s3_client=s3_client)
+
+        client.get_all_files()
+
+        assert namespace.call_count == 1
+
+    @patch(NAMESPACE_PATCH_TARGET, return_value="docs")
+    def test_each_directory_is_still_registered(self, namespace: MagicMock) -> None:
+        """The lookup also creates the NamespaceEntity the knowledge UI and namespace-selection
+        agent read, so every directory must reach it at least once."""
+        s3_client = _paginating(
+            _make_s3_client(PLAIN_MD5_ETAG),
+            [("docs/a.pdf", PLAIN_MD5_ETAG), ("reports/b.pdf", PLAIN_MD5_ETAG), ("docs/c.pdf", PLAIN_MD5_ETAG)],
+        )
+        client = S3DataLakeClient(container_name="bucket", s3_client=s3_client)
+
+        client.get_all_files()
+
+        assert namespace.call_count == 2
+        assert {call.args[1] for call in namespace.call_args_list} == {"docs", "reports"}
+
+
+class TestCreateDataLakeFileFromUri:
+    @patch(NAMESPACE_PATCH_TARGET, return_value="docs")
+    def test_heads_the_object_exactly_once(self, _namespace: MagicMock) -> None:
+        """The download path needs the object's user metadata, but one head is enough for it."""
+        s3_client = _make_s3_client(PLAIN_MD5_ETAG)
+        client = S3DataLakeClient(container_name="bucket", s3_client=s3_client)
+        s3_client.head_object.reset_mock()
+
+        client.create_data_lake_file_from_uri("s3://bucket/docs/small.pdf")
+
+        s3_client.head_object.assert_called_once()
+
+    @patch(NAMESPACE_PATCH_TARGET, return_value="docs")
+    def test_keeps_object_metadata(self, _namespace: MagicMock) -> None:
+        s3_client = _make_s3_client(PLAIN_MD5_ETAG)
+        s3_client.head_object.return_value = {
+            **s3_client.head_object.return_value,
+            "Metadata": {"namespace": "docs"},
+        }
+        client = S3DataLakeClient(container_name="bucket", s3_client=s3_client)
+
+        data_lake_file = client.create_data_lake_file_from_uri("s3://bucket/docs/small.pdf")
+
+        assert data_lake_file.metadata == {"namespace": "docs"}
+
+
+class TestCreateDataLakeFilesFromUris:
+    @patch(NAMESPACE_PATCH_TARGET, return_value="docs")
+    def test_namespace_is_resolved_once_per_directory(self, namespace: MagicMock) -> None:
+        """The removal job loads the whole corpus at once, where a per-file namespace lookup costs
+        as much as it did in the observation."""
+        client = S3DataLakeClient(container_name="bucket", s3_client=_make_s3_client(PLAIN_MD5_ETAG))
+
+        files = client.create_data_lake_files_from_uris([f"s3://bucket/docs/file{index}.pdf" for index in range(25)])
+
+        assert len(files) == 25
+        assert namespace.call_count == 1

--- a/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/consumed_event_batch.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/consumed_event_batch.py
@@ -11,12 +11,10 @@ _FETCH_SIZE = 100
 _FETCH_TIMEOUT_SECONDS = 1.0
 
 # Messages are held unacknowledged until the tick decides, so the drain must finish well inside the
-# consumer's ack deadline (30 s by JetStream default, which JSPoller does not override). The server
-# already bounds this: max_ack_pending defaults to 1000, so a fetch returns empty once that many are
-# outstanding and the loop ends after ~1 s. This cap only removes the dependency on that default —
-# raising max_ack_pending would otherwise let a drain run long enough for its earliest messages to
-# redeliver into the same loop. A leftover backlog is harmless: single-flight bounds runs anyway and
-# the next tick collects it.
+# consumer's ack deadline (30 s by JetStream default, which JSPoller does not override) and inside
+# the 60 s deadline the Dagster daemon puts on a sensor evaluation. Stopping on a short fetch is
+# what bounds the loop; max_ack_pending (1000 by default) caps how much one drain can hold, so this
+# is only a backstop for a deployment that raises it.
 _MAX_DRAIN_MESSAGES = 5_000
 
 
@@ -33,28 +31,33 @@ class ConsumedEventBatch(BaseModel):
 
     @classmethod
     async def drain(cls, poller: Annotated[JSPoller, "Poller for this pipeline's event stream"]) -> Self:
-        """Fetches until a fetch comes back empty, rather than taking a single batch.
+        """Fetches until a fetch comes back short of the batch size, rather than taking a single one.
 
         One fetch per tick caps intake at the batch size per minute, which is what stretches a bulk
-        upload into one sensor tick per ten files.
+        upload into one sensor tick per ten files. A short fetch means the stream had nothing more
+        immediately available, so it is the signal that this tick has caught up. Waiting for a fetch
+        to come back completely empty is not: while an upload is still running the stream is never
+        empty, and the loop would follow the producer until the tick blew its deadline. Leftovers are
+        harmless — single-flight bounds the run count, and an observation scans the whole bucket
+        regardless of which events triggered it.
         """
         messages: list[PolledMessage] = []
 
         while True:
-            fetch_had_messages = False
+            fetched = 0
             async for polled_message in poller.poll(batch_size=_FETCH_SIZE, timeout=_FETCH_TIMEOUT_SECONDS):
-                fetch_had_messages = True
+                fetched += 1
                 if isinstance(polled_message.event, SourceUpdatedEvent):
                     messages.append(polled_message)
                     continue
                 logger.warning(f"Unexpected event type: {type(polled_message.event)}")
                 await polled_message.nak()
 
-            if len(messages) >= _MAX_DRAIN_MESSAGES:
-                logger.info(f"Stopping drain at {len(messages)} events; the rest is collected next tick.")
+            if fetched < _FETCH_SIZE:
                 return cls(messages=messages)
 
-            if not fetch_had_messages:
+            if len(messages) >= _MAX_DRAIN_MESSAGES:
+                logger.info(f"Stopping drain at {len(messages)} events; the rest is collected next tick.")
                 return cls(messages=messages)
 
     @property

--- a/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/consumed_event_batch.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/consumed_event_batch.py
@@ -1,0 +1,75 @@
+import logging
+from typing import Annotated, Self
+
+from pydantic import BaseModel, ConfigDict, Field
+from swiss_ai_hub.core.events.pipeline import SourceUpdatedEvent
+from swiss_ai_hub.core.polling import JSPoller, PolledMessage
+
+logger = logging.getLogger(__name__)
+
+_FETCH_SIZE = 100
+_FETCH_TIMEOUT_SECONDS = 1.0
+
+# Messages are held unacknowledged until the tick decides, so the drain must finish well inside the
+# consumer's ack deadline (30 s by JetStream default, which JSPoller does not override). The server
+# already bounds this: max_ack_pending defaults to 1000, so a fetch returns empty once that many are
+# outstanding and the loop ends after ~1 s. This cap only removes the dependency on that default —
+# raising max_ack_pending would otherwise let a drain run long enough for its earliest messages to
+# redeliver into the same loop. A leftover backlog is harmless: single-flight bounds runs anyway and
+# the next tick collects it.
+_MAX_DRAIN_MESSAGES = 5_000
+
+
+class ConsumedEventBatch(BaseModel):
+    """The events drained from JetStream in one sensor tick, still unacknowledged.
+
+    Acks are deferred until the sensor has decided what to do with the batch: acking first means a
+    tick that fails before requesting a run drops its trigger permanently.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    messages: list[PolledMessage] = Field(default_factory=list, description="Drained messages awaiting ack or nak")
+
+    @classmethod
+    async def drain(cls, poller: Annotated[JSPoller, "Poller for this pipeline's event stream"]) -> Self:
+        """Fetches until a fetch comes back empty, rather than taking a single batch.
+
+        One fetch per tick caps intake at the batch size per minute, which is what stretches a bulk
+        upload into one sensor tick per ten files.
+        """
+        messages: list[PolledMessage] = []
+
+        while True:
+            fetch_had_messages = False
+            async for polled_message in poller.poll(batch_size=_FETCH_SIZE, timeout=_FETCH_TIMEOUT_SECONDS):
+                fetch_had_messages = True
+                if isinstance(polled_message.event, SourceUpdatedEvent):
+                    messages.append(polled_message)
+                    continue
+                logger.warning(f"Unexpected event type: {type(polled_message.event)}")
+                await polled_message.nak()
+
+            if len(messages) >= _MAX_DRAIN_MESSAGES:
+                logger.info(f"Stopping drain at {len(messages)} events; the rest is collected next tick.")
+                return cls(messages=messages)
+
+            if not fetch_had_messages:
+                return cls(messages=messages)
+
+    @property
+    def count(self) -> int:
+        return len(self.messages)
+
+    @property
+    def max_sequence(self) -> int:
+        """Highest JetStream stream sequence in the batch, used to derive a stable run key."""
+        return max((message.sequence for message in self.messages), default=0)
+
+    async def ack_all(self) -> None:
+        for message in self.messages:
+            await message.ack()
+
+    async def nak_all(self) -> None:
+        for message in self.messages:
+            await message.nak()

--- a/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/nats_document_uploaded_sensor.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/nats_document_uploaded_sensor.py
@@ -1,36 +1,21 @@
 import asyncio
 import logging
+import time
 from typing import Annotated
 
-from dagster import DefaultSensorStatus, RunRequest, SensorEvaluationContext, sensor
+from dagster import DefaultSensorStatus, RunRequest, SensorEvaluationContext, SkipReason, sensor
 from dagster._core.definitions.target import ExecutableDefinition
-from swiss_ai_hub.core.events.pipeline import SourceUpdatedEvent
 from swiss_ai_hub.core.infrastructure import NatsSettings
 from swiss_ai_hub.core.polling import JSPoller
 from swiss_ai_hub.core.topic_managers import PipelineInstanceTopicManager
 
+from swiss_ai_hub.pipeline.sensors.nats.consumed_event_batch import ConsumedEventBatch
+from swiss_ai_hub.pipeline.sensors.nats.observation_run_decider import ObservationRunDecider
+from swiss_ai_hub.pipeline.sensors.nats.observation_run_history import ObservationRunHistory
+from swiss_ai_hub.pipeline.sensors.nats.observation_sensor_cursor import ObservationSensorCursor
+from swiss_ai_hub.pipeline.sensors.single_flight_run_guard import SingleFlightRunGuard
+
 logger = logging.getLogger(__name__)
-
-
-async def _consume_latest_event(poller: JSPoller) -> SourceUpdatedEvent | None:
-    """Drain the JetStream poller, acking valid `SourceUpdatedEvent`s.
-
-    Returns the most recent valid event (or None if none were found). Non-matching
-    event types and ack failures are negatively-acknowledged so JetStream redelivers.
-    """
-    latest_event: SourceUpdatedEvent | None = None
-    async for event, ack, nak in poller.poll(batch_size=10, timeout=1.0):
-        if not isinstance(event, SourceUpdatedEvent):
-            logger.warning(f"Unexpected event type: {type(event)}")
-            await nak()
-            continue
-        try:
-            latest_event = event
-            await ack()
-        except Exception as e:
-            logger.exception(f"Failed to process event: {e}")
-            await nak()
-    return latest_event
 
 
 def nats_document_uploaded_sensor(
@@ -40,8 +25,9 @@ def nats_document_uploaded_sensor(
     """
     Creates a Dagster sensor that polls NATS JetStream for SourceUpdatedEvent messages.
 
-    When documents are uploaded and validated, SourceUpdatedEvents are published to NATS.
-    This sensor polls for these events and triggers a single pipeline run to process all documents.
+    An observation scans the entire bucket, so a burst of uploads needs one run, not one per tick.
+    The sensor keeps at most one observation queued or running and re-arms itself through its
+    cursor whenever events arrive while a run is already in flight.
     """
 
     @sensor(
@@ -49,13 +35,70 @@ def nats_document_uploaded_sensor(
         minimum_interval_seconds=60,
         default_status=DefaultSensorStatus.RUNNING,
         name=f"NATSDocumentUploadedSensorFor_{job.name}",
-        description="Polls NATS JetStream for SourceUpdatedEvent messages and triggers a single pipeline run.",
+        description="Polls NATS JetStream for SourceUpdatedEvent messages and keeps one pipeline run in flight.",
     )
     def _nats_document_uploaded_sensor(context: SensorEvaluationContext):
         """Poll NATS JetStream for SourceUpdatedEvent messages and trigger a single pipeline run."""
 
-        async def check_for_events():
+        def decide(cursor: ObservationSensorCursor, batch: ConsumedEventBatch) -> RunRequest | SkipReason:
+            """Fold the drained batch into the cursor and decide what this tick should do."""
+            now = time.time()
+
+            if batch.count:
+                cursor.pending_events += batch.count
+                if cursor.first_pending_at is None:
+                    cursor.first_pending_at = now
+                cursor.max_sequence = max(cursor.max_sequence, batch.max_sequence)
+
+            in_flight = SingleFlightRunGuard.in_flight_run(context.instance, job.name)
+            if in_flight:
+                # A running observation cannot be trusted to have seen files that landed after it
+                # took its own snapshot of the bucket, so owe exactly one follow-up instead.
+                cursor.followup_armed = cursor.followup_armed or bool(batch.count)
+                return SkipReason(
+                    f"Observation run {in_flight.run_id} is already in flight ({in_flight.status.value})."
+                )
+
+            truncation_run_id = ObservationRunHistory.latest_truncating_run_id(context.instance, job.name)
+            requested_run_missing = bool(cursor.requested_run_key) and not ObservationRunHistory.run_exists_for_run_key(
+                context.instance, job.name, cursor.requested_run_key
+            )
+            reason = ObservationRunDecider.reason_to_request(
+                cursor=cursor,
+                now=now,
+                truncation_run_id=truncation_run_id,
+                requested_run_missing=requested_run_missing,
+            )
+            if not reason:
+                return SkipReason(f"Debouncing {cursor.pending_events} pending event(s).")
+
+            # Guard on the key itself, not on an empty batch: a batch whose sequences were all seen
+            # before leaves max_sequence unchanged too, which happens when the stream is recreated
+            # or restored and its sequence numbering restarts. Reusing the key we last requested
+            # would let Dagster's idempotence check drop the very run being re-armed.
+            pipeline_id = f"{topic_manager.source_id}_to_{topic_manager.target_id}"
+            run_key = f"{pipeline_id}_seq_{cursor.max_sequence}_r{cursor.rearm_count}"
+            if run_key == cursor.requested_run_key:
+                cursor.rearm_count += 1
+                run_key = f"{pipeline_id}_seq_{cursor.max_sequence}_r{cursor.rearm_count}"
+
+            cursor.pending_events = 0
+            cursor.first_pending_at = None
+            cursor.followup_armed = False
+            cursor.handled_truncation = truncation_run_id or cursor.handled_truncation
+            cursor.requested_run_key = run_key
+
+            logger.info(f"Requesting observation run {run_key}: {reason}")
+            return RunRequest(run_key=run_key)
+
+        async def evaluate() -> tuple[str, RunRequest | SkipReason]:
+            """Drain, decide and acknowledge on one connection.
+
+            Acking only once the outcome is settled means a tick that fails partway leaves the
+            events unacknowledged for JetStream to redeliver, rather than dropping the trigger.
+            """
             nc = None
+            batch = ConsumedEventBatch()
             try:
                 nc = await NatsSettings.create_client()
                 js = nc.jetstream()
@@ -70,25 +113,22 @@ def nats_document_uploaded_sensor(
                 await poller.ensure_stream_exists()
                 await poller.ensure_consumer_exists()
 
-                latest_event = await _consume_latest_event(poller)
-                if not latest_event:
-                    return []
+                batch = await ConsumedEventBatch.drain(poller)
 
-                run_key = (
-                    f"{topic_manager.source_id}_to_{topic_manager.target_id}_{context.last_tick_completion_time or 0}"
-                )
-                # As an observation request will find ALL uploaded/modified documents, we only need to request 1 run
-                return [RunRequest(run_key=run_key)]
+                cursor = ObservationSensorCursor.from_cursor(context.cursor)
+                result = decide(cursor, batch)
 
-            except Exception as e:
-                logger.exception(f"Error in NATS sensor: {e}")
-                return []
-
+                await batch.ack_all()
+                return cursor.model_dump_json(), result
+            except Exception:
+                await batch.nak_all()
+                raise
             finally:
                 if nc:
                     await nc.close()
 
-        run_requests = asyncio.run(check_for_events())
-        yield from run_requests
+        updated_cursor, result = asyncio.run(evaluate())
+        context.update_cursor(updated_cursor)
+        yield result
 
     return _nats_document_uploaded_sensor

--- a/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/nats_document_uploaded_sensor.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/nats_document_uploaded_sensor.py
@@ -43,50 +43,29 @@ def nats_document_uploaded_sensor(
         def decide(cursor: ObservationSensorCursor, batch: ConsumedEventBatch) -> RunRequest | SkipReason:
             """Fold the drained batch into the cursor and decide what this tick should do."""
             now = time.time()
-
-            if batch.count:
-                cursor.pending_events += batch.count
-                if cursor.first_pending_at is None:
-                    cursor.first_pending_at = now
-                cursor.max_sequence = max(cursor.max_sequence, batch.max_sequence)
+            cursor.absorb(batch, now)
 
             in_flight = SingleFlightRunGuard.in_flight_run(context.instance, job.name)
             if in_flight:
-                # A running observation cannot be trusted to have seen files that landed after it
-                # took its own snapshot of the bucket, so owe exactly one follow-up instead.
-                cursor.followup_armed = cursor.followup_armed or bool(batch.count)
+                cursor.arm_followup(batch)
                 return SkipReason(
                     f"Observation run {in_flight.run_id} is already in flight ({in_flight.status.value})."
                 )
 
             truncation_run_id = ObservationRunHistory.latest_truncating_run_id(context.instance, job.name)
-            requested_run_missing = bool(cursor.requested_run_key) and not ObservationRunHistory.run_exists_for_run_key(
-                context.instance, job.name, cursor.requested_run_key
-            )
             reason = ObservationRunDecider.reason_to_request(
                 cursor=cursor,
                 now=now,
                 truncation_run_id=truncation_run_id,
-                requested_run_missing=requested_run_missing,
+                requested_run_missing=ObservationRunHistory.requested_run_missing(
+                    context.instance, job.name, cursor.requested_run_key
+                ),
             )
             if not reason:
                 return SkipReason(f"Debouncing {cursor.pending_events} pending event(s).")
 
-            # Guard on the key itself, not on an empty batch: a batch whose sequences were all seen
-            # before leaves max_sequence unchanged too, which happens when the stream is recreated
-            # or restored and its sequence numbering restarts. Reusing the key we last requested
-            # would let Dagster's idempotence check drop the very run being re-armed.
-            pipeline_id = f"{topic_manager.source_id}_to_{topic_manager.target_id}"
-            run_key = f"{pipeline_id}_seq_{cursor.max_sequence}_r{cursor.rearm_count}"
-            if run_key == cursor.requested_run_key:
-                cursor.rearm_count += 1
-                run_key = f"{pipeline_id}_seq_{cursor.max_sequence}_r{cursor.rearm_count}"
-
-            cursor.pending_events = 0
-            cursor.first_pending_at = None
-            cursor.followup_armed = False
-            cursor.handled_truncation = truncation_run_id or cursor.handled_truncation
-            cursor.requested_run_key = run_key
+            run_key = cursor.next_run_key(f"{topic_manager.source_id}_to_{topic_manager.target_id}")
+            cursor.mark_requested(run_key, truncation_run_id)
 
             logger.info(f"Requesting observation run {run_key}: {reason}")
             return RunRequest(run_key=run_key)

--- a/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/observation_run_decider.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/observation_run_decider.py
@@ -1,0 +1,36 @@
+from typing import Annotated
+
+from swiss_ai_hub.pipeline.sensors.nats.observation_sensor_cursor import ObservationSensorCursor
+
+DEBOUNCE_SECONDS = 30
+
+
+class ObservationRunDecider:
+    """Decides whether a tick with no observation in flight should request one.
+
+    Kept free of NATS and Dagster so the branching can be tested directly. Firing eagerly is safe
+    because the single-flight guard, not this debounce, is what bounds the number of runs.
+    """
+
+    @staticmethod
+    def reason_to_request(
+        cursor: Annotated[ObservationSensorCursor, "State carried over from previous ticks"],
+        now: Annotated[float, "Current wall clock, injected so tests stay deterministic"],
+        truncation_run_id: Annotated[str | None, "Latest run that truncated the partition set, if any"],
+        requested_run_missing: Annotated[bool, "A previously requested run key never became a run"],
+    ) -> str | None:
+        """The reason to request a run, or None to keep waiting."""
+        if cursor.followup_armed:
+            return "events arrived while an observation was in flight"
+
+        if truncation_run_id and truncation_run_id != cursor.handled_truncation:
+            return f"run {truncation_run_id} truncated the partition set"
+
+        if requested_run_missing:
+            return f"requested run key {cursor.requested_run_key} never launched"
+
+        waited_long_enough = cursor.first_pending_at is not None and now - cursor.first_pending_at >= DEBOUNCE_SECONDS
+        if cursor.pending_events and waited_long_enough:
+            return f"{cursor.pending_events} event(s) waited {DEBOUNCE_SECONDS}s"
+
+        return None

--- a/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/observation_run_history.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/observation_run_history.py
@@ -33,6 +33,17 @@ class ObservationRunHistory:
         )
 
     @staticmethod
+    def requested_run_missing(
+        instance: Annotated[DagsterInstance, "Instance whose run records are queried"],
+        job_name: Annotated[str, "Job the run key belongs to"],
+        run_key: Annotated[str | None, "Run key the previous tick requested, if it requested one"],
+    ) -> bool:
+        """Whether a run key was requested but never became a run, so the tick should ask again."""
+        if not run_key:
+            return False
+        return not ObservationRunHistory.run_exists_for_run_key(instance, job_name, run_key)
+
+    @staticmethod
     def latest_truncating_run_id(
         instance: Annotated[DagsterInstance, "Instance whose run records are queried"],
         job_name: Annotated[str, "Observation job to inspect"],

--- a/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/observation_run_history.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/observation_run_history.py
@@ -1,0 +1,49 @@
+from typing import Annotated
+
+from dagster import DagsterInstance, RunsFilter
+
+from swiss_ai_hub.pipeline.util.partition_utils import PARTITIONS_TRUNCATED_TAG
+
+_RUN_KEY_TAG = "dagster/run_key"
+
+
+class ObservationRunHistory:
+    """Reads facts about past observation runs that the sensor cannot hold in its own cursor.
+
+    A run executes in a different process from the sensor and cannot write the sensor's cursor, so
+    anything it needs to report travels back as a run tag.
+    """
+
+    @staticmethod
+    def run_exists_for_run_key(
+        instance: Annotated[DagsterInstance, "Instance whose run records are queried"],
+        job_name: Annotated[str, "Job the run key belongs to"],
+        run_key: Annotated[str, "Run key a previous tick requested"],
+    ) -> bool:
+        """Whether a requested run key ever became a run.
+
+        The daemon creates the run only after the sensor body returns, so a crash in that window
+        loses the request silently; the next tick uses this to notice and ask again.
+        """
+        return bool(
+            instance.get_run_records(
+                RunsFilter(job_name=job_name, tags={_RUN_KEY_TAG: run_key}),
+                limit=1,
+            )
+        )
+
+    @staticmethod
+    def latest_truncating_run_id(
+        instance: Annotated[DagsterInstance, "Instance whose run records are queried"],
+        job_name: Annotated[str, "Observation job to inspect"],
+    ) -> str | None:
+        """Run id of the most recent observation that hit the ``max_partitions`` cap.
+
+        Such a run only partitioned part of the corpus, so the sensor has to observe again rather
+        than wait for the nightly schedule.
+        """
+        run_records = instance.get_run_records(
+            RunsFilter(job_name=job_name, tags=PARTITIONS_TRUNCATED_TAG),
+            limit=1,
+        )
+        return run_records[0].dagster_run.run_id if run_records else None

--- a/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/observation_sensor_cursor.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/observation_sensor_cursor.py
@@ -2,6 +2,8 @@ from typing import Annotated, Self
 
 from pydantic import BaseModel, Field, ValidationError
 
+from swiss_ai_hub.pipeline.sensors.nats.consumed_event_batch import ConsumedEventBatch
+
 
 class ObservationSensorCursor(BaseModel):
     """State the observation sensor carries between ticks, serialized into Dagster's sensor cursor.
@@ -37,3 +39,44 @@ class ObservationSensorCursor(BaseModel):
             return cls.model_validate_json(cursor)
         except ValidationError:
             return cls()
+
+    def absorb(
+        self,
+        batch: Annotated[ConsumedEventBatch, "Events drained from JetStream this tick"],
+        now: Annotated[float, "Current wall clock, injected so tests stay deterministic"],
+    ) -> None:
+        """Folds a drained batch into the debounce state, starting the clock on the first event."""
+        if not batch.count:
+            return
+        self.pending_events += batch.count
+        if self.first_pending_at is None:
+            self.first_pending_at = now
+        self.max_sequence = max(self.max_sequence, batch.max_sequence)
+
+    def arm_followup(self, batch: Annotated[ConsumedEventBatch, "Events drained this tick"]) -> None:
+        """A run already in flight may have listed the bucket before these files landed, so it
+        cannot be trusted to cover them; owe exactly one follow-up instead."""
+        self.followup_armed = self.followup_armed or bool(batch.count)
+
+    def next_run_key(self, pipeline_id: Annotated[str, "Source-to-target identifier of the pipeline"]) -> str:
+        """Guards on the key itself, not on an empty batch: a batch whose sequences were all seen
+        before leaves ``max_sequence`` unchanged too, which happens when the stream is recreated or
+        restored and its sequence numbering restarts. Reusing the key last requested would let
+        Dagster's idempotence check drop the very run being re-armed."""
+        run_key = f"{pipeline_id}_seq_{self.max_sequence}_r{self.rearm_count}"
+        if run_key != self.requested_run_key:
+            return run_key
+        self.rearm_count += 1
+        return f"{pipeline_id}_seq_{self.max_sequence}_r{self.rearm_count}"
+
+    def mark_requested(
+        self,
+        run_key: Annotated[str, "Run key just handed to Dagster"],
+        truncation_run_id: Annotated[str | None, "Truncating run this request answers, if any"],
+    ) -> None:
+        """Clears the debounce state so the next tick starts from a clean slate."""
+        self.pending_events = 0
+        self.first_pending_at = None
+        self.followup_armed = False
+        self.handled_truncation = truncation_run_id or self.handled_truncation
+        self.requested_run_key = run_key

--- a/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/observation_sensor_cursor.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/observation_sensor_cursor.py
@@ -1,0 +1,39 @@
+from typing import Annotated, Self
+
+from pydantic import BaseModel, Field, ValidationError
+
+
+class ObservationSensorCursor(BaseModel):
+    """State the observation sensor carries between ticks, serialized into Dagster's sensor cursor.
+
+    Dagster gives a sensor one opaque string of memory. Everything the sensor cannot re-derive from
+    the event stream on the next tick lives here: how long a burst has been waiting, whether a
+    follow-up run is owed, and which truncating run it has already answered.
+    """
+
+    pending_events: Annotated[int, Field(description="Events waiting for a run to be requested")] = 0
+    first_pending_at: Annotated[
+        float | None, Field(description="When the oldest waiting event arrived; drives the debounce")
+    ] = None
+    max_sequence: Annotated[int, Field(description="Highest stream sequence seen, survives debounce holds")] = 0
+    requested_run_key: Annotated[
+        str | None, Field(description="Run key of the last request, to detect one the daemon never launched")
+    ] = None
+    followup_armed: Annotated[
+        bool, Field(description="Events arrived while a run was in flight, so one follow-up is owed")
+    ] = False
+    handled_truncation: Annotated[
+        str | None, Field(description="Run id of the truncating run already re-armed for")
+    ] = None
+    rearm_count: Annotated[int, Field(description="Distinguishes run keys of re-arms carrying no new events")] = 0
+
+    @classmethod
+    def from_cursor(cls, cursor: Annotated[str | None, "Raw cursor string Dagster persisted"]) -> Self:
+        """Falls back to empty state rather than raising, so a cursor written by an older
+        version of this model cannot wedge the sensor into permanent tick failures."""
+        if not cursor:
+            return cls()
+        try:
+            return cls.model_validate_json(cursor)
+        except ValidationError:
+            return cls()

--- a/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/tests/test_consumed_event_batch.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/tests/test_consumed_event_batch.py
@@ -1,4 +1,6 @@
+import asyncio
 from collections.abc import AsyncIterator
+from itertools import count
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -28,6 +30,19 @@ def _poller_yielding(fetches: list[list[MagicMock]]) -> MagicMock:
         current = remaining.pop(0) if remaining else []
         for message in current:
             yield message
+
+    poller.poll = _poll
+    return poller
+
+
+def _poller_never_running_dry(per_fetch: int) -> MagicMock:
+    """Mock poller whose fetches never come back empty, standing in for an upload still in flight."""
+    poller = MagicMock()
+    sequences = count(1)
+
+    async def _poll(*_args, **_kwargs) -> AsyncIterator[MagicMock]:
+        for _ in range(per_fetch):
+            yield _message(next(sequences))
 
     poller.poll = _poll
     return poller
@@ -71,6 +86,22 @@ class TestDrain:
         oversized = [[_message(seq) for seq in range(start, start + 1000)] for start in range(1, 20_000, 1000)]
 
         batch = await ConsumedEventBatch.drain(_poller_yielding(oversized))
+
+        assert batch.count == _MAX_DRAIN_MESSAGES
+
+    @pytest.mark.asyncio
+    async def test_short_fetch_ends_the_drain_while_a_producer_is_still_publishing(self) -> None:
+        """A bulk upload in progress keeps the stream non-empty, so stopping only on an empty fetch
+        would follow the producer until the tick blew the 60 s deadline Dagster puts on a sensor
+        evaluation — dropping the batch and its cursor with it."""
+        batch = await asyncio.wait_for(ConsumedEventBatch.drain(_poller_never_running_dry(5)), timeout=5.0)
+
+        assert batch.count == 5
+
+    @pytest.mark.asyncio
+    async def test_full_fetches_keep_draining_up_to_the_cap(self) -> None:
+        """A full fetch means more was waiting, so a real backlog still drains in one tick."""
+        batch = await asyncio.wait_for(ConsumedEventBatch.drain(_poller_never_running_dry(100)), timeout=30.0)
 
         assert batch.count == _MAX_DRAIN_MESSAGES
 

--- a/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/tests/test_consumed_event_batch.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/tests/test_consumed_event_batch.py
@@ -1,0 +1,105 @@
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from swiss_ai_hub.core.events.pipeline import SourceUpdatedEvent
+from swiss_ai_hub.core.polling import PolledMessage
+
+from swiss_ai_hub.pipeline.sensors.nats.consumed_event_batch import _MAX_DRAIN_MESSAGES, ConsumedEventBatch
+
+
+def _message(sequence: int, event: object | None = None) -> MagicMock:
+    """A stand-in for a polled message; ``spec`` keeps it an instance of ``PolledMessage`` so the
+    Pydantic model accepts it."""
+    message = MagicMock(spec=PolledMessage)
+    message.event = event if event is not None else SourceUpdatedEvent(path=f"docs/{sequence}.pdf")
+    message.sequence = sequence
+    message.ack = AsyncMock()
+    message.nak = AsyncMock()
+    return message
+
+
+def _poller_yielding(fetches: list[list[MagicMock]]) -> MagicMock:
+    """Mock poller replaying one list of messages per ``poll()`` call, then nothing."""
+    poller = MagicMock()
+    remaining = list(fetches)
+
+    async def _poll(*_args, **_kwargs) -> AsyncIterator[MagicMock]:
+        current = remaining.pop(0) if remaining else []
+        for message in current:
+            yield message
+
+    poller.poll = _poll
+    return poller
+
+
+class TestDrain:
+    @pytest.mark.asyncio
+    async def test_empty_stream_yields_empty_batch(self) -> None:
+        batch = await ConsumedEventBatch.drain(_poller_yielding([]))
+
+        assert batch.count == 0
+        assert batch.max_sequence == 0
+
+    @pytest.mark.asyncio
+    async def test_drains_across_fetches_until_one_comes_back_empty(self) -> None:
+        """A single fetch per tick is what stretches a bulk upload over many ticks; the whole
+        backlog has to drain within one tick."""
+        fetches = [[_message(sequence) for sequence in range(start, start + 100)] for start in (1, 101, 201)]
+
+        batch = await ConsumedEventBatch.drain(_poller_yielding(fetches))
+
+        assert batch.count == 300
+        assert batch.max_sequence == 300
+
+    @pytest.mark.asyncio
+    async def test_non_matching_event_type_is_naked_and_excluded(self) -> None:
+        wrong = _message(1, event=MagicMock(name="UnexpectedEventType"))
+        valid = _message(2)
+
+        batch = await ConsumedEventBatch.drain(_poller_yielding([[wrong, valid]]))
+
+        assert batch.count == 1
+        assert batch.max_sequence == 2
+        wrong.nak.assert_awaited_once()
+        wrong.ack.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_drain_stops_at_the_cap(self) -> None:
+        """Messages are held unacked until the tick decides, so the drain must finish well inside
+        the consumer's ack deadline. Leftovers are collected on the next tick."""
+        oversized = [[_message(seq) for seq in range(start, start + 1000)] for start in range(1, 20_000, 1000)]
+
+        batch = await ConsumedEventBatch.drain(_poller_yielding(oversized))
+
+        assert batch.count == _MAX_DRAIN_MESSAGES
+
+    @pytest.mark.asyncio
+    async def test_messages_are_not_acked_while_draining(self) -> None:
+        """Acks are deferred until the tick knows whether it will request a run."""
+        messages = [_message(1), _message(2)]
+
+        await ConsumedEventBatch.drain(_poller_yielding([messages]))
+
+        for message in messages:
+            message.ack.assert_not_awaited()
+
+
+class TestAcknowledgement:
+    @pytest.mark.asyncio
+    async def test_ack_all_acks_every_message(self) -> None:
+        messages = [_message(1), _message(2)]
+
+        await ConsumedEventBatch(messages=messages).ack_all()
+
+        for message in messages:
+            message.ack.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_nak_all_naks_every_message(self) -> None:
+        messages = [_message(1), _message(2)]
+
+        await ConsumedEventBatch(messages=messages).nak_all()
+
+        for message in messages:
+            message.nak.assert_awaited_once()

--- a/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/tests/test_nats_document_uploaded_sensor.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/tests/test_nats_document_uploaded_sensor.py
@@ -1,144 +1,366 @@
-from collections.abc import AsyncIterator
-from unittest.mock import AsyncMock, MagicMock
+import time
+from collections.abc import AsyncIterator, Iterator
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from dagster import DefaultSensorStatus, SensorDefinition, job, op
-from swiss_ai_hub.core.events.pipeline import SourceUpdatedEvent
-
-from swiss_ai_hub.pipeline.sensors.nats.nats_document_uploaded_sensor import (
-    _consume_latest_event,
-    nats_document_uploaded_sensor,
+from dagster import (
+    DagsterInstance,
+    DagsterRunStatus,
+    DefaultSensorStatus,
+    JobDefinition,
+    RunRequest,
+    SensorDefinition,
+    build_sensor_context,
+    job,
+    op,
 )
+from swiss_ai_hub.core.events.pipeline import SourceUpdatedEvent
+from swiss_ai_hub.core.polling import PolledMessage
+
+from swiss_ai_hub.pipeline.sensors.nats.nats_document_uploaded_sensor import nats_document_uploaded_sensor
+from swiss_ai_hub.pipeline.sensors.nats.observation_run_decider import DEBOUNCE_SECONDS
+from swiss_ai_hub.pipeline.sensors.nats.observation_sensor_cursor import ObservationSensorCursor
+from swiss_ai_hub.pipeline.util.partition_utils import PARTITIONS_TRUNCATED_TAG
+
+_MODULE = "swiss_ai_hub.pipeline.sensors.nats.nats_document_uploaded_sensor"
 
 
-def _poller_yielding(items: list[tuple]) -> MagicMock:
-    """Build a mock `JSPoller` whose ``poll(...)`` yields the given ``(event, ack, nak)`` tuples."""
+@op
+def _noop() -> None: ...
+
+
+@job
+def observation_job() -> None:
+    _noop()
+
+
+def _topic_manager() -> MagicMock:
+    topic_manager = MagicMock()
+    topic_manager.source_type = "datalake"
+    topic_manager.source_id = "bucket"
+    topic_manager.target_type = "knowledge"
+    topic_manager.target_id = "db"
+    topic_manager.get_stream.return_value = ("stream", "subject.>")
+    return topic_manager
+
+
+def _message(sequence: int) -> MagicMock:
+    message = MagicMock(spec=PolledMessage)
+    message.event = SourceUpdatedEvent(path=f"docs/{sequence}.pdf")
+    message.sequence = sequence
+    message.ack = AsyncMock()
+    message.nak = AsyncMock()
+    return message
+
+
+@contextmanager
+def _nats_yielding(messages: list[MagicMock]) -> Iterator[None]:
+    """Stub out the NATS connection and poller so only the sensor's decisions are exercised."""
+    remaining = [messages] if messages else []
+
+    async def _poll(*_args, **_kwargs) -> AsyncIterator[MagicMock]:
+        current = remaining.pop(0) if remaining else []
+        for message in current:
+            yield message
+
     poller = MagicMock()
-
-    async def _poll(*_args, **_kwargs) -> AsyncIterator[tuple]:
-        for item in items:
-            yield item
-
     poller.poll = _poll
-    return poller
+    poller.ensure_stream_exists = AsyncMock()
+    poller.ensure_consumer_exists = AsyncMock()
+
+    connection = MagicMock()
+    connection.jetstream = MagicMock(return_value=MagicMock())
+    connection.close = AsyncMock()
+
+    with (
+        patch(f"{_MODULE}.NatsSettings.create_client", new=AsyncMock(return_value=connection)),
+        patch(f"{_MODULE}.JSPoller", return_value=poller),
+    ):
+        yield
 
 
-class TestConsumeLatestEvent:
-    """Unit tests for the polling loop extracted out of ``check_for_events``."""
+def _evaluate(
+    sensor: SensorDefinition,
+    instance: DagsterInstance,
+    cursor: ObservationSensorCursor | None = None,
+    messages: list[MagicMock] | None = None,
+):
+    context = build_sensor_context(instance=instance, cursor=cursor.model_dump_json() if cursor else None)
+    with _nats_yielding(messages or []):
+        return sensor.evaluate_tick(context)
 
-    @pytest.mark.asyncio
-    async def test_empty_stream_returns_none(self) -> None:
-        poller = _poller_yielding([])
 
-        result = await _consume_latest_event(poller)
+def _start_run(instance: DagsterInstance, target: JobDefinition = observation_job) -> str:
+    """Seeds a STARTED run: QUEUED needs a remote job origin, and the guard treats both alike."""
+    return instance.create_run_for_job(target, status=DagsterRunStatus.STARTED).run_id
 
-        assert result is None
 
-    @pytest.mark.asyncio
-    async def test_single_event_returns_event_and_acks(self) -> None:
-        event = SourceUpdatedEvent(path="docs/a.pdf")
-        ack, nak = AsyncMock(), AsyncMock()
-        poller = _poller_yielding([(event, ack, nak)])
+def _launch_requested_run(instance: DagsterInstance, result) -> None:
+    """Stands in for the daemon, which turns a RunRequest into a run tagged with its run key.
 
-        result = await _consume_latest_event(poller)
-
-        assert result is event
-        ack.assert_awaited_once()
-        nak.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_multiple_events_returns_last_and_acks_all(self) -> None:
-        """When several valid events arrive, the helper returns the LAST one but acks them all."""
-        event_a = SourceUpdatedEvent(path="docs/a.pdf")
-        event_b = SourceUpdatedEvent(path="docs/b.pdf")
-        event_c = SourceUpdatedEvent(path="docs/c.pdf")
-        acks = [AsyncMock(), AsyncMock(), AsyncMock()]
-        naks = [AsyncMock(), AsyncMock(), AsyncMock()]
-        poller = _poller_yielding(list(zip([event_a, event_b, event_c], acks, naks, strict=True)))
-
-        result = await _consume_latest_event(poller)
-
-        assert result is event_c
-        for ack in acks:
-            ack.assert_awaited_once()
-        for nak in naks:
-            nak.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_non_matching_event_type_is_naked_and_skipped(self) -> None:
-        """An event that is NOT a ``SourceUpdatedEvent`` must be nak'd (no ack) and excluded from ``latest_event``."""
-        wrong_event = MagicMock(name="UnexpectedEventType")
-        ack, nak = AsyncMock(), AsyncMock()
-        poller = _poller_yielding([(wrong_event, ack, nak)])
-
-        result = await _consume_latest_event(poller)
-
-        assert result is None
-        ack.assert_not_awaited()
-        nak.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_mixed_events_returns_last_valid(self) -> None:
-        """An invalid event between two valid ones is nak'd; the last VALID event wins."""
-        valid_a = SourceUpdatedEvent(path="docs/a.pdf")
-        invalid = MagicMock(name="UnexpectedEventType")
-        valid_b = SourceUpdatedEvent(path="docs/b.pdf")
-        ack_a, ack_invalid, ack_b = AsyncMock(), AsyncMock(), AsyncMock()
-        nak_a, nak_invalid, nak_b = AsyncMock(), AsyncMock(), AsyncMock()
-        poller = _poller_yielding(
-            [
-                (valid_a, ack_a, nak_a),
-                (invalid, ack_invalid, nak_invalid),
-                (valid_b, ack_b, nak_b),
-            ]
+    Without this a later tick correctly notices the request never launched and asks again.
+    """
+    for run_request in result.run_requests:
+        run = instance.create_run_for_job(
+            observation_job,
+            status=DagsterRunStatus.STARTED,
+            tags={"dagster/run_key": run_request.run_key},
         )
-
-        result = await _consume_latest_event(poller)
-
-        assert result is valid_b
-        ack_a.assert_awaited_once()
-        ack_b.assert_awaited_once()
-        ack_invalid.assert_not_awaited()
-        nak_invalid.assert_awaited_once()
-        nak_a.assert_not_awaited()
-        nak_b.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_ack_failure_naks_and_continues(self) -> None:
-        """If ``ack()`` raises, the helper logs, nak()s, and keeps processing later events."""
-        event_a = SourceUpdatedEvent(path="docs/a.pdf")
-        event_b = SourceUpdatedEvent(path="docs/b.pdf")
-        ack_a = AsyncMock(side_effect=RuntimeError("ack failure"))
-        ack_b = AsyncMock()
-        nak_a, nak_b = AsyncMock(), AsyncMock()
-        poller = _poller_yielding([(event_a, ack_a, nak_a), (event_b, ack_b, nak_b)])
-
-        result = await _consume_latest_event(poller)
-
-        # event_b was the last successfully-handled event.
-        assert result is event_b
-        ack_a.assert_awaited_once()
-        nak_a.assert_awaited_once()  # nak'd after ack_a failed
-        ack_b.assert_awaited_once()
-        nak_b.assert_not_awaited()
+        instance.report_run_canceled(run)
 
 
-class TestNatsDocumentUploadedSensorFactory:
-    """Smoke tests for the public factory — verifies the returned Dagster sensor has correct metadata."""
+@pytest.fixture
+def sensor() -> SensorDefinition:
+    return nats_document_uploaded_sensor(observation_job, _topic_manager())
 
-    def test_returns_sensor_with_expected_metadata(self) -> None:
-        @op
-        def _noop() -> None: ...
 
-        @job
-        def my_pipeline_job() -> None:
-            _noop()
+@pytest.fixture
+def instance() -> Iterator[DagsterInstance]:
+    with DagsterInstance.ephemeral() as ephemeral:
+        yield ephemeral
 
-        topic_manager = MagicMock()
 
-        sensor = nats_document_uploaded_sensor(my_pipeline_job, topic_manager)
-
+class TestSensorMetadata:
+    def test_returns_sensor_with_expected_metadata(self, sensor: SensorDefinition) -> None:
         assert isinstance(sensor, SensorDefinition)
-        assert sensor.name == "NATSDocumentUploadedSensorFor_my_pipeline_job"
+        assert sensor.name == "NATSDocumentUploadedSensorFor_observation_job"
         assert sensor.default_status is DefaultSensorStatus.RUNNING
         assert sensor.minimum_interval_seconds == 60
+
+
+class TestSingleFlight:
+    def test_events_arriving_during_a_run_skip_and_arm_a_followup(
+        self, sensor: SensorDefinition, instance: DagsterInstance
+    ) -> None:
+        run_id = _start_run(instance)
+
+        result = _evaluate(sensor, instance, messages=[_message(1)])
+
+        assert not result.run_requests
+        assert run_id in result.skip_message
+        assert ObservationSensorCursor.from_cursor(result.cursor).followup_armed is True
+
+    def test_the_followup_is_requested_once_the_run_is_terminal(
+        self, sensor: SensorDefinition, instance: DagsterInstance
+    ) -> None:
+        """The snapshot-race guard: a file uploaded after a running observation listed the bucket
+        must not be dropped."""
+        run_id = _start_run(instance)
+        during = _evaluate(sensor, instance, messages=[_message(1)])
+        instance.report_run_canceled(instance.get_run_by_id(run_id))
+
+        after = _evaluate(sensor, instance, cursor=ObservationSensorCursor.from_cursor(during.cursor))
+
+        assert len(after.run_requests) == 1
+
+    def test_a_run_launched_by_hand_also_suppresses_the_sensor(
+        self, sensor: SensorDefinition, instance: DagsterInstance
+    ) -> None:
+        """The guard filters by job name, not by sensor, so manual runs count too."""
+        _start_run(instance)
+
+        result = _evaluate(sensor, instance, messages=[_message(1)])
+
+        assert not result.run_requests
+
+    def test_a_run_of_another_job_does_not_suppress_the_sensor(
+        self, sensor: SensorDefinition, instance: DagsterInstance
+    ) -> None:
+        @job
+        def unrelated_job() -> None:
+            _noop()
+
+        _start_run(instance, unrelated_job)
+        cursor = ObservationSensorCursor(pending_events=1, first_pending_at=0.0)
+
+        result = _evaluate(sensor, instance, cursor=cursor)
+
+        assert len(result.run_requests) == 1
+
+
+class TestDebounce:
+    def test_a_fresh_burst_is_held(self, sensor: SensorDefinition, instance: DagsterInstance) -> None:
+        result = _evaluate(sensor, instance, messages=[_message(1)])
+
+        assert not result.run_requests
+        assert ObservationSensorCursor.from_cursor(result.cursor).pending_events == 1
+
+    def test_a_whole_backlog_drains_into_one_request(self, sensor: SensorDefinition, instance: DagsterInstance) -> None:
+        """250 events in one tick must produce exactly one run, not one run per ten events."""
+        aged = ObservationSensorCursor(pending_events=1, first_pending_at=0.0)
+
+        result = _evaluate(sensor, instance, cursor=aged, messages=[_message(n) for n in range(1, 251)])
+
+        assert len(result.run_requests) == 1
+        assert ObservationSensorCursor.from_cursor(result.cursor).pending_events == 0
+
+    def test_events_are_acked_only_after_the_outcome_is_settled(
+        self, sensor: SensorDefinition, instance: DagsterInstance
+    ) -> None:
+        messages = [_message(1)]
+        aged = ObservationSensorCursor(pending_events=1, first_pending_at=0.0)
+
+        _evaluate(sensor, instance, cursor=aged, messages=messages)
+
+        messages[0].ack.assert_awaited_once()
+
+
+class TestRunKeys:
+    def test_run_key_is_derived_from_the_stream_sequence(
+        self, sensor: SensorDefinition, instance: DagsterInstance
+    ) -> None:
+        aged = ObservationSensorCursor(pending_events=1, first_pending_at=0.0)
+
+        result = _evaluate(sensor, instance, cursor=aged, messages=[_message(17)])
+
+        assert result.run_requests[0].run_key == "bucket_to_db_seq_17_r0"
+
+    def test_the_same_backlog_yields_a_key_dagster_would_deduplicate(
+        self, sensor: SensorDefinition, instance: DagsterInstance
+    ) -> None:
+        """Two ticks that saw the same events must not produce two distinct keys, so Dagster's own
+        idempotence check becomes a second line of defence rather than being defeated."""
+        aged = ObservationSensorCursor(pending_events=1, first_pending_at=0.0)
+
+        first = _evaluate(sensor, instance, cursor=aged, messages=[_message(5)])
+        second = _evaluate(sensor, instance, cursor=aged, messages=[_message(5)])
+
+        assert first.run_requests[0].run_key == second.run_requests[0].run_key
+
+    def test_a_batch_of_already_seen_sequences_gets_a_distinct_key(
+        self, sensor: SensorDefinition, instance: DagsterInstance
+    ) -> None:
+        """A recreated or restored stream restarts its sequence numbering, so a real batch can carry
+        sequences the cursor has already folded in. The key must still change, or Dagster's
+        idempotence check drops the run being re-armed and the trigger is lost silently."""
+        cursor = ObservationSensorCursor(
+            max_sequence=100,
+            requested_run_key="bucket_to_db_seq_100_r0",
+            followup_armed=True,
+        )
+        launched = instance.create_run_for_job(
+            observation_job,
+            status=DagsterRunStatus.STARTED,
+            tags={"dagster/run_key": "bucket_to_db_seq_100_r0"},
+        )
+        instance.report_run_canceled(launched)
+
+        result = _evaluate(sensor, instance, cursor=cursor, messages=[_message(50)])
+
+        assert result.run_requests[0].run_key != cursor.requested_run_key
+
+    def test_a_rearm_without_new_events_gets_a_distinct_key(
+        self, sensor: SensorDefinition, instance: DagsterInstance
+    ) -> None:
+        """A follow-up carrying no new events leaves the sequence unchanged, so the key must be
+        distinguished from the one already requested or Dagster discards the run being re-armed."""
+        cursor = ObservationSensorCursor(
+            max_sequence=5,
+            requested_run_key="bucket_to_db_seq_5_r0",
+            followup_armed=True,
+        )
+        launched = instance.create_run_for_job(
+            observation_job,
+            status=DagsterRunStatus.STARTED,
+            tags={"dagster/run_key": "bucket_to_db_seq_5_r0"},
+        )
+        instance.report_run_canceled(launched)
+
+        result = _evaluate(sensor, instance, cursor=cursor)
+
+        assert result.run_requests[0].run_key == "bucket_to_db_seq_5_r1"
+
+    def test_a_first_request_does_not_burn_a_rearm_counter(
+        self, sensor: SensorDefinition, instance: DagsterInstance
+    ) -> None:
+        """Nothing was requested before, so there is no key to collide with."""
+        aged = ObservationSensorCursor(pending_events=1, first_pending_at=0.0)
+
+        result = _evaluate(sensor, instance, cursor=aged, messages=[_message(5)])
+
+        assert result.run_requests[0].run_key == "bucket_to_db_seq_5_r0"
+
+
+class TestRecovery:
+    def test_a_requested_run_that_never_launched_is_requested_again(
+        self, sensor: SensorDefinition, instance: DagsterInstance
+    ) -> None:
+        """The daemon creates the run after the sensor returns, so a crash in that window would
+        otherwise strand the batch until the nightly schedule."""
+        cursor = ObservationSensorCursor(requested_run_key="bucket_to_db_seq_9_r0", max_sequence=9)
+
+        result = _evaluate(sensor, instance, cursor=cursor)
+
+        assert len(result.run_requests) == 1
+
+    def test_an_unparseable_cursor_does_not_wedge_the_sensor(
+        self, sensor: SensorDefinition, instance: DagsterInstance
+    ) -> None:
+        context = build_sensor_context(instance=instance, cursor="{not valid json")
+        with _nats_yielding([]):
+            result = sensor.evaluate_tick(context)
+
+        assert not result.run_requests
+
+
+class TestTruncationReArm:
+    def test_a_truncating_run_re_arms_the_sensor(self, sensor: SensorDefinition, instance: DagsterInstance) -> None:
+        """A run that hit max_partitions only observed part of the corpus, so single-flight must
+        not leave the remainder waiting for the nightly schedule."""
+        run_id = _start_run(instance)
+        instance.add_run_tags(run_id, PARTITIONS_TRUNCATED_TAG)
+        instance.report_run_canceled(instance.get_run_by_id(run_id))
+
+        result = _evaluate(sensor, instance)
+
+        assert len(result.run_requests) == 1
+        assert ObservationSensorCursor.from_cursor(result.cursor).handled_truncation == run_id
+
+    def test_the_same_truncating_run_does_not_re_arm_twice(
+        self, sensor: SensorDefinition, instance: DagsterInstance
+    ) -> None:
+        run_id = _start_run(instance)
+        instance.add_run_tags(run_id, PARTITIONS_TRUNCATED_TAG)
+        instance.report_run_canceled(instance.get_run_by_id(run_id))
+        first = _evaluate(sensor, instance)
+        _launch_requested_run(instance, first)
+
+        second = _evaluate(sensor, instance, cursor=ObservationSensorCursor.from_cursor(first.cursor))
+
+        assert not second.run_requests
+
+
+class TestFailureHandling:
+    def test_a_failing_tick_naks_the_batch_for_redelivery(
+        self, sensor: SensorDefinition, instance: DagsterInstance
+    ) -> None:
+        """Acking before the run is requested is what lets a failed tick drop its trigger."""
+        messages = [_message(1)]
+        context = build_sensor_context(instance=instance, cursor=None)
+
+        with (
+            _nats_yielding(messages),
+            patch.object(type(instance), "get_run_records", side_effect=RuntimeError("event log unavailable")),
+            pytest.raises(RuntimeError),
+        ):
+            list(sensor(context))
+
+        messages[0].nak.assert_awaited_once()
+        messages[0].ack.assert_not_awaited()
+
+
+class TestDebounceBoundary:
+    def test_a_burst_still_inside_the_debounce_is_held(
+        self, sensor: SensorDefinition, instance: DagsterInstance
+    ) -> None:
+        fresh = ObservationSensorCursor(pending_events=2, first_pending_at=time.time())
+
+        assert not _evaluate(sensor, instance, cursor=fresh).run_requests
+
+    def test_a_burst_older_than_the_debounce_fires(self, sensor: SensorDefinition, instance: DagsterInstance) -> None:
+        aged = ObservationSensorCursor(pending_events=2, first_pending_at=time.time() - DEBOUNCE_SECONDS)
+
+        result = _evaluate(sensor, instance, cursor=aged)
+
+        assert isinstance(result.run_requests[0], RunRequest)

--- a/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/tests/test_observation_run_decider.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/tests/test_observation_run_decider.py
@@ -1,0 +1,62 @@
+from swiss_ai_hub.pipeline.sensors.nats.observation_run_decider import DEBOUNCE_SECONDS, ObservationRunDecider
+from swiss_ai_hub.pipeline.sensors.nats.observation_sensor_cursor import ObservationSensorCursor
+
+_NOW = 1_700_000_000.0
+
+
+def _reason(cursor: ObservationSensorCursor, now: float = _NOW, **overrides) -> str | None:
+    return ObservationRunDecider.reason_to_request(
+        cursor=cursor,
+        now=now,
+        truncation_run_id=overrides.get("truncation_run_id"),
+        requested_run_missing=overrides.get("requested_run_missing", False),
+    )
+
+
+class TestDebounce:
+    def test_idle_cursor_requests_nothing(self) -> None:
+        assert _reason(ObservationSensorCursor()) is None
+
+    def test_events_younger_than_the_debounce_are_held(self) -> None:
+        cursor = ObservationSensorCursor(pending_events=3, first_pending_at=_NOW - (DEBOUNCE_SECONDS - 1))
+
+        assert _reason(cursor) is None
+
+    def test_events_older_than_the_debounce_are_requested(self) -> None:
+        cursor = ObservationSensorCursor(pending_events=3, first_pending_at=_NOW - DEBOUNCE_SECONDS)
+
+        assert _reason(cursor) is not None
+
+    def test_a_large_backlog_still_waits_for_the_debounce(self) -> None:
+        """Single-flight, not the debounce, is what bounds the run count, so there is no
+        pending-count escape hatch to trip here."""
+        cursor = ObservationSensorCursor(pending_events=5_000, first_pending_at=_NOW)
+
+        assert _reason(cursor) is None
+
+
+class TestReArmTriggers:
+    def test_followup_armed_requests_immediately(self) -> None:
+        """The snapshot-race guard: events seen while a run was in flight owe one follow-up,
+        regardless of how recently they arrived."""
+        cursor = ObservationSensorCursor(pending_events=1, first_pending_at=_NOW, followup_armed=True)
+
+        assert _reason(cursor) == "events arrived while an observation was in flight"
+
+    def test_unhandled_truncation_requests_a_run(self) -> None:
+        assert _reason(ObservationSensorCursor(), truncation_run_id="run-abc") is not None
+
+    def test_already_handled_truncation_does_not_request_again(self) -> None:
+        cursor = ObservationSensorCursor(handled_truncation="run-abc")
+
+        assert _reason(cursor, truncation_run_id="run-abc") is None
+
+    def test_a_newer_truncating_run_requests_again(self) -> None:
+        cursor = ObservationSensorCursor(handled_truncation="run-abc")
+
+        assert _reason(cursor, truncation_run_id="run-def") is not None
+
+    def test_requested_run_that_never_launched_is_requested_again(self) -> None:
+        cursor = ObservationSensorCursor(requested_run_key="bucket_to_db_seq_1_r0")
+
+        assert _reason(cursor, requested_run_missing=True) is not None

--- a/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/tests/test_observation_run_history.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/tests/test_observation_run_history.py
@@ -1,0 +1,69 @@
+from collections.abc import Iterator
+
+import pytest
+from dagster import DagsterInstance, DagsterRunStatus, job, op
+
+from swiss_ai_hub.pipeline.sensors.nats.observation_run_history import ObservationRunHistory
+from swiss_ai_hub.pipeline.util.partition_utils import PARTITIONS_TRUNCATED_TAG
+
+
+@op
+def _noop() -> None: ...
+
+
+@job
+def observation_job() -> None:
+    _noop()
+
+
+@pytest.fixture
+def instance() -> Iterator[DagsterInstance]:
+    with DagsterInstance.ephemeral() as ephemeral:
+        yield ephemeral
+
+
+def _finished_run(instance: DagsterInstance, tags: dict[str, str] | None = None) -> str:
+    run = instance.create_run_for_job(observation_job, status=DagsterRunStatus.STARTED, tags=tags)
+    instance.report_run_canceled(run)
+    return run.run_id
+
+
+class TestLatestTruncatingRunId:
+    def test_no_truncating_run_returns_none(self, instance: DagsterInstance) -> None:
+        _finished_run(instance)
+
+        assert ObservationRunHistory.latest_truncating_run_id(instance, observation_job.name) is None
+
+    def test_returns_the_truncating_run(self, instance: DagsterInstance) -> None:
+        run_id = _finished_run(instance, tags=PARTITIONS_TRUNCATED_TAG)
+
+        assert ObservationRunHistory.latest_truncating_run_id(instance, observation_job.name) == run_id
+
+    def test_returns_the_newest_of_several(self, instance: DagsterInstance) -> None:
+        """Regression guard for a silent failure mode: the sensor re-arms only when this run id
+        differs from the one its cursor already answered. If the oldest were returned instead, a
+        second truncation would never be answered and those documents would go unobserved.
+        """
+        run_ids = [_finished_run(instance, tags=PARTITIONS_TRUNCATED_TAG) for _ in range(3)]
+
+        assert ObservationRunHistory.latest_truncating_run_id(instance, observation_job.name) == run_ids[-1]
+
+    def test_ignores_other_jobs(self, instance: DagsterInstance) -> None:
+        @job
+        def unrelated_job() -> None:
+            _noop()
+
+        run = instance.create_run_for_job(unrelated_job, status=DagsterRunStatus.STARTED, tags=PARTITIONS_TRUNCATED_TAG)
+        instance.report_run_canceled(run)
+
+        assert ObservationRunHistory.latest_truncating_run_id(instance, observation_job.name) is None
+
+
+class TestRunExistsForRunKey:
+    def test_missing_run_key_is_reported_absent(self, instance: DagsterInstance) -> None:
+        assert ObservationRunHistory.run_exists_for_run_key(instance, observation_job.name, "never_launched") is False
+
+    def test_launched_run_key_is_found(self, instance: DagsterInstance) -> None:
+        _finished_run(instance, tags={"dagster/run_key": "bucket_to_db_seq_7_r0"})
+
+        assert ObservationRunHistory.run_exists_for_run_key(instance, observation_job.name, "bucket_to_db_seq_7_r0")

--- a/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/tests/test_observation_run_history.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/tests/test_observation_run_history.py
@@ -67,3 +67,21 @@ class TestRunExistsForRunKey:
         _finished_run(instance, tags={"dagster/run_key": "bucket_to_db_seq_7_r0"})
 
         assert ObservationRunHistory.run_exists_for_run_key(instance, observation_job.name, "bucket_to_db_seq_7_r0")
+
+
+class TestRequestedRunMissing:
+    def test_no_run_key_was_ever_requested(self, instance: DagsterInstance) -> None:
+        """A cursor that has never requested anything has nothing to re-request; without this the
+        first tick after a reset would fire on a run key it never asked for."""
+        assert ObservationRunHistory.requested_run_missing(instance, observation_job.name, None) is False
+
+    def test_requested_run_key_that_never_launched(self, instance: DagsterInstance) -> None:
+        assert ObservationRunHistory.requested_run_missing(instance, observation_job.name, "never_launched") is True
+
+    def test_requested_run_key_that_did_launch(self, instance: DagsterInstance) -> None:
+        _finished_run(instance, tags={"dagster/run_key": "bucket_to_db_seq_7_r0"})
+
+        assert (
+            ObservationRunHistory.requested_run_missing(instance, observation_job.name, "bucket_to_db_seq_7_r0")
+            is False
+        )

--- a/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/tests/test_observation_sensor_cursor.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/sensors/nats/tests/test_observation_sensor_cursor.py
@@ -1,0 +1,35 @@
+from swiss_ai_hub.pipeline.sensors.nats.observation_sensor_cursor import ObservationSensorCursor
+
+
+class TestFromCursor:
+    def test_missing_cursor_yields_empty_state(self) -> None:
+        cursor = ObservationSensorCursor.from_cursor(None)
+
+        assert cursor.pending_events == 0
+        assert cursor.first_pending_at is None
+        assert cursor.followup_armed is False
+        assert cursor.rearm_count == 0
+
+    def test_empty_cursor_yields_empty_state(self) -> None:
+        assert ObservationSensorCursor.from_cursor("") == ObservationSensorCursor()
+
+    def test_state_round_trips(self) -> None:
+        original = ObservationSensorCursor(
+            pending_events=7,
+            first_pending_at=1_700_000_000.0,
+            max_sequence=42,
+            requested_run_key="bucket_to_db_seq_42_r0",
+            followup_armed=True,
+            handled_truncation="run-abc",
+            rearm_count=3,
+        )
+
+        assert ObservationSensorCursor.from_cursor(original.model_dump_json()) == original
+
+    def test_unparseable_cursor_degrades_to_empty_state(self) -> None:
+        """A cursor written by an older version of the model must not wedge the sensor into
+        permanently failing ticks."""
+        assert ObservationSensorCursor.from_cursor("{not valid json") == ObservationSensorCursor()
+
+    def test_cursor_with_unknown_shape_degrades_to_empty_state(self) -> None:
+        assert ObservationSensorCursor.from_cursor('{"pending_events": "many"}') == ObservationSensorCursor()

--- a/packages/pipeline/swiss_ai_hub/pipeline/sensors/run_after_success_sensor.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/sensors/run_after_success_sensor.py
@@ -3,9 +3,13 @@ from dagster import (
     DefaultSensorStatus,
     JobDefinition,
     RunRequest,
+    RunStatusSensorContext,
     SensorDefinition,
+    SkipReason,
     run_status_sensor,
 )
+
+from swiss_ai_hub.pipeline.sensors.single_flight_run_guard import SingleFlightRunGuard
 
 
 def run_after_success_sensor(
@@ -31,7 +35,30 @@ def run_after_success_sensor(
         request_job=triggered_job,
         default_status=DefaultSensorStatus.RUNNING,
     )
-    def _sensor(_context) -> RunRequest:
-        return RunRequest()
+    def _sensor(context: RunStatusSensorContext) -> RunRequest | SkipReason:
+        """Skips only when the in-flight run demonstrably covers this observation.
+
+        The triggered job snapshots the corpus when it runs, so one that started *before* this
+        observation finished may not see what the observation just changed. Skipping on that would
+        drop the trigger for good — a run-status sensor advances past the record either way — and
+        leave deleted documents in the doc and vector stores until some later observation succeeds.
+        Keying the request on the observing run keeps retries idempotent.
+        """
+        in_flight = SingleFlightRunGuard.in_flight_run_record(context.instance, triggered_job.name)
+        observed = context.instance.get_run_record_by_id(context.dagster_run.run_id)
+
+        covers_this_observation = (
+            in_flight is not None
+            and in_flight.start_time is not None
+            and observed is not None
+            and observed.end_time is not None
+            and in_flight.start_time >= observed.end_time
+        )
+        if covers_this_observation:
+            return SkipReason(
+                f"{triggered_job.name} run {in_flight.dagster_run.run_id} started after this "
+                f"observation finished, so it already covers it."
+            )
+        return RunRequest(run_key=context.dagster_run.run_id)
 
     return _sensor

--- a/packages/pipeline/swiss_ai_hub/pipeline/sensors/single_flight_run_guard.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/sensors/single_flight_run_guard.py
@@ -1,0 +1,37 @@
+from typing import Annotated
+
+from dagster import DagsterInstance, DagsterRun, RunsFilter
+from dagster._core.storage.dagster_run import NOT_FINISHED_STATUSES, RunRecord
+
+
+class SingleFlightRunGuard:
+    """Keeps a sensor from requesting a run of a job that already has one queued or running.
+
+    The observation and removal jobs both compare the whole corpus, so a second concurrent run
+    repeats the work of the first while competing for the same global run slots.
+    """
+
+    @staticmethod
+    def in_flight_run_record(
+        instance: Annotated[DagsterInstance, "Instance whose run records are queried"],
+        job_name: Annotated[str, "Job to check for queued or running instances"],
+    ) -> RunRecord | None:
+        """The record rather than the run, for callers that need its timestamps.
+
+        Filtering by job name rather than by sensor means a manually launched run suppresses the
+        sensor too, which is the behaviour an operator expects.
+        """
+        run_records = instance.get_run_records(
+            RunsFilter(job_name=job_name, statuses=list(NOT_FINISHED_STATUSES)),
+            limit=1,
+        )
+        return run_records[0] if run_records else None
+
+    @staticmethod
+    def in_flight_run(
+        instance: Annotated[DagsterInstance, "Instance whose run records are queried"],
+        job_name: Annotated[str, "Job to check for queued or running instances"],
+    ) -> DagsterRun | None:
+        """Returns the most recent queued or running run of the job, whatever launched it."""
+        record = SingleFlightRunGuard.in_flight_run_record(instance, job_name)
+        return record.dagster_run if record else None

--- a/packages/pipeline/swiss_ai_hub/pipeline/sensors/tests/test_run_after_success_sensor.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/sensors/tests/test_run_after_success_sensor.py
@@ -1,0 +1,136 @@
+from collections.abc import Iterator
+
+import pytest
+from dagster import (
+    DagsterEvent,
+    DagsterEventType,
+    DagsterInstance,
+    DagsterRunStatus,
+    DefaultSensorStatus,
+    RunRequest,
+    SkipReason,
+    build_run_status_sensor_context,
+    job,
+    op,
+)
+
+from swiss_ai_hub.pipeline.sensors.run_after_success_sensor import run_after_success_sensor
+
+
+@op
+def _noop() -> None: ...
+
+
+@job
+def observe_job() -> None:
+    _noop()
+
+
+@job
+def remove_job() -> None:
+    _noop()
+
+
+@pytest.fixture
+def instance() -> Iterator[DagsterInstance]:
+    with DagsterInstance.ephemeral() as ephemeral:
+        yield ephemeral
+
+
+def _evaluate(instance: DagsterInstance, observing_run_id: str) -> RunRequest | SkipReason:
+    """Invokes the sensor body with a context standing in for a succeeded observation run."""
+    sensor = run_after_success_sensor(monitored_job=observe_job, triggered_job=remove_job)
+    dagster_run = instance.get_run_by_id(observing_run_id)
+    context = build_run_status_sensor_context(
+        sensor_name=sensor.name,
+        dagster_event=DagsterEvent(
+            event_type_value=DagsterEventType.RUN_SUCCESS.value,
+            job_name=observe_job.name,
+        ),
+        dagster_instance=instance,
+        dagster_run=dagster_run,
+    )
+    return sensor(context)
+
+
+def _started_removal(instance: DagsterInstance) -> str:
+    """A removal that is genuinely running: the RUN_START event is what populates ``start_time``."""
+    run = instance.create_run_for_job(remove_job, status=DagsterRunStatus.STARTED)
+    instance.report_dagster_event(
+        DagsterEvent(event_type_value=DagsterEventType.RUN_START.value, job_name=remove_job.name),
+        run_id=run.run_id,
+    )
+    return run.run_id
+
+
+def _succeeded_observation(instance: DagsterInstance) -> str:
+    run = instance.create_run_for_job(observe_job, status=DagsterRunStatus.STARTED)
+    instance.report_run_canceled(run)
+    return run.run_id
+
+
+class TestSensorMetadata:
+    def test_name_is_derived_from_both_jobs(self) -> None:
+        sensor = run_after_success_sensor(monitored_job=observe_job, triggered_job=remove_job)
+
+        assert sensor.name == "trigger_remove_job_after_observe_job"
+        assert sensor.default_status is DefaultSensorStatus.RUNNING
+
+    def test_explicit_name_wins(self) -> None:
+        sensor = run_after_success_sensor(monitored_job=observe_job, triggered_job=remove_job, name="custom")
+
+        assert sensor.name == "custom"
+
+
+class TestSingleFlight:
+    def test_requests_a_run_when_nothing_is_in_flight(self, instance: DagsterInstance) -> None:
+        observing_run_id = _succeeded_observation(instance)
+
+        result = _evaluate(instance, observing_run_id)
+
+        assert isinstance(result, RunRequest)
+
+    def test_run_key_is_the_observing_run_so_retries_deduplicate(self, instance: DagsterInstance) -> None:
+        observing_run_id = _succeeded_observation(instance)
+
+        result = _evaluate(instance, observing_run_id)
+
+        assert result.run_key == observing_run_id
+
+    def test_skips_when_the_in_flight_removal_started_after_this_observation(self, instance: DagsterInstance) -> None:
+        """A removal that began after the observation finished snapshots the converged corpus, so
+        it genuinely covers this observation."""
+        observing_run_id = _succeeded_observation(instance)
+        in_flight_id = _started_removal(instance)
+
+        result = _evaluate(instance, observing_run_id)
+
+        assert isinstance(result, SkipReason)
+        assert in_flight_id in result.skip_message
+
+    def test_requests_when_the_in_flight_removal_predates_this_observation(self, instance: DagsterInstance) -> None:
+        """Regression guard: the older removal may have listed the corpus before this observation
+        converged. Skipping would consume the trigger for good, leaving deleted documents in the
+        doc and vector stores until some later observation happens to succeed."""
+        _started_removal(instance)
+        observing_run_id = _succeeded_observation(instance)
+
+        result = _evaluate(instance, observing_run_id)
+
+        assert isinstance(result, RunRequest)
+        assert result.run_key == observing_run_id
+
+    def test_requests_when_the_in_flight_removal_has_no_start_time(self, instance: DagsterInstance) -> None:
+        """Queued but not yet started: without a start time the sensor cannot prove coverage, so it
+        requests rather than risk dropping the trigger."""
+        instance.create_run_for_job(remove_job, status=DagsterRunStatus.STARTED)
+        observing_run_id = _succeeded_observation(instance)
+
+        assert isinstance(_evaluate(instance, observing_run_id), RunRequest)
+
+    def test_an_in_flight_observation_does_not_block_the_removal(self, instance: DagsterInstance) -> None:
+        """The guard is scoped to the triggered job, not to every job in the code location."""
+        instance.create_run_for_job(observe_job, status=DagsterRunStatus.STARTED)
+        observing_run_id = _succeeded_observation(instance)
+
+        assert isinstance(_evaluate(instance, observing_run_id), RunRequest)

--- a/packages/pipeline/swiss_ai_hub/pipeline/util/partition_utils.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/util/partition_utils.py
@@ -1,5 +1,7 @@
 from dagster import OpExecutionContext
 
+PARTITIONS_TRUNCATED_TAG = {"partitions-truncated": "true"}
+
 
 def replace_partition_keys(
     context: OpExecutionContext,
@@ -13,11 +15,23 @@ def replace_partition_keys(
     partitions_to_add = list(new_keys_set - old_partition_keys_set)
     partitions_to_delete = list(old_partition_keys_set - new_keys_set)
 
+    truncated_additions = max(len(partitions_to_add) - max_partitions, 0)
+    truncated_deletions = max(len(partitions_to_delete) - max_partitions, 0)
+
     if len(partitions_to_add) > max_partitions:
         partitions_to_add = partitions_to_add[:max_partitions]
 
     if len(partitions_to_delete) > max_partitions:
         partitions_to_delete = partitions_to_delete[:max_partitions]
+
+    if truncated_additions or truncated_deletions:
+        context.log.warning(
+            f"Truncated to max_partitions={max_partitions}: dropped {truncated_additions} addition(s) "
+            f"and {truncated_deletions} deletion(s). The partition set is incomplete until observed again."
+        )
+        # The sensor runs in another process and cannot read this run's state, so the fact that the
+        # partition set has not converged travels back to it as a run tag.
+        context.instance.add_run_tags(context.run_id, PARTITIONS_TRUNCATED_TAG)
 
     if partitions_to_add:
         context.instance.add_dynamic_partitions(

--- a/packages/pipeline/swiss_ai_hub/pipeline/util/tests/test_partition_utils.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/util/tests/test_partition_utils.py
@@ -1,0 +1,47 @@
+from unittest.mock import MagicMock
+
+from swiss_ai_hub.pipeline.util.partition_utils import PARTITIONS_TRUNCATED_TAG, replace_partition_keys
+
+_PARTITION_NAME = "bucket_document_partitions"
+
+
+def _context(existing_keys: list[str]) -> MagicMock:
+    context = MagicMock()
+    context.run_id = "run-abc"
+    context.instance.get_dynamic_partitions.return_value = existing_keys
+    return context
+
+
+class TestTruncationSignalling:
+    def test_a_batch_within_the_cap_is_not_tagged(self) -> None:
+        context = _context([])
+
+        replace_partition_keys(context, _PARTITION_NAME, [f"key{index}" for index in range(10)], max_partitions=10)
+
+        context.instance.add_run_tags.assert_not_called()
+        context.log.warning.assert_not_called()
+
+    def test_truncated_additions_tag_the_run(self) -> None:
+        """The sensor runs in another process and cannot read this run's state, so the fact that
+        the partition set did not converge has to travel back as a run tag."""
+        context = _context([])
+
+        replace_partition_keys(context, _PARTITION_NAME, [f"key{index}" for index in range(15)], max_partitions=10)
+
+        context.instance.add_run_tags.assert_called_once_with("run-abc", PARTITIONS_TRUNCATED_TAG)
+        context.log.warning.assert_called_once()
+
+    def test_truncated_deletions_tag_the_run(self) -> None:
+        context = _context([f"key{index}" for index in range(15)])
+
+        replace_partition_keys(context, _PARTITION_NAME, [], max_partitions=10)
+
+        context.instance.add_run_tags.assert_called_once_with("run-abc", PARTITIONS_TRUNCATED_TAG)
+
+    def test_additions_are_still_capped(self) -> None:
+        context = _context([])
+
+        replace_partition_keys(context, _PARTITION_NAME, [f"key{index}" for index in range(15)], max_partitions=10)
+
+        added = context.instance.add_dynamic_partitions.call_args.kwargs["partition_keys"]
+        assert len(added) == 10


### PR DESCRIPTION
## Summary

Bulk-uploading a knowledge base spent its run slots re-scanning the corpus instead of ingesting it. Three independent causes are fixed here: how *many* corpus scans a burst triggers, what *one* scan costs, and whether a scan that is requested ever gets a run slot.

Closes bbvch-ai/aihub-core-private#192. Complements #1797 (no overlap; only a non-conflicting `CLAUDE.md` neighbourhood).

## Changes

**Part A — one observation in flight** (sensors)

- `SingleFlightRunGuard` skips the tick when an observation is queued or running. Scoped per job name, so a manually launched run suppresses the sensor too. It never *cancels* or *queues* a run — the second request is simply never made.
- Events seen while a run is in flight arm exactly one follow-up via the sensor cursor (previously unused). A running observation may already have listed the bucket before those files landed, so skipping without re-arming would drop them until 02:00.
- The whole JetStream backlog drains per tick instead of one fetch of ten, bounded so messages are never held near the consumer's ack deadline. **The drain stops on a short fetch, not an empty one** — an upload still in flight keeps the stream non-empty, so waiting for empty made the loop follow the producer until the tick blew the 60s deadline Dagster puts on a sensor evaluation, dropping the batch and its cursor with it.
- Run keys derive from the highest stream sequence plus a counter that advances whenever the key would repeat the one already requested — so Dagster's deduplication is a second line of defence rather than a way to silently drop a re-armed run.
- Acks happen only once the outcome is settled; a failed tick leaves events for JetStream to redeliver.
- `replace_partition_keys` tags its own run when it hits `max_partitions`. A run cannot write its sensor's cursor, so non-convergence travels back as a run tag and the sensor re-arms until a run truncates nothing.
- `run_after_success_sensor` keys the removal on the observing run and skips only when the in-flight removal demonstrably started after this observation finished.

**Part B — one cheap observation** (S3 client / IO manager)

- `get_all_files` resolves each namespace once per directory and skips the per-object `head_object`. The lookup also *registers* the `NamespaceEntity` the knowledge UI and namespace-selection agent read, so the first file of each directory still reaches it.
- `get_file_by_uri` passes down the head response it already holds instead of fetching the same object twice.
- The unpartitioned `load_input` branch — the whole-corpus load `remove_documents` performs — batches through `create_data_lake_files_from_uris`.

**Part C — the observation actually gets a slot** (job factories)

`QueuedRunCoordinator` sorts the entire queue by `dagster/priority` before trimming to the dequeue batch, but every run defaults to `0`, which collapses that sort into plain FIFO. Parts A and B reduce observations to 1–2 per upload; this makes sure those survivors are not stranded behind the hundreds of per-document ingestion runs they just authorized. `observe_source_job` and `materialize_asset_job` now tag their runs `dagster/priority: "10"`.

Ordering only, **not reserved capacity** — no slot is ever held idle and ingestion still uses every slot when nothing else is waiting. Dagster cannot preempt a *running* run, so the wait becomes "one ingestion run" rather than zero. Only the sensor daemon and the scheduler apply a job's `run_tags`, which covers every automated launch path (NATS sensor, chaining sensor, daily schedule); a run launched through `DagsterGraphQLClient`, which passes its own tags, still lands at priority 0.

## Behaviour changes worth a reviewer's eye

1. **The sensor now fails a tick on error** instead of swallowing it and returning `[]`. Unacked events get redelivered; failures become visible in the Dagster UI.
2. **Orchestration runs outrank ingestion runs in the queue.** A long-running ingestion backlog no longer delays observation or removal, but any other job left at the default priority now sorts behind them.

## Test plan

- **Unit**: 138 tests pass in `packages/pipeline` (~49 new); `packages/core` 1391 pass. Lint and format clean.
- **DataVersion parity** — the highest-consequence risk, since a divergence would re-parse and re-embed the whole corpus. `list_objects_v2` and `head_object` return the same ETag and modification time; verified across ~10.5k objects on SeaweedFS including **30 chunked ETags** (the frozen `<md5hex>-<n>` branch), and pinned by a test on both halves of `{updated}-{hash}`. Dumping every DataVersion from both code versions over 1200 files: **0 differences**.
- **Truncation chain**, 1200 documents with `max_partitions=1000`, ingestion assets omitted so nothing hit MinerU:
  ```
  e2e192_source_observation: 2 runs {SUCCESS: 2}
  e2e192_remove_documents:   2 runs {SUCCESS: 2}
  runs tagged partitions-truncated: 1
  dynamic partitions now: 1200
  observation run keys: [seq_1200_r1, seq_1200_r0]
  ```
  Observation #1 dropped 200 additions and tagged its run, the sensor re-armed, observation #2 brought the partition set to a converged 1200. Those two run keys are the point — the re-arm carried no new events, so without the counter suffix Dagster would have deduplicated the second run away and 200 documents would never have been observed.
- **Live-producer drain**, 1200 documents uploaded through the real API while the daemon ran: 1200/1200 events consumed, **2 observation runs, 0 failed ticks, slowest tick 1.3s**. Against the stop-on-empty rule the same upload produced `TICK FAILURE 55.0s DagsterUserCodeUnreachableError` with the cursor frozen. A unit test pins the rule directly: a poller that never runs dry drains 5 messages instead of 5000.
- **Queue priority**, 400 documents through the real API → NATS → Dagster on the dev stack (`max_concurrent_runs: 2`):

  | observation | priority | ingestion runs queued ahead | overtook | wait for a slot |
  | --- | --- | --- | --- | --- |
  | sensor-launched | **10** | ~375 | 1 | **9.4s** |
  | chained removal | **10** | ~370 | 0 | **7.6s** |
  | control, launched into the same queue | 0 | ~380 | 0 | **still queued at 148s** |

  The control is the same job on the same instance a minute later, differing only in the tag — it was draining at ~2 runs per 14s, so ~43 minutes from the front. Pre-fix runs on the same machine, same instrument: one waited 250s and was overtaken by 19 of the 21 runs ahead of it; another never started at all behind 100. Throughout the test ingestion kept both slots busy (no idle slot) and 51 ingestion + 4 orchestration runs finished with **zero failures**.
- **Incremental change** (5 edited / 5 deleted / 5 added): one extra observation, deletions and additions both reflected, partition count steady at 1200, then five idle minutes with the run count frozen — it converges rather than re-arming forever.

## Known gaps

- The **truncation re-arm** path is covered by the scripted 1200-document run above but has not been exercised through the full API → NATS → daemon path, which needs 1000+ files present before any observation runs.
- The sensor's **ack/cursor window** remains: the code server acks, the daemon persists the cursor, and a tick failing between the two still drops its batch. The drain fix removes the common trigger rather than the structural gap; the 02:00 schedule is the backstop. Worth its own issue.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>`
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [ ] CLA signed
- [x] Tests added or updated where relevant
