### PR TITLE
fix(ci-cd): Gate the nightly bundle on completed image builds

### DIFF
--- a/.github/workflows/add-tag.yml
+++ b/.github/workflows/add-tag.yml
@@ -3,9 +3,10 @@
 # Nightly Tag & Build
 # =============================================================================
 # On every push to main (each merged PR), cut an immutable nightly tag and move
-# the rolling `nightly` pointer, dispatch the image builds and docs, and refresh
-# the single rolling `nightly` prerelease (the bundle the nightly VM fetches via
-# aihub-playbook roles/aihub_application/tasks/fetch.yml).
+# the rolling `nightly` pointer, build the images AT THAT TAG and wait for them,
+# dispatch the docs, and only then refresh the single rolling `nightly`
+# prerelease (the bundle the nightly VM fetches via aihub-playbook
+# roles/aihub_application/tasks/fetch.yml and immediately pulls the images of).
 # Lightweight trunk path: no version bump, no changelog, no versioned Release,
 # no npm/PyPI. create-release runs here in `nightly` (rolling) mode only.
 #
@@ -83,21 +84,51 @@ jobs:
           git tag -f -a nightly "$TARGET" -m "Release $VERSION"
           git push origin refs/tags/nightly --force
           echo "Tagged $TARGET as $VERSION and moved 'nightly'."
-  notify-release:
-    name: Dispatch build & bundle
+  build-images:
+    name: Build nightly images
     needs: nightly-tag
     # Skip when the tag already existed (e.g. a workflow re-run): the images for
-    # this nightly tag were already built and dispatched.
+    # this nightly tag were already built.
+    if: needs.nightly-tag.outputs.created == 'true'
+    runs-on: ubuntu-slim
+    # Waits for every dispatched build, so the timeout must cover the slowest
+    # image (build-agents allows 45 minutes per agent), not just the dispatch.
+    timeout-minutes: 75
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Dispatch build workflows and wait for the images
+        uses: ./.github/actions/dispatch_builds
+        with:
+          workflows: |
+            build-agents.yml
+            build-pipelines.yml
+            build-api-and-bot.yml
+            build-dagster.yml
+            build-web.yml
+            build-backup.yml
+            build-sysadmin.yml
+          ref: ${{ needs.nightly-tag.outputs.version }}
+          release_version: ${{ needs.nightly-tag.outputs.version }}
+          secondary_tag: nightly
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+  notify-docs:
+    name: Dispatch docs deploy
+    needs: nightly-tag
     if: needs.nightly-tag.outputs.created == 'true'
     runs-on: ubuntu-slim
     timeout-minutes: 5
     steps:
-      # `release-ready` is still a live event: every build-*.yml
-      # (repository_dispatch: [release-ready]) builds the nightly images with
-      # secondary_tag=nightly, and deploy-docs.yml publishes the docs. Only
-      # create-release.yml stopped listening (it is now workflow_call only).
-      # The rolling nightly bundle is handled by the publish-nightly-bundle job.
-      - name: Dispatch release-ready (nightly image builds + docs)
+      # `release-ready` now reaches deploy-docs.yml only: the build-*.yml
+      # workflows are dispatched at the nightly tag by build-images, so the
+      # bundle can be gated on them (a repository_dispatch run carries no ref to
+      # identify it by, and runs on main rather than on the tagged commit).
+      # create-release.yml stopped listening earlier (it is workflow_call only);
+      # the rolling nightly bundle is the publish-nightly-bundle job.
+      - name: Dispatch release-ready (docs)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.nightly-tag.outputs.version }}
@@ -107,7 +138,10 @@ jobs:
             -F "client_payload[release_version]=$VERSION"
   publish-nightly-bundle:
     name: Refresh rolling nightly prerelease
-    needs: nightly-tag
+    # Gated on build-images: the nightly VMs fetch this rolling bundle and pull
+    # its pinned tags straight away, so publishing it while an image is still
+    # building fails their deploy with an unresolvable reference.
+    needs: [nightly-tag, build-images]
     # Skip when the tag already existed (re-run): the pointer/bundle are current.
     if: needs.nightly-tag.outputs.created == 'true'
     uses: ./.github/workflows/create-release.yml

--- a/.github/workflows/build-agents.yml
+++ b/.github/workflows/build-agents.yml
@@ -1,9 +1,7 @@
 ---
 name: Build and Release Agents
