### PR TITLE
fix(swiss-ai-hub): Stop silent and unalignable recordings from failing transcription

### DIFF
--- a/infra/configs/litellm/litellm-config.build.gpu.yml
+++ b/infra/configs/litellm/litellm-config.build.gpu.yml
@@ -161,12 +161,15 @@ litellm_settings:
 # Router Settings
 # ===================================================================
 router_settings:
-  # default_fallbacks registers a "*" wildcard that applies to embedding and rerank calls too, so a rejected
-  # embedding gets retried against a chat model that cannot serve it and the real error is buried three levels
-  # deep. An explicit empty list wins over the wildcard on exact match, so these surface their own error.
+  # default_fallbacks registers a "*" wildcard that applies to embedding, rerank, transcription and image
+  # calls too, so a rejected embedding gets retried against a chat model that cannot serve it and the real
+  # error is buried three levels deep. An explicit empty list wins over the wildcard on exact match, so these
+  # surface their own error. Transcription needs it most: it has a single deployment, so a retry against a
+  # chat model is pure latency on a failure that will never succeed.
   fallbacks:
     - embedding/bge-m3: []
     - reranker/bge: []
+    - transcription/faster-whisper-large-v3: []
   routing_strategy: usage-based-routing-v2
   retry_policy:
     TimeoutErrorRetries: 2

--- a/infra/configs/litellm/litellm-config.build.yml
+++ b/infra/configs/litellm/litellm-config.build.yml
@@ -234,12 +234,16 @@ litellm_settings:
 # Router Settings
 # ===================================================================
 router_settings:
-  # default_fallbacks registers a "*" wildcard that applies to embedding and rerank calls too, so a rejected
-  # embedding gets retried against a chat model that cannot serve it and the real error is buried three levels
-  # deep. An explicit empty list wins over the wildcard on exact match, so these surface their own error.
+  # default_fallbacks registers a "*" wildcard that applies to embedding, rerank, transcription and image
+  # calls too, so a rejected embedding gets retried against a chat model that cannot serve it and the real
+  # error is buried three levels deep. An explicit empty list wins over the wildcard on exact match, so these
+  # surface their own error. Transcription needs it most: it has a single deployment, so a retry against a
+  # chat model is pure latency on a failure that will never succeed.
   fallbacks:
     - embedding/bge-m3: []
     - reranker/bge: []
+    - transcription/whisper-large-v3: []
+    - image-generation/flux: []
   routing_strategy: usage-based-routing-v2
   retry_policy:
     TimeoutErrorRetries: 2

--- a/infra/configs/litellm/litellm-config.latest.gpu.yml
+++ b/infra/configs/litellm/litellm-config.latest.gpu.yml
@@ -161,12 +161,15 @@ litellm_settings:
 # Router Settings
 # ===================================================================
 router_settings:
-  # default_fallbacks registers a "*" wildcard that applies to embedding and rerank calls too, so a rejected
-  # embedding gets retried against a chat model that cannot serve it and the real error is buried three levels
-  # deep. An explicit empty list wins over the wildcard on exact match, so these surface their own error.
+  # default_fallbacks registers a "*" wildcard that applies to embedding, rerank, transcription and image
+  # calls too, so a rejected embedding gets retried against a chat model that cannot serve it and the real
+  # error is buried three levels deep. An explicit empty list wins over the wildcard on exact match, so these
+  # surface their own error. Transcription needs it most: it has a single deployment, so a retry against a
+  # chat model is pure latency on a failure that will never succeed.
   fallbacks:
     - embedding/bge-m3: []
     - reranker/bge: []
+    - transcription/faster-whisper-large-v3: []
   routing_strategy: usage-based-routing-v2
   retry_policy:
     TimeoutErrorRetries: 2

--- a/infra/configs/litellm/litellm-config.latest.yml
+++ b/infra/configs/litellm/litellm-config.latest.yml
@@ -234,12 +234,16 @@ litellm_settings:
 # Router Settings
 # ===================================================================
 router_settings:
