### PR TITLE
fix(swiss-ai-hub): Stop the LLM spend aggregation from freezing the API event loop

### DIFF
--- a/packages/api/swiss_ai_hub/api/routes/event/event_controller.py
+++ b/packages/api/swiss_ai_hub/api/routes/event/event_controller.py
@@ -259,14 +259,14 @@ class EventController(TenantScopedController):
             any single tenant, sees the whole platform.
             """
             if user.is_sys_admin:
-                return EventService.get_llm_spend_by_user(since=since)
+                return await EventService.get_llm_spend_by_user(since=since)
 
             # Deny rather than fall open: an unset acting tenant would otherwise mean "no filter",
             # handing a single-tenant admin every tenant's user spend.
             tenant_id = _acting_tenant_id(user)
             if tenant_id is None:
                 raise HTTPException(status_code=403, detail="Must act within a tenant to view user spend.")
-            return EventService.get_llm_spend_by_user(tenant_id=tenant_id, since=since)
+            return await EventService.get_llm_spend_by_user(tenant_id=tenant_id, since=since)
 
         return self
 
@@ -288,6 +288,6 @@ class EventController(TenantScopedController):
             Sysadmin-only: a cross-tenant total is exactly the view a single tenant must not have.
             """
             del user
-            return EventService.get_llm_spend_by_tenant(since=since)
+            return await EventService.get_llm_spend_by_tenant(since=since)
 
         return self

--- a/packages/api/swiss_ai_hub/api/routes/event/event_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/event/event_service.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from datetime import datetime
 
@@ -115,12 +116,19 @@ class EventService:
 
     @staticmethod
     @trace_fn
-    def get_llm_spend_by_user(tenant_id: str | None = None, since: datetime | None = None) -> list[LLMSpend]:
-        """LLM spend per user, narrowed to one tenant unless the caller may see the whole platform."""
-        return PersistedAgentEventEntity.get_llm_spend_by_user(tenant_id=tenant_id, since=since)
+    async def get_llm_spend_by_user(tenant_id: str | None = None, since: datetime | None = None) -> list[LLMSpend]:
+        """LLM spend per user, narrowed to one tenant unless the caller may see the whole platform.
+
+        Off the event loop, because the aggregation is synchronous and its runtime grows with the
+        window: measured at 123s on staging for a cold 30-day window, which froze every other
+        request — including the health probe, whose three failures then had Docker call the whole
+        container unhealthy and gunicorn kill the worker."""
+        return await asyncio.to_thread(
+            PersistedAgentEventEntity.get_llm_spend_by_user, tenant_id=tenant_id, since=since
+        )
 
     @staticmethod
     @trace_fn
-    def get_llm_spend_by_tenant(since: datetime | None = None) -> list[LLMSpend]:
-        """LLM spend per tenant across the platform."""
-        return PersistedAgentEventEntity.get_llm_spend_by_tenant(since=since)
+    async def get_llm_spend_by_tenant(since: datetime | None = None) -> list[LLMSpend]:
+        """LLM spend per tenant across the platform. Off the event loop — see `get_llm_spend_by_user`."""
+        return await asyncio.to_thread(PersistedAgentEventEntity.get_llm_spend_by_tenant, since=since)