-run-name: Build Agents - ${{ github.event.client_payload.release_version || github.event.inputs.release_version || 'manual' }}
+run-name: Build Agents - ${{ github.event.inputs.release_version || 'manual' }}
 on:
-  repository_dispatch:
-    types: [release-ready]
   workflow_dispatch:
     inputs:
       release_version:
@@ -25,9 +23,6 @@ jobs:
   discover-agents:
     runs-on: ubuntu-slim
     timeout-minutes: 5
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'repository_dispatch'
     outputs:
       matrix: ${{ steps.parse.outputs.matrix }}
     steps:
@@ -62,19 +57,10 @@ jobs:
         id: get_tag
         env:
           RELEASE_VERSION: ${{ github.event.inputs.release_version }}
-          CLIENT_PAYLOAD_VERSION: ${{ github.event.client_payload.release_version }}
         run: |
-          # 1) Prefer workflow_dispatch input
           if [ -n "$RELEASE_VERSION" ] && [ "$RELEASE_VERSION" != "manual" ]; then
             TAG_NAME="$RELEASE_VERSION"
             echo "Using release version from workflow_dispatch input: $TAG_NAME"
-
-          # 2) Then repository_dispatch client_payload
-          elif [ -n "$CLIENT_PAYLOAD_VERSION" ]; then
-            TAG_NAME="$CLIENT_PAYLOAD_VERSION"
-            echo "Using release version from repository_dispatch payload: $TAG_NAME"
-
-          # 3) No Fallback
           else
             echo "❌ No release_version provided. Failing."
             exit 1
@@ -90,7 +76,7 @@ jobs:
           context: .
           file: ./packages/agent/app/${{ matrix.image }}/Dockerfile
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          secondary_tag: ${{ github.event_name == 'repository_dispatch' && 'nightly' || github.event.inputs.secondary_tag }}
+          secondary_tag: ${{ github.event.inputs.secondary_tag }}
   # ---------------------------------------------------------------------------
   # Aggregate matrix results: fail the workflow if any agent build failed
   # ---------------------------------------------------------------------------

--- a/.github/workflows/build-api-and-bot.yml
+++ b/.github/workflows/build-api-and-bot.yml
@@ -1,9 +1,7 @@
 ---
 name: Build and Release Api and Bot Images
-run-name: Build API & Bot - ${{ github.event.client_payload.release_version || github.event.inputs.release_version || 'manual' }}
+run-name: Build API & Bot - ${{ github.event.inputs.release_version || 'manual' }}
 on:
-  repository_dispatch:
-    types: [release-ready]
   workflow_dispatch:
     inputs:
       release_version:
@@ -22,9 +20,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'repository_dispatch'
     strategy:
       matrix:
         image: [api, bot]
@@ -38,19 +33,10 @@ jobs:
         id: get_tag
         env:
           RELEASE_VERSION: ${{ github.event.inputs.release_version }}
-          CLIENT_PAYLOAD_VERSION: ${{ github.event.client_payload.release_version }}
         run: |
-          # 1) Prefer workflow_dispatch input
           if [ -n "$RELEASE_VERSION" ] && [ "$RELEASE_VERSION" != "manual" ]; then
             TAG_NAME="$RELEASE_VERSION"
             echo "Using release version from workflow_dispatch input: $TAG_NAME"
-
-          # 2) Then repository_dispatch client_payload
-          elif [ -n "$CLIENT_PAYLOAD_VERSION" ]; then
-            TAG_NAME="$CLIENT_PAYLOAD_VERSION"
-            echo "Using release version from repository_dispatch payload: $TAG_NAME"
-
-          # 3) No Fallback
           else
             echo "❌ No release_version provided. Failing."
             exit 1
@@ -66,4 +52,4 @@ jobs:
           context: .
           file: ./packages/${{ matrix.image }}/Dockerfile
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          secondary_tag: ${{ github.event_name == 'repository_dispatch' && 'nightly' || github.event.inputs.secondary_tag }}
+          secondary_tag: ${{ github.event.inputs.secondary_tag }}

--- a/.github/workflows/build-backup.yml
+++ b/.github/workflows/build-backup.yml
@@ -1,8 +1,6 @@
 ---
 name: Build and Release Backup Service Image
 on:
-  repository_dispatch:
-    types: [release-ready]
   workflow_dispatch:
     inputs:
       release_version:
@@ -21,9 +19,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'repository_dispatch'
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -33,19 +28,10 @@ jobs:
         id: get_tag
         env:
           RELEASE_VERSION: ${{ github.event.inputs.release_version }}
-          CLIENT_PAYLOAD_VERSION: ${{ github.event.client_payload.release_version }}
         run: |
-          # 1) Prefer workflow_dispatch input
           if [ -n "$RELEASE_VERSION" ] && [ "$RELEASE_VERSION" != "manual" ]; then
             TAG_NAME="$RELEASE_VERSION"
             echo "Using release version from workflow_dispatch input: $TAG_NAME"
-
-          # 2) Then repository_dispatch client_payload
-          elif [ -n "$CLIENT_PAYLOAD_VERSION" ]; then
-            TAG_NAME="$CLIENT_PAYLOAD_VERSION"
-            echo "Using release version from repository_dispatch payload: $TAG_NAME"
-
-          # 3) No Fallback
           else
             echo "No release_version provided. Failing."
             exit 1
@@ -61,4 +47,4 @@ jobs:
           context: .
           file: ./packages/backup/Dockerfile
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          secondary_tag: ${{ github.event_name == 'repository_dispatch' && 'nightly' || github.event.inputs.secondary_tag }}
+          secondary_tag: ${{ github.event.inputs.secondary_tag }}

--- a/.github/workflows/build-dagster.yml
+++ b/.github/workflows/build-dagster.yml
@@ -1,9 +1,7 @@
 ---
 name: Build and Release Dagster
-run-name: Build Dagster - ${{ github.event.client_payload.release_version || github.event.inputs.release_version || 'manual' }}
+run-name: Build Dagster - ${{ github.event.inputs.release_version || 'manual' }}
 on:
-  repository_dispatch:
-    types: [release-ready]
   workflow_dispatch:
     inputs:
       release_version:
@@ -22,9 +20,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'repository_dispatch'
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -34,19 +29,10 @@ jobs:
         id: get_tag
         env:
           RELEASE_VERSION: ${{ github.event.inputs.release_version }}
-          CLIENT_PAYLOAD_VERSION: ${{ github.event.client_payload.release_version }}
         run: |
-          # 1) Prefer workflow_dispatch input
           if [ -n "$RELEASE_VERSION" ] && [ "$RELEASE_VERSION" != "manual" ]; then
             TAG_NAME="$RELEASE_VERSION"
             echo "Using release version from workflow_dispatch input: $TAG_NAME"
-
-          # 2) Then repository_dispatch client_payload
-          elif [ -n "$CLIENT_PAYLOAD_VERSION" ]; then
-            TAG_NAME="$CLIENT_PAYLOAD_VERSION"
-            echo "Using release version from repository_dispatch payload: $TAG_NAME"
-
-          # 3) No Fallback
           else
             echo "❌ No release_version provided. Failing."
             exit 1
@@ -62,4 +48,4 @@ jobs:
           context: .
           file: ./packages/pipeline/Dockerfile
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          secondary_tag: ${{ github.event_name == 'repository_dispatch' && 'nightly' || github.event.inputs.secondary_tag }}
+          secondary_tag: ${{ github.event.inputs.secondary_tag }}

--- a/.github/workflows/build-pipelines.yml
+++ b/.github/workflows/build-pipelines.yml
@@ -1,9 +1,7 @@
 ---
 name: Build and Release Pipelines
-run-name: Build Pipelines - ${{ github.event.client_payload.release_version || github.event.inputs.release_version || 'manual' }}
+run-name: Build Pipelines - ${{ github.event.inputs.release_version || 'manual' }}
 on:
-  repository_dispatch:
-    types: [release-ready]
   workflow_dispatch:
     inputs:
       release_version:
@@ -25,9 +23,6 @@ jobs:
   discover-pipelines:
     runs-on: ubuntu-slim
     timeout-minutes: 5
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'repository_dispatch'
     outputs:
       matrix: ${{ steps.parse.outputs.matrix }}
     steps:
@@ -62,19 +57,10 @@ jobs:
         id: get_tag
         env:
           RELEASE_VERSION: ${{ github.event.inputs.release_version }}
-          CLIENT_PAYLOAD_VERSION: ${{ github.event.client_payload.release_version }}
         run: |
