### PR TITLE
fix(swiss-ai-hub): Pass the invoking user to conversation metadata on the guard-reject path

### DIFF
--- a/packages/agent/swiss_ai_hub/agent/agents/few_shot_agent/few_shot_agent.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/few_shot_agent/few_shot_agent.py
@@ -314,6 +314,7 @@ class FewShotAgent(Agent):
         displayer: EventDisplayer,
         t: LocaleHandler,
         thread_context: ThreadContext,
+        user: UserIdentity,
     ) -> StopEvent:
         # Neither title nor follow-ups have fired on this path yet — the guard rejected the request
         # before the agent produced anything, so both are missing (unlike the meta-question branch,
@@ -321,5 +322,5 @@ class FewShotAgent(Agent):
         # (GuardRejectionEvent.vue), so treat it as the answer text to ground follow-ups on, same as
         # ExpertRAGAgent's canned decline/error messages.
         chat_messages = [*start_event.messages, ChatMessage(role=MessageRole.ASSISTANT, content=event.reason)]
-        await generate_conversation_metadata(chat_messages, agent_config.task_llm, displayer, t, thread_context)
+        await generate_conversation_metadata(chat_messages, agent_config.task_llm, displayer, t, thread_context, user)
         return StopEvent()

--- a/packages/agent/swiss_ai_hub/agent/agents/few_shot_agent/tests/test_few_shot_agent_guard_reject_metadata.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/few_shot_agent/tests/test_few_shot_agent_guard_reject_metadata.py
@@ -7,6 +7,8 @@ Needs the dev stack (NATS + Valkey) but no LLM — detection, the guard, and the
 all stubbed. Marked self_hosted so the lean CI skips it.
 """
 
+from unittest.mock import patch
+
 import pytest
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
 from swiss_ai_hub.core.events.agent import (
@@ -56,17 +58,20 @@ async def test_guard_reject_generates_title_and_follow_ups(monkeypatch):
     async def fake_guard(**_):
         return GuardResult(success=False, reasoning="forced rejection")
 
-    async def fake_generate_metadata(chat_messages, llm_config, displayer, t, thread_context):
+    async def fake_generate_metadata(chat_messages, llm_config, displayer, t, thread_context, user):
         await displayer.display_event(ConversationTitleEvent(title="Fake Title"))
         await displayer.display_event(FollowUpQuestionsEvent(questions=["Fake follow-up?"]))
 
     monkeypatch.setattr(f"{FEW_SHOT_MODULE}.do_detect_meta_question", fake_detect)
     monkeypatch.setattr(f"{FEW_SHOT_MODULE}.agent_description_guard", fake_guard)
-    monkeypatch.setattr(f"{FEW_SHOT_MODULE}.generate_conversation_metadata", fake_generate_metadata)
 
     runner = AgentTestRunner(agent_type=FewShotAgent, agent_config=_config())
-    async with runner.test_run(delay_before_stop=20) as topic:
-        await runner.send_event_from_topic(topic=topic, start_event=_user_message("Fight Club"))
+    # autospec, not monkeypatch.setattr: a bare stub silently accepts whatever the step passes, so when
+    # the real helper gained its `user` parameter this test kept passing while production raised
+    # TypeError on every guard rejection. autospec binds the call against the real signature instead.
+    with patch(f"{FEW_SHOT_MODULE}.generate_conversation_metadata", autospec=True, side_effect=fake_generate_metadata):
+        async with runner.test_run(delay_before_stop=20) as topic:
+            await runner.send_event_from_topic(topic=topic, start_event=_user_message("Fight Club"))
 
     assert runner.has_stop_event, "guard-reject path did not terminate the run"
     assert runner.has_event_of_class(ConversationTitleEvent), "guard-reject path did not generate a title"

--- a/packages/agent/swiss_ai_hub/agent/conversation_metadata/tests/test_conversation_metadata_wiring.py
+++ b/packages/agent/swiss_ai_hub/agent/conversation_metadata/tests/test_conversation_metadata_wiring.py
@@ -36,7 +36,10 @@ can't silently regress to hanging off the answer event (which raced teardown), a
 can't silently gain metadata.
 """
 
