### PR TITLE
fix(swiss-ai-hub): Stop an org-memory allow-list from bricking an agent

### DIFF
--- a/docs/arc42/decisions/2026_08_07_agent_config_failures_surface_as_exception_events.md
+++ b/docs/arc42/decisions/2026_08_07_agent_config_failures_surface_as_exception_events.md
@@ -1,0 +1,86 @@
+# Agent Config Failures Surface as ExceptionEvents; Config Models Do Not Enforce Cross-Field Invariants
+
+## Status
+
+Accepted.
+
+## Context
+
+Issue #146 (aihub-core-private): an admin saved a RAG profile whose organization-memory `default_tenant_namespace`
+(`engineering`) was outside its `allowed_tenant_namespaces` (`test`, `default`). The Admin UI accepted the save. From
+then on the agent answered nothing — the chat hung on "The agent has received a message and is processing it", with no
+error anywhere the user could see.
+
+Three properties of the platform combined into that outage:
+
+1. `OrgMemoryWriteConfig` carried a Pydantic `model_validator` requiring the default to be a member of the allow-list.
+2. That rule **cannot** run at save time. Agent config schemas travel to the API as JSON Schema over NATS discovery
+   (`AgentConfigSpecs.from_agent_config` → `to_configurable_submission_model().model_json_schema()`), and the API
+   validates submissions against a model `jambo` rebuilds from that schema. JSON Schema cannot express a cross-field
+   Pydantic validator, so the constraint was silently dropped and the config was stored.
+3. `AgentDispatcher.handle_event` validates the whole agent config on **every** dispatched event, before any step runs.
+   The raise happened outside the per-step `try/except`, reached `JSSubscriber`, which only logs — and the message had
+   already been acked. No `ExceptionEvent` was published, so the run never terminated and never retried.
+
+The same shape applies to `AgentConfig.validate_locale_strings_have_content`: this was a class of bug, not one bug.
+
+## Decision Drivers
+
+- A saved config must never be able to render an agent permanently mute with no diagnostics.
+- The API cannot execute agent-side Pydantic validators without new machinery (an RPC round-trip that would also make
+  saving a config require the agent to be online).
+- An allow-list is a scoping control; silently widening it to swallow the inconsistency would be worse than failing.
+
+## Decision
+
+**1. A config model must not raise for an invariant that only some code paths depend on.** The
+`default_tenant_namespace` ∈ `allowed_tenant_namespaces` check is removed from `OrgMemoryWriteConfig`.
+`OrgMemoryNamespaceResolver.resolve_for_write` already enforces it — from inside a `@step`, where the dispatcher turns
+the failure into an `ExceptionEvent` the user sees, and only when a write actually resolves a disallowed namespace.
+Reads are unaffected: `resolve_for_search` scopes to the allow-list as before.
+
+Generally: enforce a config invariant at the point of use, not in `model_validate`, unless every code path using that
+config genuinely requires it. Config validation runs on the dispatch hot path for the whole agent; a raise there is not
+a validation error, it is an outage.
+
+**2. Config resolution failures are reported, not propagated.** `AgentDispatcher.handle_event` wraps config fetch, merge
+and validation, and publishes an `ExceptionEvent` on failure. This covers any future config-level validator, plus RPC
+and RunContext failures during resolution. `ExceptionEvent` is already terminal for the OpenAI-compatible stream and
+present in the WebSocket `DisplayEvents` union, so the hang becomes a visible error message.
+
+Terminal-event teardown sitting **above** config resolution is load-bearing for this, not cosmetic: teardown needs no
+config, and if the published `ExceptionEvent` had to pass the same validation on its way back in, it would hit the very
+error it reports and the run would never be retired. That ordering arrived independently with the redelivery fix
+(#1692), which needed it to make a redelivered terminal event idempotent; this decision depends on it and must not be
+reordered without reinstating it.
+
+**3. Admin-facing invariants are expressed as form rules.** A generic `memberOf` FormKit rule (registered in
+`packages/web/formkit.config.ts`) is attached to `default_tenant_namespace` via the existing
+`PrimeVueElement.additional_validation_rules` passthrough, so the admin sees the conflict inline while editing. FormKit
+2 tracks dependencies read through `node.at()` during rule execution, so the rule re-runs when the allow-list itself
+changes. This is **advisory**: it is client-side only, and the API still accepts a mismatch via direct REST, config
+import, or checked-in config templates. Nothing in the backend may depend on it.
+
+## Consequences
+
+**Positive**
+
+- No agent config can brick an agent silently; the worst case is a visible `ExceptionEvent` and a crashed run.
+- The reporter's configuration now chats normally. Only an org-memory *write* resolving a disallowed namespace fails,
+  and it fails with a clear message — affecting `ExpertAskingAgent`, the only agent that writes org memory.
+- Admins get immediate feedback in the form instead of discovering the conflict at write time.
+
+**Negative / risks**
+
+- A config inconsistency is no longer detectable by static validation of the stored document — it surfaces at write time
+  or in the form. Anything generating configs programmatically (templates, imports, seeders) is not guarded.
+- Config-resolution failures that used to escape (and be retried by nothing) now mark the run crashed. This is
+  intentional, but it means a transient RPC or Redis blip during resolution ends the run visibly rather than silently.
+- The `memberOf` rule is duplicated knowledge: the membership semantics live both in
+  `OrgMemoryNamespaceResolver.resolve_for_write` and in the frontend rule. They are allowed to drift only in the safe
+  direction (the form warns about something the backend permits).
+
+## Related
+
+- `2025_12_18_adopt_mem0_for_agent_memory` — organization-memory scoping this config drives.
+- Org-memory namespace overrides and allow-list: PR #1202; Milvus `in`-filter translation: PR #1548.

--- a/packages/agent/CLAUDE.md
+++ b/packages/agent/CLAUDE.md
@@ -272,6 +272,14 @@ These are `AfterValidator`s that skip validation when the value is a `FormkitEle
 6. **Injection**: `agent_config_type.model_validate(merged_dict)` reconstructs typed config in data mode. Injected into
    `@step()` methods that declare the `AgentConfig` subclass as a parameter.
 
+**This runs on every dispatched event, before any step.** So a config-level validation error is not a validation error —
+it stops the whole agent for that profile. The dispatcher reports it as an `ExceptionEvent` rather than letting it
+escape (see below), but the rule for config authors is: **do not raise in a config `model_validator` for an invariant
+only some code paths need.** Enforce it where it is used, inside a step, where the failure is scoped and visible. Note
+also that the API cannot run such validators at save time at all — it validates submissions against a JSON Schema
+rebuilt from the model, which cannot express cross-field rules — so a config violating one saves regardless. See ADR
+`2026_08_07_agent_config_failures_surface_as_exception_events`.
+
 ## AgentRunner & AgentDispatcher
 
 **AgentRunner**: Connects agent to infrastructure (NATS, JetStream, Redis, Milvus, MongoDB). Responds to discovery
@@ -291,7 +299,12 @@ await runner.run_forever()
 - Instantiates a fresh `agent()` for each step execution (stateless)
 - Publishes output events to JetStream (control) or NATS Core (display)
 - Checks idempotency: skips if step was already called with same input events
-- On `StopEvent`/`ExceptionEvent`: cleans up `RunContext`, marks completion
+- On `StopEvent`/`ExceptionEvent`: cleans up `RunContext`, marks completion. Handled **before** config resolution —
+  teardown needs no config, and the `ExceptionEvent` below would otherwise hit the same failure it reports and never
+  retire its run
+- If the config cannot be fetched, merged or validated: publishes an `ExceptionEvent` and aborts the run, so the chat
+  shows an error instead of hanging forever. The message carries field locations and reasons only — an agent config
+  holds credentials (e.g. `ImapClientConfig.password`) and this text reaches the user's chat
 
 ## Topic Hierarchy
 

--- a/packages/agent/playground/minimal_workflow/user_memory_workflow/tests/test_user_memory_agent.py
+++ b/packages/agent/playground/minimal_workflow/user_memory_workflow/tests/test_user_memory_agent.py
@@ -17,7 +17,7 @@ from swiss_ai_hub.core.events.agent import (
     StoreUserMemoryEvent,
     UserMessageEvent,
 )
-from swiss_ai_hub.core.generative_ai import LLMConfig
+from swiss_ai_hub.core.generative_ai import LLMConfig, UserMemory
 from swiss_ai_hub.core.i18n import LocaleHandler, LocaleString
 from swiss_ai_hub.core.infrastructure import enable_logging
 from swiss_ai_hub.core.testing import async_test
@@ -88,9 +88,16 @@ async def _(memory_text: str, agent_runner: AgentTestRunner):
 
 
 @given("no pre-seeded memories")
-def _():
-    """No action needed - just a documentation step."""
-    pass
+@async_test
+async def _():
+    """Clear the test user's memories so the scenario really starts from nothing.
+
+    The memory store is shared across runs and every scenario uses the same `fake_user()`. Once a run
+    has persisted the facts a scenario talks about, mem0's reconciliation call answers NONE for the
+    same input and the run stores nothing — so any assertion about newly added memories would pass
+    once and fail on every run after that.
+    """
+    await UserMemory(user=fake_user(), t=LocaleHandler(locale="en")).delete_all()
 
 
 # ============================================================================

--- a/packages/agent/playground/testing/tests/test_agent_dispatcher.py
+++ b/packages/agent/playground/testing/tests/test_agent_dispatcher.py
@@ -563,6 +563,23 @@ class TestAgentDispatcherHandleEvent:
                 )
 
     @pytest.mark.asyncio
+    async def test_terminal_event_tears_down_even_with_unusable_config(self, agent_dispatcher, agent_topic):
+        """Teardown must not depend on the config, or the ExceptionEvent above could never retire its own run."""
+        run_context = RunContext.for_topic(agent_dispatcher.redis, agent_topic)
+        await run_context.set("_agent_config", {"agent_id": "test_agent", "name": {}, "description": {}, "icon": "i"})
+        agent_dispatcher._non_configurable_values = {}
+        agent_dispatcher.publish_event = AsyncMock()
+
+        with patch("swiss_ai_hub.core.dispatcher.base_dispatcher.BaseDispatcher.handle_event", AsyncMock()):
+            await agent_dispatcher.handle_event(ExceptionEvent(message="Config was rejected"), agent_topic)
+
+        agent_dispatcher.step_store.mark_execution_context_as_crashed.assert_called_once_with(
+            agent_topic.execution_context_id
+        )
+        # Publishing here would re-enter this same failure and never converge.
+        agent_dispatcher.publish_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_handle_event_triggers_ready_steps(self, agent_dispatcher, agent_topic):
         """Test that handle_event triggers steps that are ready to execute."""
         # Arrange - agent_id comes from the topic, not the event
@@ -642,21 +659,26 @@ class TestAgentDispatcherHandleEvent:
             assert retrieved_config == stored_config
 
     @pytest.mark.asyncio
-    async def test_handle_event_raises_error_when_no_agent_config_found(self, agent_dispatcher, agent_topic):
-        """Test that handle_event raises ValueError when no agent config is found."""
+    async def test_handle_event_reports_missing_agent_config(self, agent_dispatcher, agent_topic):
+        """A run whose config was never stored is reported, not dropped on the floor."""
         # Arrange - Use a control event without any pre-stored config
         control_event = ControlEvent()
 
         # Ensure the context is empty (no config stored)
         run_context = RunContext.for_topic(agent_dispatcher.redis, agent_topic)
         await run_context.delete("_agent_config")  # Make sure no config exists
+        agent_dispatcher.publish_event = AsyncMock()
 
         with patch("swiss_ai_hub.core.dispatcher.base_dispatcher.BaseDispatcher.handle_event") as mock_base_handle:
             mock_base_handle.return_value = None
 
-            # Act & Assert - The real context should return None, causing the ValueError
-            with pytest.raises(ValueError, match="No agent config found"):
-                await agent_dispatcher.handle_event(control_event, agent_topic)
+            # Act
+            await agent_dispatcher.handle_event(control_event, agent_topic)
+
+        # Assert
+        published_event = agent_dispatcher.publish_event.await_args.args[0]
+        assert isinstance(published_event, ExceptionEvent)
+        assert "No agent config found" in published_event.message
 
     @pytest.mark.asyncio
     async def test_handle_event_stores_start_event_context_data(self, agent_dispatcher, agent_topic):
@@ -768,16 +790,22 @@ class TestAgentDispatcherErrorHandling:
 
     @pytest.mark.asyncio
     async def test_handle_event_with_invalid_agent_config_from_rpc(self, agent_dispatcher, agent_topic):
-        """Test handling of invalid agent config returned by RPC."""
-        # Arrange - agent_id comes from the topic, not the event
-        invalid_config: dict[str, Any] = {"invalid": "config"}
+        """A config the agent's own model rejects must surface, not vanish into the subscriber's logger.
+
+        The config is re-validated on every dispatched event, so letting this escape would hang the
+        whole run: the subscriber acked the message already and only logs what reaches it.
+        """
+        # Arrange - a real agent_config is form-mode and contributes no non-configurable values, so
+        # what the admin submitted is what gets validated. An empty name trips the locale validator.
+        invalid_config: dict[str, Any] = {"agent_id": "test_agent", "name": {}, "description": {}, "icon": "test-icon"}
         start_event = StartEvent()
 
-        # Mock the config client to return invalid config
+        agent_dispatcher._non_configurable_values = {}
         agent_dispatcher._config_client.fetch_config = AsyncMock(return_value=invalid_config)
 
         mock_run_context = Mock(spec=RunContext)
         mock_run_context.set = AsyncMock()
+        agent_dispatcher.publish_event = AsyncMock()
 
         with (
             patch(
@@ -787,13 +815,37 @@ class TestAgentDispatcherErrorHandling:
         ):
             mock_base_handle.return_value = None
 
-            # Act & Assert
-            with pytest.raises(Exception):  # This would be a pydantic validation error
-                await agent_dispatcher.handle_event(start_event, agent_topic)
+            # Act
+            await agent_dispatcher.handle_event(start_event, agent_topic)
+
+        # Assert
+        agent_dispatcher.publish_event.assert_awaited_once()
+        published_event = agent_dispatcher.publish_event.await_args.args[0]
+        assert isinstance(published_event, ExceptionEvent)
+        assert "configuration is invalid" in published_event.message
+        # The field that failed, so the admin can act on it...
+        assert "name" in published_event.message
+
+    @pytest.mark.asyncio
+    async def test_reported_config_failure_carries_no_field_values(self, agent_dispatcher, agent_topic):
+        """...but never the values: an agent config holds credentials and this text reaches the user's chat."""
+        secret = "s3cret-imap-token"
+        agent_dispatcher._non_configurable_values = {}
+        agent_dispatcher._config_client.fetch_config = AsyncMock(
+            return_value={"agent_id": "test_agent", "name": secret, "description": {}, "icon": "test-icon"}
+        )
+        agent_dispatcher.publish_event = AsyncMock()
+
+        with patch("swiss_ai_hub.core.dispatcher.base_dispatcher.BaseDispatcher.handle_event", AsyncMock()):
+            await agent_dispatcher.handle_event(StartEvent(), agent_topic)
+
+        published_event = agent_dispatcher.publish_event.await_args.args[0]
+        assert secret not in published_event.message
+        assert "input_value" not in published_event.message
 
     @pytest.mark.asyncio
     async def test_handle_event_with_context_setup_failure(self, agent_dispatcher, agent_topic):
-        """Test handling of context setup failures."""
+        """A RunContext failure while caching the config is reported like any other config failure."""
         # Arrange - agent_id comes from the topic, not the event
         start_event = StartEvent()
 
@@ -805,6 +857,7 @@ class TestAgentDispatcherErrorHandling:
         mock_tracer = Mock(spec=AgentRunTracer)
         mock_tracer.trace_run_start = AsyncMock(return_value=None)
         agent_dispatcher.agent_run_tracer = mock_tracer
+        agent_dispatcher.publish_event = AsyncMock()
 
         with (
             patch(
@@ -814,9 +867,13 @@ class TestAgentDispatcherErrorHandling:
         ):
             mock_base_handle.return_value = None
 
-            # Act & Assert
-            with pytest.raises(RuntimeError, match="Context setup failed"):
-                await agent_dispatcher.handle_event(start_event, agent_topic)
+            # Act
+            await agent_dispatcher.handle_event(start_event, agent_topic)
+
+        # Assert
+        published_event = agent_dispatcher.publish_event.await_args.args[0]
+        assert isinstance(published_event, ExceptionEvent)
+        assert "Context setup failed" in published_event.message
 
 
 class TestAgentDispatcherIntegration:

--- a/packages/agent/swiss_ai_hub/agent/agents/rag_agent/tests/unit/test_org_memory_namespace_config.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/rag_agent/tests/unit/test_org_memory_namespace_config.py
@@ -1,0 +1,51 @@
+"""Regression tests for issue #146: an org-memory allow-list must never brick the agent.
+
+An admin saved a profile whose `default_tenant_namespace` was outside `allowed_tenant_namespaces`.
+The API accepts that (it validates against a JSON Schema, which carries no cross-field rules), but the
+agent used to reject it in `AgentConfig.model_validate` — which the dispatcher runs on every dispatched
+event, before any step. The chat hung with nothing to show. Reads must stay unaffected; only a write
+that actually resolves a disallowed namespace may fail.
+"""
+
+from swiss_ai_hub.core.generative_ai import LLMConfig, OrgMemoryNamespaceResolver, OrgMemoryReadConfig
+from swiss_ai_hub.core.i18n import LocaleString
+
+from swiss_ai_hub.agent.agents.rag_agent.configs.rag_agent_config import RAGAgentConfig
+
+# The exact combination from the issue report.
+DEFAULT_NAMESPACE = "engineering"
+ALLOWED_NAMESPACES = ["test", "default"]
+
+
+def _config_from_the_issue() -> RAGAgentConfig:
+    return RAGAgentConfig(
+        agent_id="thong_document_02",
+        name=LocaleString(en="bbv knowledge Swiss"),
+        description=LocaleString(en="RAG agent with an org-memory allow-list"),
+        llm=LLMConfig(model_name="gemma-4-31B-it"),
+        retrievers=[],
+        org_memory=OrgMemoryReadConfig(
+            tenant_id="AIHub",
+            default_tenant_namespace=DEFAULT_NAMESPACE,
+            allowed_tenant_namespaces=ALLOWED_NAMESPACES,
+        ),
+    )
+
+
+def test_default_namespace_outside_allow_list_still_yields_a_runnable_config():
+    config = _config_from_the_issue()
+
+    assert config.org_memory.default_tenant_namespace == DEFAULT_NAMESPACE
+    assert config.org_memory.allowed_tenant_namespaces == ALLOWED_NAMESPACES
+
+
+def test_reads_stay_scoped_to_the_allow_list():
+    """This is the call `retrieve_organization_memory_step` makes for a plain chat message."""
+    config = _config_from_the_issue()
+
+    namespaces = OrgMemoryNamespaceResolver.resolve_for_search(
+        requested=[],
+        configured=config.org_memory.allowed_tenant_namespaces,
+    )
+
+    assert namespaces == ALLOWED_NAMESPACES

--- a/packages/agent/swiss_ai_hub/agent/dispatchers/agent_dispatcher.py
+++ b/packages/agent/swiss_ai_hub/agent/dispatchers/agent_dispatcher.py
@@ -8,6 +8,7 @@ from bson import ObjectId
 from nats.aio.client import Client as NATS
 from nats.js import JetStreamContext
 from opentelemetry import context as otel_context
+from pydantic import ValidationError
 from redis.asyncio import Redis
 from swiss_ai_hub.core.agents import AgentConfig, StepConfig
 from swiss_ai_hub.core.auth import UserIdentity
@@ -119,27 +120,33 @@ class AgentDispatcher(BaseDispatcher):
         thread_context = ThreadContext.for_topic(self.redis, topic)
 
         # Teardown must run before config resolution: it only needs the run id, and a redelivered
-        # terminal event would otherwise fail on the config its first delivery already deleted.
+        # terminal event would otherwise fail on the config its first delivery already deleted. It is
+        # also what lets the ExceptionEvent published for an unusable config retire its run at all —
+        # that event would otherwise hit the very failure it reports.
         if event.is_stop_event or event.is_exception_event:
             logger.debug(f"Handling final event: {event.event_name}")
             await self._teardown_run(event, run_context, topic)
             return
 
-        agent_config_dict = await self._resolve_agent_config_dict(event, run_context, topic)
-        if agent_config_dict is None:
+        try:
+            agent_config_dict = await self._resolve_agent_config_dict(event, run_context, topic)
+            if agent_config_dict is None:
+                return
+            # Transform FormKit-style arrays (dict with numeric keys) to Python lists
+            run_agent_config = self.agent_config_type.model_validate(transform_formkit_arrays(agent_config_dict))
+        except Exception as unusable_config_exception:
+            await self._report_unusable_config(topic, unusable_config_exception)
             return
 
         # Propagate X-AIHub-* request headers into RunContext so downstream steps can act on behalf
         # of the user. Written on every header-carrying event, not only StartEvent, so HITL/BITL
-        # responses refresh the stored token instead of reusing a stale one. Written after config
-        # resolution so duplicate deliveries return before re-creating deleted run-context keys.
-        # These are untrusted client input — a step must validate a header before treating it as
-        # an identity claim.
+        # responses refresh the stored token instead of reusing a stale one. Written after the config
+        # is resolved and validated, so a duplicate delivery or an unusable config returns before
+        # re-creating deleted run-context keys. These are untrusted client input — a step must
+        # validate a header before treating it as an identity claim.
         if event._aihub_headers:
             await run_context.set(self._AIHUB_HEADERS_KEY, event._aihub_headers)
 
-        # Transform FormKit-style arrays (dict with numeric keys) to Python lists
-        run_agent_config = self.agent_config_type.model_validate(transform_formkit_arrays(agent_config_dict))
         instance_topic = AgentInstanceTopic.from_agent_class_topic(
             agent_class_topic=topic,
             agent_id=run_agent_config.agent_id,
@@ -184,6 +191,43 @@ class AgentDispatcher(BaseDispatcher):
             return None
 
         raise ValueError(f"No agent config found for event {event.event_name} and topic {topic}")
+
+    async def _report_unusable_config(
+        self,
+        topic: Annotated[AgentClassTopic, "The parsed topic of the event whose config could not be resolved."],
+        cause: Annotated[Exception, "Why the config could not be fetched, merged or validated."],
+    ) -> None:
+        """
+        Turns a config failure into an ExceptionEvent instead of letting it escape into the subscriber.
+
+        A config is validated on every dispatched event, before any step runs, so a profile saved with a
+        value the agent's own model rejects (the API validates submissions against a JSON Schema that
+        cannot carry cross-field rules) would otherwise abort each event silently — the subscriber only
+        logs, and the message is acked already — leaving the chat hanging forever with nothing to show.
+        """
+        logger.exception(
+            f"Cannot resolve the configuration of {self.agent.__name__}/{topic.agent_id}, aborting the run: {cause}"
+        )
+        await self.publish_event(
+            ExceptionEvent(message=f"The agent configuration is invalid: {self._describe_config_failure(cause)}"),
+            AgentInstanceTopic.from_agent_class_topic(agent_class_topic=topic, agent_id=topic.agent_id),
+        )
+
+    @staticmethod
+    def _describe_config_failure(cause: Exception) -> str:
+        """
+        Reduces a validation failure to field locations and reasons.
+
+        An agent config carries credentials — `ImapClientConfig.password` is a plain string — and
+        Pydantic renders the offending value into `str(error)`. This text reaches the user's chat, so
+        the values must not travel with it; the full error stays in the log line above.
+        """
+        if not isinstance(cause, ValidationError):
+            return str(cause)
+        return "; ".join(
+            f"{'.'.join(str(location) for location in error['loc'])}: {error['msg']}"
+            for error in cause.errors(include_url=False, include_input=False)
+        )
 
     async def _start_run(
         self,

--- a/packages/core/swiss_ai_hub/core/generative_ai/memory/org_memory_read_config.py
+++ b/packages/core/swiss_ai_hub/core/generative_ai/memory/org_memory_read_config.py
@@ -30,6 +30,7 @@ class OrgMemoryReadConfig(OrgMemoryWriteConfig):
             default_tenant_namespace=InputText(
                 label=LocaleString.from_i18n_path("lib.org_memory.default_tenant_namespace.label"),
                 help=LocaleString.from_i18n_path("lib.org_memory.default_tenant_namespace.help"),
+                additional_validation_rules=cls.DEFAULT_NAMESPACE_FORM_RULE,
             ),
             allowed_tenant_namespaces=ChipsInput(
                 label=LocaleString.from_i18n_path("lib.org_memory.allowed_tenant_namespaces.label"),

--- a/packages/core/swiss_ai_hub/core/generative_ai/memory/org_memory_write_config.py
+++ b/packages/core/swiss_ai_hub/core/generative_ai/memory/org_memory_write_config.py
@@ -1,8 +1,7 @@
 from typing import Annotated, ClassVar, Self
 
-from pydantic import Field, model_validator
+from pydantic import Field
 
-from swiss_ai_hub.core.form.base.formkit_element import FormkitElement
 from swiss_ai_hub.core.form.elements.chips_input import ChipsInput
 from swiss_ai_hub.core.form.elements.input_text import InputText
 from swiss_ai_hub.core.form.elements.tenant_select import TenantSelect
@@ -12,10 +11,21 @@ from swiss_ai_hub.core.i18n.locale_string import LocaleString
 
 
 class OrgMemoryWriteConfig(Form):
-    """Tenant + namespace scoping for organization-memory writes (and base for read-side scoping)."""
+    """Tenant + namespace scoping for organization-memory writes (and base for read-side scoping).
+
+    A `default_tenant_namespace` outside `allowed_tenant_namespaces` is deliberately NOT a config-level
+    error. The API validates submissions against a JSON Schema rebuilt from this model, which cannot carry
+    cross-field rules, so such a config saves either way — and raising here would instead abort
+    `AgentConfig.model_validate` on every dispatched event, bricking the whole agent with no visible error.
+    `OrgMemoryNamespaceResolver.resolve_for_write` enforces the rule inside a step, where the dispatcher
+    turns it into an `ExceptionEvent` the user can see. `DEFAULT_NAMESPACE_FORM_RULE` gives admins the same
+    feedback in the form.
+    """
 
     required_access_rule: ClassVar[str] = "aihub.user.memory.organization.?>"
     required_access_rule_message_path: ClassVar[str] = "lib.common.authorization.no_access_organization_memory"
+
+    DEFAULT_NAMESPACE_FORM_RULE: ClassVar[str] = "memberOf:allowed_tenant_namespaces"
 
     tenant_id: Annotated[
         str | TenantSelect,
@@ -26,7 +36,8 @@ class OrgMemoryWriteConfig(Form):
         Field(
             description=(
                 "Default namespace used when a start event omits an override. Writes are singular — "
-                "only one namespace can be the write target."
+                "only one namespace can be the write target. A default outside the allow-list is "
+                "rejected when a write actually resolves it, not when the config is built."
             ),
         ),
     ] = Field(default_factory=lambda: MemorySettings().DEFAULT_TENANT_NAMESPACE)
@@ -40,21 +51,6 @@ class OrgMemoryWriteConfig(Form):
         ),
     ] = []
 
-    @model_validator(mode="after")
-    def _validate_default_in_allowed(self) -> Self:
-        """Ensure `default_tenant_namespace` is consistent with `allowed_tenant_namespaces`.
-
-        Skipped in form mode (when either field still holds a FormkitElement)."""
-        if isinstance(self.allowed_tenant_namespaces, FormkitElement):
-            return self
-        if isinstance(self.default_tenant_namespace, FormkitElement):
-            return self
-        allowed = self.allowed_tenant_namespaces
-        default = self.default_tenant_namespace
-        if allowed and default is not None and default not in allowed:
-            raise ValueError(f"default_tenant_namespace={default!r} is not in allowed_tenant_namespaces={allowed!r}")
-        return self
-
     @classmethod
     def as_form(cls) -> Self:
         """Factory method to create a form-mode OrgMemoryWriteConfig."""
@@ -67,6 +63,7 @@ class OrgMemoryWriteConfig(Form):
             default_tenant_namespace=InputText(
                 label=LocaleString.from_i18n_path("lib.org_memory.default_tenant_namespace.label"),
                 help=LocaleString.from_i18n_path("lib.org_memory.default_tenant_namespace.help"),
+                additional_validation_rules=cls.DEFAULT_NAMESPACE_FORM_RULE,
             ),
             allowed_tenant_namespaces=ChipsInput(
                 label=LocaleString.from_i18n_path("lib.org_memory.allowed_tenant_namespaces.label"),

--- a/packages/core/swiss_ai_hub/core/generative_ai/memory/tests/unit/test_org_memory_write_config.py
+++ b/packages/core/swiss_ai_hub/core/generative_ai/memory/tests/unit/test_org_memory_write_config.py
@@ -1,11 +1,10 @@
-import pytest
-from pydantic import ValidationError
-
 from swiss_ai_hub.core.form import ChipsInput, InputText
 from swiss_ai_hub.core.generative_ai.memory.org_memory_write_config import OrgMemoryWriteConfig
 
 
-class TestDefaultInAllowedValidator:
+class TestDefaultOutsideAllowList:
+    """A default outside the allow-list must stay a *valid* config — see the class docstring for why."""
+
     def test_valid_default_in_allowed(self):
         config = OrgMemoryWriteConfig(
             tenant_id="t1",
@@ -14,13 +13,15 @@ class TestDefaultInAllowedValidator:
         )
         assert config.default_tenant_namespace == "hr"
 
-    def test_invalid_default_not_in_allowed(self):
-        with pytest.raises(ValidationError):
-            OrgMemoryWriteConfig(
-                tenant_id="t1",
-                default_tenant_namespace="other",
-                allowed_tenant_namespaces=["hr", "legal"],
-            )
+    def test_default_not_in_allowed_is_accepted(self):
+        """Rejecting this here would abort AgentConfig.model_validate on every event and brick the agent."""
+        config = OrgMemoryWriteConfig(
+            tenant_id="t1",
+            default_tenant_namespace="other",
+            allowed_tenant_namespaces=["hr", "legal"],
+        )
+        assert config.default_tenant_namespace == "other"
+        assert config.allowed_tenant_namespaces == ["hr", "legal"]
 
     def test_valid_empty_allowed_means_unrestricted(self):
         config = OrgMemoryWriteConfig(
@@ -38,8 +39,14 @@ class TestDefaultInAllowedValidator:
         )
         assert config.default_tenant_namespace is None
 
-    def test_form_mode_skips_validation(self):
-        """When fields hold FormkitElements (form mode), the validator must not fire."""
+
+class TestForm:
+    def test_form_mode_builds_elements(self):
         config = OrgMemoryWriteConfig.as_form()
         assert isinstance(config.allowed_tenant_namespaces, ChipsInput)
         assert isinstance(config.default_tenant_namespace, InputText)
+
+    def test_default_namespace_carries_the_allow_list_form_rule(self):
+        """The admin gets the feedback in the form that the model deliberately no longer raises."""
+        default_namespace = OrgMemoryWriteConfig.as_form().default_tenant_namespace
+        assert default_namespace.validation == "memberOf:allowed_tenant_namespaces"

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/org_memory.de.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/org_memory.de.yml
@@ -16,4 +16,5 @@ rerank_organization_memory:
 default_tenant_namespace:
   label: Standard-Organisationsspeicher-Namespace
   help: Namespace für Schreiboperationen im Organisationsspeicher (und für Leseoperationen,
-    wenn kein Event-Override angegeben ist). Leer lassen für den plattformweiten Standard.
+    wenn kein Event-Override angegeben ist). Muss einer der erlaubten Namespaces sein,
+    sofern diese Liste nicht leer ist. Leer lassen für den plattformweiten Standard.

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/org_memory.en.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/org_memory.en.yml
@@ -15,4 +15,5 @@ rerank_organization_memory:
 default_tenant_namespace:
   label: Default org-memory namespace
   help: Namespace used for organization-memory writes (and reads when no event override
-    is provided). Leave empty to fall back to the platform-wide default.
+    is provided). Must be one of the allowed namespaces when that list is not empty.
+    Leave empty to fall back to the platform-wide default.

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/org_memory.fr.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/org_memory.fr.yml
@@ -16,5 +16,6 @@ rerank_organization_memory:
 default_tenant_namespace:
   label: Espace de noms de mémoire organisationnelle par défaut
   help: Espace de noms utilisé pour les écritures dans la mémoire organisationnelle
-    (et pour les lectures lorsque l'événement ne fournit pas de remplacement). Laisser
-    vide pour utiliser la valeur par défaut de la plateforme.
+    (et pour les lectures lorsque l'événement ne fournit pas de remplacement). Doit
+    figurer parmi les espaces de noms autorisés lorsque cette liste n'est pas vide.
+    Laisser vide pour utiliser la valeur par défaut de la plateforme.

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/org_memory.it.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/org_memory.it.yml
@@ -16,5 +16,6 @@ rerank_organization_memory:
 default_tenant_namespace:
   label: Namespace predefinito della memoria organizzativa
   help: Namespace utilizzato per le scritture nella memoria organizzativa (e per le
-    letture quando l'evento non fornisce una sostituzione). Lasciare vuoto per utilizzare
-    il valore predefinito della piattaforma.
+    letture quando l'evento non fornisce una sostituzione). Deve essere uno dei namespace
+    consentiti quando tale elenco non è vuoto. Lasciare vuoto per utilizzare il valore
+    predefinito della piattaforma.

--- a/packages/web/CLAUDE.md
+++ b/packages/web/CLAUDE.md
@@ -47,8 +47,8 @@ packages/web/
 
 The `.app/` directory is the actual entry point — it extends the parent via `extends: ['..']` in its `nuxt.config.ts`.
 `pnpm dev` runs `nuxi dev .app`. The parent `packages/web/` provides components, composables, pages, and config. `.app/`
-adds `runtimeConfig` (OIDC, WebSocket endpoint, env vars). Custom FormKit inputs are registered in the parent's
-`formkit.config.ts`, which `nuxt.config.ts` wires up via `formkit.configFile`.
+adds `runtimeConfig` (OIDC, WebSocket endpoint, env vars). FormKit registration lives in the layer itself
+(`packages/web/formkit.config.ts`, wired via `formkit.configFile` in `nuxt.config.ts`), so extenders inherit it.
 
 ## Page Composition Pattern
 
@@ -150,6 +150,12 @@ The backend defines form schemas (`FormkitElement[]`), the frontend renders them
 **Custom FormKit inputs** (registered in `formkit.config.ts`, which `nuxt.config.ts` points `formkit.configFile` at):
 `agentSelector`, `chipsInput`, `cronInput`, `knowledgeDatabaseSelector`, `iconSelector`, `localeInput`, `modelSelect`,
 `tenantSelect`, `vectorStoreInput`.
+
+**Custom validation rules** are registered in the same file under `rules`, with their messages under `messages` (one
+entry per locale). The backend attaches a rule to a field via `PrimeVueElement.additional_validation_rules`, which
+surfaces as the FormKit node's `validation` string. Cross-field rules read siblings with `node.at('<field_name>')` —
+FormKit tracks whatever the rule reads, so it re-runs when that sibling changes too. Such rules are advisory: the API
+validates submissions against a JSON Schema and never sees them.
 
 Custom input components receive props via `context` (not Vue props): read from `context.value`, write via
 `context.node.input(newValue)`.
@@ -267,7 +273,7 @@ The UI strictly separates blueprint from profile:
 
 - Nuxt config: `nuxt.config.ts`
 - Nuxt layer entry: `.app/nuxt.config.ts`
-- FormKit config: `formkit.config.ts`
+- FormKit config (inputs, validation rules, messages): `formkit.config.ts`
 - ESLint config: `eslint.config.js`
 - Tailwind config: `tailwind.config.mjs`
 - PrimeVue theme: `themes/aihub-theme.ts`

--- a/packages/web/formkit.config.ts
+++ b/packages/web/formkit.config.ts
@@ -12,7 +12,7 @@ import { createInput } from '@formkit/vue'
 import { primeInputs } from '@sfxcode/formkit-primevue'
 
 import type { FormKitNode } from '@formkit/core'
-import type { DefaultConfigOptions } from '@formkit/vue'
+import type { DefaultConfigOptions, PluginConfigs } from '@formkit/vue'
 
 const LOCALES = ['de', 'en', 'fr', 'it'] as const
 
@@ -32,6 +32,21 @@ function localeRequired(node: FormKitNode): boolean {
 // create form: precisely the case this rule exists to catch.
 localeRequired.skipEmpty = false
 
+/**
+ * Passes when the value is listed in the sibling field named by `address`, or when that list is
+ * empty — backend allow-lists treat empty as unrestricted. Reading the sibling through `node.at()`
+ * registers it as a validation dependency, so FormKit re-runs this rule when the list itself
+ * changes, not only when this field does.
+ *
+ * Advisory only: it exists so an admin sees the conflict in the form. The backend never depends on
+ * it — a value outside the allow-list is rejected where it is actually used.
+ */
+const memberOf: PluginConfigs['rules'][string] = (node, address: string) => {
+  const allowed = node.at(address)?.value
+  if (!Array.isArray(allowed) || allowed.length === 0) return true
+  return allowed.includes(node.value)
+}
+
 const localeRequiredMessages = {
   de: 'Mindestens eine Sprache muss ausgefüllt sein.',
   en: 'At least one language must be filled in.',
@@ -39,10 +54,22 @@ const localeRequiredMessages = {
   it: 'Almeno una lingua deve essere compilata.',
 }
 
+const memberOfMessages = {
+  de: 'Dieser Wert steht nicht in der Liste der erlaubten Werte.',
+  en: 'This value is not in the allowed list.',
+  fr: 'Cette valeur ne figure pas dans la liste des valeurs autorisées.',
+  it: 'Questo valore non è presente nell\'elenco dei valori consentiti.',
+}
+
 const config: DefaultConfigOptions = {
-  rules: { localeRequired },
+  rules: { localeRequired, memberOf },
   messages: Object.fromEntries(
-    LOCALES.map(locale => [locale, { validation: { localeRequired: localeRequiredMessages[locale] } }]),
+    LOCALES.map(locale => [locale, {
+      validation: {
+        localeRequired: localeRequiredMessages[locale],
+        memberOf: memberOfMessages[locale],
+      },
+    }]),
   ),
   inputs: {
     ...primeInputs,


### PR DESCRIPTION
Cherry-pick of #1701 onto `release/0.320` for the `v0.320.0-rc.1` release.

Original commit on `main`: `eead84a3d533e3b37ff9ac0334c2ec729ddbb18a`
Cherry-picked as: `c4f7d125` (`-x`, cherry-pick trailer retained)

Fixes the outage reported in [aihub-core-private#146](https://github.com/bbvch-ai/aihub-core-private/issues/146): an org-memory allow-list that did not contain the configured default namespace bricked the agent — every dispatched event failed config validation before any step ran, and because the raise happened outside the per-step `try/except` no `ExceptionEvent` was ever published. The chat hung forever with no error anywhere the user could see.

See #1701 for the full rationale. In short:

1. The unenforceable cross-field `model_validator` is removed — the invariant is enforced in `OrgMemoryNamespaceResolver.resolve_for_write`, inside a `@step`, where the dispatcher turns it into a visible `ExceptionEvent`.
2. The dispatcher now publishes an `ExceptionEvent` when config cannot be fetched, merged or validated, and terminal-event teardown moves above config resolution so a reported failure can still retire the run.
3. An advisory inline Admin UI warning via a generic `memberOf` FormKit rule.

Also carried over from #1701: the `ExceptionEvent` credential-leak fix (`f6543991`) and the `@given("no pre-seeded memories")` test-isolation fix (`d80d36dc`).

ADR: `docs/arc42/decisions/2026_08_07_agent_config_failures_surface_as_exception_events.md`

## Verification

- Cherry-pick applied with **no conflicts**; the resulting diff is **byte-identical** to `eead84a3` (verified by diffing the two patches).
- Rebased onto `release/0.320` head `75274d5f` after #1807 landed mid-cherry-pick.
- `packages/core` — **1396 passed**
- `packages/web` — eslint clean, no changes
- `packages/agent` — 543 passed, 2 failed

### On the two `packages/agent` failures

Both are pre-existing local flakiness, not caused by this change. A control run of the full agent suite on **unmodified `release/0.320`** failed a *different* pair of tests:

| Run | Branch | Failures |
| --- | --- | --- |
| 1 | cherry-pick | `test_llama_index_agent` |
| 2 | cherry-pick | `test_ragagent_answers_a_meta_question_...`, `test_a_heartbeat_holds_the_mailbox_across_work_longer_than_the_ttl` |
| 3 | **base (control)** | `test_verify_stored_memory_content`, `test_a_heartbeat_survives_a_redis_blip_without_abandoning_the_run` |

Every one of these passes 3/3 when run in isolation, on both the base and this branch. They are timing- and LLM-dependent and fail only under full-suite load.

Worth noting that `test_verify_stored_memory_content` — which fails on the base — is exactly the test-isolation bug this PR fixes.