-  # default_fallbacks registers a "*" wildcard that applies to embedding and rerank calls too, so a rejected
-  # embedding gets retried against a chat model that cannot serve it and the real error is buried three levels
-  # deep. An explicit empty list wins over the wildcard on exact match, so these surface their own error.
+  # default_fallbacks registers a "*" wildcard that applies to embedding, rerank, transcription and image
+  # calls too, so a rejected embedding gets retried against a chat model that cannot serve it and the real
+  # error is buried three levels deep. An explicit empty list wins over the wildcard on exact match, so these
+  # surface their own error. Transcription needs it most: it has a single deployment, so a retry against a
+  # chat model is pure latency on a failure that will never succeed.
   fallbacks:
     - embedding/bge-m3: []
     - reranker/bge: []
+    - transcription/whisper-large-v3: []
+    - image-generation/flux: []
   routing_strategy: usage-based-routing-v2
   retry_policy:
     TimeoutErrorRetries: 2

--- a/infra/configs/litellm/litellm-config.local.gpu.yml
+++ b/infra/configs/litellm/litellm-config.local.gpu.yml
@@ -161,12 +161,15 @@ litellm_settings:
 # Router Settings
 # ===================================================================
 router_settings:
-  # default_fallbacks registers a "*" wildcard that applies to embedding and rerank calls too, so a rejected
-  # embedding gets retried against a chat model that cannot serve it and the real error is buried three levels
-  # deep. An explicit empty list wins over the wildcard on exact match, so these surface their own error.
+  # default_fallbacks registers a "*" wildcard that applies to embedding, rerank, transcription and image
+  # calls too, so a rejected embedding gets retried against a chat model that cannot serve it and the real
+  # error is buried three levels deep. An explicit empty list wins over the wildcard on exact match, so these
+  # surface their own error. Transcription needs it most: it has a single deployment, so a retry against a
+  # chat model is pure latency on a failure that will never succeed.
   fallbacks:
     - embedding/bge-m3: []
     - reranker/bge: []
+    - transcription/faster-whisper-large-v3: []
   routing_strategy: usage-based-routing-v2
   retry_policy:
     TimeoutErrorRetries: 2

--- a/infra/configs/litellm/litellm-config.local.yml
+++ b/infra/configs/litellm/litellm-config.local.yml
@@ -234,12 +234,16 @@ litellm_settings:
 # Router Settings
 # ===================================================================
 router_settings:
-  # default_fallbacks registers a "*" wildcard that applies to embedding and rerank calls too, so a rejected
-  # embedding gets retried against a chat model that cannot serve it and the real error is buried three levels
-  # deep. An explicit empty list wins over the wildcard on exact match, so these surface their own error.
+  # default_fallbacks registers a "*" wildcard that applies to embedding, rerank, transcription and image
+  # calls too, so a rejected embedding gets retried against a chat model that cannot serve it and the real
+  # error is buried three levels deep. An explicit empty list wins over the wildcard on exact match, so these
+  # surface their own error. Transcription needs it most: it has a single deployment, so a retry against a
+  # chat model is pure latency on a failure that will never succeed.
   fallbacks:
     - embedding/bge-m3: []
     - reranker/bge: []
+    - transcription/whisper-large-v3: []
+    - image-generation/flux: []
   routing_strategy: usage-based-routing-v2
   retry_policy:
     TimeoutErrorRetries: 2

--- a/infra/configs/litellm/litellm-config.nightly.gpu.yml
+++ b/infra/configs/litellm/litellm-config.nightly.gpu.yml
@@ -161,12 +161,15 @@ litellm_settings:
 # Router Settings
 # ===================================================================
 router_settings:
-  # default_fallbacks registers a "*" wildcard that applies to embedding and rerank calls too, so a rejected
-  # embedding gets retried against a chat model that cannot serve it and the real error is buried three levels
-  # deep. An explicit empty list wins over the wildcard on exact match, so these surface their own error.
+  # default_fallbacks registers a "*" wildcard that applies to embedding, rerank, transcription and image
+  # calls too, so a rejected embedding gets retried against a chat model that cannot serve it and the real
+  # error is buried three levels deep. An explicit empty list wins over the wildcard on exact match, so these
+  # surface their own error. Transcription needs it most: it has a single deployment, so a retry against a
+  # chat model is pure latency on a failure that will never succeed.
   fallbacks:
     - embedding/bge-m3: []
     - reranker/bge: []
