### PR TITLE
fix(swiss-ai-hub): Reconstruct chat history from client-visible displays only

### DIFF
--- a/docs/arc42/decisions/2026_09_01_reconstruct_chat_history_from_client_visible_displays.md
+++ b/docs/arc42/decisions/2026_09_01_reconstruct_chat_history_from_client_visible_displays.md
@@ -1,0 +1,84 @@
+# Chat History Reconstruction Projects Client-Visible Displays
+
+## Context
+
+A client of the OpenAI-compatible endpoint sent follow-up requests with `metadata.reconstruct_history=true` and received
+HTTP 500. The thread contained a delegated retrieval agent whose response event (`RetrievalAgentInTheLoopResponseEvent`)
+is a custom class the API process does not import. Reconstruction deserialized every persisted display event through
+`ContextualizedAgentEvent`, whose discriminated union is designed for the UI event timeline: an unknown nested event
+fell back to its closest known parent (`RetrieverEvent`), the enclosing AITL envelope then failed its required
+`StopEvent` field, and the `ValidationError` escaped as a 500 before the target agent was ever dispatched.
+
+The same coupling caused silent correctness defects even when it did not crash:
+
+- History was scoped only by `thread_id`. AITL delegation defaults to sharing the thread while `share_display_id`
+  independently controls whether delegated output shares the client-visible surface, so chunks from hidden nested runs
+  were concatenated into reconstructed transcripts.
+- HITL questions and answers were each duplicated into both user and assistant roles.
+- Every API replica runs an `AgentEventPersister` on a fan-out NATS Core subscription, so duplicate deliveries
+  duplicated reconstructed turns.
+- Trailing chunk loss from the stop-vs-chunk delivery race was unrecoverable: history ignored stop events, unlike the
+  live response path, which falls back to `StopEvent.output_messages`.
+
+## Decision Drivers
+
+- **Reconstruction must survive arbitrary agent-specific events**\
+  Any deployed agent may define custom event classes; the API cannot be required to import them to read conversation
+  history. Unknown events must be excluded before deserialization, not interpreted.
+- **The visibility boundary is the display surface, not agent identity**\
+  The live OpenAI subscription listens to all agents within one `thread_id` + `display_id`. Issue #1283 explicitly
+  rejected filtering chunks to the selected agent because it suppresses intentionally visible delegated output. History
+  must mirror the live boundary.
+- **Chat projection must not depend on the UI event union**\
+  `ContextualizedAgentEvent` requires every displayable event type known to the API package; chat history needs only a
+  small, stable set of fields (`messages`, `content`, `question`, `response`, `output_messages`).
+- **Reads must be correct under duplicate writes**\
+  Event-persistence duplication is owned by #1203 (single-instance `aihub-daemon`); until then, reconstruction must
+  deduplicate on read.
+- **No migration weight without measured need**\
+  Existing persisted events and indexes must serve the new query; no new collection, index, or backfill.
+
+## Decision
+
+Chat history reconstruction is a two-stage projection of persisted display events:
+
+- `PersistedAgentEventEntity.conversation_events_for_thread` first resolves client-visible displays from persisted
+  `UserAgent` user/HITL marker events (exact `$in` array membership on `event_parents`, not regex `__contains`), then
+  returns only the projectable event families (`UserMessageEvent`, `HumanInTheLoopResponseEvent`, `ChunkEvent`,
+  `HumanInTheLoopRequestEvent`, `StopEvent`) on those displays. Threads without a visible marker fail closed to empty
+  history with a warning.
+- A pure projector (`conversation_history_projector.py`) maps raw persisted fields directly — validating only the last
+  `ChatMessage` of a user event (normalizing legacy byte-list audio/image payloads) and the documented scalar fields of
+  the other families — without deserializing event classes. HITL questions project as assistant messages, answers as
+  user messages, once. Consecutive same-role text on one display merges. Malformed relevant events are skipped with
+  metadata-only warnings; unrelated events are never deserialized.
+- Terminal recovery mirrors the live prefix rule and is gated on the request's primary agent identity (`agent_class` +
+  `agent_id` passed by both assistant paths), so a nested agent's stop can never supply the top-level answer suffix.
+  `ThreadService.thread_as_message_history` accepts the identity as optional keyword arguments, preserving its
+  one-argument contract.
+- Deliveries are deduplicated by full topic identity (agent, thread, display, run, event type/name/id) and ordered by
+  `created_at` with `event_id` as tie-breaker; ordering metadata that is missing or malformed skips the event rather
+  than corrupting the sort.
+
+## Consequences
+
+### Positive
+
+- Unknown custom nested events can no longer break history reconstruction; they remain untouched in the audit store.
+- Reconstructed transcripts match what the client actually saw: hidden nested output is excluded at any delegation
+  depth, shared-display delegation is retained (#1283 behavior preserved), and recursive same-agent delegation needs no
+  depth inference.
+- Both query stages use the existing `thread_id_1_event_type_1_event_parents_1` index (verified via explain); no schema,
+  index, or configuration change.
+- Any API replica produces identical history from the shared event store, so reads are replica-safe.
+
+### Trade-offs
+
+- Threads whose persisted events predate `UserAgent` markers reconstruct as empty (fail closed). Deploys onto long-lived
+  stores should verify legacy threads carry markers.
+- Eventual consistency remains: a request arriving before the previous run's display events are persisted reads
+  incomplete history. Strict read-after-write would require a persistence barrier and is out of scope.
+- Primary terminal recovery is unavailable through the unmounted thread-history endpoint, which has no selected agent
+  identity.
+- Read-side deduplication neutralizes duplicate rows but does not reduce them; write-side duplication remains owned by
+  #1203, and overall horizontal API scaling stays gated on that issue.

--- a/packages/api/playground/testing/tests/openai/test_openai_history_reconstruction.py
+++ b/packages/api/playground/testing/tests/openai/test_openai_history_reconstruction.py
@@ -1,0 +1,685 @@
+import asyncio
+import time
+import uuid
+from collections import Counter
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from asgi_lifespan import LifespanManager
+from bson import ObjectId
+from httpx import ASGITransport, AsyncClient, Response
+from llama_index.core.base.llms.types import ChatMessage, MessageRole, TextBlock
+from swiss_ai_hub.core.events import BaseEvent
+from swiss_ai_hub.core.events.agent import ChunkEvent, ControlEvent, LLMStopEvent, Message, UserMessageEvent
+from swiss_ai_hub.core.events.agent.control_and_display_event import ControlAndDisplayEvent
+from swiss_ai_hub.core.persistence.messaging.entities.persisted_agent_event_entity import (
+    PersistedAgentEventEntity,
+)
+from swiss_ai_hub.core.persistence.utils import str_to_object_id
+from swiss_ai_hub.core.publishers import NCPublisher
+from swiss_ai_hub.core.testing.auth_utils import TestAuthHandler, fake_user
+from swiss_ai_hub.core.topic_managers import AgentThreadTopicManager, AgentTopicManager
+from swiss_ai_hub.core.topics.agents import AgentInstanceTopic
+
+from swiss_ai_hub.api.routes.openai.openai_controller import OpenaiController
+from swiss_ai_hub.api.routes.thread.thread_service import ThreadService
+from swiss_ai_hub.api.runners.simulation.agent.simulated_agent_api_test_runner import SimulatedAgentApiTestRunner
+
+BASE_URL = "http://test/api/v1/active"
+COMPLETIONS_ENDPOINT = "/openai/chat/completions"
+
+AGENT_CLASS = "history_agent"
+AGENT_ID = "history_agent_1"
+REPLY_TEXT = "Reply from the simulated agent"
+RUNTIME_NESTED_PROMPT = "Seed a live nested AITL-shaped response"
+
+PERSISTENCE_TIMEOUT_SECONDS = 10
+
+
+class RecordingSimulatedAgentRunner(SimulatedAgentApiTestRunner):
+    """Records the UserMessageEvents the simulated agent receives, so tests can assert on the
+    message history the API reconstructed for the agent."""
+
+    def __init__(self, agent_class: str, agent_id: str):
+        super().__init__(agent_class=agent_class, agent_id=agent_id)
+        self.received_user_message_events: list[UserMessageEvent] = []
+
+    async def simulate_agent(self, event: ControlEvent, topic: AgentInstanceTopic):
+        if isinstance(event, UserMessageEvent):
+            self.received_user_message_events.append(event)
+            if event.user_query == RUNTIME_NESTED_PROMPT:
+                await self._publish_nested_runtime_events(topic)
+                return
+        await super().simulate_agent(event, topic)
+
+    async def _publish_display_as(
+        self,
+        event: BaseEvent,
+        topic: AgentInstanceTopic,
+        *,
+        agent_class: str,
+        agent_id: str,
+        display_id: str,
+        run_id: str,
+    ) -> None:
+        assert self.nc is not None
+        topic_manager = AgentThreadTopicManager(
+            agent_class=agent_class,
+            agent_id=agent_id,
+            thread_id=topic.thread_id,
+            display_id=display_id,
+            run_id=run_id,
+        )
+        subject = topic_manager.get_subject_for_display_event_in_thread(event.event_name, event.event_id)
+        await NCPublisher("RuntimeNestedHistoryTest", self.nc).publish_event(event, subject)
+
+    async def _publish_nested_runtime_events(self, topic: AgentInstanceTopic) -> None:
+        hidden_display = str(ObjectId())
+        primary_chunk = ChunkEvent(content="Primary ", model_name="sim")
+        primary_chunk.event_id = "runtime-primary-chunk"
+        shared_chunk = ChunkEvent(content="nested ", model_name="sim")
+        shared_chunk.event_id = "runtime-shared-chunk"
+        deep_chunk = ChunkEvent(content="deep ", model_name="sim")
+        deep_chunk.event_id = "runtime-deep-chunk"
+        hidden_chunk = ChunkEvent(content="HIDDEN", model_name="sim")
+        hidden_chunk.event_id = "runtime-hidden-chunk"
+        unknown_hidden = ControlAndDisplayEvent.deserialize_event(
+            {
+                "event_id": "runtime-hidden-aitl",
+                "created_at": time.time_ns(),
+                "_event_name": "RetrievalAgentInTheLoopResponseEvent",
+                "_parent_event_names": [
+                    "RetrievalAgentInTheLoopResponseEvent",
+                    "AgentInTheLoopResponseEvent",
+                    "ControlAndDisplayEvent",
+                    "DisplayEvent",
+                    "ControlEvent",
+                ],
+                "stop_event": {
+                    "event_id": "runtime-hidden-retrieval-stop",
+                    "created_at": time.time_ns(),
+                    "_event_name": "RetrievalResponseEvent",
+                    "_parent_event_names": [
+                        "RetrievalResponseEvent",
+                        "RetrieverEvent",
+                        "SemanticEvent",
+                        "StopEvent",
+                        "ControlAndDisplayEvent",
+                        "DisplayEvent",
+                        "ControlEvent",
+                    ],
+                    "nodes": [],
+                },
+            }
+        )
+        primary_stop = LLMStopEvent(
+            output_messages=[Message.from_string(role="assistant", content="Primary nested deep final")]
+        )
+        primary_stop.event_id = "runtime-primary-stop"
+
+        await self._publish_display_as(
+            primary_chunk,
+            topic,
+            agent_class=AGENT_CLASS,
+            agent_id=AGENT_ID,
+            display_id=topic.display_id,
+            run_id=topic.run_id,
+        )
+        await self._publish_display_as(
+            shared_chunk,
+            topic,
+            agent_class="NestedAgent",
+            agent_id="nested-shared",
+            display_id=topic.display_id,
+            run_id="runtime-nested-run",
+        )
+        await self._publish_display_as(
+            deep_chunk,
+            topic,
+            agent_class="DeepNestedAgent",
+            agent_id="nested-deep",
+            display_id=topic.display_id,
+            run_id="runtime-deep-run",
+        )
+        await self._publish_display_as(
+            hidden_chunk,
+            topic,
+            agent_class="HiddenNestedAgent",
+            agent_id="nested-hidden",
+            display_id=hidden_display,
+            run_id="runtime-hidden-run",
+        )
+        await self._publish_display_as(
+            unknown_hidden,
+            topic,
+            agent_class="HiddenNestedAgent",
+            agent_id="nested-hidden",
+            display_id=hidden_display,
+            run_id="runtime-hidden-run",
+        )
+        await self._publish_display_as(
+            primary_stop,
+            topic,
+            agent_class=AGENT_CLASS,
+            agent_id=AGENT_ID,
+            display_id=topic.display_id,
+            run_id=topic.run_id,
+        )
+        assert self.nc is not None
+        await self.nc.flush()
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="module")
+async def api_client_and_runner():
+    auth = TestAuthHandler()
+    controller = OpenaiController(auth=auth).chat_completion_with_assistants()
+
+    runner = RecordingSimulatedAgentRunner(agent_class=AGENT_CLASS, agent_id=AGENT_ID)
+    runner.simulated_events = [
+        ChunkEvent(content=REPLY_TEXT, model_name="sim"),
+        LLMStopEvent(output_messages=[Message.from_string(role="assistant", content=REPLY_TEXT)]),
+    ]
+
+    runner.mount(controller)
+    await runner.start_simulation()
+    app = runner.create_app()
+    async with LifespanManager(app) as lifespan:
+        runner.create_agent_config_in_db()
+        async with AsyncClient(transport=ASGITransport(app=lifespan.app), base_url=BASE_URL) as client:
+            yield client, runner
+
+
+async def _completion(
+    client: AsyncClient,
+    thread_id: str,
+    content: str,
+    reconstruct_history: bool,
+    *,
+    display_id: str | None = None,
+    stream: bool = False,
+    send_display_id: bool = True,
+) -> Response:
+    metadata: dict[str, str | bool] = {"thread_id": thread_id}
+    if send_display_id:
+        metadata["display_id"] = display_id or str(ObjectId())
+    if reconstruct_history:
+        metadata["reconstruct_history"] = True
+    response = await client.post(
+        COMPLETIONS_ENDPOINT,
+        json={
+            "model": f"{AGENT_CLASS}/{AGENT_ID}",
+            "messages": [{"role": "user", "content": content}],
+            "stream": stream,
+            "metadata": metadata,
+        },
+    )
+    assert response.status_code == 200, f"Response: {response.text}"
+    return response
+
+
+async def _await_persisted_display_events(thread_id: str, event_names: set[str]) -> None:
+    """Event persistence runs on a NATS subscriber outside the request lifecycle, so wait until the
+    given event names are persisted for the thread before continuing."""
+    deadline = time.monotonic() + PERSISTENCE_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        persisted = PersistedAgentEventEntity.display_events_for_thread(thread_id)
+        if event_names <= {event.event_name for event in persisted}:
+            return
+        await asyncio.sleep(0.1)
+    pytest.fail(f"Events {event_names} not persisted for thread {thread_id} within {PERSISTENCE_TIMEOUT_SECONDS}s")
+
+
+async def _await_persisted_event_ids(thread_id: str, event_ids: set[str]) -> None:
+    deadline = time.monotonic() + PERSISTENCE_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        persisted = PersistedAgentEventEntity.display_events_for_thread(thread_id)
+        if event_ids <= {event.event_id for event in persisted}:
+            return
+        await asyncio.sleep(0.1)
+    pytest.fail(f"Events {event_ids} not persisted for thread {thread_id} within {PERSISTENCE_TIMEOUT_SECONDS}s")
+
+
+def _last_received_event(
+    runner: RecordingSimulatedAgentRunner, start_index: int, expected_count: int
+) -> UserMessageEvent:
+    received_events = runner.received_user_message_events[start_index:]
+    assert len(received_events) == expected_count
+    return received_events[-1]
+
+
+def _assert_messages(event: UserMessageEvent, expected: list[tuple[MessageRole, str]]) -> None:
+    # These tests target identifier canonicalization: assert the complete message set without
+    # coupling them to ThreadService's separate event-ordering contract.
+    assert Counter((message.role, message.content) for message in event.messages) == Counter(expected)
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_reconstruct_history_with_non_object_id_thread_id(api_client_and_runner):
+    """Regression test: a client thread id that is not a 24-hex ObjectID (e.g. a UUID) is
+    canonicalized via str_to_object_id before events are persisted, so history reconstruction must
+    query the canonicalized id. Otherwise the agent receives only the latest user message."""
+    client, runner = api_client_and_runner
+    thread_id = str(uuid.uuid4())
+    start_index = len(runner.received_user_message_events)
+
+    await _completion(client, thread_id, "First question", reconstruct_history=False)
+    await _await_persisted_display_events(str(str_to_object_id(thread_id)), {"UserMessageEvent", "ChunkEvent"})
+    await _completion(client, thread_id, "Second question", reconstruct_history=True)
+
+    event = _last_received_event(runner, start_index, expected_count=2)
+    _assert_messages(
+        event,
+        [
+            (MessageRole.USER, "First question"),
+            (MessageRole.ASSISTANT, REPLY_TEXT),
+            (MessageRole.USER, "Second question"),
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    ("thread_id", "case_name"),
+    [
+        pytest.param("g" + uuid.uuid4().hex[:23], "24-character non-hex ID", id="24-character-non-hex"),
+        pytest.param(("ABCDEF" + str(ObjectId())[6:]).upper(), "uppercase ObjectID", id="uppercase-object-id"),
+        pytest.param(f"ext-{uuid.uuid4().hex[:8]}", "short external ID", id="short-external-id"),
+    ],
+)
+@pytest.mark.asyncio(loop_scope="module")
+async def test_reconstruct_history_with_adversarial_thread_id_formats(
+    api_client_and_runner, thread_id: str, case_name: str
+):
+    """Canonicalization must be symmetric for valid and invalid ObjectID-shaped client identifiers."""
+    client, runner = api_client_and_runner
+    start_index = len(runner.received_user_message_events)
+    first_message = f"First question for {case_name}"
+    second_message = f"Second question for {case_name}"
+
+    await _completion(client, thread_id, first_message, reconstruct_history=False)
+    await _await_persisted_display_events(str(str_to_object_id(thread_id)), {"UserMessageEvent", "ChunkEvent"})
+    await _completion(client, thread_id, second_message, reconstruct_history=True)
+
+    event = _last_received_event(runner, start_index, expected_count=2)
+    _assert_messages(
+        event,
+        [
+            (MessageRole.USER, first_message),
+            (MessageRole.ASSISTANT, REPLY_TEXT),
+            (MessageRole.USER, second_message),
+        ],
+    )
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_reconstruct_history_on_new_thread_keeps_only_current_message(api_client_and_runner):
+    """Requesting reconstruction for a thread with no persisted events must not invent history."""
+    client, runner = api_client_and_runner
+    start_index = len(runner.received_user_message_events)
+    current_message = "Only message in a new thread"
+
+    await _completion(client, str(uuid.uuid4()), current_message, reconstruct_history=True)
+
+    event = _last_received_event(runner, start_index, expected_count=1)
+    _assert_messages(event, [(MessageRole.USER, current_message)])
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_reconstruct_history_false_does_not_load_existing_history(api_client_and_runner):
+    """Persisted history must remain opt-in even when the client reuses the same external thread ID."""
+    client, runner = api_client_and_runner
+    thread_id = str(uuid.uuid4())
+    start_index = len(runner.received_user_message_events)
+
+    await _completion(client, thread_id, "Prior message that must stay hidden", reconstruct_history=False)
+    await _await_persisted_display_events(str(str_to_object_id(thread_id)), {"UserMessageEvent", "ChunkEvent"})
+    with patch.object(PersistedAgentEventEntity, "conversation_events_for_thread") as history_query:
+        await _completion(client, thread_id, "Current message without reconstruction", reconstruct_history=False)
+    history_query.assert_not_called()
+
+    event = _last_received_event(runner, start_index, expected_count=2)
+    _assert_messages(event, [(MessageRole.USER, "Current message without reconstruction")])
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_reconstruct_history_does_not_leak_between_external_thread_ids(api_client_and_runner):
+    """Different external IDs must remain isolated after deterministic ObjectID conversion."""
+    client, runner = api_client_and_runner
+    thread_a = str(uuid.uuid4())
+    thread_b = str(uuid.uuid4())
+    start_index = len(runner.received_user_message_events)
+
+    await _completion(client, thread_a, "Thread A prior question", reconstruct_history=False)
+    await _await_persisted_display_events(str(str_to_object_id(thread_a)), {"UserMessageEvent", "ChunkEvent"})
+    await _completion(client, thread_b, "Thread B private question", reconstruct_history=False)
+    await _await_persisted_display_events(str(str_to_object_id(thread_b)), {"UserMessageEvent", "ChunkEvent"})
+    await _completion(client, thread_a, "Thread A follow-up", reconstruct_history=True)
+
+    event = _last_received_event(runner, start_index, expected_count=3)
+    _assert_messages(
+        event,
+        [
+            (MessageRole.USER, "Thread A prior question"),
+            (MessageRole.ASSISTANT, REPLY_TEXT),
+            (MessageRole.USER, "Thread A follow-up"),
+        ],
+    )
+
+
+def _save_persisted_event(
+    *,
+    thread_id: str,
+    display_id: str,
+    event_name: str,
+    event_parents: list[str],
+    event_data: dict,
+    event_id: str,
+    agent_class: str,
+    agent_id: str,
+    run_id: str,
+) -> None:
+    PersistedAgentEventEntity(
+        agent_class=agent_class,
+        agent_id=agent_id,
+        thread_id=thread_id,
+        display_id=display_id,
+        run_id=run_id,
+        event_id=event_id,
+        event_type=AgentTopicManager.DISPLAY_EVENT,
+        event_name=event_name,
+        event_data=event_data,
+        event_parents=event_parents,
+    ).save()
+
+
+def _seed_nested_history(thread_id: str) -> str:
+    visible_display = str(ObjectId())
+    hidden_display = str(ObjectId())
+    user_event = UserMessageEvent(
+        user=fake_user(),
+        messages=[ChatMessage(role=MessageRole.USER, blocks=[TextBlock(text="Persisted visible question")])],
+    )
+    user_data = user_event.model_dump()
+    user_data["created_at"] = 1
+    _save_persisted_event(
+        thread_id=thread_id,
+        display_id=visible_display,
+        event_name=user_event.event_name,
+        event_parents=user_event._parent_event_names,
+        event_data=user_data,
+        event_id="visible-user",
+        agent_class="UserAgent",
+        agent_id=fake_user().id,
+        run_id="top-level-run",
+    )
+
+    def save_chunk(
+        content: str,
+        *,
+        event_id: str,
+        created_at: int,
+        display_id: str,
+        agent_class: str,
+        agent_id: str,
+        run_id: str,
+    ) -> None:
+        chunk = ChunkEvent(content=content, model_name="sim")
+        chunk_data = chunk.model_dump()
+        chunk_data["created_at"] = created_at
+        _save_persisted_event(
+            thread_id=thread_id,
+            display_id=display_id,
+            event_name=chunk.event_name,
+            event_parents=chunk._parent_event_names,
+            event_data=chunk_data,
+            event_id=event_id,
+            agent_class=agent_class,
+            agent_id=agent_id,
+            run_id=run_id,
+        )
+
+    save_chunk(
+        "Primary ",
+        event_id="primary-chunk",
+        created_at=2,
+        display_id=visible_display,
+        agent_class=AGENT_CLASS,
+        agent_id=AGENT_ID,
+        run_id="top-level-run",
+    )
+    save_chunk(
+        "delegated ",
+        event_id="shared-nested-chunk",
+        created_at=3,
+        display_id=visible_display,
+        agent_class="NestedAgent",
+        agent_id="nested-shared",
+        run_id="nested-shared-run",
+    )
+    save_chunk(
+        "delegated ",
+        event_id="shared-nested-chunk",
+        created_at=3,
+        display_id=visible_display,
+        agent_class="NestedAgent",
+        agent_id="nested-shared",
+        run_id="nested-shared-run",
+    )
+    save_chunk(
+        "HIDDEN",
+        event_id="hidden-chunk",
+        created_at=4,
+        display_id=hidden_display,
+        agent_class="NestedAgent",
+        agent_id="nested-hidden",
+        run_id="nested-hidden-run",
+    )
+    _save_persisted_event(
+        thread_id=thread_id,
+        display_id=hidden_display,
+        event_name="RetrievalAgentInTheLoopResponseEvent",
+        event_parents=["RetrievalAgentInTheLoopResponseEvent", "AgentInTheLoopResponseEvent"],
+        event_data={
+            "created_at": 5,
+            "stop_event": {
+                "_event_name": "RetrievalResponseEvent",
+                "_parent_event_names": ["RetrievalResponseEvent", "RetrieverEvent", "StopEvent"],
+                "nodes": [],
+            },
+        },
+        event_id="unknown-hidden-aitl",
+        agent_class="NestedAgent",
+        agent_id="nested-hidden",
+        run_id="nested-hidden-run",
+    )
+    stop = LLMStopEvent(output_messages=[Message.from_string(role="assistant", content="Primary delegated final")])
+    stop_data = stop.model_dump()
+    stop_data["created_at"] = 6
+    _save_persisted_event(
+        thread_id=thread_id,
+        display_id=visible_display,
+        event_name=stop.event_name,
+        event_parents=stop._parent_event_names,
+        event_data=stop_data,
+        event_id="primary-stop",
+        agent_class=AGENT_CLASS,
+        agent_id=AGENT_ID,
+        run_id="top-level-run",
+    )
+    return visible_display
+
+
+@pytest.mark.parametrize("stream", [False, True], ids=["json", "stream"])
+@pytest.mark.asyncio(loop_scope="module")
+async def test_nested_visibility_unknown_events_and_duplicates_end_to_end(api_client_and_runner, stream: bool):
+    client, runner = api_client_and_runner
+    external_thread_id = str(uuid.uuid4())
+    thread_id = str(str_to_object_id(external_thread_id))
+    visible_display = _seed_nested_history(thread_id)
+    start_index = len(runner.received_user_message_events)
+
+    first_read = await ThreadService.thread_as_message_history(
+        thread_id,
+        primary_agent_class=AGENT_CLASS,
+        primary_agent_id=AGENT_ID,
+    )
+    second_read = await ThreadService.thread_as_message_history(
+        thread_id,
+        primary_agent_class=AGENT_CLASS,
+        primary_agent_id=AGENT_ID,
+    )
+    assert first_read.model_dump_json() == second_read.model_dump_json()
+
+    await _completion(
+        client,
+        external_thread_id,
+        "Current follow-up",
+        reconstruct_history=True,
+        display_id=str(ObjectId()),
+        stream=stream,
+    )
+
+    event = _last_received_event(runner, start_index, expected_count=1)
+    _assert_messages(
+        event,
+        [
+            (MessageRole.USER, "Persisted visible question"),
+            (MessageRole.ASSISTANT, "Primary delegated final"),
+            (MessageRole.USER, "Current follow-up"),
+        ],
+    )
+    assert all("HIDDEN" not in (message.content or "") for message in event.messages)
+    persisted = list(PersistedAgentEventEntity.display_events_for_thread(thread_id))
+    assert sum(item.event_id == "unknown-hidden-aitl" for item in persisted) == 1
+    assert sum(item.display_id == visible_display and item.event_id == "shared-nested-chunk" for item in persisted) == 2
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_live_nested_nats_flow_reconstructs_only_client_visible_history(api_client_and_runner):
+    client, runner = api_client_and_runner
+    external_thread_id = str(uuid.uuid4())
+    thread_id = str(str_to_object_id(external_thread_id))
+    start_index = len(runner.received_user_message_events)
+    first_display = str(ObjectId())
+
+    first_response = await _completion(
+        client,
+        external_thread_id,
+        RUNTIME_NESTED_PROMPT,
+        reconstruct_history=False,
+        display_id=first_display,
+    )
+    assert first_response.json()["choices"][0]["message"]["content"] == "Primary nested deep final"
+    await _await_persisted_event_ids(
+        thread_id,
+        {
+            "runtime-primary-chunk",
+            "runtime-shared-chunk",
+            "runtime-deep-chunk",
+            "runtime-hidden-chunk",
+            "runtime-hidden-aitl",
+            "runtime-primary-stop",
+        },
+    )
+
+    await _completion(
+        client,
+        external_thread_id,
+        "Follow-up after live nesting",
+        reconstruct_history=True,
+    )
+
+    event = _last_received_event(runner, start_index, expected_count=2)
+    _assert_messages(
+        event,
+        [
+            (MessageRole.USER, RUNTIME_NESTED_PROMPT),
+            (MessageRole.ASSISTANT, "Primary nested deep final"),
+            (MessageRole.USER, "Follow-up after live nesting"),
+        ],
+    )
+    assert all("HIDDEN" not in (message.content or "") for message in event.messages)
+    persisted = list(PersistedAgentEventEntity.display_events_for_thread(thread_id))
+    assert sum(item.event_id == "runtime-hidden-aitl" for item in persisted) == 1
+
+
+@pytest.mark.parametrize("messages", [[], None], ids=["empty", "null"])
+@pytest.mark.asyncio(loop_scope="module")
+async def test_empty_messages_with_reconstruction_returns_http_400(api_client_and_runner, messages):
+    client, runner = api_client_and_runner
+    start_index = len(runner.received_user_message_events)
+
+    response = await client.post(
+        COMPLETIONS_ENDPOINT,
+        json={
+            "model": f"{AGENT_CLASS}/{AGENT_ID}",
+            "messages": messages,
+            "stream": False,
+            "metadata": {
+                "thread_id": str(uuid.uuid4()),
+                "reconstruct_history": True,
+            },
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "At least one message is required when reconstruct_history is enabled."
+    assert len(runner.received_user_message_events) == start_index
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_openwebui_shaped_request_passes_client_history_through_untouched(api_client_and_runner):
+    """The OpenWebUI pipeline sends the full client-managed message list with thread/display ids and
+    no reconstruct_history flag. The API must pass those messages through exactly as sent."""
+    client, runner = api_client_and_runner
+    thread_id = str(ObjectId())
+    start_index = len(runner.received_user_message_events)
+
+    client_messages = [
+        {"role": "user", "content": "Client-managed first question"},
+        {"role": "assistant", "content": "Client-managed first answer"},
+        {"role": "user", "content": "Client-managed second question"},
+    ]
+    with patch.object(PersistedAgentEventEntity, "conversation_events_for_thread") as history_query:
+        response = await client.post(
+            COMPLETIONS_ENDPOINT,
+            json={
+                "model": f"{AGENT_CLASS}/{AGENT_ID}",
+                "messages": client_messages,
+                "stream": False,
+                "metadata": {"thread_id": thread_id, "display_id": str(ObjectId())},
+            },
+        )
+
+    assert response.status_code == 200, f"Response: {response.text}"
+    history_query.assert_not_called()
+    event = _last_received_event(runner, start_index, expected_count=1)
+    assert [(message.role, message.content) for message in event.messages] == [
+        (MessageRole.USER, "Client-managed first question"),
+        (MessageRole.ASSISTANT, "Client-managed first answer"),
+        (MessageRole.USER, "Client-managed second question"),
+    ]
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_web_chat_shaped_request_reconstructs_without_client_display_id(api_client_and_runner):
+    """The web chat composable sends only the latest message with a canonical thread id and
+    reconstruct_history=true, omitting display_id entirely. Every per-run display the API
+    generates must remain visible to reconstruction."""
+    client, runner = api_client_and_runner
+    thread_id = str(ObjectId())
+    start_index = len(runner.received_user_message_events)
+
+    await _completion(client, thread_id, "First web chat question", reconstruct_history=False, send_display_id=False)
+    await _await_persisted_display_events(thread_id, {"UserMessageEvent", "ChunkEvent"})
+    await _completion(client, thread_id, "Second web chat question", reconstruct_history=True, send_display_id=False)
+
+    event = _last_received_event(runner, start_index, expected_count=2)
+    _assert_messages(
+        event,
+        [
+            (MessageRole.USER, "First web chat question"),
+            (MessageRole.ASSISTANT, REPLY_TEXT),
+            (MessageRole.USER, "Second web chat question"),
+        ],
+    )

--- a/packages/api/playground/testing/tests/threads/test_thread_service_history_unit_tests.py
+++ b/packages/api/playground/testing/tests/threads/test_thread_service_history_unit_tests.py
@@ -14,7 +14,7 @@ from swiss_ai_hub.core.persistence.messaging.entities.persisted_agent_event_enti
 from swiss_ai_hub.core.testing.auth_utils import fake_user
 from swiss_ai_hub.core.topic_managers import AgentTopicManager
 
-from swiss_ai_hub.api.routes.thread.conversation_history_projector import project_conversation_history
+from swiss_ai_hub.api.routes.thread.conversation_history_projector import ConversationHistoryProjector
 from swiss_ai_hub.api.routes.thread.thread_service import ThreadService
 
 THREAD_ID = str(ObjectId())
@@ -195,7 +195,7 @@ def _project(
     primary_agent_class: str | None = PRIMARY_CLASS,
     primary_agent_id: str | None = PRIMARY_ID,
 ) -> list[ChatCompletionMessageParam]:
-    return project_conversation_history(
+    return ConversationHistoryProjector.project(
         events,
         primary_agent_class=primary_agent_class,
         primary_agent_id=primary_agent_id,
@@ -295,6 +295,18 @@ def test_malformed_relevant_event_is_skipped_and_later_event_survives(caplog):
 
     assert messages == [_text("user", "question"), _text("assistant", "valid answer")]
     assert caplog.records[-1].event_id == "bad-chunk"
+    assert caplog.records[-1].error_type == "ValueError"
+
+
+def test_empty_chunk_is_skipped_without_creating_assistant_message(caplog):
+    marker = _user("question", created_at=1, event_id="u1")
+    empty_chunk = _chunk("", created_at=2, event_id="empty-chunk")
+
+    with caplog.at_level(logging.WARNING, logger=PROJECTOR_LOGGER):
+        messages = _project([marker, empty_chunk])
+
+    assert messages == [_text("user", "question")]
+    assert caplog.records[-1].event_id == "empty-chunk"
     assert caplog.records[-1].error_type == "ValueError"
 
 
@@ -578,7 +590,7 @@ async def test_thread_service_preserves_optional_primary_identity_contract():
     with (
         patch.object(PersistedAgentEventEntity, "conversation_events_for_thread", return_value=events) as query,
         patch(
-            "swiss_ai_hub.api.routes.thread.thread_service.project_conversation_history",
+            "swiss_ai_hub.api.routes.thread.thread_service.ConversationHistoryProjector.project",
             return_value=expected,
         ) as projector,
     ):

--- a/packages/api/playground/testing/tests/threads/test_thread_service_history_unit_tests.py
+++ b/packages/api/playground/testing/tests/threads/test_thread_service_history_unit_tests.py
@@ -1,0 +1,590 @@
+import logging
+from collections.abc import Iterable
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from bson import ObjectId
+from llama_index.core.base.llms.types import AudioBlock, ChatMessage, ImageBlock, MessageRole, TextBlock
+from openai.types.chat import ChatCompletionMessageParam
+from swiss_ai_hub.core.events.agent import ChunkEvent, Message, UserMessageEvent
+from swiss_ai_hub.core.persistence.messaging.entities.persisted_agent_event_entity import (
+    PersistedAgentEventEntity,
+)
+from swiss_ai_hub.core.testing.auth_utils import fake_user
+from swiss_ai_hub.core.topic_managers import AgentTopicManager
+
+from swiss_ai_hub.api.routes.thread.conversation_history_projector import project_conversation_history
+from swiss_ai_hub.api.routes.thread.thread_service import ThreadService
+
+THREAD_ID = str(ObjectId())
+VISIBLE_DISPLAY = str(ObjectId())
+HIDDEN_DISPLAY = str(ObjectId())
+PRIMARY_CLASS = "PrimaryAgent"
+PRIMARY_ID = "primary"
+PROJECTOR_LOGGER = "swiss_ai_hub.api.routes.thread.conversation_history_projector"
+
+
+def _raw_event(
+    *,
+    event_name: str,
+    parents: list[str],
+    created_at: int,
+    event_id: str,
+    agent_class: str = PRIMARY_CLASS,
+    agent_id: str = PRIMARY_ID,
+    display_id: str = VISIBLE_DISPLAY,
+    run_id: str = "run-1",
+    event_data: dict[str, Any] | None = None,
+) -> PersistedAgentEventEntity:
+    return PersistedAgentEventEntity(
+        agent_class=agent_class,
+        agent_id=agent_id,
+        thread_id=THREAD_ID,
+        display_id=display_id,
+        run_id=run_id,
+        event_id=event_id,
+        event_type=AgentTopicManager.DISPLAY_EVENT,
+        event_name=event_name,
+        event_data={"created_at": created_at, **(event_data or {})},
+        event_parents=parents,
+    )
+
+
+def _persisted_event(
+    event,
+    *,
+    created_at: int,
+    event_id: str,
+    agent_class: str = PRIMARY_CLASS,
+    agent_id: str = PRIMARY_ID,
+    display_id: str = VISIBLE_DISPLAY,
+    run_id: str = "run-1",
+) -> PersistedAgentEventEntity:
+    event_data = event.model_dump()
+    event_data["created_at"] = created_at
+    return _raw_event(
+        event_name=event.event_name,
+        parents=event._parent_event_names,
+        created_at=created_at,
+        event_id=event_id,
+        agent_class=agent_class,
+        agent_id=agent_id,
+        display_id=display_id,
+        run_id=run_id,
+        event_data=event_data,
+    )
+
+
+def _user(
+    text: str,
+    *,
+    created_at: int,
+    event_id: str,
+    display_id: str = VISIBLE_DISPLAY,
+    messages: list[ChatMessage] | None = None,
+) -> PersistedAgentEventEntity:
+    user_messages = messages or [ChatMessage(role=MessageRole.USER, blocks=[TextBlock(text=text)])]
+    return _persisted_event(
+        UserMessageEvent(user=fake_user(), messages=user_messages),
+        created_at=created_at,
+        event_id=event_id,
+        agent_class="UserAgent",
+        agent_id=fake_user().id,
+        display_id=display_id,
+    )
+
+
+def _empty_user(*, created_at: int, event_id: str) -> PersistedAgentEventEntity:
+    return _persisted_event(
+        UserMessageEvent(user=fake_user(), messages=[]),
+        created_at=created_at,
+        event_id=event_id,
+        agent_class="UserAgent",
+        agent_id=fake_user().id,
+    )
+
+
+def _chunk(
+    text: str,
+    *,
+    created_at: int,
+    event_id: str,
+    agent_class: str = PRIMARY_CLASS,
+    agent_id: str = PRIMARY_ID,
+    display_id: str = VISIBLE_DISPLAY,
+    run_id: str = "run-1",
+) -> PersistedAgentEventEntity:
+    return _persisted_event(
+        ChunkEvent(content=text, model_name="sim"),
+        created_at=created_at,
+        event_id=event_id,
+        agent_class=agent_class,
+        agent_id=agent_id,
+        display_id=display_id,
+        run_id=run_id,
+    )
+
+
+def _hitl_request(
+    question: Any,
+    *,
+    created_at: int,
+    event_id: str,
+    display_id: str = VISIBLE_DISPLAY,
+) -> PersistedAgentEventEntity:
+    return _raw_event(
+        event_name="CustomHumanInTheLoopRequestEvent",
+        parents=["CustomHumanInTheLoopRequestEvent", "HumanInTheLoopRequestEvent"],
+        created_at=created_at,
+        event_id=event_id,
+        display_id=display_id,
+        event_data={"question": question},
+    )
+
+
+def _hitl_response(
+    response: Any,
+    *,
+    created_at: int,
+    event_id: str,
+    display_id: str = VISIBLE_DISPLAY,
+    request_event: Any = None,
+) -> PersistedAgentEventEntity:
+    return _raw_event(
+        event_name="CustomHumanInTheLoopResponseEvent",
+        parents=["CustomHumanInTheLoopResponseEvent", "HumanInTheLoopResponseEvent"],
+        created_at=created_at,
+        event_id=event_id,
+        agent_class="UserAgent",
+        agent_id=fake_user().id,
+        display_id=display_id,
+        event_data={"response": response, "request_event": request_event},
+    )
+
+
+def _stop(
+    full_answer: Any,
+    *,
+    created_at: int,
+    event_id: str,
+    agent_class: str = PRIMARY_CLASS,
+    agent_id: str = PRIMARY_ID,
+    display_id: str = VISIBLE_DISPLAY,
+) -> PersistedAgentEventEntity:
+    output_messages = (
+        [Message.from_string(role="assistant", content=full_answer).model_dump()]
+        if isinstance(full_answer, str)
+        else full_answer
+    )
+    return _raw_event(
+        event_name="CustomStopEvent",
+        parents=["CustomStopEvent", "StopEvent"],
+        created_at=created_at,
+        event_id=event_id,
+        agent_class=agent_class,
+        agent_id=agent_id,
+        display_id=display_id,
+        event_data={"output_messages": output_messages},
+    )
+
+
+def _project(
+    events: Iterable[PersistedAgentEventEntity],
+    *,
+    primary_agent_class: str | None = PRIMARY_CLASS,
+    primary_agent_id: str | None = PRIMARY_ID,
+) -> list[ChatCompletionMessageParam]:
+    return project_conversation_history(
+        events,
+        primary_agent_class=primary_agent_class,
+        primary_agent_id=primary_agent_id,
+    )
+
+
+def _text(role: str, content: str) -> dict[str, Any]:
+    return {"role": role, "content": [{"type": "text", "text": content}]}
+
+
+def test_existing_non_nested_conversation_order_is_preserved():
+    events = [
+        _user("question one", created_at=1, event_id="u1"),
+        _chunk("Hel", created_at=2, event_id="c1"),
+        _chunk("lo", created_at=3, event_id="c2"),
+        _user("question two", created_at=4, event_id="u2"),
+        _chunk("Next answer", created_at=5, event_id="c3"),
+    ]
+
+    assert _project(events) == [
+        _text("user", "question one"),
+        _text("assistant", "Hello"),
+        _text("user", "question two"),
+        _text("assistant", "Next answer"),
+    ]
+
+
+def test_multimodal_user_input_uses_last_message_and_normalizes_legacy_audio():
+    stale = ChatMessage(role=MessageRole.USER, blocks=[TextBlock(text="stale")])
+    latest = ChatMessage(
+        role=MessageRole.USER,
+        blocks=[
+            TextBlock(text="latest"),
+            ImageBlock(url="https://example.com/image.png"),
+            AudioBlock(audio=b"encoded-audio", format="wav"),
+        ],
+    )
+    event = _user("", created_at=1, event_id="u1", messages=[stale, latest])
+
+    assert _project([event]) == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "latest"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}},
+                {
+                    "type": "input_audio",
+                    "input_audio": {"data": "ZW5jb2RlZC1hdWRpbw==", "format": "wav"},
+                },
+            ],
+        }
+    ]
+
+
+def test_empty_user_event_is_skipped_with_metadata_only_warning(caplog):
+    event = _empty_user(created_at=1, event_id="empty-user")
+
+    with caplog.at_level(logging.WARNING, logger=PROJECTOR_LOGGER):
+        assert _project([event]) == []
+
+    record = caplog.records[-1]
+    assert record.message == "Skipping malformed visible history event"
+    assert record.event_id == "empty-user"
+    assert record.error_type == "ValueError"
+    assert "messages" not in record.getMessage()
+
+
+def test_unrelated_visible_event_is_ignored_without_payload_access(caplog):
+    marker = _user("question", created_at=1, event_id="u1")
+    unrelated = _raw_event(
+        event_name="RetrievalAgentInTheLoopResponseEvent",
+        parents=["RetrievalAgentInTheLoopResponseEvent", "AgentInTheLoopResponseEvent"],
+        created_at=2,
+        event_id="aitl",
+        event_data={"secret": "must-not-be-read", "created_at": "malformed-but-unread"},
+    )
+
+    with caplog.at_level(logging.WARNING, logger=PROJECTOR_LOGGER):
+        assert _project([marker, unrelated]) == [_text("user", "question")]
+
+    assert not caplog.records
+
+
+def test_malformed_relevant_event_is_skipped_and_later_event_survives(caplog):
+    marker = _user("question", created_at=1, event_id="u1")
+    malformed = _raw_event(
+        event_name="ChunkEvent",
+        parents=["ChunkEvent"],
+        created_at=2,
+        event_id="bad-chunk",
+        event_data={"content": 12345},
+    )
+    valid = _chunk("valid answer", created_at=3, event_id="good-chunk")
+
+    with caplog.at_level(logging.WARNING, logger=PROJECTOR_LOGGER):
+        messages = _project([marker, malformed, valid])
+
+    assert messages == [_text("user", "question"), _text("assistant", "valid answer")]
+    assert caplog.records[-1].event_id == "bad-chunk"
+    assert caplog.records[-1].error_type == "ValueError"
+
+
+def test_invalid_order_metadata_is_skipped_before_sorting(caplog):
+    marker = _user("question", created_at=1, event_id="u1")
+    malformed_order = _raw_event(
+        event_name="ChunkEvent",
+        parents=["ChunkEvent"],
+        created_at=2,
+        event_id="bad-order",
+        event_data={"created_at": "not-an-integer", "content": "must not project"},
+    )
+    valid = _chunk("valid answer", created_at=3, event_id="good-chunk")
+
+    with caplog.at_level(logging.WARNING, logger=PROJECTOR_LOGGER):
+        messages = _project([marker, malformed_order, valid])
+
+    assert messages == [_text("user", "question"), _text("assistant", "valid answer")]
+    assert caplog.records[-1].event_id == "bad-order"
+    assert caplog.records[-1].error_type == "TypeError"
+
+
+def test_replica_delivery_duplicates_contribute_once():
+    marker = _user("question", created_at=1, event_id="u1")
+    chunk = _chunk("answer", created_at=2, event_id="c1")
+
+    assert _project([marker, marker, chunk, chunk, chunk]) == [
+        _text("user", "question"),
+        _text("assistant", "answer"),
+    ]
+
+
+def test_equal_created_at_is_ordered_by_event_id():
+    marker = _user("question", created_at=1, event_id="u1")
+    first = _chunk("A", created_at=2, event_id="a")
+    second = _chunk("B", created_at=2, event_id="b")
+
+    assert _project([marker, second, first]) == [
+        _text("user", "question"),
+        _text("assistant", "AB"),
+    ]
+
+
+def test_three_level_shared_display_includes_all_agent_chunks():
+    events = [
+        _user("question", created_at=1, event_id="u1"),
+        _chunk("A", created_at=2, event_id="a", agent_class="AgentA", agent_id="a"),
+        _chunk("B", created_at=3, event_id="b", agent_class="AgentB", agent_id="b"),
+        _chunk("C", created_at=4, event_id="c", agent_class="AgentC", agent_id="c"),
+    ]
+
+    assert _project(events) == [_text("user", "question"), _text("assistant", "ABC")]
+
+
+def test_hidden_nested_subtree_is_excluded_before_payload_access(caplog):
+    events = [
+        _user("question", created_at=1, event_id="u1"),
+        _chunk("visible", created_at=2, event_id="a"),
+        _chunk("hidden B", created_at=3, event_id="b", display_id=HIDDEN_DISPLAY),
+        _raw_event(
+            event_name="UnknownNestedRetrievalEvent",
+            parents=["UnknownNestedRetrievalEvent", "ChunkEvent"],
+            created_at=4,
+            event_id="c",
+            agent_class="AgentC",
+            agent_id="c",
+            display_id=HIDDEN_DISPLAY,
+            event_data={"content": {"malformed": "hidden"}},
+        ),
+    ]
+
+    with caplog.at_level(logging.WARNING, logger=PROJECTOR_LOGGER):
+        assert _project(events) == [_text("user", "question"), _text("assistant", "visible")]
+
+    assert not caplog.records
+
+
+def test_mixed_visible_hidden_nesting_includes_visible_before_and_after():
+    events = [
+        _user("question", created_at=1, event_id="u1"),
+        _chunk("A", created_at=2, event_id="a", agent_class="AgentA", agent_id="a"),
+        _chunk("hidden", created_at=3, event_id="c", display_id=HIDDEN_DISPLAY),
+        _chunk("B", created_at=4, event_id="b", agent_class="AgentB", agent_id="b"),
+    ]
+
+    assert _project(events) == [_text("user", "question"), _text("assistant", "AB")]
+
+
+def test_recursive_same_agent_delegation_uses_display_not_identity_or_run():
+    events = [
+        _user("question", created_at=1, event_id="u1"),
+        _chunk("outer", created_at=2, event_id="a", run_id="outer-run"),
+        _chunk("inner", created_at=3, event_id="b", run_id="inner-run"),
+        _chunk("resumed", created_at=4, event_id="c", run_id="outer-run"),
+    ]
+
+    assert _project(events) == [_text("user", "question"), _text("assistant", "outerinnerresumed")]
+
+
+def test_nested_stop_on_visible_display_cannot_supply_primary_fallback():
+    events = [
+        _user("question", created_at=1, event_id="u1"),
+        _chunk("stream", created_at=2, event_id="c1"),
+        _stop(
+            "stream nested secret",
+            created_at=3,
+            event_id="nested-stop",
+            agent_class="NestedAgent",
+            agent_id="nested",
+        ),
+        _stop("stream final", created_at=4, event_id="primary-stop"),
+    ]
+
+    assert _project(events) == [_text("user", "question"), _text("assistant", "stream final")]
+
+
+def test_visible_delegated_chunk_from_other_agent_is_included():
+    events = [
+        _user("question", created_at=1, event_id="u1"),
+        _chunk("delegated answer", created_at=2, event_id="worker", agent_class="Worker", agent_id="worker"),
+    ]
+
+    assert _project(events) == [_text("user", "question"), _text("assistant", "delegated answer")]
+
+
+def test_hitl_request_projects_assistant_question():
+    events = [
+        _user("initial", created_at=1, event_id="u1"),
+        _hitl_request("Please clarify", created_at=2, event_id="request"),
+    ]
+
+    assert _project(events) == [_text("user", "initial"), _text("assistant", "Please clarify")]
+
+
+def test_hitl_response_projects_user_answer_once():
+    response = _hitl_response("Human answer", created_at=1, event_id="response")
+
+    assert _project([response]) == [_text("user", "Human answer")]
+
+
+def test_boolean_hitl_confirmation_projects_as_text():
+    confirmed = _hitl_response(True, created_at=1, event_id="confirmed")
+    rejected = _hitl_response(False, created_at=2, event_id="rejected")
+
+    assert _project([rejected]) == [_text("user", "false")]
+    assert _project([confirmed]) == [_text("user", "true")]
+
+
+def test_unsupported_audio_format_warns_and_keeps_representable_parts(caplog):
+    latest = ChatMessage(
+        role=MessageRole.USER,
+        blocks=[
+            TextBlock(text="see attached"),
+            AudioBlock(audio=b"legacy", format="ogg"),
+        ],
+    )
+    event = _user("", created_at=1, event_id="u1", messages=[latest])
+
+    with caplog.at_level(logging.WARNING, logger=PROJECTOR_LOGGER):
+        messages = _project([event])
+
+    assert messages == [_text("user", "see attached")]
+    record = caplog.records[-1]
+    assert record.message == "Skipping visible history audio block with unsupported format"
+    assert record.event_id == "u1"
+    assert record.audio_format == "ogg"
+
+
+def test_boolean_audio_payload_is_rejected_as_malformed(caplog):
+    event = _raw_event(
+        event_name="UserMessageEvent",
+        parents=["UserMessageEvent", "StartEvent"],
+        created_at=1,
+        event_id="bool-audio",
+        agent_class="UserAgent",
+        agent_id=fake_user().id,
+        event_data={
+            "messages": [
+                {
+                    "role": "user",
+                    "blocks": [{"block_type": "audio", "audio": [True, False], "format": "wav"}],
+                }
+            ]
+        },
+    )
+
+    with caplog.at_level(logging.WARNING, logger=PROJECTOR_LOGGER):
+        assert _project([event]) == []
+
+    assert caplog.records[-1].event_id == "bool-audio"
+    assert caplog.records[-1].error_type == "ValidationError"
+
+
+def test_resumed_chunks_form_following_assistant_turn():
+    events = [
+        _user("initial", created_at=1, event_id="u1"),
+        _hitl_request("Please clarify", created_at=2, event_id="request"),
+        _hitl_response("Human answer", created_at=3, event_id="response"),
+        _chunk("Resumed answer", created_at=4, event_id="chunk"),
+    ]
+
+    assert _project(events) == [
+        _text("user", "initial"),
+        _text("assistant", "Please clarify"),
+        _text("user", "Human answer"),
+        _text("assistant", "Resumed answer"),
+    ]
+
+
+def test_hitl_response_ignores_malformed_nested_request_when_response_is_valid():
+    response = _hitl_response(
+        "Human answer",
+        created_at=1,
+        event_id="response",
+        request_event={"unknown_custom_event": object()},
+    )
+
+    assert _project([response]) == [_text("user", "Human answer")]
+
+
+def test_hidden_hitl_is_excluded_until_user_marker_makes_display_visible():
+    initial = _user("initial", created_at=1, event_id="u1")
+    hidden_request = _hitl_request(
+        "Hidden question",
+        created_at=2,
+        event_id="request",
+        display_id=HIDDEN_DISPLAY,
+    )
+
+    assert _project([initial, hidden_request]) == [_text("user", "initial")]
+
+    hidden_response = _hitl_response(
+        "Visible answer",
+        created_at=3,
+        event_id="response",
+        display_id=HIDDEN_DISPLAY,
+    )
+    assert _project([initial, hidden_request, hidden_response]) == [
+        _text("user", "initial"),
+        _text("assistant", "Hidden question"),
+        _text("user", "Visible answer"),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("chunks", "full_answer", "expected"),
+    [
+        pytest.param([], "full answer", "full answer", id="no-chunks"),
+        pytest.param(["partial "], "partial answer", "partial answer", id="partial-prefix"),
+        pytest.param(["complete answer"], "complete answer", "complete answer", id="complete"),
+        pytest.param(["divergent"], "different answer", "divergent", id="divergent"),
+    ],
+)
+def test_primary_terminal_fallback_matches_live_prefix_rule(chunks: list[str], full_answer: str, expected: str):
+    events: list[PersistedAgentEventEntity] = [_user("question", created_at=1, event_id="u1")]
+    events.extend(_chunk(chunk, created_at=index + 2, event_id=f"c{index}") for index, chunk in enumerate(chunks))
+    events.append(_stop(full_answer, created_at=len(chunks) + 2, event_id="stop"))
+
+    assert _project(events) == [_text("user", "question"), _text("assistant", expected)]
+
+
+def test_malformed_primary_stop_preserves_valid_chunks_and_warns(caplog):
+    events = [
+        _user("question", created_at=1, event_id="u1"),
+        _chunk("streamed", created_at=2, event_id="chunk"),
+        _stop([{"role": "assistant", "contents": "invalid"}], created_at=3, event_id="bad-stop"),
+    ]
+
+    with caplog.at_level(logging.WARNING, logger=PROJECTOR_LOGGER):
+        messages = _project(events)
+
+    assert messages == [_text("user", "question"), _text("assistant", "streamed")]
+    assert caplog.records[-1].event_id == "bad-stop"
+    assert caplog.records[-1].error_type == "ValidationError"
+
+
+@pytest.mark.asyncio
+async def test_thread_service_preserves_optional_primary_identity_contract():
+    events = [_user("question", created_at=1, event_id="u1")]
+    expected = [_text("user", "question")]
+    with (
+        patch.object(PersistedAgentEventEntity, "conversation_events_for_thread", return_value=events) as query,
+        patch(
+            "swiss_ai_hub.api.routes.thread.thread_service.project_conversation_history",
+            return_value=expected,
+        ) as projector,
+    ):
+        response = await ThreadService.thread_as_message_history(THREAD_ID)
+
+    query.assert_called_once_with(THREAD_ID)
+    projector.assert_called_once_with(events, primary_agent_class=None, primary_agent_id=None)
+    assert response.messages[0]["role"] == "user"
+    assert list(response.messages[0]["content"]) == expected[0]["content"]