+import ast
 import inspect
+
+import pytest
 
 from swiss_ai_hub.agent.agents.agent import Agent
 from swiss_ai_hub.agent.agents.expert_asking_agent.expert_asking_agent import ExpertAskingAgent
@@ -47,6 +50,7 @@ from swiss_ai_hub.agent.agents.mcp_react_agent.mcp_react_agent import McpReactAg
 from swiss_ai_hub.agent.agents.namespace_selection_agent.namespace_selection_agent import NamespaceSelectionAgent
 from swiss_ai_hub.agent.agents.rag_agent.rag_agent import RAGAgent
 from swiss_ai_hub.agent.agents.retrieval_agent.retrieval_agent import RetrievalAgent
+from swiss_ai_hub.agent.conversation_metadata import conversation_metadata_step_functions
 
 INLINE_HELPER = "generate_conversation_metadata"
 TITLE_GENERATOR = "generate_title"
@@ -54,6 +58,11 @@ FOLLOW_UP_GENERATOR = "generate_follow_up_questions"
 TITLE_STEP = "generate_conversation_title_step"
 FOLLOW_UP_STEP = "generate_follow_up_questions_step"
 METADATA_STEP_WRAPPERS = {TITLE_STEP, FOLLOW_UP_STEP}
+METADATA_HELPERS = {INLINE_HELPER, TITLE_GENERATOR, FOLLOW_UP_GENERATOR}
+
+# Stands in for every argument at a call site: the signature check is about arity and parameter names,
+# so the values never matter.
+PLACEHOLDER = object()
 
 META_ANSWER_STEP = "answer_meta_question_step"
 META_TITLE_STEP = "generate_meta_question_title_step"
@@ -206,3 +215,35 @@ def test_mcp_react_agent_max_iterations_generates_no_metadata():
     assert INLINE_HELPER not in source, (
         "McpReactAgent.max_iterations_reached_step must not call generate_conversation_metadata"
     )
+
+
+def _metadata_calls(agent_type) -> list[ast.Call]:
+    module_source = inspect.getsource(inspect.getmodule(agent_type))
+    return [
+        node
+        for node in ast.walk(ast.parse(module_source))
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id in METADATA_HELPERS
+    ]
+
+
+def test_every_metadata_call_site_matches_its_helper_signature():
+    """Every adopter's call must bind against the real helper signature, not merely name it.
+
+    The other tests here are substring checks, so a call site that names the right helper with the wrong
+    arguments passes them. That is exactly how the guard-reject path in ``FewShotAgent.stop_step`` kept a
+    five-argument call after the helpers gained ``user`` for cost attribution: every wiring assertion
+    stayed green while production raised ``TypeError`` on each guard rejection. Binding placeholders
+    against ``inspect.signature`` catches any future parameter a call site forgets, not just ``user``.
+    """
+    for agent_type in SPLIT_AGENTS + INLINE_AGENTS:
+        for call in _metadata_calls(agent_type):
+            signature = inspect.signature(getattr(conversation_metadata_step_functions, call.func.id))
+            positional = [PLACEHOLDER] * len(call.args)
+            keywords = {keyword.arg: PLACEHOLDER for keyword in call.keywords}
+            try:
+                signature.bind(*positional, **keywords)
+            except TypeError as mismatch:
+                pytest.fail(
+                    f"{agent_type.__name__} line {call.lineno}: {call.func.id}{signature} does not accept this "
+                    f"call — {mismatch}"
+                )


### PR DESCRIPTION
## Problem

Every guard rejection in `FewShotAgent` crashes the step instead of terminating the run gracefully:

```
File "/app/packages/agent/swiss_ai_hub/agent/agents/few_shot_agent/few_shot_agent.py", line 324, in stop_step
    await generate_conversation_metadata(chat_messages, agent_config.task_llm, displayer, t, thread_context)
TypeError: generate_conversation_metadata() missing 1 required positional argument: 'user'
```

## Root cause

PR #1772 (*Attribute LLM cost to the invoking user and tenant*) added a required `user: UserIdentity` parameter to `generate_conversation_metadata`, so the helper can attribute the title/follow-up LLM spend to the caller. `FewShotAgent` has two call sites; the PR updated `respond_with_llm_step` and missed `stop_step` — the guard-reject exit path — which neither declared `user` nor passed it.

An AST sweep binding every call site in `packages/agent` against the real helper signatures confirms this was the only one missed. `LLMWrappingAgent`, `McpReactAgent`, and every `generate_title` / `generate_follow_up_questions` call site in `RAGAgent` / `ExpertRAGAgent` are correct.

## Impact

Only the guard-reject branch of `FewShotAgent`, reached when `agent_description_guard` decides the request does not suit the agent. `stop_step` runs with the default `stop_on_error=True`, so the dispatcher publishes an `ExceptionEvent` instead of the `StopEvent`. The run still retires (`is_exception_event` terminates it), but:

- the user sees an error bubble instead of the guard's rejection reason,
- no conversation title and no follow-up questions are generated on that path.

The happy path is unaffected.

## Why nothing caught it

Three layers failed independently, which is why the fix touches all three:

1. **No static type checker** — the repo runs only `ruff` (E/F/UP/I). An arity mismatch is exactly what a type checker catches for free.
2. **The integration test masked it** — `test_few_shot_agent_guard_reject_metadata.py` replaced the helper via `monkeypatch.setattr` with a five-argument stub matching the *old* signature. A bare stub accepts whatever the step passes, so the test stayed green while production raised. It is also marked `self_hosted`, so lean CI skips it entirely.
3. **The wiring test is a substring check** — `test_conversation_metadata_wiring.py` asserted only that the helper's *name* appears in the step source, which says nothing about the arguments.

## Changes

- **`few_shot_agent.py`** — `stop_step` declares `user: UserIdentity` (injected by the dispatcher via type annotation) and passes it through.
- **`test_few_shot_agent_guard_reject_metadata.py`** — replaced `monkeypatch.setattr` with `patch(..., autospec=True)`, which binds the call against the real signature, so a future signature change breaks the fake loudly instead of silently.
- **`test_conversation_metadata_wiring.py`** — new `test_every_metadata_call_site_matches_its_helper_signature`: walks each adopter's AST, finds every call to the three metadata helpers, and binds placeholders against `inspect.signature`. Catches *any* future parameter a call site forgets, not just `user`. This is the layer that runs in lean CI.

Verified by reverting only the production fix: the new guard fails with the exact production error (`FewShotAgent line 324: … missing a required argument: 'user'`), and passes with the fix.

## Test results

- `test_conversation_metadata_wiring.py` — 10 passed
- `conversation_metadata` + `few_shot_agent` + `agents/tests` + `self_awareness`, `-m "not flaky and not self_hosted"` — 138 passed, 3 skipped, 1 failed
- `ruff format --check` and `ruff check` — clean

The one failure is `test_few_shot_agent.py::test_validate_the_fewshotagent_workflow`, a `pytest-bdd` scenario that drives the real dispatcher over NATS against a live self-hosted LLM. It timed out because NATS and Milvus are not running locally; it exercises the happy path (`AgentSuitabilityAcceptEvent` → condense → few-shot → `LLMEvent` → `StopEvent`) and never reaches `stop_step`, so it is unrelated to this change.

## Follow-up (not in this PR)

All three gaps above are symptoms of having no static type checker. A `mypy` (or `ty`) pass over `packages/agent` would catch this class of bug in CI without a single test. Worth its own issue — deliberately kept out of a release-branch fix.