+    - transcription/faster-whisper-large-v3: []
   routing_strategy: usage-based-routing-v2
   retry_policy:
     TimeoutErrorRetries: 2

--- a/infra/configs/litellm/litellm-config.nightly.yml
+++ b/infra/configs/litellm/litellm-config.nightly.yml
@@ -234,12 +234,16 @@ litellm_settings:
 # Router Settings
 # ===================================================================
 router_settings:
-  # default_fallbacks registers a "*" wildcard that applies to embedding and rerank calls too, so a rejected
-  # embedding gets retried against a chat model that cannot serve it and the real error is buried three levels
-  # deep. An explicit empty list wins over the wildcard on exact match, so these surface their own error.
+  # default_fallbacks registers a "*" wildcard that applies to embedding, rerank, transcription and image
+  # calls too, so a rejected embedding gets retried against a chat model that cannot serve it and the real
+  # error is buried three levels deep. An explicit empty list wins over the wildcard on exact match, so these
+  # surface their own error. Transcription needs it most: it has a single deployment, so a retry against a
+  # chat model is pure latency on a failure that will never succeed.
   fallbacks:
     - embedding/bge-m3: []
     - reranker/bge: []
+    - transcription/whisper-large-v3: []
+    - image-generation/flux: []
   routing_strategy: usage-based-routing-v2
   retry_policy:
     TimeoutErrorRetries: 2

--- a/infra/deployment/templates/configs/litellm-config.yml.j2
+++ b/infra/deployment/templates/configs/litellm-config.yml.j2
@@ -322,12 +322,21 @@ litellm_settings:
 # ===================================================================
 router_settings:
   {%- if stage != "dev" %}
-  # default_fallbacks registers a "*" wildcard that applies to embedding and rerank calls too, so a rejected
-  # embedding gets retried against a chat model that cannot serve it and the real error is buried three levels
-  # deep. An explicit empty list wins over the wildcard on exact match, so these surface their own error.
+  # default_fallbacks registers a "*" wildcard that applies to embedding, rerank, transcription and image
+  # calls too, so a rejected embedding gets retried against a chat model that cannot serve it and the real
+  # error is buried three levels deep. An explicit empty list wins over the wildcard on exact match, so these
+  # surface their own error. Transcription needs it most: it has a single deployment, so a retry against a
+  # chat model is pure latency on a failure that will never succeed.
   fallbacks:
     - embedding/bge-m3: []
     - reranker/bge: []
+{%- if has_local_models %}
+    - transcription/faster-whisper-large-v3: []
+{%- endif %}
+{%- if not has_local_models %}
+    - transcription/whisper-large-v3: []
+    - image-generation/flux: []
+{%- endif %}
   {%- endif %}
   routing_strategy: "usage-based-routing-v2"
   retry_policy:

--- a/packages/api/playground/testing/tests/audio/test_transcription_gateway_contract.py
+++ b/packages/api/playground/testing/tests/audio/test_transcription_gateway_contract.py
@@ -1,0 +1,124 @@
+import io
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import UploadFile
+from openai.types.audio import TranscriptionVerbose
+from pydub import AudioSegment
+from pydub.generators import Sine
+from swiss_ai_hub.core.auth import AccessChecker
+from swiss_ai_hub.core.testing.auth_utils import fake_user
+
+from swiss_ai_hub.api.audio.audio_chunking_service import AudioChunkingService
+from swiss_ai_hub.api.routes.openai.openai_service import OpenaiService
+
+_SERVICE = "swiss_ai_hub.api.routes.openai.openai_service"
+_MODEL = "transcription/whisper-large-v3"
+
+
+def _upload(audio: AudioSegment, filename: str = "recording.wav") -> UploadFile:
+    buffer = io.BytesIO()
+    audio.export(buffer, format="wav")
+    return UploadFile(filename=filename, file=buffer, size=len(audio.raw_data))
+
+
+def _spoken_audio() -> AudioSegment:
+    return AudioSegment.silent(duration=500) + Sine(440).to_audio_segment(duration=3000)
+
+
+async def _transcribe(file: UploadFile, mock_client: AsyncMock, **overrides):
+    kwargs = {
+        "model_name": _MODEL,
+        "file": file,
+        "user": fake_user(),
+        "language": None,
+        "prompt": None,
+        "response_format": "json",
+        "temperature": 0.0,
+        "timestamp_granularities": None,
+    } | overrides
+
+    with (
+        patch(f"{_SERVICE}.LiteLLMService.openai_aclient_for_user", return_value=mock_client),
+        patch.object(OpenaiService, "_model_names_by_type", new=AsyncMock(return_value=[_MODEL])),
+        patch(
+            f"{_SERVICE}.AccessChecker.from_user",
+            return_value=AccessChecker(["aihub.user.model.transcription.*"], tenant_access_rules=["aihub.admin.>"]),
+        ),
+    ):
+        return await OpenaiService.stt(**kwargs)
+
+
+def _client_returning(text: str) -> AsyncMock:
+    client = AsyncMock()
+    transcription = MagicMock()
+    transcription.text = text
+    client.audio.transcriptions.create = AsyncMock(return_value=transcription)
+    return client
+
+
+class TestSilentUploadsNeverReachTheGateway:
+    """The provider raises `Transcription failed: 0` on an upload with no speech instead of
+    returning an empty transcript, so a recording nobody spoke into must be answered locally."""
+
+    def test_silence_is_not_speech(self):
+        assert AudioChunkingService.contains_speech(AudioSegment.silent(duration=5000)) is False
+
+    def test_sound_is_speech(self):
+        assert AudioChunkingService.contains_speech(_spoken_audio()) is True
+
+    @pytest.mark.asyncio
+    async def test_silent_upload_returns_empty_transcript_without_calling_the_gateway(self):
+        client = _client_returning("should never be reached")
+
+        result = await _transcribe(_upload(AudioSegment.silent(duration=5000)), client)
+
+        assert result.text == ""
+        client.audio.transcriptions.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_silent_upload_honours_the_requested_response_format(self):
+        client = _client_returning("should never be reached")
+
+        result = await _transcribe(_upload(AudioSegment.silent(duration=5000)), client, response_format="text")
+
+        assert result == ""
+        client.audio.transcriptions.create.assert_not_called()
+
+
+class TestWordTimestampsAreOnlyRequestedWhenTheyCanBeReturned:
+    """`timestamp_granularities` only shapes a `verbose_json` response, and asking for it drives the
+    provider's alignment stage — the one that fails outright for languages it ships no model for."""
+
+    @pytest.mark.asyncio
+    async def test_granularities_are_dropped_for_a_json_response(self):
+        client = _client_returning("hello")
+
+        await _transcribe(_upload(_spoken_audio()), client, timestamp_granularities=["word"])
+
+        assert client.audio.transcriptions.create.await_args.kwargs["timestamp_granularities"] is None
+
+    @pytest.mark.asyncio
+    async def test_granularities_are_forwarded_for_a_verbose_response(self):
+        client = _client_returning("hello")
+
+        await _transcribe(
+            _upload(_spoken_audio()), client, response_format="verbose_json", timestamp_granularities=["word"]
+        )
+
+        assert client.audio.transcriptions.create.await_args.kwargs["timestamp_granularities"] == ["word"]
+
+
+class TestVerboseResponsesSurviveAnUnspecifiedLanguage:
+    """`TranscriptionVerbose.language` is a required string, so echoing the caller's unset language
+    made the whole request fail validation after the transcription had already been paid for."""
+
+    @pytest.mark.asyncio
+    async def test_verbose_json_without_a_language_is_returned(self):
+        client = _client_returning("hello")
+
+        result = await _transcribe(_upload(_spoken_audio()), client, response_format="verbose_json")
+
+        assert isinstance(result, TranscriptionVerbose)
+        assert result.language == ""
+        assert result.text == "hello"

--- a/packages/api/swiss_ai_hub/api/audio/audio_chunking_service.py
+++ b/packages/api/swiss_ai_hub/api/audio/audio_chunking_service.py
@@ -34,6 +34,24 @@ class AudioChunkingService:
     ] = -40  # -40dB threshold identifies most speech pauses without excessive chunking
 
     @staticmethod
