### PR TITLE
fix(ci-cd): Accept literal staging as release_version on the staging channel

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -88,7 +88,19 @@ jobs:
           NOTES_FROM: ${{ inputs.notes_from }}
         run: |
           set -euo pipefail
-          if ! printf '%s' "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-(nightly|rc)\.[0-9]+)?$'; then
+          # A version tag always passes. The literal `staging` is additionally
+          # accepted on the staging channel for deploy-branch-to-staging.yml,
+          # which builds the bundle straight from the moving `staging` tag so the
+          # compose pins the moving :staging image tag. Anything version-shaped
+          # there would have to be a real git ref carrying real images, i.e. a
+          # throwaway tag and release per verification deploy.
+          version_ok=false
+          if printf '%s' "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-(nightly|rc)\.[0-9]+)?$'; then
+            version_ok=true
+          elif [ "$VERSION" = "staging" ] && [ "$CHANNEL" = "staging" ]; then
+            version_ok=true
+          fi
+          if [ "$version_ok" != "true" ]; then
             echo "::error::release_version '$VERSION' is not a valid version tag."
             exit 1
           fi
@@ -220,7 +232,14 @@ jobs:
               ;;
             staging)
               # 1) Rolling pointer release the QC staging VM fetches (stable tag + asset).
-              publish "staging" "Swiss AI Hub Staging ${VERSION}" true false "$ROLL_A1" "$ROLL_A2"
+              #    A branch verification deploy passes the literal `staging`, which
+              #    would otherwise title the release "Swiss AI Hub Staging staging".
+              if [ "$VERSION" = "staging" ]; then
+                roll_title="Swiss AI Hub Staging (branch verification build)"
+              else
+                roll_title="Swiss AI Hub Staging ${VERSION}"
+              fi
+              publish "staging" "$roll_title" true false "$ROLL_A1" "$ROLL_A2"
               # 2) Immutable, PRESERVED per-rc release for humans, version-named assets.
               #    Only for real rc builds (build-rc.yml). promote-to-staging.yml
               #    promotes a nightly to staging — that must not create a versioned entry.


### PR DESCRIPTION
## What

Follow-up to #1846. `deploy-branch-to-staging.yml` fails at its last job:

```
##[error]release_version 'staging' is not a valid version tag.
```

[Run 34187815792](https://github.com/bbvch-ai/aihub-core/actions/runs/34187815792/job/101940317590), dispatched for `chore/openwebui-0.11.3`.

## Why it happened

`create-release.yml` validates `release_version` against `^v[0-9]+\.[0-9]+\.[0-9]+(-(nightly|rc)\.[0-9]+)?$` before doing anything else. #1846 passes the literal `staging`, which that guard rejects. The guard was missed when the calling workflow was written — everything downstream of it handles `staging` correctly, which is why the rest of the design held up.

Passing something version-shaped instead is not an option: `create-release.yml` checks out `ref: <release_version>` and runs `make generate-release TAG=<release_version>`, so the value has to be a real git ref that also names real pushed images. That means cutting a throwaway tag and release for every verification deploy — exactly what #1846 exists to avoid.

## Change

1. Widen the guard to also accept the literal `staging`, but **only on `channel=staging`**. Every other channel keeps the original regex, so a typo in a `latest`/`backport` promote still fails as loudly as before.
2. Title the rolling release "Swiss AI Hub Staging (branch verification build)" in that case. It would otherwise read "Swiss AI Hub Staging staging".

Guard behaviour, simulated across both channels:

| `release_version` | `channel=staging` | `channel=latest` |
|---|---|---|
| `staging` | accepted | rejected |
| `v0.322.0` | accepted | accepted |
| `v0.322.0-rc.2` | accepted | accepted |
| `v0.322.0-nightly.9` | accepted | accepted |
| `bogus` | rejected | rejected |

## Current staging state

The failed run got as far as `move-pointer`, so the `staging` git tag already points at `chore/openwebui-0.11.3` while the published bundle is still the previous rc. That bundle pins concrete versions whose images still exist, so **the VM keeps running the old rc — no outage**, only a pointer that is temporarily ahead of the bundle. Re-running the deploy workflow after this merges converges both.

## Test plan

- [ ] Re-run `deploy-branch-to-staging.yml` for `chore/openwebui-0.11.3` and confirm `publish-bundle` completes.
- [ ] Confirm the rolling `staging` release is refreshed in place and no new Release entry appears.
- [ ] Confirm an rc build (`build-rc.yml`) still publishes with its version-shaped title and its immutable per-rc entry.
