### PR TITLE
fix(swiss-ai-hub): Offload blocking event queries off the API event loop

### DIFF
--- a/packages/api/playground/testing/tests/event/test_event_timeseries_offload_api.py
+++ b/packages/api/playground/testing/tests/event/test_event_timeseries_offload_api.py
@@ -1,0 +1,54 @@
+import threading
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from asgi_lifespan import LifespanManager
+from httpx import ASGITransport, AsyncClient
+from swiss_ai_hub.core.persistence.messaging.entities.persisted_agent_event_entity import Resolution
+from swiss_ai_hub.core.persistence.messaging.entities.types.event_bucket import EventBucket
+from swiss_ai_hub.core.testing.auth_utils import TestAuthHandler
+
+from swiss_ai_hub.api.routes.event.event_controller import EventController
+from swiss_ai_hub.api.runners.api_test_runner import ApiTestRunner
+
+BASE_URL = "http://test"
+TIMESERIES_ENDPOINT = "/api/v1/active/events/agents/timeseries/365d"
+
+ENTITY_TIMESERIES = (
+    "swiss_ai_hub.core.persistence.messaging.entities.persisted_agent_event_entity"
+    ".PersistedAgentEventEntity.get_event_timeseries"
+)
+
+
+@pytest.mark.asyncio
+async def test_timeseries_aggregation_does_not_run_on_the_event_loop() -> None:
+    """The synchronous aggregation must be offloaded, or it stalls every concurrent request.
+
+    Regression guard for aihub-core-private#186: run on the event loop, an unfiltered aggregation
+    froze the loop for minutes, which pushed concurrent token-validation calls to Keycloak past
+    their timeout and failed valid logins with 500s. Asserting which thread ran the query rather
+    than timing the request keeps this deterministic.
+    """
+    ran_on_thread: list[int] = []
+
+    def fake_aggregation(**_kwargs: Any) -> tuple[list[EventBucket], datetime, datetime, Resolution]:
+        ran_on_thread.append(threading.get_ident())
+        now = datetime.now(UTC)
+        return [], now, now, Resolution.ONE_WEEK
+
+    runner = ApiTestRunner()
+    runner.mount(EventController(auth=TestAuthHandler()).get_agent_event_timeseries())
+    app = runner.create_app()
+
+    with patch(ENTITY_TIMESERIES, side_effect=fake_aggregation):
+        async with LifespanManager(app) as lifespan:
+            async with AsyncClient(transport=ASGITransport(app=lifespan.app), base_url=BASE_URL) as client:
+                response = await client.get(TIMESERIES_ENDPOINT)
+
+    assert response.status_code == 200, response.text
+    assert ran_on_thread, "the aggregation was never called"
+    assert ran_on_thread[0] != threading.get_ident(), (
+        "get_event_timeseries ran on the event loop thread; it must be offloaded via asyncio.to_thread"
+    )

--- a/packages/api/swiss_ai_hub/api/routes/event/event_controller.py
+++ b/packages/api/swiss_ai_hub/api/routes/event/event_controller.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from datetime import datetime
 from typing import Annotated, Self
@@ -80,7 +81,10 @@ class EventController(TenantScopedController):
                     detail=NO_THREAD_ACCESS_DETAIL,
                 )
 
-            return EventService.get_events_in_thread(
+            # Offloaded: reads and deserialises every display event in the thread, so its cost grows
+            # with conversation length. On the event loop that stalls every concurrent request.
+            return await asyncio.to_thread(
+                EventService.get_events_in_thread,
                 locale=t.locale,
                 thread_id=str_to_object_id(thread_id),
                 display_id=str_to_object_id(display_id) if display_id else None,
@@ -176,8 +180,16 @@ class EventController(TenantScopedController):
                         detail=NO_THREAD_ACCESS_DETAIL,
                     )
 
-            return EventService.get_event_timeseries(
-                time_range, agent_id=agent_id, agent_class=agent_class, event_name=event_name, thread_id=thread_id
+            # Offloaded: an unfiltered range aggregates the whole agent_events collection, which took
+            # minutes in production and, on the event loop, pushed concurrent token validation past
+            # its Keycloak timeout — failing valid logins with 500s (aihub-core-private#186).
+            return await asyncio.to_thread(
+                EventService.get_event_timeseries,
+                time_range,
+                agent_id=agent_id,
+                agent_class=agent_class,
+                event_name=event_name,
+                thread_id=thread_id,
             )
 
         return self


### PR DESCRIPTION
## Summary

Backports the event-loop offload fix from `release/0.319` (#1751) to `release/0.320`, which was cut
from `main` before the fix landed there and so never received it. Sysadmin logins were failing with
`500 Authentication error` because a synchronous MongoDB aggregation ran on the API's event loop and
starved concurrent Keycloak token validation past its timeout (bbvch-ai/aihub-core-private#186).

Cherry-pick of e4a4bd5d7bd8f5de1cfb418507f6e1e11c71683e. See #1751 for the full root-cause analysis.

## Changes

- `event_controller.py` — `get_agent_event_timeseries` and `get_agent_events_in_thread` now run
  their synchronous `EventService` calls via `asyncio.to_thread` instead of on the event loop.
- New regression test asserting the aggregation does not execute on the event loop thread.

## Why this was missing

`release/0.320` already carried the other two `release/0.319` fixes (#1742 and #1745) via `main`,
which had them as separate cherry-picks (#1748 and #1746) before the branch was cut. This one was
never applied to `main`, so `release/0.320` inherited the gap. Companion PR against `main`: #1806.

## Scope

This **contains the outage; it does not make the query faster.** The follow-ups listed in #1751
(aggregation cost and missing tenant filter, per-replica event duplication, thread-list N+1,
auth-path fragility) remain deliberately deferred.

## Test plan

- Cherry-pick applied with no conflict; the `get_llm_spend_by_user` / `get_llm_spend_by_tenant`
  endpoints and their imports are preserved intact. The resulting `event_controller.py` is
  byte-identical to the one on the `main` PR (#1806).
- `make test` in `packages/api`: 560 passed, 3 failed. The new regression test
  `test_event_timeseries_offload_api.py` passes.
- The 3 failures are pre-existing and unrelated — they fail identically on the unmodified
  `origin/release/0.320` base (`test_audio_chunking`, `test_bearer_api`, `test_memory_api`); they
  require the Docker dev stack and ffmpeg, which were not running locally. CI should confirm.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>`
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [x] Tests added or updated where relevant (regression test came with the cherry-pick)
