### PR TITLE
fix(ci-cd): Wait for image builds before publishing the release bundle

### DIFF
--- a/.github/actions/dispatch_builds/action.yml
+++ b/.github/actions/dispatch_builds/action.yml
@@ -1,0 +1,90 @@
+---
+name: Dispatch Image Builds And Wait
+description: Dispatch the per-image build workflows at a release ref and block until
+  every dispatched run has finished successfully.
+# `gh workflow run` returns as soon as the dispatch is accepted, so a caller that
+# only dispatches has no idea whether the images exist yet. Anything downstream
+# that publishes a release bundle (which the deploy VMs fetch and immediately
+# `docker compose pull`) must not run before the tags are in the registry, or the
+# deploy fails with "not found" for whichever image was still building.
+#
+# The release ref is a unique version tag, so a workflow_dispatch run on it
+# belongs to this fan-out. Run ids seen BEFORE the dispatch are recorded so a
+# re-dispatch at an existing tag waits for its own run instead of returning the
+# previous one immediately.
+inputs:
+  workflows:
+    description: Newline-separated build workflow filenames to dispatch.
+    required: true
+  ref:
+    description: Git ref (release tag) to dispatch the workflows at.
+    required: true
+  release_version:
+    description: Value for the build workflows' release_version input.
+    required: true
+  secondary_tag:
+    description: 'Value for the build workflows'' secondary_tag input: nightly, staging,
+      latest, or empty.'
+    required: false
+    default: ''
+  github_token:
+    description: Token used for the dispatch and the run lookups (needs actions:write).
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Dispatch build workflows and wait for them
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        GH_REPO: ${{ github.repository }}
+        WORKFLOWS: ${{ inputs.workflows }}
+        REF: ${{ inputs.ref }}
+        RELEASE_VERSION: ${{ inputs.release_version }}
+        SECONDARY_TAG: ${{ inputs.secondary_tag }}
+      run: |-
+        set -euo pipefail
+
+        mapfile -t builds < <(printf '%s\n' "$WORKFLOWS" | sed '/^[[:space:]]*$/d')
+
+        newest_run() {
+          gh run list --workflow "$1" --branch "$REF" --event workflow_dispatch \
+            --limit 1 --json databaseId --jq '.[0].databaseId // empty'
+        }
+
+        declare -A previous_run
+        for wf in "${builds[@]}"; do
+          previous_run["$wf"]="$(newest_run "$wf")"
+        done
+
+        for wf in "${builds[@]}"; do
+          echo "Dispatching $wf @ $REF (secondary_tag='${SECONDARY_TAG}')"
+          gh workflow run "$wf" --ref "$REF" \
+            -f release_version="$RELEASE_VERSION" -f secondary_tag="$SECONDARY_TAG"
+        done
+
+        # The API needs a moment to materialise a run for an accepted dispatch;
+        # poll for a run id that is not the one seen before dispatching.
+        for wf in "${builds[@]}"; do
+          run_id=""
+          for _ in $(seq 1 40); do
+            candidate="$(newest_run "$wf")"
+            if [ -n "$candidate" ] && [ "$candidate" != "${previous_run["$wf"]}" ]; then
+              run_id="$candidate"
+              break
+            fi
+            sleep 5
+          done
+          if [ -z "$run_id" ]; then
+            echo "::error::No workflow_dispatch run appeared for $wf @ $REF."
+            exit 1
+          fi
+          echo "Waiting for $wf: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$run_id"
+          if ! gh run watch "$run_id" --interval 15 --exit-status >/dev/null; then
+            echo "::error::$wf did not succeed: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$run_id"
+            exit 1
+          fi
+          echo "✅ $wf finished"
+        done
+
+        echo "All ${#builds[@]} image builds succeeded at $REF."

--- a/.github/workflows/build-rc.yml
+++ b/.github/workflows/build-rc.yml
@@ -8,7 +8,8 @@
 #                 cut the immutable tag vX.Y.Z-rc.N, move the rolling `staging`
 #                 pointer to it, and work out the changelog base ref.
 #   2. fan-out  - dispatch the per-image build-*.yml at the rc tag, tagging
-#                 images vX.Y.Z-rc.N and the rolling :staging.
+#                 images vX.Y.Z-rc.N and the rolling :staging, and WAIT for all
+#                 of them: step 3 must not run before the images are pushed.
 #   3. publish  - create-release.yml (channel=staging): refresh the rolling
 #                 `staging` bundle the QC VM fetches AND publish the immutable,
 #                 preserved per-rc release "Swiss AI Hub vX.Y.Z-rc.N" + rc notes.