-          # 1) Prefer workflow_dispatch input
           if [ -n "$RELEASE_VERSION" ] && [ "$RELEASE_VERSION" != "manual" ]; then
             TAG_NAME="$RELEASE_VERSION"
             echo "Using release version from workflow_dispatch input: $TAG_NAME"
-
-          # 2) Then repository_dispatch client_payload
-          elif [ -n "$CLIENT_PAYLOAD_VERSION" ]; then
-            TAG_NAME="$CLIENT_PAYLOAD_VERSION"
-            echo "Using release version from repository_dispatch payload: $TAG_NAME"
-
-          # 3) No Fallback
           else
             echo "❌ No release_version provided. Failing."
             exit 1
@@ -90,4 +76,4 @@ jobs:
           context: .
           file: ./packages/pipeline/app/${{ matrix.image }}/Dockerfile
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          secondary_tag: ${{ github.event_name == 'repository_dispatch' && 'nightly' || github.event.inputs.secondary_tag }}
+          secondary_tag: ${{ github.event.inputs.secondary_tag }}

--- a/.github/workflows/build-sysadmin.yml
+++ b/.github/workflows/build-sysadmin.yml
@@ -1,9 +1,7 @@
 ---
 name: Build and Release Sysadmin Images
-run-name: Build Sysadmin - ${{ github.event.client_payload.release_version || github.event.inputs.release_version || 'manual' }}
+run-name: Build Sysadmin - ${{ github.event.inputs.release_version || 'manual' }}
 on:
-  repository_dispatch:
-    types: [release-ready]
   workflow_dispatch:
     inputs:
       release_version:
@@ -22,9 +20,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'repository_dispatch'
     strategy:
       matrix:
         image: [sysadmin-api, sysadmin-web]
@@ -38,19 +33,10 @@ jobs:
         id: get_tag
         env:
           INPUT_RELEASE_VERSION: ${{ github.event.inputs.release_version }}
-          PAYLOAD_RELEASE_VERSION: ${{ github.event.client_payload.release_version }}
         run: |
-          # 1) Prefer workflow_dispatch input
           if [ -n "$INPUT_RELEASE_VERSION" ] && [ "$INPUT_RELEASE_VERSION" != "manual" ]; then
             TAG_NAME="$INPUT_RELEASE_VERSION"
             echo "Using release version from workflow_dispatch input: $TAG_NAME"
-
-          # 2) Then repository_dispatch client_payload
-          elif [ -n "$PAYLOAD_RELEASE_VERSION" ]; then
-            TAG_NAME="$PAYLOAD_RELEASE_VERSION"
-            echo "Using release version from repository_dispatch payload: $TAG_NAME"
-
-          # 3) No Fallback
           else
             echo "❌ No release_version provided. Failing."
             exit 1
@@ -66,4 +52,4 @@ jobs:
           context: .
           file: ./packages/${{ matrix.image }}/Dockerfile
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          secondary_tag: ${{ github.event_name == 'repository_dispatch' && 'nightly' || github.event.inputs.secondary_tag }}
+          secondary_tag: ${{ github.event.inputs.secondary_tag }}

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -1,9 +1,7 @@
 ---
 name: Build and Release Web Image
-run-name: Build Web - ${{ github.event.client_payload.release_version || github.event.inputs.release_version || 'manual' }}
+run-name: Build Web - ${{ github.event.inputs.release_version || 'manual' }}
 on:
-  repository_dispatch:
-    types: [release-ready]
   workflow_dispatch:
     inputs:
       release_version:
@@ -22,9 +20,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'repository_dispatch'
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -34,19 +29,10 @@ jobs:
         id: get_tag
         env:
           RELEASE_VERSION: ${{ github.event.inputs.release_version }}
-          CLIENT_PAYLOAD_VERSION: ${{ github.event.client_payload.release_version }}
         run: |
-          # 1) Prefer workflow_dispatch input
           if [ -n "$RELEASE_VERSION" ] && [ "$RELEASE_VERSION" != "manual" ]; then
             TAG_NAME="$RELEASE_VERSION"
             echo "Using release version from workflow_dispatch input: $TAG_NAME"
