### PR TITLE
fix(swiss-ai-hub): Restore non-admin chat access on OpenWebUI 0.11.3

### DIFF
--- a/docs/arc42/decisions/2026_09_04_openwebui_models_registered_as_base_rows.md
+++ b/docs/arc42/decisions/2026_09_04_openwebui_models_registered_as_base_rows.md
@@ -1,0 +1,128 @@
+# OpenWebUI Models Are Registered As Base Rows, Not Presets
+
+## Context
+
+Bumping OpenWebUI from `0.9.5` to `0.11.3` (`compose-config.yml`, branch `chore/openwebui-0.11.3`) broke chat for every
+non-admin user on every model — agent-backed and raw LLM alike:
+
+```
+2026-09-02 08:06:55 | WARNING | open_webui.main:chat_completion:1618 - Error processing chat metadata: Model not found
+"POST /api/chat/completions HTTP/1.1" 400
+```
+
+The model was visible in the picker, admins could chat with it, and the OpenWebUI database had zero base-model override
+rows — the state the provisioner is supposed to maintain. Reading the running container's own source
+(`utils/access_control/__init__.py::has_base_model_access`) found the actual change between the two versions:
+
+```python
+base_model_info = await Models.get_model_by_id(base_model_id, db=db)
+if base_model_info is None:
+    return user_role == 'admin'      # 0.11.3. Was `return True` in 0.9.5.
+```
+
+`OpenWebuiProvisioner` (`packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_provisioner.py`, ADR
+`2026_03_05_aihub_manages_openwebui_model_visibility.md`) was built entirely around the *old* meaning of an unregistered
+base: every provisioned model was a preset (`aihub-agent-{class}-{id}`, `aihub-model-{capability}-{name}`) whose
+`base_model_id` pointed at a raw id (`aihub-pipeline.{class}.{id}`, `{capability}/{name}`) that
+`_delete_shadowing_base_models` actively kept unregistered — on the explicit assumption that a registered base entry
+would deny non-admin access to everything above it. 0.11.3 makes the opposite true, and that method was re-asserting the
+now-broken state on every sync.
+
+Every mechanism below was confirmed against a real running OpenWebUI instance, not inferred from source alone:
+
+- Creating a base-registry row directly on a raw LLM id (no `base_model_id`), granting one group read access, and
+  chatting as a non-admin member of that group returned `200`; clearing the grant reproduced the original `400`.
+  Identical result for a raw agent-pipe id against a genuinely online agent instance.
+- Restarting the local API — which runs `OpenWebuiProvisioner.provision()` on startup — with the fix applied deleted
+  every legacy preset row from the live database and replaced them with base rows carrying real, role-derived grants; a
+  non-admin user then chatted the real (not synthetic) production rows successfully.
+- `OpenWebuiClient.update_model_access` was separately found to send `access_grants: null` whenever the computed grant
+  list was empty, and OpenWebUI's update endpoint treats a null list as "leave existing grants untouched" — so a role or
+  tenant-ceiling change that revokes a group's last grant on a model was silently not taking effect. Unrelated to the
+  version bump, found while instrumenting the same code path.
+
+A patch to the OpenWebUI fork (reverting the one line above) was considered and rejected: the project does not maintain
+a divergent OpenWebUI fork, and every fix here had to live in `packages/core`.
+
+## Decision Drivers
+
+- **No fork patches.** The platform does not maintain a patched OpenWebUI image; the fix must be entirely within the
+  provisioner.
+- **The existing gating design stays intact.** Tenant ceilings, role rules, and `AccessChecker` must keep working
+  exactly as before — this is a change to *where* a grant is registered, not to how access is computed.
+- **One picker entry per model.** An alternative (keep the preset, additionally register its base with the union of the
+  preset's grants) was built and tested live: it left two picker entries per model (the preset and its now-visible
+  base), which is a worse outcome than the bug being fixed. `is_active: False` on the base does not hide it either — it
+  removes the row for every viewer, admin included, since `get_all_models` filters it out unconditionally — and doing so
+  also drops it from `app.state.MODELS` entirely, so the preset it backs 404s instead of merely mis-gating.
+- **The picker and the chat check must not be allowed to disagree.** Reading `utils/models.py::get_filtered_models`
+  confirmed the non-admin picker filter checks only the model's own grant, never its base chain — so a preset can be
+  visible while its base silently denies chat. Collapsing preset and base into one row removes this class of bug rather
+  than working around its current symptom.
+- **The escalation 0.11.3 guards against does not exist in this deployment.** The admin-only fallback exists so an
+  unregistered base cannot be reached through a preset by someone who could not use the raw model directly. Here,
+  `get_filtered_models` already hides row-less raw models from every non-admin — a managed row is the *only* path a
+  non-admin ever has to a raw model, so the guard has nothing to protect against in this design.
+
+## Decision
+
+**Every provisioned model — agent-backed or raw LLM — is registered as a single base-registry row on its own raw id,
+carrying its own access grants directly, instead of a preset pointing at an unregistered base one hop above it.**
+
+1. **Row construction changed to emit the raw id, with no `base_model_id`.** An agent's row id is
+   `aihub-pipeline.{agent_class}.{agent_id}` (previously the *base* of a separate `aihub-agent-{class}-{id}` preset); an
+   LLM row id is `{capability}/{name}` (previously the base of `aihub-model-{capability}-{name}`). A
+   `meta.aihub_managed = True` marker distinguishes a provisioner-owned row from one a human created directly in the
+   OpenWebUI workspace, so a sync never overwrites or deletes the latter.
+2. **Reconciliation reads `list_base_models`, never `list_models`.** OpenWebUI's model search filters on
+   `base_model_id != None`, so any row shaped like the ones above — and the Workspace UI built on that same search —
+   cannot see them; `GET /models/base` is the only way. All three sync methods (workspace models, LLM models, access
+   grants) switched accordingly, filtered by the managed marker and, where both row kinds share one listing, by the
+   `aihub-pipeline.` id prefix to keep them from colliding in the same diff.
+3. **`_delete_shadowing_base_models` is deleted, not repaired.** Its purpose — deleting a base-registry entry because
+   its mere existence was assumed dangerous — is exactly the inverted assumption; keeping it to do the opposite under a
+   new name would just relocate the same coupling. Grant computation and id parsing now dispatch on the row's own id
+   shape instead of a `base_model_id` that no longer exists on any managed row.
+4. **A one-time migration removes the pre-0.11.3 preset rows.** `_delete_legacy_preset_models` runs on every access sync
+   (every entry point funnels through `_sync_access_grants`) rather than once, since there is no reliable one-shot hook
+   across replicas; it is a no-op once no legacy-prefixed id remains. Both legacy prefix constants and this method are
+   commented as removable one release after this ships.
+5. **`TASK_MODEL`/`TASK_MODEL_EXTERNAL` now name the raw model id directly.** They previously had to name the workspace
+   preset id: OpenWebUI's background-task calls (chat titles, follow-up questions) run under the end user's own identity
+   and hit the same access check as chat, so naming the raw id used to be denied outright for anyone without the
+   preset's grant. With the preset layer gone, the raw id is simultaneously the routable id and the one carrying the
+   grant, so the two settings converge on the same value as `OPENWEBUI_CONVERSATION_METADATA_MODEL`.
+6. **The independently found grant-revocation bug is fixed alongside this.** `OpenWebuiClient.update_model_access` now
+   always sends the computed grant list verbatim, including empty, instead of substituting `null` — which OpenWebUI's
+   update endpoint reads as "leave existing grants untouched."
+
+## Consequences
+
+### Positive
+
+- The reported failure (every non-admin denied chat on every model) is fixed, verified against the real dev-stack
+  database and a genuinely online agent — not only by unit test.
+- Picker visibility and chat access are now backed by the same row, so a model can no longer be shown as usable and then
+  deny the chat request.
+- One entry per model in the OpenWebUI Workspace and picker; no duplicate raw/preset pair.
+- The grant-revocation bug is closed as a side effect — a role or tenant-ceiling change that drops a group's access to
+  zero now actually clears the stale grant, independent of the version-bump work that surfaced it.
+- No OpenWebUI fork required; the fix is entirely within `packages/core`.
+
+### Trade-offs
+
+- **A managed row is invisible to the OpenWebUI Workspace UI.** Only `GET /models/base` sees it; an admin cannot browse
+  or hand-edit these rows through the normal Workspace screen, so diagnosing a provisioning problem now requires the API
+  or database rather than the UI.
+- **The legacy-preset migration runs on every sync indefinitely**, until someone removes it by hand. Cheap once there is
+  nothing left to migrate, but it is dead code carried forward with only a comment — not a mechanism — reminding that it
+  should go.
+- **The whole fix rests on undocumented OpenWebUI internals**, not a published contract: `has_base_model_access` and the
+  base-row/preset distinction were both reverse-engineered by reading the running container's source. A future OpenWebUI
+  release could change this again without any changelog entry, exactly as `0.11.3` did here.
+- **Agent-row registration was verified against a single online agent class.** The id-construction mechanism
+  (`aihub-pipeline.{class}.{id}`) is identical for every agent class — it matches OpenWebUI's own manifold id
+  construction in `functions.py` (`f'{pipe.id}.{p["id"]}'`) — but only one class was actually online to confirm live.
+- **`TASK_MODEL` and `OPENWEBUI_CONVERSATION_METADATA_MODEL` now always carry the same value** where they previously
+  differed by a string transform. They remain two separate settings, read by two different consumers, on the expectation
+  that a future change could make them diverge again — not collapsed into one.

--- a/infra/deployment/compose-config.yml
+++ b/infra/deployment/compose-config.yml
@@ -45,7 +45,7 @@ image_tags:
   presidio_analyzer: presidio-analyzer:2.2.359
   presidio_anonymizer: presidio-anonymizer:2.2.359
   oauth2proxy: ghcr.io/bbvch-ai/bbvch-ai/oauth2-proxy:latest
-  open_webui: open-webui:v0.9.5
+  open_webui: open-webui:v0.11.3
   open_webui_init: postgres:17
   playwright: playwright:v1.58.0-jammy
   vllm: vllm-openai:v0.15.1