--- a/packages/api/swiss_ai_hub/api/routes/openai/openai_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/openai/openai_service.py
@@ -384,7 +384,10 @@ class OpenaiService:
         thread_id, display_id = OpenaiService._extract_thread_and_display_id(chat_completion_request)
         if thread_id and chat_completion_request.metadata.reconstruct_history:
             chat_completion_request.messages = await OpenaiService._reconstruct_history(
-                chat_completion_request, thread_id
+                chat_completion_request,
+                thread_id,
+                primary_agent_class=agent_class,
+                primary_agent_id=agent_id,
             )
         files = OpenaiService._extract_files(chat_completion_request)
 
@@ -450,7 +453,10 @@ class OpenaiService:
         thread_id, display_id = OpenaiService._extract_thread_and_display_id(chat_completion_request)
         if thread_id and chat_completion_request.metadata.reconstruct_history:
             chat_completion_request.messages = await OpenaiService._reconstruct_history(
-                chat_completion_request, thread_id
+                chat_completion_request,
+                thread_id,
+                primary_agent_class=agent_class,
+                primary_agent_id=agent_id,
             )
         files = OpenaiService._extract_files(chat_completion_request)
 
@@ -679,11 +685,24 @@ class OpenaiService:
 
     @staticmethod
     async def _reconstruct_history(
-        chat_completion_request: ChatCompletionRequest, thread_id: str
+        chat_completion_request: ChatCompletionRequest,
+        thread_id: str,
+        *,
+        primary_agent_class: str,
+        primary_agent_id: str,
     ) -> list[ChatCompletionMessageParam]:
-        history = await ThreadService.thread_as_message_history(thread_id)
-        user_message = chat_completion_request.messages[-1]
-        return history.messages + [user_message]
+        if not chat_completion_request.messages:
+            raise HTTPException(
+                status_code=400,
+                detail="At least one message is required when reconstruct_history is enabled.",
+            )
+        normalized_thread_id = str(str_to_object_id(thread_id))
+        history = await ThreadService.thread_as_message_history(
+            normalized_thread_id,
+            primary_agent_class=primary_agent_class,
+            primary_agent_id=primary_agent_id,
+        )
+        return [*history.messages, chat_completion_request.messages[-1]]
 
     @staticmethod
     def _filter_kwargs(

--- a/packages/api/swiss_ai_hub/api/routes/openai/openai_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/openai/openai_service.py
@@ -509,15 +509,8 @@ class OpenaiService:
             return stop_event.question
         if stop_event.is_exception_event:
             return f"\n\n>[!CAUTION]\n>**Error:** {stop_event.message}\n"
-        # Backstop: emit only the portion of the authoritative answer the client never received, in case
-        # chunks were lost to the stop-vs-chunk dispatch race. Empty once everything has already streamed.
-        # Best-effort: the prefix match can miss if the stream parser normalized whitespace differently
-        # from output_messages, in which case we keep what streamed rather than risk duplicating it.
-        output_messages = getattr(stop_event, "output_messages", None) or []
-        full_answer = (output_messages[-1].content or "") if output_messages else ""
-        if full_answer and full_answer.startswith(streamed):
-            return full_answer[len(streamed) :]
-        return "" if streamed else full_answer
+        full_answer = ChatService.terminal_output_text(getattr(stop_event, "output_messages", None))
+        return ChatService.missing_suffix(streamed, full_answer)
 
     @staticmethod
     def _build_chunk_sse(*, content: str, model: str, finish_reason: str | None = None) -> str:

--- a/packages/api/swiss_ai_hub/api/routes/thread/conversation_history_projector.py
+++ b/packages/api/swiss_ai_hub/api/routes/thread/conversation_history_projector.py
@@ -1,29 +1,25 @@
 import logging
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass, field
 from typing import Any, Literal, cast
 
-from llama_index.core.base.llms.types import AudioBlock, ChatMessage, ImageBlock, TextBlock
+from llama_index.core.base.llms.types import AudioBlock, ChatMessage, ContentBlock, ImageBlock, TextBlock
 from openai.types.chat import (
-    ChatCompletionAssistantMessageParam,
     ChatCompletionContentPartImageParam,
     ChatCompletionContentPartInputAudioParam,
     ChatCompletionContentPartTextParam,
     ChatCompletionMessageParam,
-    ChatCompletionUserMessageParam,
 )
 from openai.types.chat.chat_completion_content_part_image_param import ImageURL
 from openai.types.chat.chat_completion_content_part_input_audio_param import InputAudio
 from pydantic import ValidationError
-from swiss_ai_hub.core.events.agent import Message
 from swiss_ai_hub.core.persistence.messaging.entities.persisted_agent_event_entity import PersistedAgentEventEntity
+from swiss_ai_hub.core.routes import ChatService
+
+from swiss_ai_hub.api.routes.thread.conversation_transcript_builder import ContentPart, ConversationTranscriptBuilder
 
 logger = logging.getLogger(__name__)
 
 DeliveryKey = tuple[str, str, str, str, str, str, str, str]
-ContentPart = (
-    ChatCompletionContentPartTextParam | ChatCompletionContentPartImageParam | ChatCompletionContentPartInputAudioParam
-)
 _VISIBLE_MARKER_PARENTS = {"UserMessageEvent", "HumanInTheLoopResponseEvent"}
 _PROJECTABLE_PARENTS = {
     "UserMessageEvent",
@@ -34,320 +30,272 @@ _PROJECTABLE_PARENTS = {
 }
 
 
-@dataclass
-class _ProjectedMessage:
-    role: Literal["user", "assistant"]
-    display_id: str
-    content: list[ContentPart] = field(default_factory=list)
+class ConversationHistoryProjector:
+    """Projects persisted client-visible events into the OpenAI chat message surface."""
 
+    @staticmethod
+    def _warning_context(event: PersistedAgentEventEntity, error_type: str) -> dict[str, str]:
+        return {
+            "thread_id": str(getattr(event, "thread_id", "")),
+            "display_id": str(getattr(event, "display_id", "")),
+            "run_id": str(getattr(event, "run_id", "")),
+            "event_id": str(getattr(event, "event_id", "")),
+            "event_name": str(getattr(event, "event_name", "")),
+            "error_type": error_type,
+        }
 
-class _TranscriptBuilder:
-    def __init__(self) -> None:
-        self.messages: list[_ProjectedMessage] = []
-        self.assistant_text_by_display: dict[str, str] = {}
-
-    def add_user_parts(self, display_id: str, parts: list[ContentPart]) -> None:
-        self.assistant_text_by_display[display_id] = ""
-        if not parts:
-            raise ValueError("User event has no supported content")
-
-        if self.messages and self.messages[-1].role == "user" and self.messages[-1].display_id == display_id:
-            self.messages[-1].content.extend(parts)
-            return
-        self.messages.append(_ProjectedMessage(role="user", display_id=display_id, content=parts))
-
-    def add_assistant_text(self, display_id: str, text: str) -> None:
-        if not text:
-            raise ValueError("Assistant event has no text")
-
-        if self.messages and self.messages[-1].role == "assistant" and self.messages[-1].display_id == display_id:
-            current = self.messages[-1]
-            if current.content and current.content[-1]["type"] == "text":
-                current.content[-1]["text"] += text
-            else:
-                current.content.append(ChatCompletionContentPartTextParam(type="text", text=text))
-        else:
-            self.messages.append(
-                _ProjectedMessage(
-                    role="assistant",
-                    display_id=display_id,
-                    content=[ChatCompletionContentPartTextParam(type="text", text=text)],
-                )
-            )
-        self.assistant_text_by_display[display_id] = self.assistant_text_by_display.get(display_id, "") + text
-
-    def start_user_segment(self, display_id: str) -> None:
-        self.assistant_text_by_display[display_id] = ""
-
-    def streamed_assistant_text(self, display_id: str) -> str:
-        return self.assistant_text_by_display.get(display_id, "")
-
-    def to_openai_messages(self) -> list[ChatCompletionMessageParam]:
-        result: list[ChatCompletionMessageParam] = []
-        for message in self.messages:
-            if message.role == "user":
-                result.append(
-                    ChatCompletionUserMessageParam(
-                        role="user",
-                        content=cast(Any, message.content),
-                    )
-                )
-            else:
-                result.append(
-                    ChatCompletionAssistantMessageParam(
-                        role="assistant",
-                        content=cast(Any, message.content),
-                    )
-                )
-        return result
-
-
-def _warning_context(event: PersistedAgentEventEntity, error_type: str) -> dict[str, str]:
-    return {
-        "thread_id": str(getattr(event, "thread_id", "")),
-        "display_id": str(getattr(event, "display_id", "")),
-        "run_id": str(getattr(event, "run_id", "")),
-        "event_id": str(getattr(event, "event_id", "")),
-        "event_name": str(getattr(event, "event_name", "")),
-        "error_type": error_type,
-    }
-
-
-def _warn_malformed(event: PersistedAgentEventEntity, error: Exception) -> None:
-    logger.warning(
-        "Skipping malformed visible history event",
-        extra=_warning_context(event, type(error).__name__),
-    )
-
-
-def _required_string(event: PersistedAgentEventEntity, field_name: str) -> str:
-    value = getattr(event, field_name, None)
-    if not isinstance(value, str) or not value:
-        raise ValueError(f"Missing {field_name}")
-    return value
-
-
-def _delivery_key(event: PersistedAgentEventEntity) -> DeliveryKey:
-    return (
-        _required_string(event, "agent_class"),
-        _required_string(event, "agent_id"),
-        _required_string(event, "thread_id"),
-        _required_string(event, "display_id"),
-        _required_string(event, "run_id"),
-        _required_string(event, "event_type"),
-        _required_string(event, "event_name"),
-        _required_string(event, "event_id"),
-    )
-
-
-def _parent_names(event: PersistedAgentEventEntity) -> set[str]:
-    parents = event.event_parents
-    if not isinstance(parents, list):
-        return set()
-    return {parent for parent in parents if isinstance(parent, str)}
-
-
-def _visible_projectable_events(
-    events: Iterable[PersistedAgentEventEntity],
-) -> list[PersistedAgentEventEntity]:
-    candidates = list(events)
-    visible_display_ids = {
-        event.display_id
-        for event in candidates
-        if event.agent_class == "UserAgent"
-        and isinstance(event.display_id, str)
-        and _parent_names(event) & _VISIBLE_MARKER_PARENTS
-    }
-    return [
-        event
-        for event in candidates
-        if event.display_id in visible_display_ids and _parent_names(event) & _PROJECTABLE_PARENTS
-    ]
-
-
-def _created_at(event: PersistedAgentEventEntity) -> int:
-    event_data = event.event_data
-    if not isinstance(event_data, Mapping):
-        raise TypeError("Event data is not a mapping")
-    created_at = event_data.get("created_at")
-    if isinstance(created_at, bool) or not isinstance(created_at, int):
-        raise TypeError("Event created_at is not an integer")
-    return created_at
-
-
-def _ordered_unique_events(
-    events: Iterable[PersistedAgentEventEntity],
-) -> list[PersistedAgentEventEntity]:
-    unique: dict[DeliveryKey, tuple[int, PersistedAgentEventEntity]] = {}
-    for event in events:
-        try:
-            key = _delivery_key(event)
-            created_at = _created_at(event)
-        except (TypeError, ValueError) as error:
-            _warn_malformed(event, error)
-            continue
-        unique.setdefault(key, (created_at, event))
-
-    return [
-        event
-        for _, event in sorted(
-            unique.values(),
-            key=lambda item: (item[0], item[1].event_id, _delivery_key(item[1])),
+    @staticmethod
+    def _warn_malformed(event: PersistedAgentEventEntity, error: Exception) -> None:
+        logger.warning(
+            "Skipping malformed visible history event",
+            extra=ConversationHistoryProjector._warning_context(event, type(error).__name__),
         )
-    ]
 
+    @staticmethod
+    def _required_string(event: PersistedAgentEventEntity, field_name: str) -> str:
+        value = getattr(event, field_name, None)
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"Missing {field_name}")
+        return value
 
-def _normalized_binary(value: Any) -> Any:
-    if isinstance(value, list) and all(
-        isinstance(byte, int) and not isinstance(byte, bool) and 0 <= byte <= 255 for byte in value
-    ):
-        return bytes(value)
-    return value
+    @staticmethod
+    def _delivery_key(event: PersistedAgentEventEntity) -> DeliveryKey:
+        return (
+            ConversationHistoryProjector._required_string(event, "agent_class"),
+            ConversationHistoryProjector._required_string(event, "agent_id"),
+            ConversationHistoryProjector._required_string(event, "thread_id"),
+            ConversationHistoryProjector._required_string(event, "display_id"),
+            ConversationHistoryProjector._required_string(event, "run_id"),
+            ConversationHistoryProjector._required_string(event, "event_type"),
+            ConversationHistoryProjector._required_string(event, "event_name"),
+            ConversationHistoryProjector._required_string(event, "event_id"),
+        )
 
+    @staticmethod
+    def _parent_names(event: PersistedAgentEventEntity) -> set[str]:
+        parents = event.event_parents
+        if not isinstance(parents, list):
+            return set()
+        return {parent for parent in parents if isinstance(parent, str)}
 
-def _last_chat_message(event: PersistedAgentEventEntity) -> ChatMessage:
-    event_data = event.event_data
-    if not isinstance(event_data, Mapping):
-        raise TypeError("Event data is not a mapping")
-    raw_messages = event_data.get("messages")
-    if not isinstance(raw_messages, list) or not raw_messages:
-        raise ValueError("User event has no messages")
-    raw_message = raw_messages[-1]
-    if not isinstance(raw_message, Mapping):
-        raise TypeError("Last user message is not a mapping")
+    @staticmethod
+    def _visible_projectable_events(
+        events: Iterable[PersistedAgentEventEntity],
+    ) -> list[PersistedAgentEventEntity]:
+        candidates = list(events)
+        visible_display_ids = {
+            event.display_id
+            for event in candidates
+            if event.agent_class == "UserAgent"
+            and isinstance(event.display_id, str)
+            and ConversationHistoryProjector._parent_names(event) & _VISIBLE_MARKER_PARENTS
+        }
+        return [
+            event
+            for event in candidates
+            if event.display_id in visible_display_ids
+            and ConversationHistoryProjector._parent_names(event) & _PROJECTABLE_PARENTS
+        ]
 
-    normalized_message = dict(raw_message)
-    raw_blocks = normalized_message.get("blocks")
-    if not isinstance(raw_blocks, list):
-        raise TypeError("Last user message blocks are not a list")
+    @staticmethod
+    def _event_data(event: PersistedAgentEventEntity) -> Mapping[str, Any]:
+        event_data = event.event_data
+        if not isinstance(event_data, Mapping):
+            raise TypeError("Event data is not a mapping")
+        return event_data
 
-    normalized_blocks: list[dict[str, Any]] = []
-    for raw_block in raw_blocks:
-        if not isinstance(raw_block, Mapping):
-            raise TypeError("User message block is not a mapping")
-        block = dict(raw_block)
-        block_type = block.get("block_type")
-        if block_type not in {"text", "image", "audio"}:
-            continue
-        if block_type == "image":
-            block["image"] = _normalized_binary(block.get("image"))
-        elif block_type == "audio":
-            block["audio"] = _normalized_binary(block.get("audio"))
-        normalized_blocks.append(block)
+    @staticmethod
+    def _created_at(event: PersistedAgentEventEntity) -> int:
+        created_at = ConversationHistoryProjector._event_data(event).get("created_at")
+        if isinstance(created_at, bool) or not isinstance(created_at, int):
+            raise TypeError("Event created_at is not an integer")
+        return created_at
 
-    normalized_message["blocks"] = normalized_blocks
-    return ChatMessage.model_validate(normalized_message)
-
-
-def _user_content_parts(event: PersistedAgentEventEntity) -> list[ContentPart]:
-    parts: list[ContentPart] = []
-    for block in _last_chat_message(event).blocks:
-        if isinstance(block, TextBlock) and block.text:
-            parts.append(ChatCompletionContentPartTextParam(type="text", text=block.text))
-        elif isinstance(block, ImageBlock) and block.url:
-            parts.append(
-                ChatCompletionContentPartImageParam(
-                    type="image_url",
-                    image_url=ImageURL(url=str(block.url)),
-                )
-            )
-        elif isinstance(block, AudioBlock):
-            if block.format not in {"wav", "mp3"}:
-                if block.audio is not None:
-                    logger.warning(
-                        "Skipping visible history audio block with unsupported format",
-                        extra={
-                            **_warning_context(event, "UnsupportedAudioFormat"),
-                            "audio_format": str(block.format),
-                        },
-                    )
+    @staticmethod
+    def _ordered_unique_events(
+        events: Iterable[PersistedAgentEventEntity],
+    ) -> list[PersistedAgentEventEntity]:
+        unique: dict[DeliveryKey, tuple[int, PersistedAgentEventEntity]] = {}
+        for event in events:
+            try:
+                key = ConversationHistoryProjector._delivery_key(event)
+                created_at = ConversationHistoryProjector._created_at(event)
+            except (TypeError, ValueError) as error:
+                ConversationHistoryProjector._warn_malformed(event, error)
                 continue
-            if isinstance(block.audio, bytes):
-                audio_format = cast(Literal["wav", "mp3"], block.format)
-                parts.append(
-                    ChatCompletionContentPartInputAudioParam(
-                        type="input_audio",
-                        input_audio=InputAudio(data=block.audio.decode("ascii"), format=audio_format),
+            unique.setdefault(key, (created_at, event))
+
+        return [
+            event
+            for _, event in sorted(
+                unique.values(),
+                key=lambda item: (
+                    item[0],
+                    item[1].event_id,
+                    ConversationHistoryProjector._delivery_key(item[1]),
+                ),
+            )
+        ]
+
+    @staticmethod
+    def _normalized_binary(value: Any) -> Any:
+        if isinstance(value, list) and all(
+            isinstance(byte, int) and not isinstance(byte, bool) and 0 <= byte <= 255 for byte in value
+        ):
+            return bytes(value)
+        return value
+
+    @staticmethod
+    def _last_chat_message(event: PersistedAgentEventEntity) -> ChatMessage:
+        raw_messages = ConversationHistoryProjector._event_data(event).get("messages")
+        if not isinstance(raw_messages, list) or not raw_messages:
+            raise ValueError("User event has no messages")
+        raw_message = raw_messages[-1]
+        if not isinstance(raw_message, Mapping):
+            raise TypeError("Last user message is not a mapping")
+
+        normalized_message = dict(raw_message)
+        raw_blocks = normalized_message.get("blocks")
+        if not isinstance(raw_blocks, list):
+            raise TypeError("Last user message blocks are not a list")
+
+        normalized_blocks: list[dict[str, Any]] = []
+        for raw_block in raw_blocks:
+            if not isinstance(raw_block, Mapping):
+                raise TypeError("User message block is not a mapping")
+            block = dict(raw_block)
+            block_type = block.get("block_type")
+            if block_type not in {"text", "image", "audio"}:
+                continue
+            if block_type == "image":
+                block["image"] = ConversationHistoryProjector._normalized_binary(block.get("image"))
+            elif block_type == "audio":
+                block["audio"] = ConversationHistoryProjector._normalized_binary(block.get("audio"))
+            normalized_blocks.append(block)
+
+        normalized_message["blocks"] = normalized_blocks
+        return ChatMessage.model_validate(normalized_message)
+
+    @staticmethod
+    def _audio_content_part(
+        event: PersistedAgentEventEntity,
+        block: AudioBlock,
+    ) -> ChatCompletionContentPartInputAudioParam | None:
+        if block.format not in {"wav", "mp3"}:
+            if block.audio is not None:
+                logger.warning(
+                    "Skipping visible history audio block with unsupported format",
+                    extra={
+                        **ConversationHistoryProjector._warning_context(event, "UnsupportedAudioFormat"),
+                        "audio_format": str(block.format),
+                    },
+                )
+            return None
+        if not isinstance(block.audio, bytes):
+            return None
+        audio_format = cast(Literal["wav", "mp3"], block.format)
+        return ChatCompletionContentPartInputAudioParam(
+            type="input_audio",
+            input_audio=InputAudio(data=block.audio.decode("ascii"), format=audio_format),
+        )
+
+    @staticmethod
+    def _content_part(event: PersistedAgentEventEntity, block: ContentBlock) -> ContentPart | None:
+        if isinstance(block, TextBlock) and block.text:
+            return ChatCompletionContentPartTextParam(type="text", text=block.text)
+        if isinstance(block, ImageBlock) and block.url:
+            return ChatCompletionContentPartImageParam(
+                type="image_url",
+                image_url=ImageURL(url=str(block.url)),
+            )
+        if isinstance(block, AudioBlock):
+            return ConversationHistoryProjector._audio_content_part(event, block)
+        return None
+
+    @staticmethod
+    def _user_content_parts(event: PersistedAgentEventEntity) -> list[ContentPart]:
+        parts: list[ContentPart] = []
+        for block in ConversationHistoryProjector._last_chat_message(event).blocks:
+            part = ConversationHistoryProjector._content_part(event, block)
+            if part is not None:
+                parts.append(part)
+        return parts
+
+    @staticmethod
+    def _required_text(event: PersistedAgentEventEntity, field_name: str) -> str:
+        text = ConversationHistoryProjector._event_data(event).get(field_name)
+        if not isinstance(text, str) or not text:
+            raise ValueError(f"Event has no {field_name}")
+        return text
+
+    @staticmethod
+    def _hitl_response_text(event: PersistedAgentEventEntity) -> str:
+        response = ConversationHistoryProjector._event_data(event).get("response")
+        if isinstance(response, bool):
+            return "true" if response else "false"
+        if not isinstance(response, str) or not response:
+            raise ValueError("Event has no response")
+        return response
+
+    @staticmethod
+    def _terminal_output_text(event: PersistedAgentEventEntity) -> str:
+        output_messages = ConversationHistoryProjector._event_data(event).get("output_messages")
+        if output_messages is not None and not isinstance(output_messages, list):
+            raise TypeError("Event output_messages is not a list")
+        return ChatService.terminal_output_text(output_messages)
+
+    @staticmethod
+    def project(
+        events: Iterable[PersistedAgentEventEntity],
+        *,
+        primary_agent_class: str | None = None,
+        primary_agent_id: str | None = None,
+    ) -> list[ChatCompletionMessageParam]:
+        transcript = ConversationTranscriptBuilder()
+
+        visible_events = ConversationHistoryProjector._visible_projectable_events(events)
+        for event in ConversationHistoryProjector._ordered_unique_events(visible_events):
+            parents = ConversationHistoryProjector._parent_names(event)
+            try:
+                if event.agent_class == "UserAgent" and "UserMessageEvent" in parents:
+                    transcript.start_user_segment(event.display_id)
+                    transcript.add_user_parts(event.display_id, ConversationHistoryProjector._user_content_parts(event))
+                elif event.agent_class == "UserAgent" and "HumanInTheLoopResponseEvent" in parents:
+                    transcript.start_user_segment(event.display_id)
+                    transcript.add_user_parts(
+                        event.display_id,
+                        [
+                            ChatCompletionContentPartTextParam(
+                                type="text",
+                                text=ConversationHistoryProjector._hitl_response_text(event),
+                            )
+                        ],
                     )
-                )
-    return parts
+                elif "ChunkEvent" in parents:
+                    transcript.add_assistant_text(
+                        event.display_id,
+                        ConversationHistoryProjector._required_text(event, "content"),
+                    )
+                elif "HumanInTheLoopRequestEvent" in parents:
+                    transcript.add_assistant_text(
+                        event.display_id,
+                        ConversationHistoryProjector._required_text(event, "question"),
+                    )
+                elif (
+                    "StopEvent" in parents
+                    and primary_agent_class is not None
+                    and primary_agent_id is not None
+                    and event.agent_class == primary_agent_class
+                    and event.agent_id == primary_agent_id
+                ):
+                    full_answer = ConversationHistoryProjector._terminal_output_text(event)
+                    suffix = ChatService.missing_suffix(
+                        transcript.streamed_assistant_text(event.display_id),
+                        full_answer,
+                    )
+                    if suffix:
+                        transcript.add_assistant_text(event.display_id, suffix)
+            except (KeyError, TypeError, ValueError, ValidationError) as error:
+                ConversationHistoryProjector._warn_malformed(event, error)
 
-
-def _required_text(event: PersistedAgentEventEntity, field_name: str) -> str:
-    event_data = event.event_data
-    if not isinstance(event_data, Mapping):
-        raise TypeError("Event data is not a mapping")
-    text = event_data.get(field_name)
-    if not isinstance(text, str) or not text:
-        raise ValueError(f"Event has no {field_name}")
-    return text
-
-
-def _hitl_response_text(event: PersistedAgentEventEntity) -> str:
-    event_data = event.event_data
-    if not isinstance(event_data, Mapping):
-        raise TypeError("Event data is not a mapping")
-    response = event_data.get("response")
-    if isinstance(response, bool):
-        return "true" if response else "false"
-    if not isinstance(response, str) or not response:
-        raise ValueError("Event has no response")
-    return response
-
-
-def _terminal_output_text(event: PersistedAgentEventEntity) -> str:
-    event_data = event.event_data
-    if not isinstance(event_data, Mapping):
-        raise TypeError("Event data is not a mapping")
-    output_messages = event_data.get("output_messages")
-    if not isinstance(output_messages, list) or not output_messages:
-        return ""
-    return Message.model_validate(output_messages[-1]).content
-
-
-def _missing_suffix(streamed: str, full_answer: str) -> str:
-    if full_answer and full_answer.startswith(streamed):
-        return full_answer[len(streamed) :]
-    return "" if streamed else full_answer
-
-
-def project_conversation_history(
-    events: Iterable[PersistedAgentEventEntity],
-    *,
-    primary_agent_class: str | None = None,
-    primary_agent_id: str | None = None,
-) -> list[ChatCompletionMessageParam]:
-    """Project persisted client-visible events into the OpenAI chat message surface."""
-    transcript = _TranscriptBuilder()
-
-    for event in _ordered_unique_events(_visible_projectable_events(events)):
-        parents = _parent_names(event)
-        try:
-            if event.agent_class == "UserAgent" and "UserMessageEvent" in parents:
-                transcript.start_user_segment(event.display_id)
-                transcript.add_user_parts(event.display_id, _user_content_parts(event))
-            elif event.agent_class == "UserAgent" and "HumanInTheLoopResponseEvent" in parents:
-                transcript.start_user_segment(event.display_id)
-                transcript.add_user_parts(
-                    event.display_id,
-                    [ChatCompletionContentPartTextParam(type="text", text=_hitl_response_text(event))],
-                )
-            elif "ChunkEvent" in parents:
-                transcript.add_assistant_text(event.display_id, _required_text(event, "content"))
-            elif "HumanInTheLoopRequestEvent" in parents:
-                transcript.add_assistant_text(event.display_id, _required_text(event, "question"))
-            elif (
-                "StopEvent" in parents
-                and primary_agent_class is not None
-                and primary_agent_id is not None
-                and event.agent_class == primary_agent_class
-                and event.agent_id == primary_agent_id
-            ):
-                full_answer = _terminal_output_text(event)
-                suffix = _missing_suffix(transcript.streamed_assistant_text(event.display_id), full_answer)
-                if suffix:
-                    transcript.add_assistant_text(event.display_id, suffix)
-        except (KeyError, TypeError, ValueError, ValidationError) as error:
-            _warn_malformed(event, error)
-
-    return transcript.to_openai_messages()
+        return transcript.to_openai_messages()

--- a/packages/api/swiss_ai_hub/api/routes/thread/conversation_history_projector.py
+++ b/packages/api/swiss_ai_hub/api/routes/thread/conversation_history_projector.py
@@ -1,0 +1,353 @@
+import logging
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal, cast
+
+from llama_index.core.base.llms.types import AudioBlock, ChatMessage, ImageBlock, TextBlock
+from openai.types.chat import (
+    ChatCompletionAssistantMessageParam,
+    ChatCompletionContentPartImageParam,
+    ChatCompletionContentPartInputAudioParam,
+    ChatCompletionContentPartTextParam,
+    ChatCompletionMessageParam,
+    ChatCompletionUserMessageParam,
+)
+from openai.types.chat.chat_completion_content_part_image_param import ImageURL
+from openai.types.chat.chat_completion_content_part_input_audio_param import InputAudio
+from pydantic import ValidationError
+from swiss_ai_hub.core.events.agent import Message
+from swiss_ai_hub.core.persistence.messaging.entities.persisted_agent_event_entity import PersistedAgentEventEntity
+
+logger = logging.getLogger(__name__)
+
+DeliveryKey = tuple[str, str, str, str, str, str, str, str]
+ContentPart = (
+    ChatCompletionContentPartTextParam | ChatCompletionContentPartImageParam | ChatCompletionContentPartInputAudioParam
+)
+_VISIBLE_MARKER_PARENTS = {"UserMessageEvent", "HumanInTheLoopResponseEvent"}
+_PROJECTABLE_PARENTS = {
+    "UserMessageEvent",
+    "HumanInTheLoopResponseEvent",
+    "ChunkEvent",
+    "HumanInTheLoopRequestEvent",
+    "StopEvent",
+}
+
+
+@dataclass
+class _ProjectedMessage:
+    role: Literal["user", "assistant"]
+    display_id: str
+    content: list[ContentPart] = field(default_factory=list)
+
+
+class _TranscriptBuilder:
+    def __init__(self) -> None:
+        self.messages: list[_ProjectedMessage] = []
+        self.assistant_text_by_display: dict[str, str] = {}
+
+    def add_user_parts(self, display_id: str, parts: list[ContentPart]) -> None:
+        self.assistant_text_by_display[display_id] = ""
+        if not parts:
+            raise ValueError("User event has no supported content")
+
+        if self.messages and self.messages[-1].role == "user" and self.messages[-1].display_id == display_id:
+            self.messages[-1].content.extend(parts)
+            return
+        self.messages.append(_ProjectedMessage(role="user", display_id=display_id, content=parts))
+
+    def add_assistant_text(self, display_id: str, text: str) -> None:
+        if not text:
+            raise ValueError("Assistant event has no text")
+
+        if self.messages and self.messages[-1].role == "assistant" and self.messages[-1].display_id == display_id:
+            current = self.messages[-1]
+            if current.content and current.content[-1]["type"] == "text":
+                current.content[-1]["text"] += text
+            else:
+                current.content.append(ChatCompletionContentPartTextParam(type="text", text=text))
+        else:
+            self.messages.append(
+                _ProjectedMessage(
+                    role="assistant",
+                    display_id=display_id,
+                    content=[ChatCompletionContentPartTextParam(type="text", text=text)],
+                )
+            )
+        self.assistant_text_by_display[display_id] = self.assistant_text_by_display.get(display_id, "") + text
+
+    def start_user_segment(self, display_id: str) -> None:
+        self.assistant_text_by_display[display_id] = ""
+
+    def streamed_assistant_text(self, display_id: str) -> str:
+        return self.assistant_text_by_display.get(display_id, "")
+
+    def to_openai_messages(self) -> list[ChatCompletionMessageParam]:
+        result: list[ChatCompletionMessageParam] = []
+        for message in self.messages:
+            if message.role == "user":
+                result.append(
+                    ChatCompletionUserMessageParam(
+                        role="user",
+                        content=cast(Any, message.content),
+                    )
+                )
+            else:
+                result.append(
+                    ChatCompletionAssistantMessageParam(
+                        role="assistant",
+                        content=cast(Any, message.content),
+                    )
+                )
+        return result
+
+
+def _warning_context(event: PersistedAgentEventEntity, error_type: str) -> dict[str, str]:
+    return {
+        "thread_id": str(getattr(event, "thread_id", "")),
+        "display_id": str(getattr(event, "display_id", "")),
+        "run_id": str(getattr(event, "run_id", "")),
+        "event_id": str(getattr(event, "event_id", "")),
+        "event_name": str(getattr(event, "event_name", "")),
+        "error_type": error_type,
+    }
+
+
+def _warn_malformed(event: PersistedAgentEventEntity, error: Exception) -> None:
+    logger.warning(
+        "Skipping malformed visible history event",
+        extra=_warning_context(event, type(error).__name__),
+    )
+
+
+def _required_string(event: PersistedAgentEventEntity, field_name: str) -> str:
+    value = getattr(event, field_name, None)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"Missing {field_name}")
+    return value
+
+
+def _delivery_key(event: PersistedAgentEventEntity) -> DeliveryKey:
+    return (
+        _required_string(event, "agent_class"),
+        _required_string(event, "agent_id"),
+        _required_string(event, "thread_id"),
+        _required_string(event, "display_id"),
+        _required_string(event, "run_id"),
+        _required_string(event, "event_type"),
+        _required_string(event, "event_name"),
+        _required_string(event, "event_id"),
+    )
+
+
+def _parent_names(event: PersistedAgentEventEntity) -> set[str]:
+    parents = event.event_parents
+    if not isinstance(parents, list):
+        return set()
+    return {parent for parent in parents if isinstance(parent, str)}
+
+
+def _visible_projectable_events(
+    events: Iterable[PersistedAgentEventEntity],
+) -> list[PersistedAgentEventEntity]:
+    candidates = list(events)
+    visible_display_ids = {
+        event.display_id
+        for event in candidates
+        if event.agent_class == "UserAgent"
+        and isinstance(event.display_id, str)
+        and _parent_names(event) & _VISIBLE_MARKER_PARENTS
+    }
+    return [
+        event
+        for event in candidates
+        if event.display_id in visible_display_ids and _parent_names(event) & _PROJECTABLE_PARENTS
+    ]
+
+
+def _created_at(event: PersistedAgentEventEntity) -> int:
+    event_data = event.event_data
+    if not isinstance(event_data, Mapping):
+        raise TypeError("Event data is not a mapping")
+    created_at = event_data.get("created_at")
+    if isinstance(created_at, bool) or not isinstance(created_at, int):
+        raise TypeError("Event created_at is not an integer")
+    return created_at
+
+
+def _ordered_unique_events(
+    events: Iterable[PersistedAgentEventEntity],
+) -> list[PersistedAgentEventEntity]:
+    unique: dict[DeliveryKey, tuple[int, PersistedAgentEventEntity]] = {}
+    for event in events:
+        try:
+            key = _delivery_key(event)
+            created_at = _created_at(event)
+        except (TypeError, ValueError) as error:
+            _warn_malformed(event, error)
+            continue
+        unique.setdefault(key, (created_at, event))
+
+    return [
+        event
+        for _, event in sorted(
+            unique.values(),
+            key=lambda item: (item[0], item[1].event_id, _delivery_key(item[1])),
+        )
+    ]
+
+
+def _normalized_binary(value: Any) -> Any:
+    if isinstance(value, list) and all(
+        isinstance(byte, int) and not isinstance(byte, bool) and 0 <= byte <= 255 for byte in value
+    ):
+        return bytes(value)
+    return value
+
+
+def _last_chat_message(event: PersistedAgentEventEntity) -> ChatMessage:
+    event_data = event.event_data
+    if not isinstance(event_data, Mapping):
+        raise TypeError("Event data is not a mapping")
+    raw_messages = event_data.get("messages")
+    if not isinstance(raw_messages, list) or not raw_messages:
+        raise ValueError("User event has no messages")
+    raw_message = raw_messages[-1]
+    if not isinstance(raw_message, Mapping):
+        raise TypeError("Last user message is not a mapping")
+
+    normalized_message = dict(raw_message)
+    raw_blocks = normalized_message.get("blocks")
+    if not isinstance(raw_blocks, list):
+        raise TypeError("Last user message blocks are not a list")
+
+    normalized_blocks: list[dict[str, Any]] = []
+    for raw_block in raw_blocks:
+        if not isinstance(raw_block, Mapping):
+            raise TypeError("User message block is not a mapping")
+        block = dict(raw_block)
+        block_type = block.get("block_type")
+        if block_type not in {"text", "image", "audio"}:
+            continue
+        if block_type == "image":
+            block["image"] = _normalized_binary(block.get("image"))
+        elif block_type == "audio":
+            block["audio"] = _normalized_binary(block.get("audio"))
+        normalized_blocks.append(block)
+
+    normalized_message["blocks"] = normalized_blocks
+    return ChatMessage.model_validate(normalized_message)
+
+
+def _user_content_parts(event: PersistedAgentEventEntity) -> list[ContentPart]:
+    parts: list[ContentPart] = []
+    for block in _last_chat_message(event).blocks:
+        if isinstance(block, TextBlock) and block.text:
+            parts.append(ChatCompletionContentPartTextParam(type="text", text=block.text))
+        elif isinstance(block, ImageBlock) and block.url:
+            parts.append(
+                ChatCompletionContentPartImageParam(
+                    type="image_url",
+                    image_url=ImageURL(url=str(block.url)),
+                )
+            )
+        elif isinstance(block, AudioBlock):
+            if block.format not in {"wav", "mp3"}:
+                if block.audio is not None:
+                    logger.warning(
+                        "Skipping visible history audio block with unsupported format",
+                        extra={
+                            **_warning_context(event, "UnsupportedAudioFormat"),
+                            "audio_format": str(block.format),
+                        },
+                    )
+                continue
+            if isinstance(block.audio, bytes):
+                audio_format = cast(Literal["wav", "mp3"], block.format)
+                parts.append(
+                    ChatCompletionContentPartInputAudioParam(
+                        type="input_audio",
+                        input_audio=InputAudio(data=block.audio.decode("ascii"), format=audio_format),
+                    )
+                )
+    return parts
+
+
+def _required_text(event: PersistedAgentEventEntity, field_name: str) -> str:
+    event_data = event.event_data
+    if not isinstance(event_data, Mapping):
+        raise TypeError("Event data is not a mapping")
+    text = event_data.get(field_name)
+    if not isinstance(text, str) or not text:
+        raise ValueError(f"Event has no {field_name}")
+    return text
+
+
+def _hitl_response_text(event: PersistedAgentEventEntity) -> str:
+    event_data = event.event_data
+    if not isinstance(event_data, Mapping):
+        raise TypeError("Event data is not a mapping")
+    response = event_data.get("response")
+    if isinstance(response, bool):
+        return "true" if response else "false"
+    if not isinstance(response, str) or not response:
+        raise ValueError("Event has no response")
+    return response
+
+
+def _terminal_output_text(event: PersistedAgentEventEntity) -> str:
+    event_data = event.event_data
+    if not isinstance(event_data, Mapping):
+        raise TypeError("Event data is not a mapping")
+    output_messages = event_data.get("output_messages")
+    if not isinstance(output_messages, list) or not output_messages:
+        return ""
+    return Message.model_validate(output_messages[-1]).content
+
+
+def _missing_suffix(streamed: str, full_answer: str) -> str:
+    if full_answer and full_answer.startswith(streamed):
+        return full_answer[len(streamed) :]
+    return "" if streamed else full_answer
+
+
+def project_conversation_history(
+    events: Iterable[PersistedAgentEventEntity],
+    *,
+    primary_agent_class: str | None = None,
+    primary_agent_id: str | None = None,
+) -> list[ChatCompletionMessageParam]:
+    """Project persisted client-visible events into the OpenAI chat message surface."""
+    transcript = _TranscriptBuilder()
+
+    for event in _ordered_unique_events(_visible_projectable_events(events)):
+        parents = _parent_names(event)
+        try:
+            if event.agent_class == "UserAgent" and "UserMessageEvent" in parents:
+                transcript.start_user_segment(event.display_id)
+                transcript.add_user_parts(event.display_id, _user_content_parts(event))
+            elif event.agent_class == "UserAgent" and "HumanInTheLoopResponseEvent" in parents:
+                transcript.start_user_segment(event.display_id)
+                transcript.add_user_parts(
+                    event.display_id,
+                    [ChatCompletionContentPartTextParam(type="text", text=_hitl_response_text(event))],
+                )
+            elif "ChunkEvent" in parents:
+                transcript.add_assistant_text(event.display_id, _required_text(event, "content"))
+            elif "HumanInTheLoopRequestEvent" in parents:
+                transcript.add_assistant_text(event.display_id, _required_text(event, "question"))
+            elif (
+                "StopEvent" in parents
+                and primary_agent_class is not None
+                and primary_agent_id is not None
+                and event.agent_class == primary_agent_class
+                and event.agent_id == primary_agent_id
+            ):
+                full_answer = _terminal_output_text(event)
+                suffix = _missing_suffix(transcript.streamed_assistant_text(event.display_id), full_answer)
+                if suffix:
+                    transcript.add_assistant_text(event.display_id, suffix)
+        except (KeyError, TypeError, ValueError, ValidationError) as error:
+            _warn_malformed(event, error)
+
+    return transcript.to_openai_messages()

--- a/packages/api/swiss_ai_hub/api/routes/thread/conversation_transcript_builder.py
+++ b/packages/api/swiss_ai_hub/api/routes/thread/conversation_transcript_builder.py
@@ -1,0 +1,84 @@
+from typing import Any, Literal, cast
+
+from openai.types.chat import (
+    ChatCompletionAssistantMessageParam,
+    ChatCompletionContentPartImageParam,
+    ChatCompletionContentPartInputAudioParam,
+    ChatCompletionContentPartTextParam,
+    ChatCompletionMessageParam,
+    ChatCompletionUserMessageParam,
+)
+from pydantic import BaseModel, Field
+
+ContentPart = (
+    ChatCompletionContentPartTextParam | ChatCompletionContentPartImageParam | ChatCompletionContentPartInputAudioParam
+)
+
+
+class _ProjectedMessage(BaseModel):
+    role: Literal["user", "assistant"]
+    display_id: str
+    content: list[ContentPart] = Field(default_factory=list)
+
+
+class ConversationTranscriptBuilder:
+    """Accumulates projected user/assistant turns per display into OpenAI chat messages."""
+
+    def __init__(self) -> None:
+        self.messages: list[_ProjectedMessage] = []
+        self.assistant_text_by_display: dict[str, str] = {}
+
+    def add_user_parts(self, display_id: str, parts: list[ContentPart]) -> None:
+        self.assistant_text_by_display[display_id] = ""
+        if not parts:
+            raise ValueError("User event has no supported content")
+
+        if self.messages and self.messages[-1].role == "user" and self.messages[-1].display_id == display_id:
+            self.messages[-1].content.extend(parts)
+            return
+        self.messages.append(_ProjectedMessage(role="user", display_id=display_id, content=parts))
+
+    def add_assistant_text(self, display_id: str, text: str) -> None:
+        if not text:
+            raise ValueError("Assistant event has no text")
+
+        if self.messages and self.messages[-1].role == "assistant" and self.messages[-1].display_id == display_id:
+            current = self.messages[-1]
+            if current.content and current.content[-1]["type"] == "text":
+                current.content[-1]["text"] += text
+            else:
+                current.content.append(ChatCompletionContentPartTextParam(type="text", text=text))
+        else:
+            self.messages.append(
+                _ProjectedMessage(
+                    role="assistant",
+                    display_id=display_id,
+                    content=[ChatCompletionContentPartTextParam(type="text", text=text)],
+                )
+            )
+        self.assistant_text_by_display[display_id] = self.assistant_text_by_display.get(display_id, "") + text
+
+    def start_user_segment(self, display_id: str) -> None:
+        self.assistant_text_by_display[display_id] = ""
+
+    def streamed_assistant_text(self, display_id: str) -> str:
+        return self.assistant_text_by_display.get(display_id, "")
+
+    def to_openai_messages(self) -> list[ChatCompletionMessageParam]:
+        result: list[ChatCompletionMessageParam] = []
+        for message in self.messages:
+            if message.role == "user":
+                result.append(
+                    ChatCompletionUserMessageParam(
+                        role="user",
+                        content=cast(Any, message.content),
+                    )
+                )
+            else:
+                result.append(
+                    ChatCompletionAssistantMessageParam(
+                        role="assistant",
+                        content=cast(Any, message.content),
+                    )
+                )
+        return result

--- a/packages/api/swiss_ai_hub/api/routes/thread/thread_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/thread/thread_service.py
@@ -5,23 +5,11 @@ from datetime import UTC, datetime
 from bson import ObjectId
 from cachetools import TTLCache, cached
 from fastapi import HTTPException
-from llama_index.core.base.llms.types import AudioBlock, ImageBlock, TextBlock
 from mongoengine import DoesNotExist
-from openai.types.chat import (
-    ChatCompletionAssistantMessageParam,
-    ChatCompletionContentPartImageParam,
-    ChatCompletionContentPartInputAudioParam,
-    ChatCompletionContentPartTextParam,
-    ChatCompletionMessageParam,
-    ChatCompletionUserMessageParam,
-)
-from openai.types.chat.chat_completion_content_part_image_param import ImageURL
-from openai.types.chat.chat_completion_content_part_input_audio_param import InputAudio
 from swiss_ai_hub.core.auth.access.access_checker import AccessChecker
 from swiss_ai_hub.core.auth.identity.tenant_identity import TenantIdentity
 from swiss_ai_hub.core.auth.keycloak.keycloak_admin_service import KeycloakAdminService
 from swiss_ai_hub.core.auth.realm_roles import SYS_ADMIN_ROLE
-from swiss_ai_hub.core.events import BaseEvent
 from swiss_ai_hub.core.events.agent import HumanInTheLoopRequestEvent, HumanInTheLoopResponseEvent
 from swiss_ai_hub.core.i18n import LocaleHandler
 from swiss_ai_hub.core.infrastructure import trace_fn
@@ -34,8 +22,8 @@ from swiss_ai_hub.core.persistence.messaging.entities.types.thread_sort import S
 
 from swiss_ai_hub.api.routes.agent.dto.agent_identifier import AgentIdentifier
 from swiss_ai_hub.api.routes.agent.dto.minimal_agent_instance_dto import MinimalAgentInstanceDTO
-from swiss_ai_hub.api.routes.event.event_service import EventService
 from swiss_ai_hub.api.routes.openai.dto.history_response import HistoryResponse
+from swiss_ai_hub.api.routes.thread.conversation_history_projector import project_conversation_history
 from swiss_ai_hub.api.routes.thread.dto.open_chat_hitl_response import OpenChatHitlResponse
 from swiss_ai_hub.api.routes.thread.dto.statistics.calculated_thread_stats import CalculatedThreadStats
 from swiss_ai_hub.api.routes.thread.dto.statistics.display_statistics import DisplayStatistics
@@ -46,7 +34,6 @@ from swiss_ai_hub.api.routes.thread.dto.thread_agent_dto import ThreadAgentDTO
 from swiss_ai_hub.api.routes.thread.dto.thread_dto import ThreadDTO
 from swiss_ai_hub.api.routes.user.dto.minimal_user_dto import MinimalUserDTO
 from swiss_ai_hub.api.routes.user.user_service import UserService
-from swiss_ai_hub.api.sockets.events.server_to_user.contextualized_agent_event import ContextualizedAgentEvent
 
 logger = logging.getLogger(__name__)
 
@@ -188,75 +175,20 @@ class ThreadService:
 
     @staticmethod
     @trace_fn
-    async def thread_as_message_history(thread_id: str) -> HistoryResponse:
-        persisted_events = EventService.get_all_thread_display_events(thread_id)
-        contextualized_events = [ContextualizedAgentEvent.from_persisted_event(event) for event in persisted_events]
-
-        messages: list[ChatCompletionMessageParam] = []
-
-        def is_user_event(event: BaseEvent) -> bool:
-            return event.is_user_message_event or event.is_hitl_response_event
-
-        def is_agent_event(event: BaseEvent) -> bool:
-            return event.is_chunk_event or event.is_hitl_response_event
-
-        continue_chunk = False
-
-        for contextualized_event in contextualized_events:
-            event = contextualized_event.event
-
-            if is_user_event(event):
-                continue_chunk = False
-
-                if len(messages) == 0 or messages[-1]["role"] != "user":
-                    messages.append(ChatCompletionUserMessageParam(role="user", content=[]))
-
-                current_message = messages[-1]
-                if event.is_user_message_event and len(event.messages) > 0:
-                    for block in event.messages[-1].blocks:
-                        if isinstance(block, TextBlock):
-                            current_message["content"].append(
-                                ChatCompletionContentPartTextParam(text=block.text, type="text")
-                            )
-                        if isinstance(block, ImageBlock):
-                            current_message["content"].append(
-                                ChatCompletionContentPartImageParam(
-                                    image_url=ImageURL(url=str(block.url)), type="image_url"
-                                )
-                            )
-                        if isinstance(block, AudioBlock):
-                            current_message["content"].append(
-                                ChatCompletionContentPartInputAudioParam(
-                                    input_audio=InputAudio(data=block.audio, format=block.format), type="input_audio"
-                                )
-                            )
-
-                if event.is_hitl_response_event:
-                    current_message["content"].append(
-                        ChatCompletionContentPartTextParam(text=event.response, type="text")
-                    )
-
-            if is_agent_event(event):
-                if len(messages) == 0 or messages[-1]["role"] != "assistant":
-                    messages.append(ChatCompletionAssistantMessageParam(role="assistant", content=[]))
-
-                current_message = messages[-1]
-                if event.is_chunk_event:
-                    if continue_chunk:
-                        current_message["content"][-1]["text"] += event.content
-                    else:
-                        current_message["content"].append(
-                            ChatCompletionContentPartTextParam(text=event.content, type="text")
-                        )
-                        continue_chunk = True
-
-                if event.is_hitl_response_event:
-                    continue_chunk = False
-                    current_message["content"].append(
-                        ChatCompletionContentPartTextParam(text=event.response, type="text")
-                    )
-
-        return HistoryResponse(messages=messages)
+    async def thread_as_message_history(
+        thread_id: str,
+        *,
+        primary_agent_class: str | None = None,
+        primary_agent_id: str | None = None,
+    ) -> HistoryResponse:
+        persisted_events = PersistedAgentEventEntity.conversation_events_for_thread(thread_id)
+        return HistoryResponse(
+            messages=project_conversation_history(
+                persisted_events,
+                primary_agent_class=primary_agent_class,
+                primary_agent_id=primary_agent_id,
+            )
+        )
 
     @staticmethod
     @trace_fn

--- a/packages/api/swiss_ai_hub/api/routes/thread/thread_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/thread/thread_service.py
@@ -23,7 +23,7 @@ from swiss_ai_hub.core.persistence.messaging.entities.types.thread_sort import S
 from swiss_ai_hub.api.routes.agent.dto.agent_identifier import AgentIdentifier
 from swiss_ai_hub.api.routes.agent.dto.minimal_agent_instance_dto import MinimalAgentInstanceDTO
 from swiss_ai_hub.api.routes.openai.dto.history_response import HistoryResponse
-from swiss_ai_hub.api.routes.thread.conversation_history_projector import project_conversation_history
+from swiss_ai_hub.api.routes.thread.conversation_history_projector import ConversationHistoryProjector
 from swiss_ai_hub.api.routes.thread.dto.open_chat_hitl_response import OpenChatHitlResponse
 from swiss_ai_hub.api.routes.thread.dto.statistics.calculated_thread_stats import CalculatedThreadStats
 from swiss_ai_hub.api.routes.thread.dto.statistics.display_statistics import DisplayStatistics
@@ -183,7 +183,7 @@ class ThreadService:
     ) -> HistoryResponse:
         persisted_events = PersistedAgentEventEntity.conversation_events_for_thread(thread_id)
         return HistoryResponse(
-            messages=project_conversation_history(
+            messages=ConversationHistoryProjector.project(
                 persisted_events,
                 primary_agent_class=primary_agent_class,
                 primary_agent_id=primary_agent_id,

--- a/packages/core/swiss_ai_hub/core/persistence/messaging/entities/persisted_agent_event_entity.py
+++ b/packages/core/swiss_ai_hub/core/persistence/messaging/entities/persisted_agent_event_entity.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 from bson import ObjectId
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from mongoengine import DictField, Document, ListField, StringField
+from mongoengine.queryset.visitor import Q
 
 from swiss_ai_hub.core.infrastructure.opentelemetry.tracing.decorators.trace_fn import trace_fn
 from swiss_ai_hub.core.persistence.messaging.entities.types.event_bucket import EventBucket
@@ -18,6 +19,21 @@ if TYPE_CHECKING:
     from swiss_ai_hub.core.topics import AgentInstanceTopic
 
 logger = logging.getLogger(__name__)
+_VISIBLE_DISPLAY_MARKER = Q(
+    event_parents__in=[
+        "UserMessageEvent",
+        "HumanInTheLoopResponseEvent",
+    ]
+)
+_PROJECTABLE_CONVERSATION_EVENT = Q(
+    event_parents__in=[
+        "UserMessageEvent",
+        "HumanInTheLoopResponseEvent",
+        "ChunkEvent",
+        "HumanInTheLoopRequestEvent",
+        "StopEvent",
+    ]
+)
 
 
 class TimeRange(StrEnum):
@@ -175,6 +191,36 @@ class PersistedAgentEventEntity(Document):
             query = query.filter(event_parents__contains=event_name)
 
         return query.order_by("event_data__created_at")
+
+    @classmethod
+    @trace_fn
+    def conversation_events_for_thread(cls, thread_id: str) -> list["PersistedAgentEventEntity"]:
+        """Return only OpenAI-projectable events on displays proven visible to a user."""
+        visible_display_ids = (
+            cls.objects(
+                thread_id=thread_id,
+                event_type=AgentTopicManager.DISPLAY_EVENT,
+                agent_class="UserAgent",
+            )
+            .filter(_VISIBLE_DISPLAY_MARKER)
+            .distinct("display_id")
+        )
+        if not visible_display_ids:
+            logger.warning(
+                "No client-visible display marker found for thread history",
+                extra={"thread_id": thread_id},
+            )
+            return []
+
+        return list(
+            cls.objects(
+                thread_id=thread_id,
+                event_type=AgentTopicManager.DISPLAY_EVENT,
+                display_id__in=visible_display_ids,
+            )
+            .filter(_PROJECTABLE_CONVERSATION_EVENT)
+            .order_by("event_data__created_at", "event_id")
+        )
 
     @classmethod
     @trace_fn

--- a/packages/core/swiss_ai_hub/core/persistence/messaging/entities/tests/unit/test_persisted_agent_event_entity.py
+++ b/packages/core/swiss_ai_hub/core/persistence/messaging/entities/tests/unit/test_persisted_agent_event_entity.py
@@ -33,11 +33,13 @@ def _persist_event(
     event_type: str = AgentTopicManager.CONTROL_EVENT,
     display_id: str = "disp",
     agent_id: str = "test",
+    agent_class: str = "TestAgent",
     run_id: str = "run",
+    created_at: int = 1_730_000_000_000_000_000,
 ) -> None:
-    """Insert a minimal event. Only thread_id / event_id / event_parents / event_type drive classification."""
+    """Insert a minimal persisted event for repository query tests."""
     PersistedAgentEventEntity(
-        agent_class="TestAgent",
+        agent_class=agent_class,
         agent_id=agent_id,
         thread_id=thread_id,
         display_id=display_id,
@@ -45,7 +47,7 @@ def _persist_event(
         event_id=event_id,
         event_type=event_type,
         event_name=event_parents[0],
-        event_data={"created_at": 1_730_000_000_000_000_000},
+        event_data={"created_at": created_at},
         event_parents=event_parents,
     ).save()
 
@@ -123,6 +125,133 @@ class TestThreadIdForDisplay:
         _persist_event("t_b", ["StartEvent"], "e2", display_id="d_b")
         assert PersistedAgentEventEntity.thread_id_for_display("d_a") == "t_a"
         assert PersistedAgentEventEntity.thread_id_for_display("d_b") == "t_b"
+
+
+class TestConversationEventsForThread:
+    def test_user_agent_markers_select_user_and_hitl_displays(self):
+        _persist_event(
+            "thread",
+            ["UserMessageEvent"],
+            "visible-user",
+            event_type=AgentTopicManager.DISPLAY_EVENT,
+            display_id="user-display",
+            agent_class="UserAgent",
+        )
+        _persist_event(
+            "thread",
+            ["HumanInTheLoopResponseEvent"],
+            "visible-hitl",
+            event_type=AgentTopicManager.DISPLAY_EVENT,
+            display_id="hitl-display",
+            agent_class="UserAgent",
+        )
+        _persist_event(
+            "thread",
+            ["UserMessageEvent"],
+            "wrong-agent",
+            event_type=AgentTopicManager.DISPLAY_EVENT,
+            display_id="hidden-agent-display",
+        )
+        _persist_event(
+            "thread",
+            ["UserMessageEvent"],
+            "wrong-type",
+            event_type=AgentTopicManager.CONTROL_EVENT,
+            display_id="hidden-control-display",
+            agent_class="UserAgent",
+        )
+        _persist_event(
+            "thread",
+            ["NotUserMessageEvent"],
+            "substring-only-parent",
+            event_type=AgentTopicManager.DISPLAY_EVENT,
+            display_id="hidden-substring-display",
+            agent_class="UserAgent",
+        )
+
+        events = PersistedAgentEventEntity.conversation_events_for_thread("thread")
+
+        assert {event.event_id for event in events} == {"visible-user", "visible-hitl"}
+
+    def test_returns_only_projectable_events_on_visible_displays(self):
+        _persist_event(
+            "thread",
+            ["UserMessageEvent"],
+            "user",
+            event_type=AgentTopicManager.DISPLAY_EVENT,
+            display_id="visible",
+            agent_class="UserAgent",
+            created_at=1,
+        )
+        _persist_event(
+            "thread",
+            ["ChunkEvent"],
+            "chunk",
+            event_type=AgentTopicManager.DISPLAY_EVENT,
+            display_id="visible",
+            created_at=2,
+        )
+        _persist_event(
+            "thread",
+            ["HumanInTheLoopRequestEvent"],
+            "hitl-request",
+            event_type=AgentTopicManager.DISPLAY_EVENT,
+            display_id="visible",
+            created_at=3,
+        )
+        _persist_event(
+            "thread",
+            ["StopEvent"],
+            "stop",
+            event_type=AgentTopicManager.DISPLAY_EVENT,
+            display_id="visible",
+            created_at=4,
+        )
+        _persist_event(
+            "thread",
+            ["ThoughtEvent"],
+            "irrelevant-visible",
+            event_type=AgentTopicManager.DISPLAY_EVENT,
+            display_id="visible",
+            created_at=5,
+        )
+        _persist_event(
+            "thread",
+            ["RetrievalAgentInTheLoopResponseEvent", "AgentInTheLoopResponseEvent"],
+            "malformed-hidden",
+            event_type=AgentTopicManager.DISPLAY_EVENT,
+            display_id="hidden",
+            created_at=6,
+        )
+        _persist_event(
+            "other-thread",
+            ["UserMessageEvent"],
+            "other-user",
+            event_type=AgentTopicManager.DISPLAY_EVENT,
+            display_id="visible",
+            agent_class="UserAgent",
+            created_at=7,
+        )
+
+        events = PersistedAgentEventEntity.conversation_events_for_thread("thread")
+
+        assert [event.event_id for event in events] == ["user", "chunk", "hitl-request", "stop"]
+
+    def test_markerless_thread_returns_empty_and_warns(self, caplog):
+        _persist_event(
+            "thread",
+            ["ChunkEvent"],
+            "hidden-chunk",
+            event_type=AgentTopicManager.DISPLAY_EVENT,
+            display_id="hidden",
+        )
+
+        with caplog.at_level("WARNING"):
+            events = PersistedAgentEventEntity.conversation_events_for_thread("thread")
+
+        assert events == []
+        assert caplog.records[-1].message == "No client-visible display marker found for thread history"
+        assert caplog.records[-1].thread_id == "thread"
 
 
 def _persist_cost_event(

--- a/packages/core/swiss_ai_hub/core/routes/chat/chat_service.py
+++ b/packages/core/swiss_ai_hub/core/routes/chat/chat_service.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
-from typing import Annotated
+from typing import Annotated, Any
 
 import mongoengine.errors
 from bson import ObjectId
@@ -36,6 +36,7 @@ from swiss_ai_hub.core.events.agent.hitl.response.human_in_the_loop_input_respon
 from swiss_ai_hub.core.events.agent.hitl.response.human_in_the_loop_response_event import (
     HumanInTheLoopResponseEvent,
 )
+from swiss_ai_hub.core.events.agent.semantic.llm.message import Message
 from swiss_ai_hub.core.events.agent.user.user_message_event import UserMessageEvent
 from swiss_ai_hub.core.events.agent.user.user_uploaded_file import UserUploadedFile
 from swiss_ai_hub.core.generative_ai.resources.costs.llm_costs import LLMCosts
@@ -411,13 +412,30 @@ class ChatService:
         return resources
 
     @staticmethod
+    def terminal_output_text(output_messages: list[Any] | None) -> str:
+        """Return terminal answer text from live LlamaIndex/core messages or raw persisted payloads."""
+        if not output_messages:
+            return ""
+        last_message = output_messages[-1]
+        if isinstance(last_message, ChatMessage):
+            return last_message.content or ""
+        if isinstance(last_message, Message):
+            return last_message.content
+        return Message.model_validate(last_message).content
+
+    @staticmethod
+    def missing_suffix(streamed: str, full_answer: str) -> str:
+        """Return the unstreamed suffix when the full answer extends the streamed prefix."""
+        if full_answer and full_answer.startswith(streamed):
+            return full_answer[len(streamed) :]
+        return "" if streamed else full_answer
+
+    @staticmethod
     @trace_fn
     def build_json_response_content(
         chunk_events: list[ChunkEvent | ThoughtEvent], stop_event: StopEvent | HumanInTheLoopRequestEvent | None
     ) -> ChatContent:
-        """
-        Construct a JSON response from collected chunk events.
-        """
+        """Construct a JSON response from collected chunk events."""
         sorted_chunks = sorted(chunk_events, key=lambda x: x.created_at)
         streamed = "".join(chunk.content for chunk in sorted_chunks)
         chat_content = ChatContent(content=streamed, reasoning_content="")
@@ -425,11 +443,8 @@ class ChatService:
         if stop_event.is_hitl_request_event:
             chat_content.content += stop_event.question
             return chat_content
-        # Backstop: if chunks were lost to the stop-vs-chunk dispatch race, recover from the stop event's
-        # durable payload. Use the full answer whenever what streamed is a prefix of it (covers a fully
-        # empty body and a partial loss). Best-effort: a streamed value that diverges keeps what streamed.
-        output_messages = getattr(stop_event, "output_messages", None) or []
-        full_answer = (output_messages[-1].content or "") if output_messages else ""
-        if full_answer and full_answer.startswith(streamed):
-            chat_content.content = full_answer
+        full_answer = ChatService.terminal_output_text(getattr(stop_event, "output_messages", None))
+        suffix = ChatService.missing_suffix(streamed, full_answer)
+        if suffix:
+            chat_content.content = streamed + suffix
         return chat_content

--- a/packages/core/swiss_ai_hub/core/routes/chat/tests/unit/test_chat_service_terminal_recovery.py
+++ b/packages/core/swiss_ai_hub/core/routes/chat/tests/unit/test_chat_service_terminal_recovery.py
@@ -1,0 +1,29 @@
+import pytest
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+
+from swiss_ai_hub.core.events.agent.semantic.llm.message import Message
+from swiss_ai_hub.core.routes.chat.chat_service import ChatService
+
+
+@pytest.mark.parametrize(
+    ("streamed", "full_answer", "expected"),
+    [
+        pytest.param("", "whole answer", "whole answer", id="no-stream"),
+        pytest.param("whole ", "whole answer", "answer", id="partial-stream"),
+        pytest.param("whole answer", "whole answer", "", id="complete-stream"),
+        pytest.param("diverged", "whole answer", "", id="diverged-stream"),
+    ],
+)
+def test_missing_suffix_matches_live_response_contract(streamed: str, full_answer: str, expected: str):
+    assert ChatService.missing_suffix(streamed, full_answer) == expected
+
+
+def test_terminal_output_text_accepts_live_and_persisted_message_representations():
+    core_message = Message.from_string(role="assistant", content="whole answer")
+    llama_message = ChatMessage(role=MessageRole.ASSISTANT, content="whole answer")
+
+    assert ChatService.terminal_output_text(None) == ""
+    assert ChatService.terminal_output_text([]) == ""
+    assert ChatService.terminal_output_text([llama_message]) == "whole answer"
+    assert ChatService.terminal_output_text([core_message]) == "whole answer"
+    assert ChatService.terminal_output_text([core_message.model_dump()]) == "whole answer"


### PR DESCRIPTION
Closes #1817.

## Problem

`reconstruct_history=true` crashed with HTTP 500 whenever a thread contained nested agent-in-the-loop events whose custom classes the API process doesn't know. The exact incident shape: an unknown `RetrievalAgentInTheLoopResponseEvent` whose nested response inherits both `StopEvent` and `RetrieverEvent` — the UI event union fell back to `RetrieverEvent`, the outer AITL envelope then failed `StopEvent` validation, and the reconstruction request never reached the agent.

Even without the crash, reconstruction was wrong: it deserialized every display event in the thread, so output from nested agents on hidden displays (delegated with `share_display_id=false`) was concatenated into the visible transcript, HITL questions and answers were duplicated into both roles, and duplicate event deliveries from multiple API replicas produced repeated turns.

## Solution

Replace the UI-union reconstruction with a projection of persisted events on client-visible messages:

- `PersistedAgentEventEntity.conversation_events_for_thread` selects displays proven visible by persisted `UserAgent` user/HITL markers (exact `$in` hierarchy matching) and returns only OpenAI-projectable event families from those displays. Unknown custom events are excluded before deserialization and remain untouched in the audit store.
- New pure projector (`conversation_history_projector.py`) maps user messages (last message, text/image/audio), chunks, HITL questions (→ assistant) and HITL answers (→ user, once) to OpenAI messages, merges consecutive same-role text per display, recovers lost trailing text from the selected primary agent's terminal event using the same prefix rule as the live response, deduplicates replica deliveries by topic identity, orders deterministically, and skips malformed relevant events with metadata-only warnings.
- `OpenaiService._reconstruct_history` canonicalizes external thread ids, passes primary agent identity (JSON + streaming paths), and rejects empty message lists with HTTP 400 instead of an IndexError.
- `ThreadService.thread_as_message_history` keeps its one-argument signature; primary identity is optional and only enables terminal fallback.

## Compatibility

- OpenAI wire contract, DTOs, controllers, and the generated web SDK are unchanged.
- Web chat (single-message + reconstruct) and OpenWebUI pipelines keep working; consumer-shaped contract tests pin both payload shapes.
- Delegated output on shared displays remains in history (preserves the #1283 behavior); hidden nested output is excluded at any nesting depth.
- Non-nested text/image conversations reconstruct identically to before, except the intentional corrections (empty user turns dropped, HITL roles fixed).
- No new configuration, schema migration, or index: both query stages use the existing `thread_id_1_event_type_1_event_parents_1` index (verified via explain).

## Testing

- 25 pure projector/ThreadService unit tests (ordering, multimodal incl. legacy byte-list audio, malformed degradation, duplicates, tie-breaks, three-level nesting, hidden subtrees, recursive same-agent delegation, HITL roles, terminal fallback matrix, boolean confirmations, unsupported audio formats).
- 16 persistence query tests (marker constraints, visible-display restriction, substring-parent rejection, markerless fail-closed).
- 14 OpenAI integration tests over real NATS/Mongo: UUID/adversarial ids, live nested AITL flow with unknown custom events on hidden displays, replica duplicates, JSON + SSE parity, reconstruction-disabled passthrough, OpenWebUI- and web-chat-shaped payloads, empty-message 400.