-
-          # 2) Then repository_dispatch client_payload
-          elif [ -n "$CLIENT_PAYLOAD_VERSION" ]; then
-            TAG_NAME="$CLIENT_PAYLOAD_VERSION"
-            echo "Using release version from repository_dispatch payload: $TAG_NAME"
-
-          # 3) No Fallback
           else
             echo "❌ No release_version provided. Failing."
             exit 1
@@ -62,4 +48,4 @@ jobs:
           context: .
           file: ./packages/web/Dockerfile
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          secondary_tag: ${{ github.event_name == 'repository_dispatch' && 'nightly' || github.event.inputs.secondary_tag }}
+          secondary_tag: ${{ github.event.inputs.secondary_tag }}

--- a/docs/arc42/decisions/2026_08_31_gate_release_bundles_on_completed_image_builds.md
+++ b/docs/arc42/decisions/2026_08_31_gate_release_bundles_on_completed_image_builds.md
@@ -1,0 +1,67 @@
+# Gate Release Bundles on Completed Image Builds
+
+## Context
+
+Every release channel publishes a deployment bundle as a GitHub Release asset. The deploy VMs fetch that bundle on their
+15-minute `infra-pull` tick and immediately `docker compose pull` the version-pinned tags inside it. Until now the
+bundle was published in parallel with the image builds:
+
+- `build-rc.yml` dispatched the seven `build-*.yml` workflows and returned, while `publish-rc-bundle` depended only on
+  the tagging job.
+- `add-tag.yml` fired the `release-ready` `repository_dispatch` and returned, while `publish-nightly-bundle` depended
+  only on the tagging job.
+- `promote.yml` waited for the image retag in rc mode, but the hotfix path dispatched the builds and left
+  `build-release` gated on npm/PyPI alone.
+
+Whichever image finishes last therefore decides whether a deploy in that window succeeds. On `v0.320.0-rc.1` the bundle
+was published at 02:39:44 UTC and `email_classification_agent` finished pushing at 02:41:24; the staging deploy in
+between failed with `failed to resolve reference ...: not found`. Every build had succeeded — the bundle was simply
+~100 seconds early. The Ansible deploy retries three times at 10-second intervals and then alerts Slack and SigNoz, so
+the window produces a spurious failure alert and a stack that only updates on the next tick.
+
+Decision 3.1 of [the component-specific build pipeline ADR](2025_08_11_microservice_build_pipeline_architecture.md)
+chose `repository_dispatch` over `workflow_run` for chaining builds. That choice is what makes the nightly race
+unfixable in place: a `repository_dispatch` run carries no ref that identifies it, and it runs the workflow on the
+default branch rather than at the tagged commit, so the tagging workflow cannot tell which runs are its own and cannot
+wait for them.
+
+## Decision Drivers
+
+- *A published bundle must be deployable* — the deploy VMs treat the bundle as the signal that a version is ready.
+- *Real failures must stay visible* — a channel that cries wolf every build trains everyone to ignore its alerts.
+- *An image must match its tag* — a build triggered on the default branch can pick up a later commit than the one the
+  tag points at.
+- *One mechanism for all channels* — nightly, rc and hotfix should fail (or not) for the same reasons.
+
+## Decision
+
+Dispatch the per-image build workflows with `workflow_dispatch` **at the release ref**, and block the publishing job
+until every dispatched run has completed successfully.
+
+- A composite action, `.github/actions/dispatch_builds`, dispatches the workflows and waits on each run with
+  `gh run watch --exit-status`. The release ref is a unique version tag, so `--branch <tag> --event workflow_dispatch`
+  identifies a run of this fan-out; run ids seen before the dispatch are recorded so a re-dispatch at an existing tag
+  waits for its own run.
+- `build-rc.yml` (`publish-rc-bundle`), `add-tag.yml` (`publish-nightly-bundle`) and `promote.yml` (`build-release`, for
+  the hotfix path) declare the fan-out job in `needs`.
+- The seven `build-*.yml` workflows drop their `repository_dispatch: [release-ready]` trigger and the
+  `client_payload` / `event_name == 'repository_dispatch'` branches that only that trigger reached. This supersedes
+  Decision 3.1 of the 2025-08-11 ADR **for release image builds**.
+- `release-ready` remains as the trigger for `deploy-docs.yml`, which has no ordering constraint and legitimately wants
+  the payload version.
+
+## Consequences
+
+### Positive
+
+- A published bundle always has its images in the registry, so a deploy that fails on a missing tag is a real failure.
+- Nightly images are now built from the tagged commit instead of whatever `main` pointed at when the build started.
+- The three channels share one mechanism, so a fix or a diagnosis applies to all of them.
+
+### Negative
+
+- The bundle now lands roughly as late as the slowest image build (a few minutes) instead of immediately.
+- The publishing job's fate is tied to the builds: one failing image blocks the bundle for the whole channel. That is
+  the intent, but it makes a flaky build more disruptive than before.
+- The wait relies on `gh run watch`, so a workflow whose failure is masked (for example a matrix job with
+  `continue-on-error: true`) is still reported as a success to the gate.