+    def contains_speech(audio: AudioSegment) -> bool:
+        """Whether the upload holds anything worth sending to the transcription gateway.
+
+        OpenAI answers a silent upload with an empty transcript, but the gateway's WhisperX service
+        raises instead — a recording the user never spoke into comes back as `Transcription failed: 0`,
+        an HTTP 500 the caller can do nothing with. Verified against the provider on 2026-09-03 with
+        silence, white noise and a pure tone.
+        """
+        return bool(
+            detect_nonsilent(
+                audio,
+                min_silence_len=AudioChunkingService.MIN_SILENCE_LEN,
+                silence_thresh=AudioChunkingService.SILENCE_THRESH,
+                seek_step=10,
+            )
+        )
+
+    @staticmethod
     async def chunk_audio(audio: AudioSegment) -> list[AudioSegment]:
         file_size: Annotated[int, "bytes"] = len(audio.raw_data)
         total_duration: Annotated[int, "ms"] = len(audio)

--- a/packages/api/swiss_ai_hub/api/routes/openai/openai_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/openai/openai_service.py
@@ -581,6 +581,12 @@ class OpenaiService:
 
         file_ext = file.filename.rsplit(".", 1)[-1].lower()
         audio = AudioSegment.from_file(file.file, format=file_ext)
+
+        if not AudioChunkingService.contains_speech(audio):
+            return OpenaiService._transcription_response(
+                text="", audio=audio, language=language, response_format=response_format
+            )
+
         audio_chunks: list[AudioSegment] = await AudioChunkingService.chunk_audio(audio)
         transcription_chunks: list[TranscriptionChunk] = []
 
@@ -598,28 +604,40 @@ class OpenaiService:
                 prompt=prompt,
                 response_format=response_format,
                 temperature=temperature,
-                timestamp_granularities=timestamp_granularities,
+                timestamp_granularities=timestamp_granularities if response_format == "verbose_json" else None,
             )
 
             transcription_chunks.append(result)
 
         merged_text: str = AudioChunkingService.merge_transcriptions(transcription_chunks)
 
+        return OpenaiService._transcription_response(
+            text=merged_text, audio=audio, language=language, response_format=response_format
+        )
+
+    @staticmethod
+    def _transcription_response(
+        *, text: str, audio: AudioSegment, language: str | None, response_format: str | None
+    ) -> Transcription | TranscriptionVerbose | str:
+        """Chunking merges every chunk into one text, so the formats that carry per-segment timing
+        cannot be reassembled and degrade to plain text."""
         if response_format == "text":
-            return merged_text
+            return text
         elif response_format == "srt" or response_format == "vtt":
             logger.warning(f"Format {response_format} not fully supported with chunking, returning as text")
-            return merged_text
+            return text
         elif response_format == "verbose_json":
             return TranscriptionVerbose(
-                text=merged_text,
-                language=language,
+                text=text,
+                # The gateway reports no detected language, and the field is required, so an
+                # unrequested language has nothing to report but the empty string.
+                language=language or "",
                 duration=len(audio) / 1000,  # Convert milliseconds to seconds
                 segments=[],
                 words=[],
             )
         else:
-            return Transcription(text=merged_text)
+            return Transcription(text=text)
 
     @staticmethod
     @trace_fn

--- a/packages/core/swiss_ai_hub/core/exceptions/model_gateway_error_handler.py
+++ b/packages/core/swiss_ai_hub/core/exceptions/model_gateway_error_handler.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import Any, ClassVar
 
 from fastapi import FastAPI
@@ -44,6 +45,17 @@ class ModelGatewayErrorHandler:
     # which is the very incident this handler exists for.
     NON_ACTIONABLE_STATUSES: ClassVar[frozenset[int]] = frozenset({413, 422, 429})
 