@@ -109,22 +110,22 @@ jobs:
           echo "notes_from=$notes_from" >> "$GITHUB_OUTPUT"
           echo "rc changelog base: ${notes_from:-<none>}"
   fan-out:
-    name: Dispatch image builds at the rc tag
+    name: Build images at the rc tag
     needs: rc-tag
     runs-on: ubuntu-slim
-    timeout-minutes: 5
+    # Waits for every dispatched build, so the timeout must cover the slowest
+    # image (build-agents allows 45 minutes per agent), not just the dispatch.
+    timeout-minutes: 75
     permissions:
       actions: write
       contents: read
     steps:
-      - name: Dispatch build workflows
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          VERSION: ${{ needs.rc-tag.outputs.version }}
-        run: |-
-          set -euo pipefail
-          BUILDS=(
+      - name: Checkout release branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Dispatch build workflows and wait for the images
+        uses: ./.github/actions/dispatch_builds
+        with:
+          workflows: |
             build-agents.yml
             build-pipelines.yml
             build-api-and-bot.yml
@@ -132,15 +133,16 @@ jobs:
             build-web.yml
             build-backup.yml
             build-sysadmin.yml
-          )
-          for wf in "${BUILDS[@]}"; do
-            echo "Dispatching $wf @ $VERSION"
-            gh workflow run "$wf" --ref "$VERSION" \
-              -f release_version="$VERSION" -f secondary_tag=staging
-          done
+          ref: ${{ needs.rc-tag.outputs.version }}
+          release_version: ${{ needs.rc-tag.outputs.version }}
+          secondary_tag: staging
+          github_token: ${{ secrets.GITHUB_TOKEN }}
   publish-rc-bundle:
     name: Publish rc release + refresh rolling staging