### PR DESCRIPTION
## Summary

Stacked on #1801 — base is that PR's branch, so this diff is only the nightly change. Merge #1801 first.

`add-tag.yml` had the same publish-before-images race that #1801 fixed for release candidates: `notify-release` fired
the `release-ready` `repository_dispatch` and returned, while `publish-nightly-bundle` depended only on `nightly-tag`.
The nightly VMs fetch that rolling bundle and `docker compose pull` its pinned tags immediately, so any image still
building fails their deploy with `failed to resolve reference ...: not found` and alerts Slack/SigNoz — on every merge
to main, not just once per release.

It could not be closed in place: a `repository_dispatch` run carries no ref to identify it by, and it runs on the
default branch rather than at the tagged commit.

## Changes

- `add-tag.yml`: new `build-images` job dispatches the seven `build-*.yml` at the nightly tag via
  `.github/actions/dispatch_builds` (from #1801) and waits for them; `publish-nightly-bundle` is gated on it. The
  `release-ready` dispatch stays, reduced to what still needs it — `deploy-docs.yml`, which wants the payload version
  and has no ordering constraint. Job renamed `notify-docs`.
- The seven build workflows drop `repository_dispatch: [release-ready]` and the code only that trigger reached: the
  `client_payload` branch of `Extract Tag / Version`, the `github.event_name == 'repository_dispatch'` job guards, and
  the `&& 'nightly' ||` half of the `secondary_tag` expression. `publish-npm.yml` / `publish-pypi.yml` already dropped
  the trigger the same way, and nothing outside `add-tag.yml` fires the event.
- ADR `docs/arc42/decisions/2026_08_31_gate_release_bundles_on_completed_image_builds.md` — Decision 3.1 of the
  2025-08-11 build-pipeline ADR chose `repository_dispatch` for chaining builds, and this supersedes it for release
  image builds.

Side effect worth having: nightly images are now built from the tagged commit. Under `repository_dispatch` the build
checked out the default branch at build time, so a nightly image could contain commits its tag does not.

## Two things to weigh

**Throughput.** The workflow-level `nightly-tag` concurrency group is now held for the whole build (~5-8 min) instead
of ~1 min. GitHub keeps only one pending run per group, so during a burst of merges intermediate nightlies get
cancelled while pending — no tag, no bundle for those commits; the next merge tags a higher git height and the rolling
channel moves straight to it. I kept the group workflow-level on purpose: dropping it to the tag job would let two runs
race to publish the rolling bundle and move `nightly` backwards, which is worse than skipping intermediate builds.

**A gap this does not close.** `build-api-and-bot.yml` and `build-sysadmin.yml` set `continue-on-error: true` on their
matrix jobs and have no aggregation job, so a failed api/bot/sysadmin image still reports the run as successful and the
gate lets the bundle through. `build-agents.yml` gets this right with its `build-summary` job. Worth a follow-up for
both this PR and #1801.

## Test plan

- All eight workflow files parse; triggers verified as `workflow_dispatch` only on the seven builds, `push` on
  `add-tag.yml`.
- `deploy-docs.yml` still listens to `release-ready`, and `add-tag.yml` still fires it with the same payload.
- Grepped for remaining `release-ready` / `repository_dispatch` references: only `deploy-docs.yml`, the historical notes
  in `publish-npm.yml` / `publish-pypi.yml`, and `docs/CLAUDE.md`'s docs-deploy line, which stays accurate.
- End-to-end verification is the first merge to main after this lands: `build-images` should stay green for the build
  duration and `publish-nightly-bundle` should start only after it.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>`
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [ ] CLA signed
- [x] Tests added or updated where relevant (workflow-only change; no test surface)