--- a/infra/deployment/templates/docker-compose.yml.j2
+++ b/infra/deployment/templates/docker-compose.yml.j2
@@ -30,11 +30,11 @@
 {%- set hardware = 'gpu' if gpu_enabled else 'cpu' %}
 {%- set default_model = 'text-generation/Qwen3-VL-30B-A3B-Instruct-FP8' if gpu_enabled else 'text-generation/gemma-4-31B-it' %}
 {#- OpenWebUI resolves TASK_MODEL against its own registry and denies non-admins any model without a
-    read grant. Only the provisioned workspace model carries grants — the raw LiteLLM name behind it is
-    deliberately left unregistered — so background tasks must name the workspace model, not the raw one.
-    Corollary: chat titles and follow-up questions only work for roles whose access rules grant this
-    model. A role that excludes it loses both features silently (admins are exempt from the check). #}
-{%- set task_model = 'aihub-model-' + default_model | replace('/', '-') %}
+    read grant. The provisioner registers this raw LiteLLM id directly as the base-registry row — no
+    separate preset one hop above it (see OpenWebuiProvisioner._build_llm_model_data) — so TASK_MODEL
+    names the raw id as-is. Corollary: chat titles and follow-up questions only work for roles whose
+    access rules grant this model. A role that excludes it loses both features silently (admins are
+    exempt from the check). #}
 {#- Must match the transcription model_name registered in configs/litellm-config.yml.j2 for the same hardware variant. #}
 {%- set stt_model = 'transcription/faster-whisper-large-v3' if gpu_enabled else 'transcription/whisper-large-v3' %}
 
@@ -2289,8 +2289,8 @@ services:
       MODELS_CACHE_TTL: 60
       OPENAI_API_BASE_URL: http://{{ 'localhost' if stage == 'dev' else 'api' }}:8000/api/v1/active/openai
       OPENAI_API_KEY: ${SUPERUSER_TOKEN}
-      TASK_MODEL: {{ task_model }}
-      TASK_MODEL_EXTERNAL: {{ task_model }}
+      TASK_MODEL: {{ default_model }}
+      TASK_MODEL_EXTERNAL: {{ default_model }}
       ENABLE_OLLAMA_API: False
       ENABLE_OPENAI_API: True
       # Conversation metadata is owned by the agent pipeline (#1047): the agent emits the title and
@@ -2921,8 +2921,8 @@ services:
       OPENWEBUI_SCIM_TOKEN: ${OPENWEBUI_SCIM_TOKEN}
       OPENWEBUI_WEBHOOK_SECRET: ${OPENWEBUI_WEBHOOK_SECRET}
       OPENWEBUI_SERVICE_ACCOUNT_ID: ${OPENWEBUI_SERVICE_ACCOUNT_ID}
-      {#- Same model as open-webui's TASK_MODEL above, but in raw LiteLLM form: the access catalog matches
-          it against the `capability/name` pairs it enumerates, so the workspace-id translation stays there. #}
+      {#- Same value as open-webui's TASK_MODEL above (both name the raw LiteLLM id directly now); kept
+          as its own setting since the access catalog reads it independently as a `capability/name` pair. #}
       OPENWEBUI_CONVERSATION_METADATA_MODEL: {{ default_model }}
 
 

--- a/infra/docker-compose.build.gpu.yml
+++ b/infra/docker-compose.build.gpu.yml
@@ -1949,7 +1949,7 @@ services:
   # License: Open WebUI License (modified BSD-3-Clause) — third-party (see LICENSE_REPORT.md)
   open-webui:
     container_name: open-webui
-    image: ghcr.io/bbvch-ai/aihub-core/open-webui:v0.9.5
+    image: ghcr.io/bbvch-ai/aihub-core/open-webui:v0.11.3
     restart: always
     volumes: ['${VOLUME_ROOT:-./.docker-volumes}/open-webui:/app/backend/data']
     depends_on:

--- a/infra/docker-compose.build.gpu.yml
+++ b/infra/docker-compose.build.gpu.yml
@@ -2043,8 +2043,8 @@ services:
       MODELS_CACHE_TTL: 60
       OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       OPENAI_API_KEY: ${SUPERUSER_TOKEN}
-      TASK_MODEL: aihub-model-text-generation-Qwen3-VL-30B-A3B-Instruct-FP8
-      TASK_MODEL_EXTERNAL: aihub-model-text-generation-Qwen3-VL-30B-A3B-Instruct-FP8
+      TASK_MODEL: text-generation/Qwen3-VL-30B-A3B-Instruct-FP8
+      TASK_MODEL_EXTERNAL: text-generation/Qwen3-VL-30B-A3B-Instruct-FP8
       ENABLE_OLLAMA_API: false
       ENABLE_OPENAI_API: true
       # Conversation metadata is owned by the agent pipeline (#1047): the agent emits the title and

--- a/infra/docker-compose.build.yml
+++ b/infra/docker-compose.build.yml
@@ -1729,7 +1729,7 @@ services:
   # License: Open WebUI License (modified BSD-3-Clause) — third-party (see LICENSE_REPORT.md)
   open-webui:
     container_name: open-webui
-    image: ghcr.io/bbvch-ai/aihub-core/open-webui:v0.9.5
+    image: ghcr.io/bbvch-ai/aihub-core/open-webui:v0.11.3
     restart: always
     volumes: ['${VOLUME_ROOT:-./.docker-volumes}/open-webui:/app/backend/data']
     depends_on:

--- a/infra/docker-compose.build.yml
+++ b/infra/docker-compose.build.yml
@@ -1823,8 +1823,8 @@ services:
       MODELS_CACHE_TTL: 60
       OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       OPENAI_API_KEY: ${SUPERUSER_TOKEN}
-      TASK_MODEL: aihub-model-text-generation-gemma-4-31B-it
-      TASK_MODEL_EXTERNAL: aihub-model-text-generation-gemma-4-31B-it
+      TASK_MODEL: text-generation/gemma-4-31B-it
+      TASK_MODEL_EXTERNAL: text-generation/gemma-4-31B-it
       ENABLE_OLLAMA_API: false
       ENABLE_OPENAI_API: true
       # Conversation metadata is owned by the agent pipeline (#1047): the agent emits the title and

--- a/infra/docker-compose.dev.gpu.yml
+++ b/infra/docker-compose.dev.gpu.yml
@@ -1637,7 +1637,7 @@ services:
   # License: Open WebUI License (modified BSD-3-Clause) — third-party (see LICENSE_REPORT.md)
   open-webui:
     container_name: open-webui
-    image: ghcr.io/bbvch-ai/aihub-core/open-webui:v0.9.5
+    image: ghcr.io/bbvch-ai/aihub-core/open-webui:v0.11.3
     restart: always
     network_mode: host
     volumes: ['${VOLUME_ROOT:-./.docker-volumes}/open-webui:/app/backend/data']

--- a/infra/docker-compose.dev.gpu.yml
+++ b/infra/docker-compose.dev.gpu.yml
@@ -1732,8 +1732,8 @@ services:
       MODELS_CACHE_TTL: 60
       OPENAI_API_BASE_URL: http://localhost:8000/api/v1/active/openai
       OPENAI_API_KEY: ${SUPERUSER_TOKEN}
-      TASK_MODEL: aihub-model-text-generation-Qwen3-VL-30B-A3B-Instruct-FP8
-      TASK_MODEL_EXTERNAL: aihub-model-text-generation-Qwen3-VL-30B-A3B-Instruct-FP8
+      TASK_MODEL: text-generation/Qwen3-VL-30B-A3B-Instruct-FP8
+      TASK_MODEL_EXTERNAL: text-generation/Qwen3-VL-30B-A3B-Instruct-FP8
       ENABLE_OLLAMA_API: false
       ENABLE_OPENAI_API: true
       # Conversation metadata is owned by the agent pipeline (#1047): the agent emits the title and

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -1417,7 +1417,7 @@ services:
   # License: Open WebUI License (modified BSD-3-Clause) — third-party (see LICENSE_REPORT.md)
   open-webui:
     container_name: open-webui
-    image: ghcr.io/bbvch-ai/aihub-core/open-webui:v0.9.5
+    image: ghcr.io/bbvch-ai/aihub-core/open-webui:v0.11.3
     restart: always
     network_mode: host
     volumes: ['${VOLUME_ROOT:-./.docker-volumes}/open-webui:/app/backend/data']

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -1512,8 +1512,8 @@ services:
       MODELS_CACHE_TTL: 60
       OPENAI_API_BASE_URL: http://localhost:8000/api/v1/active/openai
       OPENAI_API_KEY: ${SUPERUSER_TOKEN}
-      TASK_MODEL: aihub-model-text-generation-gemma-4-31B-it
-      TASK_MODEL_EXTERNAL: aihub-model-text-generation-gemma-4-31B-it
+      TASK_MODEL: text-generation/gemma-4-31B-it
+      TASK_MODEL_EXTERNAL: text-generation/gemma-4-31B-it
       ENABLE_OLLAMA_API: false
       ENABLE_OPENAI_API: true
       # Conversation metadata is owned by the agent pipeline (#1047): the agent emits the title and

--- a/infra/docker-compose.latest.gpu.yml
+++ b/infra/docker-compose.latest.gpu.yml
@@ -1902,7 +1902,7 @@ services:
   # License: Open WebUI License (modified BSD-3-Clause) — third-party (see LICENSE_REPORT.md)
   open-webui:
     container_name: open-webui
-    image: ghcr.io/bbvch-ai/aihub-core/open-webui:v0.9.5
+    image: ghcr.io/bbvch-ai/aihub-core/open-webui:v0.11.3
     restart: always
     volumes: ['${VOLUME_ROOT:-./.docker-volumes}/open-webui:/app/backend/data']
     depends_on:

--- a/infra/docker-compose.latest.gpu.yml
+++ b/infra/docker-compose.latest.gpu.yml
@@ -1996,8 +1996,8 @@ services:
       MODELS_CACHE_TTL: 60
       OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       OPENAI_API_KEY: ${SUPERUSER_TOKEN}
-      TASK_MODEL: aihub-model-text-generation-Qwen3-VL-30B-A3B-Instruct-FP8
-      TASK_MODEL_EXTERNAL: aihub-model-text-generation-Qwen3-VL-30B-A3B-Instruct-FP8
+      TASK_MODEL: text-generation/Qwen3-VL-30B-A3B-Instruct-FP8
+      TASK_MODEL_EXTERNAL: text-generation/Qwen3-VL-30B-A3B-Instruct-FP8
       ENABLE_OLLAMA_API: false
       ENABLE_OPENAI_API: true
       # Conversation metadata is owned by the agent pipeline (#1047): the agent emits the title and

--- a/infra/docker-compose.latest.yml
+++ b/infra/docker-compose.latest.yml
@@ -1688,7 +1688,7 @@ services:
   # License: Open WebUI License (modified BSD-3-Clause) — third-party (see LICENSE_REPORT.md)
   open-webui:
     container_name: open-webui
-    image: ghcr.io/bbvch-ai/aihub-core/open-webui:v0.9.5
+    image: ghcr.io/bbvch-ai/aihub-core/open-webui:v0.11.3
     restart: always
     volumes: ['${VOLUME_ROOT:-./.docker-volumes}/open-webui:/app/backend/data']
     depends_on:

--- a/infra/docker-compose.latest.yml
+++ b/infra/docker-compose.latest.yml
@@ -1782,8 +1782,8 @@ services:
       MODELS_CACHE_TTL: 60
       OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       OPENAI_API_KEY: ${SUPERUSER_TOKEN}
-      TASK_MODEL: aihub-model-text-generation-gemma-4-31B-it
-      TASK_MODEL_EXTERNAL: aihub-model-text-generation-gemma-4-31B-it
+      TASK_MODEL: text-generation/gemma-4-31B-it
+      TASK_MODEL_EXTERNAL: text-generation/gemma-4-31B-it
       ENABLE_OLLAMA_API: false
       ENABLE_OPENAI_API: true
       # Conversation metadata is owned by the agent pipeline (#1047): the agent emits the title and

--- a/infra/docker-compose.local.gpu.yml
+++ b/infra/docker-compose.local.gpu.yml
@@ -1942,7 +1942,7 @@ services:
   # License: Open WebUI License (modified BSD-3-Clause) — third-party (see LICENSE_REPORT.md)
   open-webui:
     container_name: open-webui
-    image: ghcr.io/bbvch-ai/aihub-core/open-webui:v0.9.5
+    image: ghcr.io/bbvch-ai/aihub-core/open-webui:v0.11.3
     restart: always
     volumes: ['${VOLUME_ROOT:-./.docker-volumes}/open-webui:/app/backend/data']
     depends_on:

--- a/infra/docker-compose.local.gpu.yml
+++ b/infra/docker-compose.local.gpu.yml
@@ -2036,8 +2036,8 @@ services:
       MODELS_CACHE_TTL: 60
       OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       OPENAI_API_KEY: ${SUPERUSER_TOKEN}
-      TASK_MODEL: aihub-model-text-generation-Qwen3-VL-30B-A3B-Instruct-FP8
-      TASK_MODEL_EXTERNAL: aihub-model-text-generation-Qwen3-VL-30B-A3B-Instruct-FP8
+      TASK_MODEL: text-generation/Qwen3-VL-30B-A3B-Instruct-FP8
+      TASK_MODEL_EXTERNAL: text-generation/Qwen3-VL-30B-A3B-Instruct-FP8
       ENABLE_OLLAMA_API: false
       ENABLE_OPENAI_API: true
       # Conversation metadata is owned by the agent pipeline (#1047): the agent emits the title and

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -1722,7 +1722,7 @@ services:
   # License: Open WebUI License (modified BSD-3-Clause) — third-party (see LICENSE_REPORT.md)
   open-webui:
     container_name: open-webui
-    image: ghcr.io/bbvch-ai/aihub-core/open-webui:v0.9.5
+    image: ghcr.io/bbvch-ai/aihub-core/open-webui:v0.11.3
     restart: always
     volumes: ['${VOLUME_ROOT:-./.docker-volumes}/open-webui:/app/backend/data']
     depends_on:

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -1816,8 +1816,8 @@ services:
       MODELS_CACHE_TTL: 60
       OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       OPENAI_API_KEY: ${SUPERUSER_TOKEN}
-      TASK_MODEL: aihub-model-text-generation-gemma-4-31B-it
-      TASK_MODEL_EXTERNAL: aihub-model-text-generation-gemma-4-31B-it
+      TASK_MODEL: text-generation/gemma-4-31B-it
+      TASK_MODEL_EXTERNAL: text-generation/gemma-4-31B-it
       ENABLE_OLLAMA_API: false
       ENABLE_OPENAI_API: true
       # Conversation metadata is owned by the agent pipeline (#1047): the agent emits the title and

--- a/infra/docker-compose.nightly.gpu.yml
+++ b/infra/docker-compose.nightly.gpu.yml
@@ -1902,7 +1902,7 @@ services:
   # License: Open WebUI License (modified BSD-3-Clause) — third-party (see LICENSE_REPORT.md)
   open-webui:
     container_name: open-webui
-    image: ghcr.io/bbvch-ai/aihub-core/open-webui:v0.9.5
+    image: ghcr.io/bbvch-ai/aihub-core/open-webui:v0.11.3
     restart: always
     volumes: ['${VOLUME_ROOT:-./.docker-volumes}/open-webui:/app/backend/data']
     depends_on:

--- a/infra/docker-compose.nightly.gpu.yml
+++ b/infra/docker-compose.nightly.gpu.yml
@@ -1996,8 +1996,8 @@ services:
       MODELS_CACHE_TTL: 60
       OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       OPENAI_API_KEY: ${SUPERUSER_TOKEN}
-      TASK_MODEL: aihub-model-text-generation-Qwen3-VL-30B-A3B-Instruct-FP8
-      TASK_MODEL_EXTERNAL: aihub-model-text-generation-Qwen3-VL-30B-A3B-Instruct-FP8
+      TASK_MODEL: text-generation/Qwen3-VL-30B-A3B-Instruct-FP8
+      TASK_MODEL_EXTERNAL: text-generation/Qwen3-VL-30B-A3B-Instruct-FP8
       ENABLE_OLLAMA_API: false
       ENABLE_OPENAI_API: true
       # Conversation metadata is owned by the agent pipeline (#1047): the agent emits the title and

--- a/infra/docker-compose.nightly.yml
+++ b/infra/docker-compose.nightly.yml
@@ -1688,7 +1688,7 @@ services:
   # License: Open WebUI License (modified BSD-3-Clause) — third-party (see LICENSE_REPORT.md)
   open-webui:
     container_name: open-webui
-    image: ghcr.io/bbvch-ai/aihub-core/open-webui:v0.9.5
+    image: ghcr.io/bbvch-ai/aihub-core/open-webui:v0.11.3
     restart: always
     volumes: ['${VOLUME_ROOT:-./.docker-volumes}/open-webui:/app/backend/data']
     depends_on:

--- a/infra/docker-compose.nightly.yml
+++ b/infra/docker-compose.nightly.yml
@@ -1782,8 +1782,8 @@ services:
       MODELS_CACHE_TTL: 60
       OPENAI_API_BASE_URL: http://api:8000/api/v1/active/openai
       OPENAI_API_KEY: ${SUPERUSER_TOKEN}
-      TASK_MODEL: aihub-model-text-generation-gemma-4-31B-it
-      TASK_MODEL_EXTERNAL: aihub-model-text-generation-gemma-4-31B-it
+      TASK_MODEL: text-generation/gemma-4-31B-it
+      TASK_MODEL_EXTERNAL: text-generation/gemma-4-31B-it
       ENABLE_OLLAMA_API: false
       ENABLE_OPENAI_API: true
       # Conversation metadata is owned by the agent pipeline (#1047): the agent emits the title and

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_client.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_client.py
@@ -301,7 +301,10 @@ class OpenWebuiClient:
             "name": model["name"],
             "meta": model.get("meta", {}),
             "params": model.get("params", {}),
-            "access_grants": [g.model_dump() for g in access_grants] if access_grants else None,
+            # An explicit [] is required to clear access — OpenWebUI's update endpoint treats a
+            # null access_grants as "leave untouched", so sending None here would let a revoked
+            # grant silently survive instead of being cleared.
+            "access_grants": [g.model_dump() for g in access_grants],
         }
         if model.get("base_model_id"):
             form["base_model_id"] = model["base_model_id"]

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_provisioner.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_provisioner.py
@@ -29,8 +29,25 @@ from swiss_ai_hub.core.persistence.i18n.locale_string_entity import LocaleString
 logger = logging.getLogger(__name__)
 
 AIHUB_GROUP_PREFIX = "aihub:"
+
+# Pre-0.11.3 preset id prefixes. OpenWebUI 0.11.3 made an unregistered base_model_id admin-only
+# (see _build_model_data / _build_llm_model_data below), so provisioning switched to registering the
+# raw pipe/LiteLLM id directly as a base row instead of a preset pointing at it from one hop above.
+# Kept only so _delete_legacy_preset_models can clean up presets created by prior versions of this
+# provisioner — remove both the constants and that method once every deployment has synced past the
+# change (one release after this ships).
 AIHUB_AGENT_PREFIX = "aihub-agent-"
 AIHUB_LLM_MODEL_PREFIX = "aihub-model-"
+
+# Marks a base-registry row (base_model_id is None) as managed by this provisioner, so a sync can
+# tell it apart from a base row a human created directly in the OpenWebUI workspace. See
+# _build_model_data / _build_llm_model_data.
+AIHUB_MANAGED_META_KEY = "aihub_managed"
+
+# Prefix of an agent's own base-registry id (e.g. "aihub-pipeline.RAGAgent.picasso-2"), as opposed
+# to an LLM model's (e.g. "text-generation/Kimi-K2.6") — the two managed-row shapes base-row syncs
+# and grant parsing need to tell apart now that both live in the same base-model registry.
+AGENT_PIPE_ID_PREFIX = "aihub-pipeline."
 
 _LOCK_TIMEOUT = 60
 # The group critical section lists all SCIM groups/users + all Keycloak users and then issues one
@@ -287,19 +304,24 @@ class OpenWebuiProvisioner:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _workspace_model_id(agent_class: str, agent_id: str) -> str:
-        return f"{AIHUB_AGENT_PREFIX}{agent_class}-{agent_id}"
-
-    @staticmethod
     def _base_model_id(agent_class: str, agent_id: str) -> str:
-        return f"aihub-pipeline.{agent_class}.{agent_id}"
+        return f"{AGENT_PIPE_ID_PREFIX}{agent_class}.{agent_id}"
 
     def _build_model_data(self, agent: OnlineAgent) -> dict[str, Any]:
+        """Registers the raw agent pipe id directly as a base-registry row (no base_model_id).
+
+        OpenWebUI 0.11.3 made ``has_base_model_access`` deny everyone but admins through a
+        ``base_model_id`` with no registry row of its own — the opposite of 0.9.x, which treated an
+        unregistered base as a gate-free raw provider model. A preset pointing at the pipe id from one
+        hop above no longer routes for non-admins, so the pipe id itself must carry the grant instead.
+        """
         return {
-            "id": self._workspace_model_id(agent.agent_class, agent.agent_id),
+            "id": self._base_model_id(agent.agent_class, agent.agent_id),
             "name": agent.display_name,
-            "base_model_id": self._base_model_id(agent.agent_class, agent.agent_id),
-            "meta": {"description": f"AI-Hub agent: {agent.agent_class}/{agent.agent_id}"},
+            "meta": {
+                "description": f"AI-Hub agent: {agent.agent_class}/{agent.agent_id}",
+                AIHUB_MANAGED_META_KEY: True,
+            },
         }
 
     @staticmethod
@@ -316,7 +338,7 @@ class OpenWebuiProvisioner:
         to_create: list[OnlineAgent] = []
         to_update: list[OnlineAgent] = []
         for agent in online_agents:
-            model_id = OpenWebuiProvisioner._workspace_model_id(agent.agent_class, agent.agent_id)
+            model_id = OpenWebuiProvisioner._base_model_id(agent.agent_class, agent.agent_id)
             desired_ids.add(model_id)
             existing = existing_models.get(model_id)
             if existing is None:
@@ -327,8 +349,18 @@ class OpenWebuiProvisioner:
         return to_create, to_update, to_delete
 
     async def _sync_workspace_models(self, http: httpx.AsyncClient, online_agents: list[OnlineAgent]) -> None:
-        existing_models = await self._openwebui.list_models(http)
-        existing_aihub = {m["id"]: m for m in existing_models if m.get("id", "").startswith(AIHUB_AGENT_PREFIX)}
+        """Reconciles agent pipe ids in the base-model registry (see ``_build_model_data``).
+
+        Reads ``list_base_models`` rather than ``list_models``: a managed row has no
+        ``base_model_id``, which is exactly what ``list_models``'s search filters out (and what makes
+        it invisible to the Workspace UI too — see ``OpenWebuiClient.list_base_models``).
+        """
+        existing_rows = await self._openwebui.list_base_models(http)
+        existing_aihub = {
+            m["id"]: m
+            for m in existing_rows
+            if m.get("id", "").startswith(AGENT_PIPE_ID_PREFIX) and m.get("meta", {}).get(AIHUB_MANAGED_META_KEY)
+        }
 
         to_create, to_update, to_delete = self._compute_model_diff(online_agents, existing_aihub)
 
@@ -357,28 +389,34 @@ class OpenWebuiProvisioner:
     # LLM model sync
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _llm_workspace_model_id(model: AvailableModel) -> str:
-        return f"{AIHUB_LLM_MODEL_PREFIX}{model.capability}-{model.name}"
-
     def _build_llm_model_data(self, model: AvailableModel) -> dict[str, Any]:
-        """Points ``base_model_id`` at the raw LiteLLM connection model so chat routes through it.
+        """Registers the raw LiteLLM model id directly as a base-registry row (no base_model_id).
 
-        That base has no OpenWebUI registry entry, so ``has_base_model_access`` treats it as a raw
-        provider model and lets granted users through — gating happens via this entry's access grants.
+        See ``_build_model_data`` for why: 0.11.3 denies non-admins through any unregistered
+        ``base_model_id``, so the raw id itself must carry the grant now instead of a preset above it.
         """
         return {
-            "id": self._llm_workspace_model_id(model),
+            "id": model.litellm_name,
             "name": model.display_name,
-            "base_model_id": model.litellm_name,
-            "meta": {"description": f"AI-Hub model: {model.litellm_name}"},
+            "meta": {
+                "description": f"AI-Hub model: {model.litellm_name}",
+                AIHUB_MANAGED_META_KEY: True,
+            },
         }
 
     async def _sync_llm_workspace_models(self, http: httpx.AsyncClient, models: list[AvailableModel]) -> None:
-        existing_models = await self._openwebui.list_models(http)
-        existing_aihub = {m["id"]: m for m in existing_models if m.get("id", "").startswith(AIHUB_LLM_MODEL_PREFIX)}
+        """Reconciles LLM model ids in the base-model registry (see ``_build_llm_model_data``).
 
-        desired = {self._llm_workspace_model_id(model): model for model in models}
+        Reads ``list_base_models`` rather than ``list_models`` — see ``_sync_workspace_models``.
+        """
+        existing_rows = await self._openwebui.list_base_models(http)
+        existing_aihub = {
+            m["id"]: m
+            for m in existing_rows
+            if not m.get("id", "").startswith(AGENT_PIPE_ID_PREFIX) and m.get("meta", {}).get(AIHUB_MANAGED_META_KEY)
+        }
+
+        desired = {model.litellm_name: model for model in models}
 
         for model_id, model in desired.items():
             existing = existing_aihub.get(model_id)
@@ -459,17 +497,21 @@ class OpenWebuiProvisioner:
 
     @staticmethod
     def _parse_agent_from_model(model: dict[str, Any]) -> tuple[str, str] | None:
-        """Extracts (agent_class, agent_id) from a workspace model via its base_model_id."""
-        base_model_id = model.get("base_model_id", "")
-        if not base_model_id.startswith("aihub-pipeline."):
+        """Extracts (agent_class, agent_id) from a managed base row's own id.
+
+        Ids no longer carry a ``base_model_id`` hop to read this from — the row's ``id`` *is* the
+        pipe id now (see ``_build_model_data``).
+        """
+        model_id = model.get("id", "")
+        if not model_id.startswith(AGENT_PIPE_ID_PREFIX):
             return None
-        parts = base_model_id[len("aihub-pipeline.") :].split(".", 1)
+        parts = model_id[len(AGENT_PIPE_ID_PREFIX) :].split(".", 1)
         return (parts[0], parts[1]) if len(parts) == 2 else None
 
     @staticmethod
     def _parse_llm_from_model(model: dict[str, Any]) -> tuple[str, str] | None:
-        """Extracts (capability, name) from an LLM workspace model via its base_model_id."""
-        capability, _, name = model.get("base_model_id", "").partition("/")
+        """Extracts (capability, name) from a managed base row's own id — see ``_parse_agent_from_model``."""
+        capability, _, name = model.get("id", "").partition("/")
         return (capability, name) if capability and name else None
 
     def _compute_grants_for_managed_model(
@@ -479,15 +521,13 @@ class OpenWebuiProvisioner:
         tenant_rules: TenantAccessRules,
         role_rules: RoleAccessRules,
     ) -> list[AccessGrant] | None:
-        """Dispatches grant computation by managed-model prefix; returns None for unparseable models."""
+        """Dispatches grant computation by id shape; returns None for unparseable models."""
         model_id = model.get("id", "")
-        if model_id.startswith(AIHUB_AGENT_PREFIX):
+        if model_id.startswith(AGENT_PIPE_ID_PREFIX):
             parsed = self._parse_agent_from_model(model)
             return self._compute_access_for_model(*parsed, groups, tenant_rules, role_rules) if parsed else None
-        if model_id.startswith(AIHUB_LLM_MODEL_PREFIX):
-            parsed = self._parse_llm_from_model(model)
-            return self._compute_access_for_llm_model(*parsed, groups, tenant_rules, role_rules) if parsed else None
-        return None
+        parsed = self._parse_llm_from_model(model)
+        return self._compute_access_for_llm_model(*parsed, groups, tenant_rules, role_rules) if parsed else None
 
     @staticmethod
     def _build_role_rules() -> RoleAccessRules:
@@ -501,45 +541,37 @@ class OpenWebuiProvisioner:
             if role.tenant_id in tenant_name_by_id
         }
 
-    async def _delete_shadowing_base_models(
-        self, http: httpx.AsyncClient, managed_models: list[dict[str, Any]]
-    ) -> None:
-        """Removes registry entries that shadow the raw models our workspace models point at.
+    async def _delete_legacy_preset_models(self, http: httpx.AsyncClient) -> None:
+        """One-time migration: removes pre-0.11.3 ``aihub-agent-*`` / ``aihub-model-*`` preset rows.
 
-        Both ``_build_model_data`` and ``_build_llm_model_data`` depend on those bases staying
-        unregistered. Once an entry exists for one, OpenWebUI's ``has_base_model_access`` walks
-        workspace model -> base and denies everyone lacking a grant on that entry, so the model stays
-        visible in the picker but chatting with it fails with "Model not found". Saving the model list
-        in the OpenWebUI workspace (``POST /models/sync``) writes such an entry for every model it
-        renders, so reassert the invariant on every sync rather than cleaning up once.
-
-        Derived from each workspace model's own ``base_model_id`` so agent pipes and raw LiteLLM
-        models are covered by the same pass.
+        Those pointed ``base_model_id`` at an unregistered raw id; provisioning now registers that
+        raw id directly as a base row instead (see ``_build_model_data`` / ``_build_llm_model_data``),
+        so a preset left behind by a prior version of this provisioner would otherwise sit alongside
+        its replacement and double up the picker. Safe to remove once every deployment has synced
+        past the change (see the comment on ``AIHUB_AGENT_PREFIX`` / ``AIHUB_LLM_MODEL_PREFIX``).
         """
-        shadowing_ids = {m.get("id", "") for m in await self._openwebui.list_base_models(http)}
-        preset_by_base = {
-            m["base_model_id"]: m["id"]
-            for m in managed_models
-            if m.get("base_model_id") and m["base_model_id"] in shadowing_ids
-        }
-
-        for base_model_id, preset_id in preset_by_base.items():
-            await self._openwebui.delete_model(http, base_model_id)
-            logger.warning(
-                f"OpenWebUI: Deleted registry entry '{base_model_id}' shadowing the raw model behind "
-                f"'{preset_id}' — it denied every non-admin access to the workspace model above it"
+        existing_models = await self._openwebui.list_models(http)
+        legacy_ids = [
+            m["id"] for m in existing_models if m.get("id", "").startswith((AIHUB_AGENT_PREFIX, AIHUB_LLM_MODEL_PREFIX))
+        ]
+        for model_id in legacy_ids:
+            await self._openwebui.delete_model(http, model_id)
+            logger.info(
+                f"OpenWebUI: Deleted legacy preset model '{model_id}' (superseded by direct base-row registration)"
             )
 
     async def _sync_access_grants(self, http: httpx.AsyncClient) -> None:
-        existing_models = await self._openwebui.list_models(http)
-        aihub_models = [
-            m for m in existing_models if m.get("id", "").startswith((AIHUB_AGENT_PREFIX, AIHUB_LLM_MODEL_PREFIX))
-        ]
+        """Recomputes and pushes access grants for every managed base-registry row.
+
+        Reads ``list_base_models`` rather than ``list_models`` — see ``_sync_workspace_models``.
+        """
+        await self._delete_legacy_preset_models(http)
+
+        existing_rows = await self._openwebui.list_base_models(http)
+        aihub_models = [m for m in existing_rows if m.get("meta", {}).get(AIHUB_MANAGED_META_KEY)]
 
         if not aihub_models:
             return
-
-        await self._delete_shadowing_base_models(http, aihub_models)
 
         async with self._openwebui.scim_session() as scim:
             all_groups = await self._openwebui.list_groups(scim=scim)

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/conftest.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/conftest.py
@@ -11,9 +11,9 @@ _MOCK_SCIM = MagicMock(name="mock_scim_client")
 
 @pytest.fixture(autouse=True)
 def unregistered_base_models():
-    """Defaults every sync to the healthy state — raw bases carry no registry entry.
+    """Defaults every sync's base-registry read to the healthy state — no managed rows yet.
 
-    Tests exercising the shadowing repair shadow this with their own instance-level
+    Tests exercising specific base rows shadow this with their own instance-level
     ``list_base_models`` patch, which takes precedence over this class-level one.
     """
     with patch.object(OpenWebuiClient, "list_base_models", return_value=[]):
@@ -56,4 +56,9 @@ def provisioner(mock_settings: MagicMock, mock_redis: MagicMock) -> OpenWebuiPro
     ):
         prov = OpenWebuiProvisioner(redis=mock_redis)
         prov._openwebui.scim_session = _mock_scim_session
+        # Defaults _delete_legacy_preset_models's read to the healthy state — nothing to migrate.
+        # Scoped to this instance (not OpenWebuiClient globally) so it doesn't affect
+        # test_openwebui_client.py's direct tests of the real list_models implementation. Tests
+        # exercising the migration itself override this with their own patch.object call.
+        prov._openwebui.list_models = AsyncMock(return_value=[])
         return prov

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_client.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_client.py
@@ -48,7 +48,9 @@ class TestUpdateModelAccess:
         assert result == {"id": "m1"}
 
         call_args = mock_client.post.call_args
-        assert call_args.kwargs["json"]["access_grants"] is None
+        # OpenWebUI's update endpoint treats a null access_grants as "leave untouched", so an
+        # explicit [] must be sent to actually clear a revoked grant — None would silently keep it.
+        assert call_args.kwargs["json"]["access_grants"] == []
 
 
 class TestUpdateModel:

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_provisioner_access.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_provisioner_access.py
@@ -8,6 +8,7 @@ from swiss_ai_hub.core.infrastructure.openwebui.access_grant import AccessGrant
 from swiss_ai_hub.core.infrastructure.openwebui.openwebui_provisioner import (
     AIHUB_AGENT_PREFIX,
     AIHUB_LLM_MODEL_PREFIX,
+    AIHUB_MANAGED_META_KEY,
     OpenWebuiProvisioner,
 )
 
@@ -16,6 +17,10 @@ def _group(display_name: str, group_id: str) -> Group:
     g = Group(display_name=display_name)
     g.id = group_id
     return g
+
+
+def _managed_row(model_id: str, name: str) -> dict:
+    return {"id": model_id, "name": name, "meta": {AIHUB_MANAGED_META_KEY: True}}
 
 
 class TestComputeAccessForModel:
@@ -97,20 +102,95 @@ class TestComputeAccessForModel:
 
 
 class TestParseAgentFromModel:
-    def test_parses_from_base_model_id(self) -> None:
-        model = {"id": f"{AIHUB_AGENT_PREFIX}cls-id", "base_model_id": "aihub-pipeline.cls.id"}
+    def test_parses_from_id(self) -> None:
+        model = {"id": "aihub-pipeline.cls.id"}
         result = OpenWebuiProvisioner._parse_agent_from_model(model)
         assert result == ("cls", "id")
 
-    def test_returns_none_without_base_model_id(self) -> None:
-        model = {"id": f"{AIHUB_AGENT_PREFIX}cls-id", "base_model_id": ""}
+    def test_returns_none_without_pipe_prefix(self) -> None:
+        model = {"id": "text-generation/Kimi-K2.6"}
         result = OpenWebuiProvisioner._parse_agent_from_model(model)
         assert result is None
 
-    def test_returns_none_for_malformed_base_model_id(self) -> None:
-        model = {"id": f"{AIHUB_AGENT_PREFIX}cls-id", "base_model_id": "aihub-pipeline.nodot"}
+    def test_returns_none_for_malformed_id(self) -> None:
+        model = {"id": "aihub-pipeline.nodot"}
         result = OpenWebuiProvisioner._parse_agent_from_model(model)
         assert result is None
+
+
+class TestDeleteLegacyPresetModels:
+    """One-time migration off the pre-0.11.3 aihub-agent-*/aihub-model-* preset rows — see the
+    comment on AIHUB_AGENT_PREFIX/AIHUB_LLM_MODEL_PREFIX for why they'd otherwise linger forever."""
+
+    @pytest.mark.asyncio
+    async def test_deletes_legacy_agent_preset(self, provisioner: OpenWebuiProvisioner) -> None:
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        with (
+            patch.object(
+                provisioner._openwebui,
+                "list_models",
+                return_value=[{"id": f"{AIHUB_AGENT_PREFIX}rag-default"}],
+            ),
+            patch.object(provisioner._openwebui, "delete_model") as mock_delete,
+        ):
+            await provisioner._delete_legacy_preset_models(mock_client)
+
+            mock_delete.assert_called_once_with(mock_client, f"{AIHUB_AGENT_PREFIX}rag-default")
+
+    @pytest.mark.asyncio
+    async def test_deletes_legacy_llm_preset(self, provisioner: OpenWebuiProvisioner) -> None:
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        with (
+            patch.object(
+                provisioner._openwebui,
+                "list_models",
+                return_value=[{"id": f"{AIHUB_LLM_MODEL_PREFIX}text-generation-Kimi"}],
+            ),
+            patch.object(provisioner._openwebui, "delete_model") as mock_delete,
+        ):
+            await provisioner._delete_legacy_preset_models(mock_client)
+
+            mock_delete.assert_called_once_with(mock_client, f"{AIHUB_LLM_MODEL_PREFIX}text-generation-Kimi")
+
+    @pytest.mark.asyncio
+    async def test_leaves_non_legacy_models_alone(self, provisioner: OpenWebuiProvisioner) -> None:
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        with (
+            patch.object(
+                provisioner._openwebui,
+                "list_models",
+                return_value=[{"id": "someones-custom-model"}],
+            ),
+            patch.object(provisioner._openwebui, "delete_model") as mock_delete,
+        ):
+            await provisioner._delete_legacy_preset_models(mock_client)
+
+            mock_delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sync_access_grants_runs_the_migration(self, provisioner: OpenWebuiProvisioner) -> None:
+        """The migration runs on every _sync_access_grants call, not just once, since every entry
+        point (provision/sync_agents/sync_access) funnels through it."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        with (
+            patch.object(
+                provisioner._openwebui,
+                "list_models",
+                return_value=[{"id": f"{AIHUB_AGENT_PREFIX}stale-default"}],
+            ),
+            patch.object(provisioner._openwebui, "delete_model") as mock_delete,
+            patch.object(provisioner._openwebui, "list_groups") as mock_list_groups,
+        ):
+            await provisioner._sync_access_grants(mock_client)
+
+            mock_delete.assert_called_once_with(mock_client, f"{AIHUB_AGENT_PREFIX}stale-default")
+            # No managed base rows in this scenario (empty list_base_models default), so grant
+            # computation short-circuits before ever listing groups.
+            mock_list_groups.assert_not_called()
 
 
 class TestSyncAccessGrants:
@@ -121,10 +201,8 @@ class TestSyncAccessGrants:
         with (
             patch.object(
                 provisioner._openwebui,
-                "list_models",
-                return_value=[
-                    {"id": f"{AIHUB_AGENT_PREFIX}rag-default", "base_model_id": "aihub-pipeline.rag.default"}
-                ],
+                "list_base_models",
+                return_value=[_managed_row("aihub-pipeline.rag.default", "RAG Agent")],
             ),
             patch.object(
                 provisioner._openwebui,
@@ -153,22 +231,21 @@ class TestSyncAccessGrants:
 
             mock_update.assert_called_once()
             call_args = mock_update.call_args
-            assert call_args[0][1] == f"{AIHUB_AGENT_PREFIX}rag-default"
+            assert call_args[0][1] == "aihub-pipeline.rag.default"
             grants = call_args[0][2]
             assert AccessGrant(principal_type="group", principal_id="grp-1", permission="read") in grants
 
     @pytest.mark.asyncio
-    async def test_sync_parses_agent_from_base_model_id(self, provisioner: OpenWebuiProvisioner) -> None:
-        """base_model_id is the preferred source for agent_class/agent_id parsing."""
+    async def test_sync_wires_a_differently_named_agent_end_to_end(self, provisioner: OpenWebuiProvisioner) -> None:
+        """Exercises the full chain (id -> _parse_agent_from_model -> _compute_access_for_model) for
+        an agent class/id pair distinct from the primary happy-path test above."""
         mock_client = AsyncMock(spec=httpx.AsyncClient)
 
         with (
             patch.object(
                 provisioner._openwebui,
-                "list_models",
-                return_value=[
-                    {"id": f"{AIHUB_AGENT_PREFIX}my-rag-default", "base_model_id": "aihub-pipeline.my-rag.default"}
-                ],
+                "list_base_models",
+                return_value=[_managed_row("aihub-pipeline.my-rag.default", "My RAG Agent")],
             ),
             patch.object(
                 provisioner._openwebui,
@@ -200,53 +277,15 @@ class TestSyncAccessGrants:
             assert len(grants) == 1
 
     @pytest.mark.asyncio
-    async def test_sync_skips_model_without_base_model_id(self, provisioner: OpenWebuiProvisioner) -> None:
-        """Models without a valid base_model_id are skipped during access sync."""
+    async def test_sync_skips_managed_row_with_malformed_agent_id(self, provisioner: OpenWebuiProvisioner) -> None:
+        """An agent-pipe-shaped id without a dot separator after the prefix is unparseable — skipped."""
         mock_client = AsyncMock(spec=httpx.AsyncClient)
 
         with (
             patch.object(
                 provisioner._openwebui,
-                "list_models",
-                return_value=[{"id": f"{AIHUB_AGENT_PREFIX}rag-default"}],
-            ),
-            patch.object(
-                provisioner._openwebui,
-                "list_groups",
-                return_value=[_group("aihub:T1:R1", "grp-1")],
-            ),
-            patch.object(provisioner._openwebui, "update_model_access") as mock_update,
-            patch(
-                "swiss_ai_hub.core.infrastructure.openwebui.openwebui_provisioner.TenantMetadataEntity"
-            ) as mock_tenant,
-            patch("swiss_ai_hub.core.infrastructure.openwebui.openwebui_provisioner.RoleEntity") as mock_role,
-        ):
-            tenant = MagicMock()
-            tenant.name = "T1"
-            tenant.id = "T1"
-            tenant.access_rules = ["aihub.user.agent.rag.*"]
-            mock_tenant.objects.return_value = [tenant]
-
-            role = MagicMock()
-            role.name = "R1"
-            role.tenant_id = "T1"
-            role.access_rules = ["aihub.user.agent.rag.*"]
-            mock_role.objects.return_value = [role]
-
-            await provisioner._sync_access_grants(mock_client)
-
-            mock_update.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_sync_skips_model_with_malformed_base_model_id(self, provisioner: OpenWebuiProvisioner) -> None:
-        """A base_model_id without a dot separator after the prefix is unparseable — model is skipped."""
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-
-        with (
-            patch.object(
-                provisioner._openwebui,
-                "list_models",
-                return_value=[{"id": f"{AIHUB_AGENT_PREFIX}broken", "base_model_id": "aihub-pipeline.nodot"}],
+                "list_base_models",
+                return_value=[_managed_row("aihub-pipeline.nodot", "Broken")],
             ),
             patch.object(
                 provisioner._openwebui,
@@ -276,16 +315,37 @@ class TestSyncAccessGrants:
             mock_update.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_sync_leaves_non_managed_base_row_grants_untouched(self, provisioner: OpenWebuiProvisioner) -> None:
+        """A base row a human created directly in the workspace (no aihub_managed marker) must not
+        have its grants recomputed and overwritten by this sync."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        with (
+            patch.object(
+                provisioner._openwebui,
+                "list_base_models",
+                return_value=[{"id": "aihub-pipeline.rag.default", "name": "RAG Agent"}],
+            ),
+            patch.object(
+                provisioner._openwebui,
+                "list_groups",
+                return_value=[_group("aihub:T1:R1", "grp-1")],
+            ),
+            patch.object(provisioner._openwebui, "update_model_access") as mock_update,
+        ):
+            await provisioner._sync_access_grants(mock_client)
+
+            mock_update.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_model_accessible_by_multiple_groups(self, provisioner: OpenWebuiProvisioner) -> None:
         mock_client = AsyncMock(spec=httpx.AsyncClient)
 
         with (
             patch.object(
                 provisioner._openwebui,
-                "list_models",
-                return_value=[
-                    {"id": f"{AIHUB_AGENT_PREFIX}rag-default", "base_model_id": "aihub-pipeline.rag.default"}
-                ],
+                "list_base_models",
+                return_value=[_managed_row("aihub-pipeline.rag.default", "RAG Agent")],
             ),
             patch.object(
                 provisioner._openwebui,
@@ -329,7 +389,7 @@ class TestSyncAccessGrants:
         mock_client = AsyncMock(spec=httpx.AsyncClient)
 
         with (
-            patch.object(provisioner._openwebui, "list_models", return_value=[]),
+            patch.object(provisioner._openwebui, "list_base_models", return_value=[]),
             patch.object(provisioner._openwebui, "list_groups") as mock_list_groups,
         ):
             await provisioner._sync_access_grants(mock_client)
@@ -394,75 +454,6 @@ class TestBuildRoleRules:
             mock_role.objects.return_value = [orphan]
 
             assert OpenWebuiProvisioner._build_role_rules() == {}
-
-
-class TestDeleteShadowingBaseModels:
-    """A registry entry at a workspace model's ``base_model_id`` makes OpenWebUI's
-    ``has_base_model_access`` deny every non-admin without a grant on it, so the model stays in the
-    picker but chat fails with "Model not found". ``POST /models/sync`` — which the OpenWebUI workspace
-    issues when an admin saves the model list — writes such an entry for every model it renders.
-    Only ``list_base_models`` can see them: OpenWebUI's model search filters on
-    ``base_model_id != None``, so ``list_models`` never returns them."""
-
-    @staticmethod
-    def _sync_with(provisioner: OpenWebuiProvisioner, workspace_models, base_models):
-        return (
-            patch.object(provisioner._openwebui, "list_models", return_value=workspace_models),
-            patch.object(provisioner._openwebui, "list_base_models", return_value=base_models),
-            patch.object(provisioner._openwebui, "list_groups", return_value=[]),
-        )
-
-    @pytest.mark.asyncio
-    async def test_deletes_entry_shadowing_an_llm_base(self, provisioner: OpenWebuiProvisioner) -> None:
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        workspace = [{"id": f"{AIHUB_LLM_MODEL_PREFIX}text-generation-Kimi", "base_model_id": "text-generation/Kimi"}]
-        list_models, list_base, list_groups = self._sync_with(provisioner, workspace, [{"id": "text-generation/Kimi"}])
-
-        with list_models, list_base, list_groups, patch.object(provisioner._openwebui, "delete_model") as mock_delete:
-            await provisioner._sync_access_grants(mock_client)
-
-            mock_delete.assert_called_once_with(mock_client, "text-generation/Kimi")
-
-    @pytest.mark.asyncio
-    async def test_deletes_entry_shadowing_an_agent_pipe(self, provisioner: OpenWebuiProvisioner) -> None:
-        """The half #1595 never covered: agent presets point at ``aihub-pipeline.*`` bases, which
-        shadow identically once the workspace materialises a row for them."""
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        workspace = [{"id": f"{AIHUB_AGENT_PREFIX}RAGAgent-doc", "base_model_id": "aihub-pipeline.RAGAgent.doc"}]
-        list_models, list_base, list_groups = self._sync_with(
-            provisioner, workspace, [{"id": "aihub-pipeline.RAGAgent.doc"}]
-        )
-
-        with list_models, list_base, list_groups, patch.object(provisioner._openwebui, "delete_model") as mock_delete:
-            await provisioner._sync_access_grants(mock_client)
-
-            mock_delete.assert_called_once_with(mock_client, "aihub-pipeline.RAGAgent.doc")
-
-    @pytest.mark.asyncio
-    async def test_leaves_unregistered_base_alone(self, provisioner: OpenWebuiProvisioner) -> None:
-        """The healthy state: the raw model has no registry entry, so there is nothing to repair."""
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        workspace = [{"id": f"{AIHUB_AGENT_PREFIX}RAGAgent-doc", "base_model_id": "aihub-pipeline.RAGAgent.doc"}]
-        list_models, list_base, list_groups = self._sync_with(provisioner, workspace, [])
-
-        with list_models, list_base, list_groups, patch.object(provisioner._openwebui, "delete_model") as mock_delete:
-            await provisioner._sync_access_grants(mock_client)
-
-            mock_delete.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_does_not_delete_foreign_base_models(self, provisioner: OpenWebuiProvisioner) -> None:
-        """Only bases of models we provision are repaired; entries owned by anyone else stay put."""
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        workspace = [{"id": f"{AIHUB_AGENT_PREFIX}RAGAgent-doc", "base_model_id": "aihub-pipeline.RAGAgent.doc"}]
-        list_models, list_base, list_groups = self._sync_with(
-            provisioner, workspace, [{"id": "text-generation/somebody-elses-model"}]
-        )
-
-        with list_models, list_base, list_groups, patch.object(provisioner._openwebui, "delete_model") as mock_delete:
-            await provisioner._sync_access_grants(mock_client)
-
-            mock_delete.assert_not_called()
 
 
 class TestCrossTenantIsolation:

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_provisioner_llm_models.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_provisioner_llm_models.py
@@ -11,11 +11,17 @@ from swiss_ai_hub.core.infrastructure.openwebui.access_grant import AccessGrant
 from swiss_ai_hub.core.infrastructure.openwebui.available_model import AvailableModel
 from swiss_ai_hub.core.infrastructure.openwebui.openwebui_provisioner import (
     AIHUB_LLM_MODEL_PREFIX,
+    AIHUB_MANAGED_META_KEY,
     OpenWebuiProvisioner,
 )
 
 _GEMMA = AvailableModel(capability="text-generation", name="gemma-4-31B-it", display_name="gemma-4-31B-it")
 _GEMMA_ID = f"{AIHUB_LLM_MODEL_PREFIX}text-generation-gemma-4-31B-it"
+_GEMMA_LLM_ID = _GEMMA.litellm_name
+
+
+def _managed_row(model_id: str, name: str) -> dict:
+    return {"id": model_id, "name": name, "meta": {AIHUB_MANAGED_META_KEY: True}}
 
 
 def _group(display_name: str, group_id: str) -> Group:
@@ -70,12 +76,13 @@ class TestGetAvailableLlmModels:
 
 
 class TestBuildLlmModelData:
-    def test_id_and_base_model_id(self, provisioner: OpenWebuiProvisioner) -> None:
+    def test_registers_raw_id_with_no_base_model_id(self, provisioner: OpenWebuiProvisioner) -> None:
         data = provisioner._build_llm_model_data(_GEMMA)
 
-        assert data["id"] == _GEMMA_ID
-        assert data["base_model_id"] == "text-generation/gemma-4-31B-it"
+        assert data["id"] == "text-generation/gemma-4-31B-it"
+        assert "base_model_id" not in data
         assert data["name"] == "gemma-4-31B-it"
+        assert data["meta"][AIHUB_MANAGED_META_KEY] is True
 
 
 class TestSyncLlmWorkspaceModels:
@@ -84,7 +91,7 @@ class TestSyncLlmWorkspaceModels:
         mock_client = AsyncMock(spec=httpx.AsyncClient)
 
         with (
-            patch.object(provisioner._openwebui, "list_models", return_value=[]),
+            patch.object(provisioner._openwebui, "list_base_models", return_value=[]),
             patch.object(provisioner._openwebui, "create_model") as mock_create,
             patch.object(provisioner._openwebui, "delete_model") as mock_delete,
         ):
@@ -92,8 +99,8 @@ class TestSyncLlmWorkspaceModels:
 
             mock_create.assert_called_once()
             create_data = mock_create.call_args[0][1]
-            assert create_data["id"] == _GEMMA_ID
-            assert create_data["base_model_id"] == "text-generation/gemma-4-31B-it"
+            assert create_data["id"] == _GEMMA_LLM_ID
+            assert "base_model_id" not in create_data
             mock_delete.assert_not_called()
 
     @pytest.mark.asyncio
@@ -101,21 +108,23 @@ class TestSyncLlmWorkspaceModels:
         mock_client = AsyncMock(spec=httpx.AsyncClient)
 
         with (
-            patch.object(provisioner._openwebui, "list_models", return_value=[{"id": _GEMMA_ID}]),
+            patch.object(
+                provisioner._openwebui, "list_base_models", return_value=[_managed_row(_GEMMA_LLM_ID, "gemma-4-31B-it")]
+            ),
             patch.object(provisioner._openwebui, "create_model") as mock_create,
             patch.object(provisioner._openwebui, "delete_model") as mock_delete,
         ):
             await provisioner._sync_llm_workspace_models(mock_client, [])
 
             mock_create.assert_not_called()
-            mock_delete.assert_called_once_with(mock_client, _GEMMA_ID)
+            mock_delete.assert_called_once_with(mock_client, _GEMMA_LLM_ID)
 
     @pytest.mark.asyncio
     async def test_updates_name_on_drift(self, provisioner: OpenWebuiProvisioner) -> None:
         mock_client = AsyncMock(spec=httpx.AsyncClient)
 
         with (
-            patch.object(provisioner._openwebui, "list_models", return_value=[{"id": _GEMMA_ID, "name": "Old"}]),
+            patch.object(provisioner._openwebui, "list_base_models", return_value=[_managed_row(_GEMMA_LLM_ID, "Old")]),
             patch.object(provisioner._openwebui, "create_model") as mock_create,
             patch.object(provisioner._openwebui, "update_model") as mock_update,
             patch.object(provisioner._openwebui, "delete_model") as mock_delete,
@@ -133,7 +142,9 @@ class TestSyncLlmWorkspaceModels:
 
         with (
             patch.object(
-                provisioner._openwebui, "list_models", return_value=[{"id": _GEMMA_ID, "name": "gemma-4-31B-it"}]
+                provisioner._openwebui,
+                "list_base_models",
+                return_value=[_managed_row(_GEMMA_LLM_ID, "gemma-4-31B-it")],
             ),
             patch.object(provisioner._openwebui, "create_model") as mock_create,
             patch.object(provisioner._openwebui, "update_model") as mock_update,
@@ -146,12 +157,35 @@ class TestSyncLlmWorkspaceModels:
             mock_delete.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_ignores_agent_workspace_models(self, provisioner: OpenWebuiProvisioner) -> None:
-        """An aihub-agent-* entry must not be deleted by the LLM sync (different prefix)."""
+    async def test_ignores_agent_pipe_rows(self, provisioner: OpenWebuiProvisioner) -> None:
+        """A managed agent-pipe row must not be deleted by the LLM sync (different id shape)."""
         mock_client = AsyncMock(spec=httpx.AsyncClient)
 
         with (
-            patch.object(provisioner._openwebui, "list_models", return_value=[{"id": "aihub-agent-rag-default"}]),
+            patch.object(
+                provisioner._openwebui,
+                "list_base_models",
+                return_value=[_managed_row("aihub-pipeline.rag.default", "RAG Agent")],
+            ),
+            patch.object(provisioner._openwebui, "create_model") as mock_create,
+            patch.object(provisioner._openwebui, "delete_model") as mock_delete,
+        ):
+            await provisioner._sync_llm_workspace_models(mock_client, [])
+
+            mock_create.assert_not_called()
+            mock_delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ignores_non_managed_base_rows(self, provisioner: OpenWebuiProvisioner) -> None:
+        """A human-created base row (no aihub_managed marker) must not be deleted by the LLM sync."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        with (
+            patch.object(
+                provisioner._openwebui,
+                "list_base_models",
+                return_value=[{"id": "text-generation/some-custom-model", "name": "Human-made"}],
+            ),
             patch.object(provisioner._openwebui, "create_model") as mock_create,
             patch.object(provisioner._openwebui, "delete_model") as mock_delete,
         ):
@@ -163,15 +197,15 @@ class TestSyncLlmWorkspaceModels:
 
 class TestParseLlmFromModel:
     def test_parses_capability_and_name(self) -> None:
-        model = {"id": _GEMMA_ID, "base_model_id": "text-generation/gemma-4-31B-it"}
+        model = {"id": "text-generation/gemma-4-31B-it"}
         assert OpenWebuiProvisioner._parse_llm_from_model(model) == ("text-generation", "gemma-4-31B-it")
 
     def test_returns_none_without_slash(self) -> None:
-        model = {"id": _GEMMA_ID, "base_model_id": "no-slash"}
+        model = {"id": "no-slash"}
         assert OpenWebuiProvisioner._parse_llm_from_model(model) is None
 
-    def test_returns_none_without_base_model_id(self) -> None:
-        assert OpenWebuiProvisioner._parse_llm_from_model({"id": _GEMMA_ID}) is None
+    def test_returns_none_for_empty_id(self) -> None:
+        assert OpenWebuiProvisioner._parse_llm_from_model({}) is None
 
 
 class TestComputeAccessForLlmModel:
@@ -236,11 +270,13 @@ class TestComputeAccessForLlmModel:
 
 
 class TestComputeGrantsForManagedModel:
+    """Dispatch is by id shape now — a managed row carries no base_model_id hop to key off."""
+
     def test_dispatches_llm_model_to_model_access(self, provisioner: OpenWebuiProvisioner) -> None:
         groups = [_group("aihub:T1:R1", "grp-1")]
         tenant_rules = {"T1": ["aihub.user.model.>"]}
         role_rules = {("T1", "R1"): ["aihub.user.model.>"]}
-        model = {"id": _GEMMA_ID, "base_model_id": "text-generation/gemma-4-31B-it"}
+        model = {"id": _GEMMA_LLM_ID}
 
         result = provisioner._compute_grants_for_managed_model(model, groups, tenant_rules, role_rules)
 
@@ -250,18 +286,18 @@ class TestComputeGrantsForManagedModel:
         groups = [_group("aihub:T1:R1", "grp-1")]
         tenant_rules = {"T1": ["aihub.user.agent.>"]}
         role_rules = {("T1", "R1"): ["aihub.user.agent.>"]}
-        model = {"id": "aihub-agent-rag-default", "base_model_id": "aihub-pipeline.rag.default"}
+        model = {"id": "aihub-pipeline.rag.default"}
 
         result = provisioner._compute_grants_for_managed_model(model, groups, tenant_rules, role_rules)
 
         assert result == [AccessGrant(principal_type="group", principal_id="grp-1", permission="read")]
 
-    def test_unknown_prefix_returns_none(self, provisioner: OpenWebuiProvisioner) -> None:
-        model = {"id": "custom-model-123", "base_model_id": "whatever/x"}
+    def test_bare_id_returns_none(self, provisioner: OpenWebuiProvisioner) -> None:
+        model = {"id": "custom-model-123"}
         assert provisioner._compute_grants_for_managed_model(model, [], {}, {}) is None
 
-    def test_unparseable_llm_returns_none(self, provisioner: OpenWebuiProvisioner) -> None:
-        model = {"id": _GEMMA_ID, "base_model_id": "no-slash"}
+    def test_malformed_agent_pipe_id_returns_none(self, provisioner: OpenWebuiProvisioner) -> None:
+        model = {"id": "aihub-pipeline.nodot"}
         assert provisioner._compute_grants_for_managed_model(model, [], {}, {}) is None
 
 
@@ -273,8 +309,8 @@ class TestSyncAccessGrantsLlm:
         with (
             patch.object(
                 provisioner._openwebui,
-                "list_models",
-                return_value=[{"id": _GEMMA_ID, "base_model_id": "text-generation/gemma-4-31B-it"}],
+                "list_base_models",
+                return_value=[_managed_row(_GEMMA_LLM_ID, "gemma-4-31B-it")],
             ),
             patch.object(provisioner._openwebui, "list_groups", return_value=[_group("aihub:T1:R1", "grp-1")]),
             patch.object(provisioner._openwebui, "update_model_access") as mock_update,
@@ -298,6 +334,6 @@ class TestSyncAccessGrantsLlm:
             await provisioner._sync_access_grants(mock_client)
 
             mock_update.assert_called_once()
-            assert mock_update.call_args[0][1] == _GEMMA_ID
+            assert mock_update.call_args[0][1] == _GEMMA_LLM_ID
             grants = mock_update.call_args[0][2]
             assert AccessGrant(principal_type="group", principal_id="grp-1", permission="read") in grants

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_provisioner_models.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_provisioner_models.py
@@ -5,7 +5,7 @@ import pytest
 
 from swiss_ai_hub.core.infrastructure.openwebui.online_agent import OnlineAgent
 from swiss_ai_hub.core.infrastructure.openwebui.openwebui_provisioner import (
-    AIHUB_AGENT_PREFIX,
+    AIHUB_MANAGED_META_KEY,
     OpenWebuiProvisioner,
 )
 from swiss_ai_hub.core.persistence.i18n.locale_string_entity import LocaleStringEntity
@@ -34,7 +34,11 @@ class TestResolveDisplayName:
         assert provisioner._resolve_display_name(name, "rag") == "rag"
 
 
-_RAG_MODEL_ID = f"{AIHUB_AGENT_PREFIX}rag-default"
+_RAG_MODEL_ID = "aihub-pipeline.rag.default"
+
+
+def _managed_row(model_id: str, name: str) -> dict:
+    return {"id": model_id, "name": name, "meta": {AIHUB_MANAGED_META_KEY: True}}
 
 
 class TestComputeModelDiff:
@@ -86,7 +90,7 @@ class TestSyncWorkspaceModels:
         mock_client = AsyncMock(spec=httpx.AsyncClient)
 
         with (
-            patch.object(provisioner._openwebui, "list_models", return_value=[]) as mock_list,
+            patch.object(provisioner._openwebui, "list_base_models", return_value=[]) as mock_list,
             patch.object(provisioner._openwebui, "create_model") as mock_create,
             patch.object(provisioner._openwebui, "delete_model") as mock_delete,
         ):
@@ -95,9 +99,10 @@ class TestSyncWorkspaceModels:
             mock_list.assert_called_once()
             mock_create.assert_called_once()
             create_data = mock_create.call_args[0][1]
-            assert create_data["id"] == "aihub-agent-rag-default"
-            assert create_data["base_model_id"] == "aihub-pipeline.rag.default"
+            assert create_data["id"] == _RAG_MODEL_ID
+            assert "base_model_id" not in create_data
             assert create_data["name"] == "RAG Agent"
+            assert create_data["meta"][AIHUB_MANAGED_META_KEY] is True
             mock_delete.assert_not_called()
 
     @pytest.mark.asyncio
@@ -108,8 +113,11 @@ class TestSyncWorkspaceModels:
         with (
             patch.object(
                 provisioner._openwebui,
-                "list_models",
-                return_value=[{"id": "aihub-agent-rag-default", "name": "RAG Agent"}, {"id": "aihub-agent-gone-old"}],
+                "list_base_models",
+                return_value=[
+                    _managed_row(_RAG_MODEL_ID, "RAG Agent"),
+                    _managed_row("aihub-pipeline.gone.old", "Gone"),
+                ],
             ),
             patch.object(provisioner._openwebui, "create_model") as mock_create,
             patch.object(provisioner._openwebui, "delete_model") as mock_delete,
@@ -117,7 +125,7 @@ class TestSyncWorkspaceModels:
             await provisioner._sync_workspace_models(mock_client, [_RAG_AGENT])
 
             mock_create.assert_not_called()
-            mock_delete.assert_called_once_with(mock_client, "aihub-agent-gone-old")
+            mock_delete.assert_called_once_with(mock_client, "aihub-pipeline.gone.old")
 
     @pytest.mark.asyncio
     async def test_sync_skips_deletion_when_no_agent_is_online(self, provisioner: OpenWebuiProvisioner) -> None:
@@ -128,8 +136,11 @@ class TestSyncWorkspaceModels:
         with (
             patch.object(
                 provisioner._openwebui,
-                "list_models",
-                return_value=[{"id": "aihub-agent-rag-default"}, {"id": "aihub-agent-search-default"}],
+                "list_base_models",
+                return_value=[
+                    _managed_row(_RAG_MODEL_ID, "RAG Agent"),
+                    _managed_row("aihub-pipeline.search.default", "Search Agent"),
+                ],
             ),
             patch.object(provisioner._openwebui, "create_model") as mock_create,
             patch.object(provisioner._openwebui, "delete_model") as mock_delete,
@@ -146,8 +157,8 @@ class TestSyncWorkspaceModels:
         with (
             patch.object(
                 provisioner._openwebui,
-                "list_models",
-                return_value=[{"id": "aihub-agent-rag-default", "name": "Old Name"}],
+                "list_base_models",
+                return_value=[_managed_row(_RAG_MODEL_ID, "Old Name")],
             ),
             patch.object(provisioner._openwebui, "create_model") as mock_create,
             patch.object(provisioner._openwebui, "update_model") as mock_update,
@@ -159,7 +170,7 @@ class TestSyncWorkspaceModels:
             mock_delete.assert_not_called()
             mock_update.assert_called_once()
             update_data = mock_update.call_args[0][1]
-            assert update_data["id"] == "aihub-agent-rag-default"
+            assert update_data["id"] == _RAG_MODEL_ID
             assert update_data["name"] == "RAG Agent"
 
     @pytest.mark.asyncio
@@ -169,8 +180,8 @@ class TestSyncWorkspaceModels:
         with (
             patch.object(
                 provisioner._openwebui,
-                "list_models",
-                return_value=[{"id": "aihub-agent-rag-default", "name": "RAG Agent"}],
+                "list_base_models",
+                return_value=[_managed_row(_RAG_MODEL_ID, "RAG Agent")],
             ),
             patch.object(provisioner._openwebui, "create_model") as mock_create,
             patch.object(provisioner._openwebui, "update_model") as mock_update,
@@ -183,14 +194,15 @@ class TestSyncWorkspaceModels:
             mock_delete.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_sync_ignores_non_aihub_models(self, provisioner: OpenWebuiProvisioner) -> None:
+    async def test_sync_ignores_non_managed_base_rows(self, provisioner: OpenWebuiProvisioner) -> None:
+        """A human-created base row (no aihub_managed marker) must survive an agent sync untouched."""
         mock_client = AsyncMock(spec=httpx.AsyncClient)
 
         with (
             patch.object(
                 provisioner._openwebui,
-                "list_models",
-                return_value=[{"id": "custom-model-123"}],
+                "list_base_models",
+                return_value=[{"id": "aihub-pipeline.custom.123", "name": "Human-made"}],
             ),
             patch.object(provisioner._openwebui, "create_model") as mock_create,
             patch.object(provisioner._openwebui, "delete_model") as mock_delete,
@@ -198,4 +210,25 @@ class TestSyncWorkspaceModels:
             await provisioner._sync_workspace_models(mock_client, [])
 
             mock_create.assert_not_called()
+            mock_delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sync_ignores_managed_llm_rows(self, provisioner: OpenWebuiProvisioner) -> None:
+        """An LLM model's managed row must not be mistaken for a stale agent row and deleted."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        with (
+            patch.object(
+                provisioner._openwebui,
+                "list_base_models",
+                return_value=[_managed_row("text-generation/Kimi-K2.6", "Kimi")],
+            ),
+            patch.object(provisioner._openwebui, "create_model") as mock_create,
+            patch.object(provisioner._openwebui, "delete_model") as mock_delete,
+        ):
+            await provisioner._sync_workspace_models(mock_client, [_RAG_AGENT])
+
+            mock_create.assert_called_once()
+            create_data = mock_create.call_args[0][1]
+            assert create_data["id"] == _RAG_MODEL_ID
             mock_delete.assert_not_called()


### PR DESCRIPTION
## Summary

- Bumps OpenWebUI `0.9.5` → `0.11.3` (cherry-picked from `chore/openwebui-0.11.3`) and fixes what that upgrade
  breaks: 0.11.3 changed `has_base_model_access` so an unregistered `base_model_id` is now admin-only (was
  previously treated as an unrestricted raw provider model). Every provisioned model — agent-backed and raw LLM —
  was a preset pointing at exactly such an unregistered base, so every non-admin got `400 Model not found` on
  every model. See `docs/arc42/decisions/2026_09_04_openwebui_models_registered_as_base_rows.md` for the full
  design rationale.
- `OpenWebuiProvisioner` now registers each model directly as a base-registry row on its own raw id
  (`aihub-pipeline.{class}.{id}` / `{capability}/{name}`), carrying its own access grants, instead of a preset
  pointing at an unregistered base one hop above it. `_delete_shadowing_base_models` — whose entire premise
  inverted under 0.11.3 — is removed; a one-time migration cleans up the legacy `aihub-agent-*`/`aihub-model-*`
  preset rows on every sync.
- `TASK_MODEL`/`TASK_MODEL_EXTERNAL` in the compose template now name the raw model id directly (no more
  workspace-id translation needed, since there's no more preset layer).
- Also fixes an independently-found, pre-existing bug: `OpenWebuiClient.update_model_access` sent
  `access_grants: null` whenever the computed grant list was empty, which OpenWebUI's update endpoint reads as
  "leave existing grants untouched" rather than "clear" — so a role or tenant-ceiling change that revoked a
  group's last access to a model silently failed to revoke it.

## Test plan

- [x] `make test` — 118/118 pass in `packages/core/swiss_ai_hub/core/infrastructure/openwebui/`
- [x] Live-verified against the dev stack (not just unit tests): a scoped, non-admin test role chatting a raw LLM
      model and chatting a genuinely-online agent both went `400` → `200` after the fix, for the real production
      rows (not synthetic probes)
- [x] Confirmed picker and chat access now agree — a model visible to a non-admin is always usable, closing the
      inconsistency where `get_filtered_models` and `check_model_access` could disagree
- [x] Confirmed the grant-revocation fix live: granting then revoking a group's access to a model via
      `update_model_access` now actually clears it (previously the stale grant survived)