### PR TITLE
fix(swiss-ai-hub): Bump nltk to 3.10.3 for CVE-2026-79675

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,11 @@ package = false
 # only a transitive dependency (fastapi, mcp, sse-starlette, dagster-graphql), so pin the
 # lower bound to the first fixed release to stop the resolver selecting the affected version.
 constraint-dependencies = ["starlette>=1.0.1"]
+# nltk >= 3.10.3 hardens corpus loading and refuses files with st_nlink > 1 (CWE-59
+# hardlink defence). uv installs with hardlinks by default, so the bundled
+# llama-index nltk_cache lands multiply-linked and SentenceSplitter dies. Every
+# Dockerfile already sets UV_LINK_MODE=copy; this aligns local + CI with them.
+link-mode = "copy"
 
 [tool.uv.workspace]
 members = [

--- a/uv.lock
+++ b/uv.lock
@@ -1300,8 +1300,8 @@ name = "faiss-cpu"
 version = "1.13.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "packaging" },
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "packaging", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/c9/671f66f6b31ec48e5825d36435f0cb91189fa8bb6b50724029dbff4ca83c/faiss_cpu-1.13.2-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a9064eb34f8f64438dd5b95c8f03a780b1a3f0b99c46eeacb1f0b5d15fc02dc1", size = 3452776, upload-time = "2025-12-24T10:27:01.419Z" },
@@ -3114,10 +3114,10 @@ name = "milvus-lite"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "faiss-cpu" },
-    { name = "grpcio" },
-    { name = "numpy" },
-    { name = "pyarrow" },
+    { name = "faiss-cpu", marker = "sys_platform != 'win32'" },
+    { name = "grpcio", marker = "sys_platform != 'win32'" },
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "pyarrow", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/9a/d80d260e6fe1246818a8ef782c374ba9c6ca46ca3b987c14eabe914ef805/milvus_lite-3.0.tar.gz", hash = "sha256:2c35d0d046b1faae3402cde1fb73d65f51ee8c6aba65f54de1dda46f7bb18b9b", size = 589749, upload-time = "2026-05-13T07:14:05.827Z" }
 wheels = [
@@ -3345,17 +3345,18 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.9.4"
+version = "3.10.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
+    { name = "defusedxml" },
     { name = "joblib" },
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/e6/fe51d2bb1a3b446f59c5c8165999a9fee208bc346af90a7cbf7657bc0d75/nltk-3.10.3.tar.gz", hash = "sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4", size = 5137152, upload-time = "2026-08-12T23:46:37.258Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6d/ebd2af4640b12168fdf0cb74b6118df2f32a2f62ec7e0c06fbfd80706639/nltk-3.10.3-py3-none-any.whl", hash = "sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c", size = 1798643, upload-time = "2026-08-12T23:44:13.478Z" },
 ]
 
 [[package]]
@@ -4125,7 +4126,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -5268,8 +5269,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
Closes Dependabot alert [375](https://github.com/bbvch-ai/aihub-core/security/dependabot/375) — GHSA-m4rf-3fr8-xwx3 / CVE-2026-79675 (critical, CVSS 9.8). `nltk <= 3.10.2` applies `_validate_java_options()` only in `config_java()`, so the per-call `java(options=...)` path bypasses the CVE-2026-12841 fix entirely. Fixed in 3.10.3.

`nltk` is transitive (only reverse dependency is `llama-index-core`, which allows `nltk>=3.9.3`), so this is a lockfile bump.

## Why `pyproject.toml` changes too

The bump alone breaks RAG chunking in local and CI environments. nltk 3.10.3 adds `nltk/pathsec.py`, a hardened corpus opener that refuses any file with `st_nlink > 1` as a CWE-59 hardlink defence. uv installs with hardlinks by default, so the corpus bundled by `llama-index-core` lands multiply-linked and every `SentenceSplitter` call dies:

```
PermissionError: Security Violation [pathsec.open]: refusing multiply-linked file
'.../llama_index/core/_static/nltk_cache/corpora/stopwords/english' (st_nlink=3)
```

This is reachable from our own code — `SentenceSplitter` is used in `markdown_structural_node_parser.py:174` and `recursive_summary_parser.py:64`.

Setting `link-mode = "copy"` under `[tool.uv]` fixes it. **Production images were never affected**: all 18 Python Dockerfiles already set `UV_LINK_MODE=copy`, so this only aligns local + CI with what the images already do.

A/B on one venv with only nltk swapped:

| nltk | `st_nlink` | parsers tests |
| --- | --- | --- |
| 3.9.4 | 4 | 25 passed |
| 3.10.3 | 4 | 1 failed |
| 3.10.3 | 1 (copy) | 25 passed |

No upstream nltk issue is indexed for the `st_nlink > 1` rejection, so this is not worth waiting out.

## Verification

Ran against the full local dev stack (31 containers). Lockfile is byte-identical whether resolved with uv 0.10.4 on Windows or 0.11.17 on Linux; `revision` stays 3.

| Scope | Result |
| --- | --- |
| `core` | 1428 passed |
| `pipeline` | 149 passed |
| `process` | 17 passed |
| `sysadmin-api` | 50 passed |
| `backup` | 248 passed |
| `api` | 6 failed, 559 passed |
| `bot` | 1 failed, 14 passed |
| `agent` | 15 failed, 521 passed |

`core` is the only scope that reaches nltk and it is fully green. Every failure above was A/B'd against nltk 3.9.4 on the same venv and the failure sets are identical, i.e. all pre-existing: `api` and `agent` both report `IDENTICAL FAILURE SETS`, and `bot`'s `test_conversation_ttl_with_bot` is flaky (passes consistently in isolation on both versions). All of them live in `playground/testing/` and need live external services — Speaches audio, Keycloak tokens, mem0/Neo4j, and LLM provider credentials.

The four `sys_platform != 'win32'` marker hunks in `uv.lock` are a no-op: each parent (`milvus-lite`, `pexpect`, `secretstorage`) is already platform-gated, so uv is only propagating the parent's marker onto its children. They appear identically when resolving on Linux.

`LICENSE_REPORT.md` still lists nltk 3.9.4; CI regenerates it via `make license-check` and does not fail on drift, matching the precedent of #1432.