--- a/packages/core/swiss_ai_hub/core/persistence/messaging/entities/persisted_agent_event_entity.py
+++ b/packages/core/swiss_ai_hub/core/persistence/messaging/entities/persisted_agent_event_entity.py
@@ -531,11 +531,11 @@ class PersistedAgentEventEntity(Document):
         carried_fields = [*group_fields, *cost_fields]
         pipeline = [
             {"$match": match},
-            # Lift the handful of fields the group stages read out of `event_data` before the dedup,
-            # rather than carrying the document with `$first: "$event_data"`. A cost event's payload
-            # holds the whole request context, so the old shape hauled every matched event's full
-            # body through the aggregation: 123s for a cold 30-day window on staging's 405k-event
-            # collection, against 1s once the fields are projected first.
+            # Lift the five fields the group stages read out of `event_data` before the dedup, rather
+            # than carrying the document with `$first: "$event_data"`: a cost event's payload holds the
+            # whole request context, and the stage needs none of it. Measured on staging over 33k cost
+            # events, this is worth single-digit seconds at most — the 123s that took the API's event
+            # loop down was a cold read of 30 days off disk, which no pipeline shape avoids.
             {"$project": {"_id": 0, "event_id": 1, **{field: f"$event_data.{field}" for field in carried_fields}}},
             {"$group": {"_id": "$event_id", **{field: {"$first": f"${field}"} for field in carried_fields}}},
             {

--- a/packages/core/swiss_ai_hub/core/persistence/messaging/entities/persisted_agent_event_entity.py
+++ b/packages/core/swiss_ai_hub/core/persistence/messaging/entities/persisted_agent_event_entity.py
@@ -528,14 +528,21 @@ class PersistedAgentEventEntity(Document):
             match["event_data.tenant_id"] = tenant_id
 
         cost_fields = ["prompt_tokens_costs", "completion_tokens_costs", "embedding_tokens_costs"]
+        carried_fields = [*group_fields, *cost_fields]
         pipeline = [
             {"$match": match},
-            {"$group": {"_id": "$event_id", "event_data": {"$first": "$event_data"}}},
+            # Lift the handful of fields the group stages read out of `event_data` before the dedup,
+            # rather than carrying the document with `$first: "$event_data"`. A cost event's payload
+            # holds the whole request context, so the old shape hauled every matched event's full
+            # body through the aggregation: 123s for a cold 30-day window on staging's 405k-event
+            # collection, against 1s once the fields are projected first.
+            {"$project": {"_id": 0, "event_id": 1, **{field: f"$event_data.{field}" for field in carried_fields}}},
+            {"$group": {"_id": "$event_id", **{field: {"$first": f"${field}"} for field in carried_fields}}},
             {
                 "$group": {
-                    "_id": {field: f"$event_data.{field}" for field in group_fields},
+                    "_id": {field: f"${field}" for field in group_fields},
                     "calls": {"$sum": 1},
-                    **{field: {"$sum": {"$ifNull": [f"$event_data.{field}", 0]}} for field in cost_fields},
+                    **{field: {"$sum": {"$ifNull": [f"${field}", 0]}} for field in cost_fields},
                 }
             },
             {"$sort": {"_id": 1}},

--- a/packages/core/swiss_ai_hub/core/persistence/messaging/entities/persisted_agent_event_entity.py
+++ b/packages/core/swiss_ai_hub/core/persistence/messaging/entities/persisted_agent_event_entity.py
@@ -533,9 +533,10 @@ class PersistedAgentEventEntity(Document):
             {"$match": match},
             # Lift the five fields the group stages read out of `event_data` before the dedup, rather
             # than carrying the document with `$first: "$event_data"`: a cost event's payload holds the
-            # whole request context, and the stage needs none of it. Measured on staging over 33k cost
-            # events, this is worth single-digit seconds at most — the 123s that took the API's event
-            # loop down was a cold read of 30 days off disk, which no pipeline shape avoids.
+            # whole request context, and the stage needs none of it. Measured warm on staging over 33k
+            # cost events, 6.5s carrying the documents against 1.2s carrying the fields. It is not what
+            # took the event loop down, though — that was a 123s cold read of 30 days off disk, which
+            # no pipeline shape avoids and only the threadpool hand-off contains.
             {"$project": {"_id": 0, "event_id": 1, **{field: f"$event_data.{field}" for field in carried_fields}}},
             {"$group": {"_id": "$event_id", **{field: {"$first": f"${field}"} for field in carried_fields}}},
             {

--- a/packages/core/swiss_ai_hub/core/persistence/messaging/entities/tests/unit/test_persisted_agent_event_entity.py
+++ b/packages/core/swiss_ai_hub/core/persistence/messaging/entities/tests/unit/test_persisted_agent_event_entity.py
@@ -305,9 +305,8 @@ class TestLLMSpendAggregation:
         assert spend[0].calls == 1
 
     def test_payload_beyond_the_attributed_fields_does_not_change_the_sum(self):
-        """The pipeline projects the five fields it groups on instead of carrying `event_data` whole —
-        a cost event's payload holds the entire request context, and hauling it through the dedup stage
-        cost 123s for a 30-day window on staging. Anything outside those fields must be irrelevant."""
+        """The pipeline projects the five fields it groups on instead of carrying `event_data` whole, so
+        anything outside those fields must be unable to change the result."""
         _persist_cost_event("e1", user_id="u1", tenant_id="acme", prompt=1.0, completion=2.0)
         event = PersistedAgentEventEntity.objects(event_id="e1").first()
         event.event_data["messages"] = ["x" * 4096]

--- a/packages/core/swiss_ai_hub/core/persistence/messaging/entities/tests/unit/test_persisted_agent_event_entity.py
+++ b/packages/core/swiss_ai_hub/core/persistence/messaging/entities/tests/unit/test_persisted_agent_event_entity.py
@@ -303,3 +303,18 @@ class TestLLMSpendAggregation:
 
         assert len(spend) == 1
         assert spend[0].calls == 1
+
+    def test_payload_beyond_the_attributed_fields_does_not_change_the_sum(self):
+        """The pipeline projects the five fields it groups on instead of carrying `event_data` whole —
+        a cost event's payload holds the entire request context, and hauling it through the dedup stage
+        cost 123s for a 30-day window on staging. Anything outside those fields must be irrelevant."""
+        _persist_cost_event("e1", user_id="u1", tenant_id="acme", prompt=1.0, completion=2.0)
+        event = PersistedAgentEventEntity.objects(event_id="e1").first()
+        event.event_data["messages"] = ["x" * 4096]
+        event.event_data["model_parameters"] = {"temperature": 0.7, "prompt": "y" * 4096}
+        event.save()
+
+        spend = PersistedAgentEventEntity.get_llm_spend_by_user()
+
+        assert spend[0].calls == 1
+        assert spend[0].total_costs == pytest.approx(3.0)


### PR DESCRIPTION
## What

`GET /api/v1/events/spend/{users,tenants}` ran a synchronous 30-day `$group` aggregation directly on the API's event loop. On staging that call takes **123 s** cold, so every other request — including the container's own health probe — was blocked for the duration.

Two changes:

1. **Off the loop.** `EventService.get_llm_spend_by_user` / `get_llm_spend_by_tenant` are now async and run the aggregation via `asyncio.to_thread`. A slow spend query becomes one slow request instead of a dead API.
2. **Project before dedup.** The pipeline now lifts the five attributed fields out of `event_data` before the dedup stage, instead of carrying the whole document with `$first: "$event_data"`. Verified on staging against 33k cost events: the two shapes return **identical** figures, and warm the projected one runs in **1.2 s** against **6.5 s** for the old shape. It is not what took the loop down, though — the 123 s was a cold read of 30 days off disk, which no pipeline shape avoids and only the threadpool hand-off contains.

## Why this is a hotfix for 0.320

Staging (`v0.320.0-rc.7`) had **six** event-loop freezes of 3–5 minutes on 2026-09-04 between 09:38 and 10:54 UTC. Evidence chain:

- Container never restarted (`RestartCount 0`); gunicorn's arbiter killed the single worker (`-w 1 --timeout=300`) five times with `WORKER TIMEOUT` + `SIGABRT`, each followed by a full lifespan re-init.
- Docker marked the container unhealthy ~100 s into each freeze (15 s `start_period` + 3 × 30 s probe failures). The first freeze self-resolved without a kill, because 123 s < the 300 s gunicorn timeout.
- The cron scheduler runs in-process, so its per-minute tick is a clock for the loop: ticks at 10:22:27 / 10:23:27 / 10:24:27, last log line 10:25:13, and the 10:25:27 tick never arrived.
- Persisted-event counts per minute show the same six gaps and nothing else: event traffic is a flat 11/min.

Measured on staging, same 30-day window:

| Query | Cold | Warm |
| --- | --- | --- |
| `get_llm_spend_by_tenant()` | **123.0 s** | — |
| `get_llm_spend_by_user()` | — | 1.0 s |

33k cost events matched the window. A re-run of the same query minutes later took 11 s, so the cold figure is dominated by disk, not by CPU or by the pipeline shape.

Ruled out with evidence: OOM (599 MiB / 47 GiB), exception storms (2 exceptions in the whole window), Milvus (#1830 is already in rc.7), FerretDB/Postgres stalls (clean logs, clean `dmesg`), NATS (`publish_failures=0` on every tick up to the freeze), and the auth path (`KeycloakAdminService` uses python-keycloak's `a_*` API).

## Test plan

- [ ] CI `core` and `api` test jobs (both run against a real FerretDB) — the existing `TestLLMSpendAggregation` suite covers grouping, `event_id` dedup, the `$ifNull` guard for absent `embedding_tokens_costs`, tenant scoping and the window bounds against the new pipeline shape.
- [ ] `test_llm_spend_api.py` exercises both endpoints through the real controller, so it covers the new `await`.
- [ ] New test: `test_payload_beyond_the_attributed_fields_does_not_change_the_sum` pins that fields outside the projection cannot affect the totals.
- [ ] On staging after deploy: `/api/v1/events/spend/tenants` returns the same figures, and the health probe stays green while it runs.

## Follow-ups (main, not this hotfix)

Same pattern, smaller blast radius, measured at ~3 s each on today's data — deliberately out of scope here:

- `EventService.get_events_in_thread` and `ThreadService.thread_as_message_history` read every display event of a thread synchronously on the loop, unbounded.
- `EventPersister.persist_agent_event` writes synchronously on the loop for every agent event.
- `connect()` sets no `socketTimeoutMS`, so a slow FerretDB query has no ceiling — a timeout would have turned this incident into a named traceback instead of silence.
- Staging has `SCHEDULER_EVENT_RETENTION_DAYS: 0` with a per-minute schedule, so the collection this aggregation scans grows without bound.
