### PR TITLE
fix(swiss-ai-hub): Stop the LLM spend aggregation from freezing the API event loop

### DIFF
--- a/packages/api/swiss_ai_hub/api/routes/event/event_controller.py
+++ b/packages/api/swiss_ai_hub/api/routes/event/event_controller.py
@@ -247,14 +247,14 @@ class EventController(TenantScopedController):
             any single tenant, sees the whole platform.
             """
             if user.is_sys_admin:
-                return EventService.get_llm_spend_by_user(since=since)
+                return await EventService.get_llm_spend_by_user(since=since)
 
             # Deny rather than fall open: an unset acting tenant would otherwise mean "no filter",
             # handing a single-tenant admin every tenant's user spend.
             tenant_id = _acting_tenant_id(user)
             if tenant_id is None:
                 raise HTTPException(status_code=403, detail="Must act within a tenant to view user spend.")
-            return EventService.get_llm_spend_by_user(tenant_id=tenant_id, since=since)
+            return await EventService.get_llm_spend_by_user(tenant_id=tenant_id, since=since)
 
         return self
 
@@ -276,6 +276,6 @@ class EventController(TenantScopedController):
             Sysadmin-only: a cross-tenant total is exactly the view a single tenant must not have.
             """
             del user
-            return EventService.get_llm_spend_by_tenant(since=since)
+            return await EventService.get_llm_spend_by_tenant(since=since)
 
         return self

--- a/packages/api/swiss_ai_hub/api/routes/event/event_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/event/event_service.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from datetime import datetime
 
@@ -115,12 +116,19 @@ class EventService:
 
     @staticmethod
     @trace_fn
-    def get_llm_spend_by_user(tenant_id: str | None = None, since: datetime | None = None) -> list[LLMSpend]:
-        """LLM spend per user, narrowed to one tenant unless the caller may see the whole platform."""
-        return PersistedAgentEventEntity.get_llm_spend_by_user(tenant_id=tenant_id, since=since)
+    async def get_llm_spend_by_user(tenant_id: str | None = None, since: datetime | None = None) -> list[LLMSpend]:
+        """LLM spend per user, narrowed to one tenant unless the caller may see the whole platform.
+
+        Off the event loop, because the aggregation is synchronous and its runtime grows with the
+        window: measured at 123s on staging for a cold 30-day window, which froze every other
+        request — including the health probe, whose three failures then had Docker call the whole
+        container unhealthy and gunicorn kill the worker."""
+        return await asyncio.to_thread(
+            PersistedAgentEventEntity.get_llm_spend_by_user, tenant_id=tenant_id, since=since
+        )
 
     @staticmethod
     @trace_fn
-    def get_llm_spend_by_tenant(since: datetime | None = None) -> list[LLMSpend]:
-        """LLM spend per tenant across the platform."""
-        return PersistedAgentEventEntity.get_llm_spend_by_tenant(since=since)
+    async def get_llm_spend_by_tenant(since: datetime | None = None) -> list[LLMSpend]:
+        """LLM spend per tenant across the platform. Off the event loop — see `get_llm_spend_by_user`."""
+        return await asyncio.to_thread(PersistedAgentEventEntity.get_llm_spend_by_tenant, since=since)

--- a/packages/core/swiss_ai_hub/core/persistence/messaging/entities/persisted_agent_event_entity.py
+++ b/packages/core/swiss_ai_hub/core/persistence/messaging/entities/persisted_agent_event_entity.py
@@ -528,14 +528,22 @@ class PersistedAgentEventEntity(Document):
             match["event_data.tenant_id"] = tenant_id
 
         cost_fields = ["prompt_tokens_costs", "completion_tokens_costs", "embedding_tokens_costs"]