+    # Upstream failures whose own wording names a component of the provider's pipeline rather than
+    # anything the caller can recognise. The raw message still goes to the log — only the response
+    # is rewritten, because the caller reading it is a chat user, not an operator.
+    UPSTREAM_CAUSE_PATTERNS: ClassVar[tuple[tuple[re.Pattern[str], str], ...]] = (
+        (
+            re.compile(r"No default align-model for language: (?P<language>[A-Za-z-]+)"),
+            "Transcription is not available for the language detected in this recording "
+            "('{language}'): the speech-to-text provider ships no alignment model for it.",
+        ),
+    )
+
     @staticmethod
     def register(app: FastAPI) -> None:
         """``APITimeoutError`` subclasses ``APIConnectionError``, and every concrete status
@@ -84,7 +96,7 @@ class ModelGatewayErrorHandler:
         ModelGatewayErrorHandler._log_status_error(request, exception.status_code, message)
         return ModelGatewayErrorHandler._failure_response(
             status_code=ModelGatewayErrorHandler._caller_facing_status(exception.status_code),
-            message=message,
+            message=ModelGatewayErrorHandler._readable_cause(message),
             upstream_status=exception.status_code,
             exception=exception,
         )
@@ -156,8 +168,21 @@ class ModelGatewayErrorHandler:
         way too. Anything that is not a gateway error is returned unchanged.
         """
         if isinstance(exception, APIStatusError):
-            return ModelGatewayErrorHandler._upstream_message(exception)
+            return ModelGatewayErrorHandler._readable_cause(ModelGatewayErrorHandler._upstream_message(exception))
         return str(exception)
+
+    @staticmethod
+    def _readable_cause(message: str) -> str:
+        """Rewrites the known provider-internal failures into what the caller can act on.
+
+        A message that matches nothing is returned unchanged: the gateway's own wording is still the
+        best available description, and guessing at an unrecognised failure would hide it.
+        """
+        for pattern, template in ModelGatewayErrorHandler.UPSTREAM_CAUSE_PATTERNS:
+            match = pattern.search(message)
+            if match:
+                return template.format(**match.groupdict())
+        return message
 
     @staticmethod
     def _upstream_message(exception: APIStatusError) -> str:

--- a/packages/core/swiss_ai_hub/core/exceptions/tests/unit/test_upstream_cause_rewriting.py
+++ b/packages/core/swiss_ai_hub/core/exceptions/tests/unit/test_upstream_cause_rewriting.py
@@ -1,0 +1,43 @@
+import httpx
+import pytest
+from openai import InternalServerError
+
+from swiss_ai_hub.core.exceptions.model_gateway_error_handler import ModelGatewayErrorHandler
+
+pytestmark = pytest.mark.unit
+
+UPSTREAM_URL = "http://litellm:4000/audio/transcriptions"
+
+# Recorded verbatim from the provider on 2026-09-03 by transcribing an Indonesian recording.
+ALIGNMENT_FAILURE = (
+    "litellm.InternalServerError: InternalServerError: OpenAIException - Error code: 500 - "
+    "{'detail': \"Transcription failed: Request 03486716-5ed9-4a4d-b7b9-ffcffe6713b4 failed: 500: "
+    "Transcription failed: 503: Failed to load alignment model for 'id': "
+    'No default align-model for language: id"}. Received Model Group=inference-whisper-large-v3\n'
+    "Available Model Group Fallbacks=None"
+)
+
+
+def _internal_server_error(message: str) -> InternalServerError:
+    body = {"error": {"message": message, "type": None, "param": None, "code": "500"}}
+    request = httpx.Request("POST", UPSTREAM_URL)
+    return InternalServerError("Error code: 500", response=httpx.Response(500, request=request, json=body), body=body)
+
+
+class TestProviderInternalsAreRewrittenForTheCaller:
+    """The transcription provider names its own pipeline stage — "align-model" means nothing to a
+    chat user, and the language it names is the one it detected, not one the caller chose."""
+
+    def test_alignment_failure_names_the_language_instead_of_the_stage(self):
+        cause = ModelGatewayErrorHandler.cause_of(_internal_server_error(ALIGNMENT_FAILURE))
+
+        assert "align-model" not in cause
+        assert "'id'" in cause
+        assert cause.startswith("Transcription is not available for the language")
+
+    def test_unrecognised_failures_keep_the_gateway_wording(self):
+        """Guessing at an unmatched failure would hide it; the gateway's own wording is still the
+        best description available."""
+        message = "litellm.InternalServerError: OpenAIException - upstream exploded in a new way"
+
+        assert ModelGatewayErrorHandler.cause_of(_internal_server_error(message)) == message


