### PR TITLE
fix(deploy): Pass DAGSTER_MAX_CONCURRENT_RUNS to the document ingestion pipeline

### DIFF
--- a/infra/deployment/templates/docker-compose.yml.j2
+++ b/infra/deployment/templates/docker-compose.yml.j2
@@ -4284,6 +4284,7 @@ services:
 
       # DAGSTER
       DAGSTER_HOME: /dagster_home
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
 
       # S3 Access connection (access and secret key same as SeaweedFS)
       S3_STORAGE_ENDPOINT: {{ S3_STORAGE_ENDPOINT }}

--- a/infra/docker-compose.build.gpu.yml
+++ b/infra/docker-compose.build.gpu.yml
@@ -3679,6 +3679,7 @@ services:
 
       # DAGSTER
       DAGSTER_HOME: /dagster_home
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
 
       # S3 Access connection (access and secret key same as SeaweedFS)
       S3_STORAGE_ENDPOINT: http://seaweedfs-s3:9000

--- a/infra/docker-compose.build.yml
+++ b/infra/docker-compose.build.yml
@@ -3467,6 +3467,7 @@ services:
 
       # DAGSTER
       DAGSTER_HOME: /dagster_home
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
 
       # S3 Access connection (access and secret key same as SeaweedFS)
       S3_STORAGE_ENDPOINT: http://seaweedfs-s3:9000

--- a/infra/docker-compose.latest.gpu.yml
+++ b/infra/docker-compose.latest.gpu.yml
@@ -3774,6 +3774,7 @@ services:
 
       # DAGSTER
       DAGSTER_HOME: /dagster_home
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
 
       # S3 Access connection (access and secret key same as SeaweedFS)
       S3_STORAGE_ENDPOINT: http://seaweedfs-s3:9000

--- a/infra/docker-compose.latest.yml
+++ b/infra/docker-compose.latest.yml
@@ -3568,6 +3568,7 @@ services:
 
       # DAGSTER
       DAGSTER_HOME: /dagster_home
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
 
       # S3 Access connection (access and secret key same as SeaweedFS)
       S3_STORAGE_ENDPOINT: http://seaweedfs-s3:9000

--- a/infra/docker-compose.local.gpu.yml
+++ b/infra/docker-compose.local.gpu.yml
@@ -3638,6 +3638,7 @@ services:
 
       # DAGSTER
       DAGSTER_HOME: /dagster_home
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
 
       # S3 Access connection (access and secret key same as SeaweedFS)
       S3_STORAGE_ENDPOINT: http://seaweedfs-s3:9000

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -3426,6 +3426,7 @@ services:
 
       # DAGSTER
       DAGSTER_HOME: /dagster_home
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
 
       # S3 Access connection (access and secret key same as SeaweedFS)
       S3_STORAGE_ENDPOINT: http://seaweedfs-s3:9000

--- a/infra/docker-compose.nightly.gpu.yml
+++ b/infra/docker-compose.nightly.gpu.yml
@@ -3774,6 +3774,7 @@ services:
 
       # DAGSTER
       DAGSTER_HOME: /dagster_home
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
 
       # S3 Access connection (access and secret key same as SeaweedFS)
       S3_STORAGE_ENDPOINT: http://seaweedfs-s3:9000

--- a/infra/docker-compose.nightly.yml
+++ b/infra/docker-compose.nightly.yml
@@ -3568,6 +3568,7 @@ services:
 
       # DAGSTER
       DAGSTER_HOME: /dagster_home
+      DAGSTER_MAX_CONCURRENT_RUNS: ${DAGSTER_MAX_CONCURRENT_RUNS}
 
       # S3 Access connection (access and secret key same as SeaweedFS)
       S3_STORAGE_ENDPOINT: http://seaweedfs-s3:9000


### PR DESCRIPTION
## The failure

Every Dagster run launched in the `document_ingestion_pipeline` container failed on nightly with:

```
dagster._config.errors.PostProcessingError: You have attempted to fetch the environment variable
"DAGSTER_MAX_CONCURRENT_RUNS" which is not set.
```

The variable *is* set on the VM and on the Dagster webserver and daemon. It was missing from the
one container that actually needed it.

`DefaultRunLauncher` spawns run workers inside the code location's own container and hands them a
serialized `InstanceRef`. That ref stores the run-coordinator config with its `env:` indirection
still unresolved — literally `{'env': 'DAGSTER_MAX_CONCURRENT_RUNS'}`, which is what the error
prints back. Resolution is deferred until something touches the run coordinator, and
`InstanceConcurrencyContext.__init__` does exactly that via
`get_pool_config() → get_concurrency_config() → isinstance(self.run_coordinator, QueuedRunCoordinator)`.
That happens in the **worker's** environment, inside the pipeline container.

`.env` is used by compose for `${...}` interpolation; each service receives only what its own
`environment:` block names. Both legacy pipelines name this variable and carry a comment spelling
out this exact mechanism. The service added by #1603 did not.

This is not specific to the observation step — any in-process execution builds an
`InstanceConcurrencyContext`, so every run in that container failed. Observation is just the first
run an upload triggers.

## Scope

The instance config references exactly three env vars: `POSTGRES_USER`, `POSTGRES_PASSWORD` and
`DAGSTER_MAX_CONCURRENT_RUNS`. The container already had the first two, so this one line closes the
whole gap — the fix does not merely move the error to the next unresolved variable.

## Verification

Both pipelines were run as **containers built from the generated nightly compose**, with each
service's `environment:` block copied verbatim. Only two host *values* were bridged (`milvus-standalone`,
`pgbouncer`) via `extra_hosts`; no key was ever added, so a variable the deployment forgets is just
as absent in the rig as on the VM.

| | Result |
| --- | --- |
| Unfixed compose → new pipeline observation | **fails** with the exact `PostProcessingError` |
| Unfixed compose → legacy pipeline observation | succeeds (it has the variable) |
| Fixed compose → new pipeline observation | succeeds |

Then a real document was uploaded through the API into one database on each pipeline and followed
all the way to retrievable vectors — parse, chunk, embed, Milvus write, `RefDoc.is_ingested` flipped
by that write:

| Check | New pipeline | Legacy pipeline |
| --- | --- | --- |
| Document in the doc store, marked ingested | pass | pass |
| Embeddings in the Milvus collection | 3 vectors | 3 vectors |

All Dagster runs succeeded (`source_observation`, `remove_documents`, and the two auto-materialize
`__ASSET_JOB` runs that did the ingestion), with zero `PostProcessingError` in the container log.
