### PR TITLE
fix(swiss-ai-hub): Answer a recording with no speech with an empty transcript

### DIFF
--- a/packages/api/CLAUDE.md
+++ b/packages/api/CLAUDE.md
@@ -144,6 +144,25 @@ flooding the log pipeline.
 New upstream integrations that raise their own SDK exception types belong in the same place — do not wrap service calls
 in try/except to compensate.
 
+**The one deliberate exception** is `OpenaiService.stt`, because one failure there is not a failure at all. The
+transcription provider reports "I found no speech in this audio" as an HTTP 500 whose body reads
+`Transcription failed: 0` — the `0` is a segment count, not a status. Measured against the provider on 2026-09-04:
+silence, a 440 Hz tone and white noise all return it; 1.3 s of speech at -24 dBFS transcribes fine. So it is a verdict
+on the audio, and it is the same verdict `AudioChunkingService.contains_speech` reaches locally for silence — where
+this API already answers with an empty transcript, as OpenAI's own API does.
+
+`stt` therefore catches exactly that classified cause (`ModelGatewayErrorHandler.is_untranscribable_audio`, never a
+bare `APIStatusError`) and treats the chunk as holding no speech: it keeps the chunks that did transcribe, and returns
+an empty transcript when none did. Everything else re-raises untouched — a misconfigured model or an expired key is not
+a verdict on the audio, and answering it with an empty transcript would report "nobody spoke" for a deployment that
+transcribes nothing. Two things make the silence recoverable afterwards, since a transcript quietly missing a passage is
+worse than a failure: each such chunk logs the provider's verbatim message (it carries the upstream request id, the
+only handle for asking the provider about it), and a summary logs how many of the recording's milliseconds are not in
+the transcript.
+
+`contains_speech` stays as a pre-filter rather than the whole answer: it detects sound at -40 dB, where the provider
+detects speech, so tone and noise pass it and are rejected upstream.
+
 ## i18n System
 
 **Hierarchy**: `LocaleString`/`LocaleHandler` (packages/core) → `ApiLocaleString`/`ApiLocaleHandler` (packages/api

--- a/packages/api/playground/testing/tests/audio/test_transcription_gateway_contract.py
+++ b/packages/api/playground/testing/tests/audio/test_transcription_gateway_contract.py
@@ -1,8 +1,11 @@
 import io
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from fastapi import UploadFile
+from openai import InternalServerError
 from openai.types.audio import TranscriptionVerbose
 from pydub import AudioSegment
 from pydub.generators import Sine
@@ -14,6 +17,16 @@ from swiss_ai_hub.api.routes.openai.openai_service import OpenaiService
 
 _SERVICE = "swiss_ai_hub.api.routes.openai.openai_service"
 _MODEL = "transcription/whisper-large-v3"
+
+# Recorded verbatim from staging (api container, 2026-09-04T10:48:11Z) on a recording a user spoke
+# into: the provider's alignment pass produced no segments and reports only their count.
+NO_SEGMENTS_FAILURE = (
+    "litellm.InternalServerError: InternalServerError: OpenAIException - Error code: 500 - "
+    "{'detail': 'Transcription failed: Request b86b9b03-eba7-48e5-b5f6-ccd832bc6a0f failed: 500: "
+    "Transcription failed: 0'}. Received Model Group=inference-whisper-large-v3\n"
+    "Available Model Group Fallbacks=None LiteLLM Retried: 2 times, LiteLLM Max Retries: 2"
+)
+INVALID_MODEL_FAILURE = "litellm.InternalServerError: OpenAIException - Invalid model name passed in model=whisper-1"
 
 
 def _upload(audio: AudioSegment, filename: str = "recording.wav") -> UploadFile:
@@ -55,6 +68,24 @@ def _client_returning(text: str) -> AsyncMock:
     transcription.text = text
     client.audio.transcriptions.create = AsyncMock(return_value=transcription)
     return client
+
+
+def _client_failing_then_returning(failure: Exception, text: str) -> AsyncMock:
+    client = AsyncMock()
+    transcription = MagicMock()
+    transcription.text = text
+    client.audio.transcriptions.create = AsyncMock(side_effect=[failure, transcription])
+    return client
+
+
+def _upstream_failure(message: str) -> InternalServerError:
+    body = {"error": {"message": message, "type": None, "param": None, "code": "500"}}
+    request = httpx.Request("POST", "http://litellm:4000/audio/transcriptions")
+    return InternalServerError("Error code: 500", response=httpx.Response(500, request=request, json=body), body=body)
+
+
+def _two_chunks() -> list[AudioSegment]:
+    return [Sine(440).to_audio_segment(duration=2000), Sine(440).to_audio_segment(duration=1500)]
 
 
 class TestSilentUploadsNeverReachTheGateway:
@@ -122,3 +153,62 @@ class TestVerboseResponsesSurviveAnUnspecifiedLanguage:
         assert isinstance(result, TranscriptionVerbose)
         assert result.language == ""
         assert result.text == "hello"
+
+
+class TestAudioTheProviderFindsNoSpeechIn:
+    """`Transcription failed: 0` is the provider's verdict, not a fault: measured against it on
+    2026-09-04, silence, a 440 Hz tone and white noise all come back with it, while 1.3 s of speech
+    transcribes fine. So it means "no speech in this audio" — the same verdict `contains_speech`
+    reaches locally for silence, and it gets the same answer: the transcript of whatever else was
+    there, empty when that is nothing. It also repeats on every retry, so aborting the upload over
+    one chunk threw away the chunks that did transcribe."""
+
+    @pytest.mark.asyncio
+    async def test_the_chunks_that_transcribed_are_still_returned(self):
+        client = _client_failing_then_returning(_upstream_failure(NO_SEGMENTS_FAILURE), "the second half")
+
+        with patch.object(AudioChunkingService, "chunk_audio", new=AsyncMock(return_value=_two_chunks())):
+            result = await _transcribe(_upload(_spoken_audio()), client)
+
+        assert result.text == "the second half"
+
+    @pytest.mark.asyncio
+    async def test_the_audio_left_out_is_logged_with_its_duration(self, caplog):
+        """A transcript quietly missing a passage is worse than a failure, so how much audio is not
+        in it has to be recoverable from the log."""
+        client = _client_failing_then_returning(_upstream_failure(NO_SEGMENTS_FAILURE), "the second half")
+
+        with (
+            patch.object(AudioChunkingService, "chunk_audio", new=AsyncMock(return_value=_two_chunks())),
+            caplog.at_level(logging.ERROR),
+        ):
+            await _transcribe(_upload(_spoken_audio()), client)
+
+        assert "Chunk 1/2 (2000 ms) of recording.wav produced no transcript" in caplog.text
+        assert "2000 ms of the 3500 ms in recording.wav is not in the transcript" in caplog.text
+        # The provider's request id is the only handle for asking it about a chunk it rejected, so
+        # the log keeps the upstream wording the response no longer carries.
+        assert "b86b9b03-eba7-48e5-b5f6-ccd832bc6a0f" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_a_recording_with_no_speech_at_all_returns_an_empty_transcript(self, caplog):
+        """This is the case staging hit: one chunk, no speech in it. Raising handed the chat user
+        LiteLLM's nested traceback for a recording that simply had nothing to transcribe."""
+        client = AsyncMock()
+        client.audio.transcriptions.create = AsyncMock(side_effect=_upstream_failure(NO_SEGMENTS_FAILURE))
+
+        with caplog.at_level(logging.ERROR):
+            result = await _transcribe(_upload(_spoken_audio()), client)
+
+        assert result.text == ""
+        assert "3500 ms of the 3500 ms in recording.wav is not in the transcript" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_a_gateway_fault_is_not_answered_with_an_empty_transcript(self):
+        """A misconfigured model or an expired key is not a verdict on the audio; answering it with
+        an empty transcript would report "nobody spoke" for a deployment that transcribes nothing."""
+        client = _client_failing_then_returning(_upstream_failure(INVALID_MODEL_FAILURE), "never reached")
+
+        with patch.object(AudioChunkingService, "chunk_audio", new=AsyncMock(return_value=_two_chunks())):
+            with pytest.raises(InternalServerError):
+                await _transcribe(_upload(_spoken_audio()), client)

--- a/packages/api/swiss_ai_hub/api/audio/audio_chunking_service.py
+++ b/packages/api/swiss_ai_hub/api/audio/audio_chunking_service.py
@@ -39,8 +39,13 @@ class AudioChunkingService:
 
         OpenAI answers a silent upload with an empty transcript, but the gateway's WhisperX service
         raises instead — a recording the user never spoke into comes back as `Transcription failed: 0`,
-        an HTTP 500 the caller can do nothing with. Verified against the provider on 2026-09-03 with
-        silence, white noise and a pure tone.
+        an HTTP 500 the caller can do nothing with.
+
+        This is a cheap pre-filter, not the whole answer: -40 dB detects *sound*, where the provider
+        detects *speech*. Measured against it on 2026-09-04, a 440 Hz tone and white noise both pass
+        here (dBFS -3.7 and -4.8) and are still rejected upstream, while 1.3 s of speech at -24 dBFS
+        transcribes fine. `OpenaiService.stt` therefore has to handle that verdict arriving from the
+        gateway as well, and answers it the same way this guard does.
         """
         return bool(
             detect_nonsilent(

--- a/packages/api/swiss_ai_hub/api/routes/openai/openai_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/openai/openai_service.py
@@ -5,11 +5,11 @@ import logging
 import uuid
 from collections.abc import AsyncGenerator, Callable
 from datetime import UTC, datetime
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from fastapi import HTTPException, UploadFile
 from nats.aio.client import Client as NATS
-from openai import AsyncOpenAI, HttpxBinaryResponseContent
+from openai import APIStatusError, AsyncOpenAI, HttpxBinaryResponseContent
 from openai.types import CompletionUsage, ImagesResponse
 from openai.types.audio import Transcription, TranscriptionVerbose
 from openai.types.chat import ChatCompletion, ChatCompletionChunk, ChatCompletionMessage, ChatCompletionMessageParam
@@ -26,6 +26,7 @@ from swiss_ai_hub.core.distributor import ExternalAgentEventDistributor
 from swiss_ai_hub.core.events.agent.control.exception.exception_event import ExceptionEvent
 from swiss_ai_hub.core.events.agent.control.stop.stop_event import StopEvent
 from swiss_ai_hub.core.events.agent.hitl.request.human_in_the_loop_request_event import HumanInTheLoopRequestEvent
+from swiss_ai_hub.core.exceptions import ModelGatewayErrorHandler
 from swiss_ai_hub.core.i18n import LocaleHandler
 from swiss_ai_hub.core.infrastructure import LiteLLMProxySettings, LiteLLMService, trace_fn
 from swiss_ai_hub.core.persistence.utils import str_to_object_id
@@ -589,30 +590,84 @@ class OpenaiService:
 
         audio_chunks: list[AudioSegment] = await AudioChunkingService.chunk_audio(audio)
         transcription_chunks: list[TranscriptionChunk] = []
+        speechless_duration: Annotated[int, "ms"] = 0
 
         for i, audio_chunk in enumerate(audio_chunks):
-            buffer = io.BytesIO()
-            audio_chunk.export(buffer, format="wav")
-            filename_without_ext = file.filename.rsplit(".", 1)[0] if "." in file.filename else file.filename
-            wav_filename = f"{filename_without_ext}_chunk{i}.wav"
-            file_tuple = (wav_filename, buffer, "audio/wav")
+            try:
+                transcription_chunks.append(
+                    await OpenaiService._transcribe_chunk(
+                        client=client,
+                        model_name=model_name,
+                        audio_chunk=audio_chunk,
+                        filename=file.filename,
+                        index=i,
+                        language=language,
+                        prompt=prompt,
+                        response_format=response_format,
+                        temperature=temperature,
+                        timestamp_granularities=timestamp_granularities,
+                    )
+                )
+            except APIStatusError as gateway_failure:
+                if not ModelGatewayErrorHandler.is_untranscribable_audio(gateway_failure):
+                    raise
 
-            result: TranscriptionChunk = await client.audio.transcriptions.create(
-                model=model_name,
-                file=file_tuple,
-                language=language,
-                prompt=prompt,
-                response_format=response_format,
-                temperature=temperature,
-                timestamp_granularities=timestamp_granularities if response_format == "verbose_json" else None,
+                speechless_duration += len(audio_chunk)
+                # The provider's own wording is kept verbatim here, unlike in the response: it
+                # carries the upstream request id, which is the only handle for asking the provider
+                # about a chunk it rejected. `str(exception)` would not do — the SDK puts the body
+                # there only when it built the exception itself, so the id has to be unwrapped.
+                logger.error(
+                    f"Chunk {i + 1}/{len(audio_chunks)} ({len(audio_chunk)} ms) of {file.filename} produced no "
+                    f"transcript: {ModelGatewayErrorHandler.upstream_message(gateway_failure)}"
+                )
+
+        if speechless_duration:
+            logger.error(
+                f"{speechless_duration} ms of the {len(audio)} ms in {file.filename} is not in the transcript: the "
+                "speech-to-text provider found no speech it could align there."
             )
 
-            transcription_chunks.append(result)
-
-        merged_text: str = AudioChunkingService.merge_transcriptions(transcription_chunks)
+        # Verified against the provider on 2026-09-04: it answers silence, a pure tone and white
+        # noise with this failure, and 1.3 s of speech with a transcript — so the failure is its
+        # verdict "no speech here", not a fault. That is the verdict `contains_speech` reaches
+        # locally for silence, and it is answered the same way: the empty transcript OpenAI's own
+        # API returns for a recording nobody spoke into.
+        merged_text: str = (
+            AudioChunkingService.merge_transcriptions(transcription_chunks) if transcription_chunks else ""
+        )
 
         return OpenaiService._transcription_response(
             text=merged_text, audio=audio, language=language, response_format=response_format
+        )
+
+    @staticmethod
+    async def _transcribe_chunk(
+        *,
+        client: AsyncOpenAI,
+        model_name: str,
+        audio_chunk: AudioSegment,
+        filename: str,
+        index: int,
+        language: str | None,
+        prompt: str | None,
+        response_format: str | None,
+        temperature: float | None,
+        timestamp_granularities: list[Literal["word", "segment"]] | None,
+    ) -> TranscriptionChunk:
+        buffer = io.BytesIO()
+        audio_chunk.export(buffer, format="wav")
+        filename_without_ext = filename.rsplit(".", 1)[0] if "." in filename else filename
+        file_tuple = (f"{filename_without_ext}_chunk{index}.wav", buffer, "audio/wav")
+
+        return await client.audio.transcriptions.create(
+            model=model_name,
+            file=file_tuple,
+            language=language,
+            prompt=prompt,
+            response_format=response_format,
+            temperature=temperature,
+            timestamp_granularities=timestamp_granularities if response_format == "verbose_json" else None,
         )
 
     @staticmethod

--- a/packages/core/swiss_ai_hub/core/exceptions/model_gateway_error_handler.py
+++ b/packages/core/swiss_ai_hub/core/exceptions/model_gateway_error_handler.py
@@ -45,6 +45,14 @@ class ModelGatewayErrorHandler:
     # which is the very incident this handler exists for.
     NON_ACTIONABLE_STATUSES: ClassVar[frozenset[int]] = frozenset({413, 422, 429})
 
+    # The provider reports a transcription that yielded nothing as a bare segment count, so its own
+    # wording names no cause at all. Matched in two places: to rewrite the response, and to let a
+    # caller transcribing in chunks tell audio the provider cannot use from a gateway fault that
+    # every chunk would hit. The lookahead is what separates the two: the provider nests its own
+    # statuses in the same phrase ("Transcription failed: 503: Failed to load alignment model"), and
+    # a status is a fault that may well be transient, while a count is a verdict on this audio.
+    UNTRANSCRIBABLE_AUDIO: ClassVar[re.Pattern[str]] = re.compile(r"Transcription failed: \d+(?!\d|:)")
+
     # Upstream failures whose own wording names a component of the provider's pipeline rather than
     # anything the caller can recognise. The raw message still goes to the log — only the response
     # is rewritten, because the caller reading it is a chat user, not an operator.
@@ -53,6 +61,11 @@ class ModelGatewayErrorHandler:
             re.compile(r"No default align-model for language: (?P<language>[A-Za-z-]+)"),
             "Transcription is not available for the language detected in this recording "
             "('{language}'): the speech-to-text provider ships no alignment model for it.",
+        ),
+        (
+            UNTRANSCRIBABLE_AUDIO,
+            "The speech-to-text provider produced no transcript for this recording: it found no "
+            "speech it could align in the audio.",
         ),
     )
 
@@ -92,7 +105,7 @@ class ModelGatewayErrorHandler:
 
     @staticmethod
     async def handle_status_error(request: Request, exception: APIStatusError) -> JSONResponse:
-        message = ModelGatewayErrorHandler._upstream_message(exception)
+        message = ModelGatewayErrorHandler.upstream_message(exception)
         ModelGatewayErrorHandler._log_status_error(request, exception.status_code, message)
         return ModelGatewayErrorHandler._failure_response(
             status_code=ModelGatewayErrorHandler._caller_facing_status(exception.status_code),
@@ -168,8 +181,25 @@ class ModelGatewayErrorHandler:
         way too. Anything that is not a gateway error is returned unchanged.
         """
         if isinstance(exception, APIStatusError):
-            return ModelGatewayErrorHandler._readable_cause(ModelGatewayErrorHandler._upstream_message(exception))
+            return ModelGatewayErrorHandler._readable_cause(ModelGatewayErrorHandler.upstream_message(exception))
         return str(exception)
+
+    @staticmethod
+    def is_untranscribable_audio(exception: Exception) -> bool:
+        """Whether the provider rejected the audio itself rather than failing to serve the request.
+
+        A caller that splits a recording into chunks needs the distinction: this failure repeats on
+        every retry of the same chunk, so aborting the whole transcription over it throws away the
+        chunks that did transcribe.
+        """
+        if not isinstance(exception, APIStatusError):
+            return False
+
+        return bool(
+            ModelGatewayErrorHandler.UNTRANSCRIBABLE_AUDIO.search(
+                ModelGatewayErrorHandler.upstream_message(exception)
+            )
+        )
 
     @staticmethod
     def _readable_cause(message: str) -> str:
@@ -185,7 +215,7 @@ class ModelGatewayErrorHandler:
         return message
 
     @staticmethod
-    def _upstream_message(exception: APIStatusError) -> str:
+    def upstream_message(exception: APIStatusError) -> str:
         """Unwraps the OpenAI error envelope, whose ``error.message`` is what actually names the
         cause ("Invalid model name passed in model=..."). ``exception.message`` only wraps that
         same body in "Error code: N - {...}"."""

--- a/packages/core/swiss_ai_hub/core/exceptions/tests/unit/test_model_gateway_error_handler.py
+++ b/packages/core/swiss_ai_hub/core/exceptions/tests/unit/test_model_gateway_error_handler.py
@@ -68,13 +68,13 @@ class TestUpstreamStatusIsTranslatedForTheCaller:
 
 class TestUpstreamMessageIsUnwrapped:
     def test_nested_openai_envelope_message_is_used(self):
-        assert ModelGatewayErrorHandler._upstream_message(_status_error(400, UPSTREAM_BODY)) == UPSTREAM_MESSAGE
+        assert ModelGatewayErrorHandler.upstream_message(_status_error(400, UPSTREAM_BODY)) == UPSTREAM_MESSAGE
 
     def test_plain_string_error_is_used(self):
-        assert ModelGatewayErrorHandler._upstream_message(_status_error(400, {"error": "no capacity"})) == "no capacity"
+        assert ModelGatewayErrorHandler.upstream_message(_status_error(400, {"error": "no capacity"})) == "no capacity"
 
     def test_unrecognized_body_falls_back_to_sdk_message(self):
-        assert ModelGatewayErrorHandler._upstream_message(_status_error(500, {"unexpected": 1})) == "Error code: 500"
+        assert ModelGatewayErrorHandler.upstream_message(_status_error(500, {"unexpected": 1})) == "Error code: 500"
 
 
 class TestFailureResponseNamesTheCause:

--- a/packages/core/swiss_ai_hub/core/exceptions/tests/unit/test_upstream_cause_rewriting.py
+++ b/packages/core/swiss_ai_hub/core/exceptions/tests/unit/test_upstream_cause_rewriting.py
@@ -18,6 +18,16 @@ ALIGNMENT_FAILURE = (
 )
 
 
+# Recorded verbatim from staging (api container, 2026-09-04T10:48:11Z) on a recording a user spoke
+# into: the provider's alignment pass produced no segments and it reports only their count.
+NO_SEGMENTS_FAILURE = (
+    "litellm.InternalServerError: InternalServerError: OpenAIException - Error code: 500 - "
+    "{'detail': 'Transcription failed: Request b86b9b03-eba7-48e5-b5f6-ccd832bc6a0f failed: 500: "
+    "Transcription failed: 0'}. Received Model Group=inference-whisper-large-v3\n"
+    "Available Model Group Fallbacks=None LiteLLM Retried: 2 times, LiteLLM Max Retries: 2"
+)
+
+
 def _internal_server_error(message: str) -> InternalServerError:
     body = {"error": {"message": message, "type": None, "param": None, "code": "500"}}
     request = httpx.Request("POST", UPSTREAM_URL)
@@ -35,9 +45,39 @@ class TestProviderInternalsAreRewrittenForTheCaller:
         assert "'id'" in cause
         assert cause.startswith("Transcription is not available for the language")
 
+    def test_a_transcription_without_segments_names_the_recording_instead_of_the_count(self):
+        cause = ModelGatewayErrorHandler.cause_of(_internal_server_error(NO_SEGMENTS_FAILURE))
+
+        assert "Transcription failed: 0" not in cause
+        assert "LiteLLM Retried" not in cause
+        assert cause.startswith("The speech-to-text provider produced no transcript")
+
     def test_unrecognised_failures_keep_the_gateway_wording(self):
         """Guessing at an unmatched failure would hide it; the gateway's own wording is still the
         best description available."""
         message = "litellm.InternalServerError: OpenAIException - upstream exploded in a new way"
 
         assert ModelGatewayErrorHandler.cause_of(_internal_server_error(message)) == message
+
+
+class TestUnusableAudioIsToldFromAGatewayFault:
+    """A caller transcribing in chunks drops what the provider cannot use and keeps the rest, so this
+    predicate must not answer for a fault that every chunk would hit alike."""
+
+    def test_a_missing_segment_count_is_unusable_audio(self):
+        assert ModelGatewayErrorHandler.is_untranscribable_audio(_internal_server_error(NO_SEGMENTS_FAILURE)) is True
+
+    def test_a_nested_provider_status_is_not_unusable_audio(self):
+        """The alignment failure reports a 503 through the very same phrase. A status can be
+        transient, and dropping a chunk over one loses audio nobody knows is missing."""
+        assert ModelGatewayErrorHandler.is_untranscribable_audio(_internal_server_error(ALIGNMENT_FAILURE)) is False
+
+    def test_an_unrelated_gateway_failure_is_not_unusable_audio(self):
+        message = "litellm.InternalServerError: OpenAIException - Invalid model name passed in model=whisper-1"
+
+        assert ModelGatewayErrorHandler.is_untranscribable_audio(_internal_server_error(message)) is False
+
+    def test_a_non_gateway_exception_is_not_unusable_audio(self):
+        """Only the gateway's own envelope carries this verdict; matching bare exception text would
+        let anything that quotes the provider decide how a chunk is handled."""
+        assert ModelGatewayErrorHandler.is_untranscribable_audio(RuntimeError("Transcription failed: 0")) is False


### PR DESCRIPTION
## What

`Transcription failed: 0` is the transcription provider's **verdict on the audio**, not a fault: the `0` is a segment count. It reached the chat user as LiteLLM's nested traceback, and on `v0.320.0-rc.7` staging it did so 6 times in one afternoon.

`OpenaiService.stt` now treats that verdict as what it says — no speech in this chunk — keeping the chunks that did transcribe and returning an empty transcript when none did, exactly as `contains_speech` already answers locally for silence and as OpenAI's own API answers a recording nobody spoke into. Every other gateway failure re-raises untouched.

## Root cause

Measured against the provider from a local LiteLLM pointed at the staging whisper upstream, 2026-09-04:

| Audio | dBFS | `contains_speech` | Provider |
| --- | --- | --- | --- |
| silence 5 s | -inf | False | (never called) |
| 440 Hz tone 3.5 s | -3.7 | **True** | 500 `Transcription failed: 0` |
| white noise 3 s | -4.8 | **True** | 500 `Transcription failed: 0` |
| speech 1.3 s | -24.6 | True | 200 `"Hello."` |
| speech 6 s | -21.0 | True | 200 full transcript |

Duration is not the trigger — 1.3 s of speech transcribes fine. The gap is that `contains_speech` detects **sound** at -40 dB where the provider detects **speech**, so any recording with sound but no words falls between them. #1832/#1833 closed only the fully-silent half of it.

## Verified end-to-end

Local api carrying this change, against the staging whisper upstream:

| Upload | Before | After |
| --- | --- | --- |
| silence | 200 `""` (guard) | 200 `""`, no upstream call, 0.5 s |
| white noise | 500 traceback wall | **200 `""`** + 2 ERROR log lines |
| 440 Hz tone | 500 traceback wall | **200 `""`** + 2 ERROR log lines |
| real speech | 200 transcript | 200 transcript, unchanged |

Zero `Model gateway returned 500` in the api log across all four.

## Logging

Silence in a transcript is worse than a failure, so two layers make it recoverable:

```
Chunk 1/1 (3000 ms) of noise.wav produced no transcript: ... 'Transcription failed: Request 3923869e-… failed: 500: Transcription failed: 0'
3000 ms of the 3000 ms in noise.wav is not in the transcript: the speech-to-text provider found no speech it could align there.
```

The per-chunk line keeps the provider's **verbatim** message because it carries the upstream request id — the only handle for asking the provider about a rejected chunk. `str(exception)` does not contain it (the SDK fills that in only when it built the exception itself), so `ModelGatewayErrorHandler.upstream_message` is now public and used for it.

## Notes for review

- The classifier is `Transcription failed: \d+(?!\d|:)`. The lookahead matters: the align-model failure nests a status in the same phrase (`Transcription failed: 503: Failed to load alignment model`), and a status may be transient — answering that with an empty transcript would lose audio. A bare count is a verdict; a nested status is not.
- This is a deliberate exception to `packages/api`'s "do not wrap service calls in try/except" rule, recorded in `packages/api/CLAUDE.md` with its reasoning so it does not read as an oversight.
- **Not addressed here:** a no-speech recording still costs ~27-43 s before returning empty, because the OpenAI SDK's 3 attempts each drive LiteLLM's 2 internal retries on a call that cannot succeed. Worth a follow-up decision on whether the gateway should own retries alone.

## Test plan

- [x] `packages/api` audio contract tests — 16 passed
- [x] `packages/core` exception tests — 55 passed
- [x] End-to-end against the real provider (table above)
- [ ] Re-record a voice note on staging once released