### PR DESCRIPTION
Fixes bbvch-ai/aihub-core-private#218.

Voice input returned an opaque `502` for two different upstream failures. Reproduced both against the live provider (`maas.phoeniqs.com`, `inference-whisper-large-v3`) before changing anything — the reproduction is what decided the fix, because it disproved the obvious one.

## What the reproduction established

| Input | Parameters | Result |
| --- | --- | --- |
| English speech | none, then `language=id` / `ja` / `de`, `verbose_json`, `timestamp_granularities[]=word` | 200 in every variant, byte-identical body |
| Indonesian speech | none | 500 — the reported `503: Failed to load alignment model for 'id'` |
| Same Indonesian audio | `language=en`, `language=de` | 500, still `align-model for 'id'` |
| Silence, white noise, pure tone | none | 500 `Transcription failed: 0` |

**The provider discards `language`.** Forcing `language=ja` onto English speech returns flawless English (verified on a file it had never seen, so not a cache), and telling it twice that an Indonesian recording is English or German does not change the language it detects. Pinning the language — the fix this issue originally proposed — cannot work here, and would actively harm GPU deployments where `speaches` *does* honour the field: a French speaker in a German UI would get a confident German transcription of French speech.

**`response_format` and `timestamp_granularities` are discarded too** (`words` and `language` are `null` in every response), so alignment is not something a caller can switch off.

**An upload with no speech is a separate 500**, not in the original report. That one is ours to prevent.

## Changes

- `AudioChunkingService.contains_speech()` — reuses the `detect_nonsilent` pass the chunker already relies on. `OpenaiService.stt` answers a recording with no speech with an empty transcript in the requested format, as OpenAI does, without calling the gateway.
- `timestamp_granularities` is only forwarded when `response_format == "verbose_json"` — it shapes nothing else, and it is what asks the alignment stage to run.
- `TranscriptionVerbose.language` falls back to `""`. The field is a required `str` and the caller's possibly-unset `language` was echoed into it, so `verbose_json` without a `language` failed validation *after* the transcription had been paid for. Response building moved into `_transcription_response()`, shared by both paths.
- `ModelGatewayErrorHandler.UPSTREAM_CAUSE_PATTERNS` rewrites the alignment failure into one sentence naming the language. Applied to the HTTP response and to `cause_of()`, so agent steps reporting through NATS get the same wording; the raw message still goes to the log, where an operator wants it.
- `transcription/*: []` and `image-generation/flux: []` in `router_settings.fallbacks`. This *disables* fallback for those groups rather than adding one — the `default_fallbacks` wildcard was retrying audio and image failures against a chat model that cannot serve them, and there is only one STT deployment to fall back to anyway.

## Verification

Run through the real `OpenaiService.stt` against the live provider, with only the access check and the model catalogue stubbed:

| Case | Before | After |
| --- | --- | --- |
| Silence 8 s | 500 `Transcription failed: 0` | `Transcription(text='')`, no gateway call |
| White noise 5 s | 500 | `Transcription(text='')` |
| English speech | 200 | 200, unchanged |
| `verbose_json`, no `language` | `ValidationError` | `TranscriptionVerbose` returned |
| Indonesian speech | quadruple-nested LiteLLM traceback | `Transcription is not available for the language detected in this recording ('id'): the speech-to-text provider ships no alignment model for it.` |

Tests: `packages/core` 99 passed; the `packages/api` unit tests covering this path 32 passed. The full `packages/api` suite needs the dev stack (its API tests error at setup without NATS/Mongo) and was not run.

## Not fixed here

The alignment failure itself cannot be fixed from this side — only its wording. Raising three things with the provider separately: alignment should degrade to segment timestamps rather than `503`, `language` should be honoured or rejected rather than silently discarded, and an upload with no speech should return an empty transcript rather than a `500`. `aihub-k8s` needs the same `fallbacks` change and a reconciled model group name (`inference-whisper-large-v3` there vs `transcription/whisper-large-v3` in the compose template).