+        carried_fields = [*group_fields, *cost_fields]
         pipeline = [
             {"$match": match},
-            {"$group": {"_id": "$event_id", "event_data": {"$first": "$event_data"}}},
+            # Lift the five fields the group stages read out of `event_data` before the dedup, rather
+            # than carrying the document with `$first: "$event_data"`: a cost event's payload holds the
+            # whole request context, and the stage needs none of it. Measured warm on staging over 33k
+            # cost events, 6.5s carrying the documents against 1.2s carrying the fields. It is not what
+            # took the event loop down, though — that was a 123s cold read of 30 days off disk, which
+            # no pipeline shape avoids and only the threadpool hand-off contains.
+            {"$project": {"_id": 0, "event_id": 1, **{field: f"$event_data.{field}" for field in carried_fields}}},
+            {"$group": {"_id": "$event_id", **{field: {"$first": f"${field}"} for field in carried_fields}}},
             {
                 "$group": {
-                    "_id": {field: f"$event_data.{field}" for field in group_fields},
+                    "_id": {field: f"${field}" for field in group_fields},
                     "calls": {"$sum": 1},
-                    **{field: {"$sum": {"$ifNull": [f"$event_data.{field}", 0]}} for field in cost_fields},
+                    **{field: {"$sum": {"$ifNull": [f"${field}", 0]}} for field in cost_fields},
                 }
             },
             {"$sort": {"_id": 1}},

--- a/packages/core/swiss_ai_hub/core/persistence/messaging/entities/tests/unit/test_persisted_agent_event_entity.py
+++ b/packages/core/swiss_ai_hub/core/persistence/messaging/entities/tests/unit/test_persisted_agent_event_entity.py
@@ -303,3 +303,17 @@ class TestLLMSpendAggregation:
 
         assert len(spend) == 1
         assert spend[0].calls == 1
+
+    def test_payload_beyond_the_attributed_fields_does_not_change_the_sum(self):
+        """The pipeline projects the five fields it groups on instead of carrying `event_data` whole, so
+        anything outside those fields must be unable to change the result."""
+        _persist_cost_event("e1", user_id="u1", tenant_id="acme", prompt=1.0, completion=2.0)
+        event = PersistedAgentEventEntity.objects(event_id="e1").first()
+        event.event_data["messages"] = ["x" * 4096]
+        event.event_data["model_parameters"] = {"temperature": 0.7, "prompt": "y" * 4096}
+        event.save()
+
+        spend = PersistedAgentEventEntity.get_llm_spend_by_user()
+
+        assert spend[0].calls == 1
+        assert spend[0].total_costs == pytest.approx(3.0)


### PR DESCRIPTION
Backport of #1837 from `release/0.320` (shipped in `v0.320.0-rc.8`) to `main`. Cherry-picked cleanly from `0244a82539e66872dc167ba47b37508d92ab108f`, no conflicts, no changes to the original patch.

## What was wrong

The `/spend/users` and `/spend/tenants` endpoints ran their MongoDB aggregation synchronously on the API event loop. A cold read of a 30-day window took 123 s on staging, and for that whole time the API served nothing at all — not even the health endpoint, which is why the incident presented as "api unhealthy" rather than as a slow report.

## What changed

- `EventService.get_llm_spend_by_user` / `get_llm_spend_by_tenant` are now `async` and hand the blocking aggregation to `asyncio.to_thread`. The event loop stays free regardless of how long the query takes. All call sites in `EventController` now `await` them.
- `PersistedAgentEventEntity`'s aggregation pipeline lifts the five fields the group stages actually read out of `event_data` with a `$project` *before* the dedup `$group`, instead of carrying the whole document via `$first: "$event_data"`. A cost event's payload holds the entire request context and the stage needs none of it. Measured warm on staging over 33k cost events: 6.5 s carrying the documents vs 1.2 s carrying the fields.

The `$project` is an improvement, not the fix — the cold-read case is what took the loop down, and no pipeline shape avoids that. Only the threadpool hand-off contains it.

## Testing

- `packages/core` — `TestLLMSpendAggregation` gains a case asserting that payload beyond the attributed fields does not change the sum, which is what pins the `$project` field list.
- These tests need a live Mongo (the fixture connects to `MONGO_MAIN_DB_NAME`), so they were not executed locally against this branch; CI covers them.

## Note on `claude-review`

That check fails here, and it fails on every branch in this repo right now — including #1837 and #1838 themselves, which merged anyway. The job aborts before reviewing anything: `Claude Code process exited with code 1 ... this workspace has not been trusted`. Pre-existing CI breakage, unrelated to this change.