-    needs: rc-tag
+    # Gated on fan-out: the bundle is what the QC VM fetches before it pulls the
+    # images, so publishing it while a build is still running hands the deploy a
+    # tag that is not in the registry yet.
+    needs: [rc-tag, fan-out]
     uses: ./.github/workflows/create-release.yml
     with:
       release_version: ${{ needs.rc-tag.outputs.version }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -242,28 +242,32 @@ jobs:
     if: ${{ github.event.inputs.hotfix_branch != '' }}
     needs: resolve
     runs-on: ubuntu-slim
-    timeout-minutes: 5
+    # Waits for every dispatched build, so the timeout must cover the slowest
+    # image (build-agents allows 45 minutes per agent), not just the dispatch.
+    timeout-minutes: 75
     permissions:
       actions: write
       contents: read
     steps:
-      - name: Dispatch build workflows at the clean tag
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          VERSION: ${{ needs.resolve.outputs.clean }}
-          SECONDARY: ${{ needs.resolve.outputs.secondary_tag }}
-        run: |-
-          set -euo pipefail
-          BUILDS=(
-            build-agents.yml build-pipelines.yml build-api-and-bot.yml
-            build-dagster.yml build-web.yml build-backup.yml build-sysadmin.yml
-          )
-          for wf in "${BUILDS[@]}"; do
-            echo "Dispatching $wf @ $VERSION (secondary_tag='${SECONDARY}')"
-            gh workflow run "$wf" --ref "$VERSION" \
-              -f release_version="$VERSION" -f secondary_tag="$SECONDARY"
-          done
+      - name: Checkout at the clean tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ needs.resolve.outputs.clean }}
+      - name: Dispatch build workflows at the clean tag and wait
+        uses: ./.github/actions/dispatch_builds
+        with:
+          workflows: |
+            build-agents.yml
+            build-pipelines.yml
+            build-api-and-bot.yml
+            build-dagster.yml
+            build-web.yml
+            build-backup.yml
+            build-sysadmin.yml
+          ref: ${{ needs.resolve.outputs.clean }}
+          release_version: ${{ needs.resolve.outputs.clean }}
+          secondary_tag: ${{ needs.resolve.outputs.secondary_tag }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   # ---- shared tail: publish -> gated release -> move latest -------------------
   publish-npm:
@@ -282,16 +286,19 @@ jobs:
     secrets: inherit
   build-release:
     name: Publish versioned Release (atomic gate)
-    # Gated on BOTH registries green. In rc mode also waits for the image retag;
-    # in hotfix mode retag-clean-docker is skipped (images build async), matching
-    # the previous hotfix behaviour.
-    needs: [resolve, retag-clean-docker, publish-npm, publish-pypi]
+    # Gated on BOTH registries green AND on the images existing: rc mode waits
+    # for the retag, hotfix mode for the builds. Exactly one of the two runs per
+    # promote; the other is skipped. Publishing the release before the images are
+    # pushed hands the deploy VMs a bundle whose tags 404 in the registry.
+    needs: [resolve, retag-clean-docker, build-hotfix-images, publish-npm, publish-pypi]
     if: >-
       always()
       && needs.resolve.result == 'success'
       && needs.publish-npm.result == 'success'
       && needs.publish-pypi.result == 'success'
       && (needs.retag-clean-docker.result == 'success' || needs.retag-clean-docker.result
+      == 'skipped')
+      && (needs.build-hotfix-images.result == 'success' || needs.build-hotfix-images.result
       == 'skipped')
     uses: ./.github/workflows/create-release.yml
     with:
@@ -327,8 +334,8 @@ jobs:
 
   # hotfix: images already carry :latest (built with secondary_tag=latest), and
   # create-release(channel=latest) marks the Release Latest — so only the git
-  # `latest` pointer remains. Done inline (not set-latest.yml) to avoid racing its
-  # docker retag against the async hotfix image builds.
+  # `latest` pointer remains. Done inline (not set-latest.yml) because its docker
+  # retag would be redundant: the hotfix images were pushed with :latest already.
   move-latest-hotfix:
     name: Move latest (hotfix)
     if: >-


### PR DESCRIPTION
## Summary

The rc pipeline publishes the release bundle in parallel with the image builds, so the QC staging VM can fetch a bundle
whose image tags are not in the registry yet. On `v0.320.0-rc.1` the bundle was published at 02:39:44 UTC while
`build (email_classification_agent)` only finished pushing at 02:41:24 — the deploy in between failed with:

```
failed to resolve reference "ghcr.io/bbvch-ai/aihub-core/email_classification_agent:v0.320.0-rc.1": not found
```

All ten agent builds succeeded; nothing was actually broken, the bundle was just ~100 seconds early. The Ansible deploy
retries three times at 10s intervals and then alerts Slack/SigNoz, so every rc produces a spurious failure alert and a
deploy that only heals on the next 15-minute `infra-pull.timer` tick.

## Changes

- New composite action `.github/actions/dispatch_builds`: dispatches the per-image `build-*.yml` workflows at a release
  ref and blocks until every dispatched run has completed successfully. Run ids observed before the dispatch are
  recorded so a re-dispatch at an existing tag waits for its own run rather than returning the previous one.
- `build-rc.yml`: `fan-out` now waits for the builds (timeout raised 5 → 75 min to cover the slowest image), and
  `publish-rc-bundle` is gated on `needs: [rc-tag, fan-out]`.
- `promote.yml`: the hotfix path had the same gap — `build-hotfix-images` dispatched and returned, and `build-release`
  was gated only on npm/PyPI. It now waits, and `build-release` requires it (skip-tolerant, since exactly one of
  `retag-clean-docker` / `build-hotfix-images` runs per promote).

Not in this PR: the nightly flow in `add-tag.yml` has the same race (`publish-nightly-bundle` needs only `nightly-tag`),
but it fans out via the `release-ready` `repository_dispatch` that `deploy-docs.yml` also listens to. Closing it means
switching the seven build workflows off that event, which is a larger change and deserves its own review.

## Test plan

- `bash -n` on the composite action's script; all three YAML files parse.
- The run-lookup key was verified against the real failing release:
  `gh run list --workflow build-agents.yml --branch v0.320.0-rc.1 --event workflow_dispatch` returns exactly the one
  dispatched run, so `--branch <release tag>` uniquely identifies a fan-out run.
- End-to-end verification happens on the next rc: `fan-out` should stay green for the full build duration and
  `publish-rc-bundle` should start only after it.

Workflow changes on `main` only take effect for release lines cut after this merge — `release/0.320` keeps the old
`build-rc.yml` for its remaining rc builds.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>`
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [ ] CLA signed
- [x] Tests added or updated where relevant (workflow-only change; no test surface)
