### PR TITLE
fix(swiss-ai-hub): Hide OpenWebUI web search on agent models

### DIFF
--- a/docs/docs/2_platform/10_chat_ui/5_websearch/index.en.md
+++ b/docs/docs/2_platform/10_chat_ui/5_websearch/index.en.md
@@ -4,8 +4,13 @@ title: Web search capability
 
 # Web search capability
 
-Agents can access web information to answer questions requiring current data beyond their training or internal knowledge
-bases. Organizations control this through configuration.
+Chats with a plain language model can reach out to the web to answer questions requiring current data beyond the model's
+training. Organizations control this through configuration.
+
+::: warning
+Web search applies to plain model chats only. AI-Hub agents ground their answers in the knowledge bases they were
+configured with, so the "Web Search" button is not offered when an agent is selected in the model picker.
+:::
 
 Select "Web Search".
 
@@ -26,11 +31,9 @@ The websites it retrieved the information from are listed as references.
 
 ## Search configuration
 
-Web search can be enabled or disabled per agent. Different policies apply to different use cases or user groups.
-
-Each agent has independent web search configuration based on purpose and risk profile. Web search can be restricted to
-specific user roles through role-based access control. Search capabilities can be modified at runtime without system
-changes.
+Web search can be enabled or disabled platform-wide, and restricted to specific user roles through role-based access
+control, so different policies apply to different use cases or user groups. It can be modified at runtime without
+system changes.
 
 ## Search restrictions
 
@@ -46,7 +49,7 @@ Search restrictions can align with industry regulations, internal policies, or c
 
 ## Source attribution
 
-When agents use web search, the system provides traceable attribution of external sources.
+When a chat uses web search, the system provides traceable attribution of external sources.
 
 Users see clear distinctions between internal knowledge and external web sources. Web results appear as structured,
 clickable citations with URLs, titles, and content previews. Users receive information about why specific sources were
@@ -57,14 +60,13 @@ from query validation through result filtering to presentation - is traceable th
 
 ## Use cases
 
-Agents supplement internal knowledge with current market data, regulatory updates, industry news, or technical
+Users supplement the model's own knowledge with current market data, regulatory updates, industry news, or technical
 documentation from external sources.
 
-When internal knowledge bases have gaps, agents access external information while clearly attributing sources.
+Where a topic is too recent or too niche for the model to know, external information fills the gap while sources stay
+clearly attributed.
 
-Agents can validate internal data against authoritative external sources.
-
-Complex research tasks benefit from orchestration of both internal and external sources.
+Claims can be validated against authoritative external sources.
 
 ## Governance and security
 

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_provisioner.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_provisioner.py
@@ -323,7 +323,8 @@ class OpenWebuiProvisioner:
         ``/models/model/update`` writes every column of ``ModelForm``, so posting a freshly built
         payload would drop whatever the workspace holds — ``params`` and every ``meta`` key AI-Hub
         never writes. The stored model is read back through ``get_model`` rather than reused from
-        ``list_models`` because the listing strips ``profile_image_url``.
+        ``list_models``: the listing hands back ``/static/favicon.png`` in place of the stored
+        ``profile_image_url``, so merging from it would overwrite a custom icon with the placeholder.
         """
         desired = self._build_model_data(agent)
         stored = await self._openwebui.get_model(http, desired["id"])

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_provisioner.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_provisioner.py
@@ -317,6 +317,27 @@ class OpenWebuiProvisioner:
             },
         }
 
+    async def _build_update_data(self, http: httpx.AsyncClient, agent: OnlineAgent) -> dict[str, Any]:
+        """Overlays the fields AI-Hub manages onto the stored model instead of replacing it.
+
+        ``/models/model/update`` writes every column of ``ModelForm``, so posting a freshly built
+        payload would drop whatever the workspace holds — ``params`` and every ``meta`` key AI-Hub
+        never writes. The stored model is read back through ``get_model`` rather than reused from
+        ``list_models`` because the listing strips ``profile_image_url``.
+        """
+        desired = self._build_model_data(agent)
+        stored = await self._openwebui.get_model(http, desired["id"])
+        stored_meta = stored.get("meta") or {}
+        return {
+            **desired,
+            "meta": {
+                **stored_meta,
+                **desired["meta"],
+                "capabilities": {**(stored_meta.get("capabilities") or {}), **desired["meta"]["capabilities"]},
+            },
+            "params": stored.get("params") or {},
+        }
+
     @staticmethod
     def _compute_model_diff(
         online_agents: list[OnlineAgent], existing_models: dict[str, dict[str, Any]]
@@ -368,7 +389,7 @@ class OpenWebuiProvisioner:
             logger.info(f"OpenWebUI: Created workspace model '{model_data['id']}'")
 
         for agent in to_update:
-            model_data = self._build_model_data(agent)
+            model_data = await self._build_update_data(http, agent)
             await self._openwebui.update_model(http, model_data)
             logger.info(f"OpenWebUI: Updated workspace model '{model_data['id']}' name to '{agent.display_name}'")
 

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_provisioner.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/openwebui_provisioner.py
@@ -294,12 +294,27 @@ class OpenWebuiProvisioner:
     def _base_model_id(agent_class: str, agent_id: str) -> str:
         return f"aihub-pipeline.{agent_class}.{agent_id}"
 
+    @staticmethod
+    def _agent_capabilities() -> dict[str, bool]:
+        """Turns OpenWebUI's own web search off for agent workspace models.
+
+        OpenWebUI runs the search before the pipe and hands the hits over as a ``files`` entry with no
+        file id, which the pipe's file processing drops — so the agent never sees a single result and
+        answers "not in the documents" while the UI claims it searched. Hiding the toggle beats leaving
+        a button that silently does nothing. Plain LLM workspace models keep web search: they bypass the
+        pipe and reach LiteLLM directly, where OpenWebUI's own RAG injection works.
+        """
+        return {"web_search": False}
+
     def _build_model_data(self, agent: OnlineAgent) -> dict[str, Any]:
         return {
             "id": self._workspace_model_id(agent.agent_class, agent.agent_id),
             "name": agent.display_name,
             "base_model_id": self._base_model_id(agent.agent_class, agent.agent_id),
-            "meta": {"description": f"AI-Hub agent: {agent.agent_class}/{agent.agent_id}"},
+            "meta": {
+                "description": f"AI-Hub agent: {agent.agent_class}/{agent.agent_id}",
+                "capabilities": self._agent_capabilities(),
+            },
         }
 
     @staticmethod
@@ -309,9 +324,12 @@ class OpenWebuiProvisioner:
         """Returns (models_to_create, models_to_update, model_ids_to_delete).
 
         An agent is updated when its workspace model exists but the stored name drifted from the
-        current agent name (e.g. after a rename) — the only field this diff reconciles. Access
+        current agent name (e.g. after a rename), or when the capabilities we push drifted from the
+        stored ones. Without the capability comparison a model created before a capability existed
+        would keep its stale meta forever, since nothing else rewrites an existing model. Access
         grants are reconciled separately by _sync_access_grants.
         """
+        desired_capabilities = OpenWebuiProvisioner._agent_capabilities()
         desired_ids: set[str] = set()
         to_create: list[OnlineAgent] = []
         to_update: list[OnlineAgent] = []
@@ -321,7 +339,12 @@ class OpenWebuiProvisioner:
             existing = existing_models.get(model_id)
             if existing is None:
                 to_create.append(agent)
-            elif existing.get("name") != agent.display_name:
+                continue
+            stored_capabilities = (existing.get("meta") or {}).get("capabilities") or {}
+            capabilities_drifted = any(
+                stored_capabilities.get(name) != value for name, value in desired_capabilities.items()
+            )
+            if existing.get("name") != agent.display_name or capabilities_drifted:
                 to_update.append(agent)
         to_delete = set(existing_models) - desired_ids
         return to_create, to_update, to_delete

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_provisioner_models.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_provisioner_models.py
@@ -37,6 +37,16 @@ class TestResolveDisplayName:
 
 _RAG_MODEL_ID = f"{AIHUB_AGENT_PREFIX}rag-default"
 _PROVISIONED_META = {"capabilities": {"web_search": False}}
+_WORKSPACE_OWNED = {
+    "id": _RAG_MODEL_ID,
+    "name": "RAG Agent",
+    "meta": {
+        "description": "AI-Hub agent: rag/default",
+        "profile_image_url": "/cache/image/rag.png",
+        "capabilities": {"web_search": True, "vision": True},
+    },
+    "params": {"temperature": 0.2},
+}
 
 
 class TestAgentCapabilities:
@@ -214,6 +224,11 @@ class TestSyncWorkspaceModels:
                 "list_models",
                 return_value=[{"id": "aihub-agent-rag-default", "name": "Old Name", "meta": _PROVISIONED_META}],
             ),
+            patch.object(
+                provisioner._openwebui,
+                "get_model",
+                return_value={"id": _RAG_MODEL_ID, "name": "Old Name", "meta": _PROVISIONED_META},
+            ),
             patch.object(provisioner._openwebui, "create_model") as mock_create,
             patch.object(provisioner._openwebui, "update_model") as mock_update,
             patch.object(provisioner._openwebui, "delete_model") as mock_delete,
@@ -238,12 +253,30 @@ class TestSyncWorkspaceModels:
                 "list_models",
                 return_value=[{"id": "aihub-agent-rag-default", "name": "RAG Agent"}],
             ),
+            patch.object(provisioner._openwebui, "get_model", return_value={"id": _RAG_MODEL_ID, "name": "RAG Agent"}),
             patch.object(provisioner._openwebui, "update_model") as mock_update,
         ):
             await provisioner._sync_workspace_models(mock_client, [_RAG_AGENT])
 
             mock_update.assert_called_once()
             assert mock_update.call_args[0][1]["meta"]["capabilities"] == {"web_search": False}
+
+    @pytest.mark.asyncio
+    async def test_sync_keeps_what_the_workspace_owns(self, provisioner: OpenWebuiProvisioner) -> None:
+        """``/models/model/update`` writes every column, so an update must carry the stored fields back."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        with (
+            patch.object(provisioner._openwebui, "list_models", return_value=[_WORKSPACE_OWNED]),
+            patch.object(provisioner._openwebui, "get_model", return_value=_WORKSPACE_OWNED),
+            patch.object(provisioner._openwebui, "update_model") as mock_update,
+        ):
+            await provisioner._sync_workspace_models(mock_client, [_RAG_AGENT])
+
+            update_data = mock_update.call_args[0][1]
+            assert update_data["meta"]["profile_image_url"] == "/cache/image/rag.png"
+            assert update_data["params"] == {"temperature": 0.2}
+            assert update_data["meta"]["capabilities"] == {"web_search": False, "vision": True}
 
     @pytest.mark.asyncio
     async def test_sync_does_not_update_when_name_unchanged(self, provisioner: OpenWebuiProvisioner) -> None:

--- a/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_provisioner_models.py
+++ b/packages/core/swiss_ai_hub/core/infrastructure/openwebui/tests/unit/test_openwebui_provisioner_models.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 
+from swiss_ai_hub.core.infrastructure.openwebui.available_model import AvailableModel
 from swiss_ai_hub.core.infrastructure.openwebui.online_agent import OnlineAgent
 from swiss_ai_hub.core.infrastructure.openwebui.openwebui_provisioner import (
     AIHUB_AGENT_PREFIX,
@@ -35,6 +36,26 @@ class TestResolveDisplayName:
 
 
 _RAG_MODEL_ID = f"{AIHUB_AGENT_PREFIX}rag-default"
+_PROVISIONED_META = {"capabilities": {"web_search": False}}
+
+
+class TestAgentCapabilities:
+    def test_web_search_is_off_for_agents(self) -> None:
+        """OpenWebUI drops web-search hits before they reach the pipe, so the toggle must not render."""
+        assert OpenWebuiProvisioner._agent_capabilities()["web_search"] is False
+
+    def test_agent_model_carries_the_capabilities(self, provisioner: OpenWebuiProvisioner) -> None:
+        model_data = provisioner._build_model_data(_RAG_AGENT)
+
+        assert model_data["meta"]["capabilities"] == {"web_search": False}
+
+    def test_llm_model_keeps_web_search(self, provisioner: OpenWebuiProvisioner) -> None:
+        """Plain LLM models bypass the pipe, so OpenWebUI's own web search works for them."""
+        model_data = provisioner._build_llm_model_data(
+            AvailableModel(capability="text-generation", name="gemma", display_name="gemma")
+        )
+
+        assert "capabilities" not in model_data["meta"]
 
 
 class TestComputeModelDiff:
@@ -61,7 +82,7 @@ class TestComputeModelDiff:
 
     def test_compute_models_unchanged(self) -> None:
         online = [_RAG_AGENT]
-        existing = {_RAG_MODEL_ID: {"id": _RAG_MODEL_ID, "name": "RAG Agent"}}
+        existing = {_RAG_MODEL_ID: {"id": _RAG_MODEL_ID, "name": "RAG Agent", "meta": _PROVISIONED_META}}
 
         to_create, to_update, to_delete = OpenWebuiProvisioner._compute_model_diff(online, existing)
 
@@ -71,13 +92,53 @@ class TestComputeModelDiff:
 
     def test_compute_models_to_update_on_rename(self) -> None:
         online = [_RAG_AGENT]
-        existing = {_RAG_MODEL_ID: {"id": _RAG_MODEL_ID, "name": "Old Name"}}
+        existing = {_RAG_MODEL_ID: {"id": _RAG_MODEL_ID, "name": "Old Name", "meta": _PROVISIONED_META}}
 
         to_create, to_update, to_delete = OpenWebuiProvisioner._compute_model_diff(online, existing)
 
         assert to_create == []
         assert to_update == [_RAG_AGENT]
         assert to_delete == set()
+
+    def test_compute_models_to_update_when_capabilities_missing(self) -> None:
+        """Models provisioned before the capability existed carry no meta and must be back-filled."""
+        online = [_RAG_AGENT]
+        existing = {_RAG_MODEL_ID: {"id": _RAG_MODEL_ID, "name": "RAG Agent"}}
+
+        to_create, to_update, to_delete = OpenWebuiProvisioner._compute_model_diff(online, existing)
+
+        assert to_create == []
+        assert to_update == [_RAG_AGENT]
+        assert to_delete == set()
+
+    def test_compute_models_to_update_when_capability_flipped(self) -> None:
+        online = [_RAG_AGENT]
+        existing = {
+            _RAG_MODEL_ID: {
+                "id": _RAG_MODEL_ID,
+                "name": "RAG Agent",
+                "meta": {"capabilities": {"web_search": True}},
+            }
+        }
+
+        to_create, to_update, to_delete = OpenWebuiProvisioner._compute_model_diff(online, existing)
+
+        assert to_update == [_RAG_AGENT]
+
+    def test_compute_models_ignores_capabilities_we_do_not_manage(self) -> None:
+        """An admin toggling vision in the OpenWebUI workspace must not trigger an endless update loop."""
+        online = [_RAG_AGENT]
+        existing = {
+            _RAG_MODEL_ID: {
+                "id": _RAG_MODEL_ID,
+                "name": "RAG Agent",
+                "meta": {"capabilities": {"web_search": False, "vision": True}},
+            }
+        }
+
+        to_create, to_update, to_delete = OpenWebuiProvisioner._compute_model_diff(online, existing)
+
+        assert to_update == []
 
 
 class TestSyncWorkspaceModels:
@@ -98,6 +159,7 @@ class TestSyncWorkspaceModels:
             assert create_data["id"] == "aihub-agent-rag-default"
             assert create_data["base_model_id"] == "aihub-pipeline.rag.default"
             assert create_data["name"] == "RAG Agent"
+            assert create_data["meta"]["capabilities"] == {"web_search": False}
             mock_delete.assert_not_called()
 
     @pytest.mark.asyncio
@@ -109,7 +171,10 @@ class TestSyncWorkspaceModels:
             patch.object(
                 provisioner._openwebui,
                 "list_models",
-                return_value=[{"id": "aihub-agent-rag-default", "name": "RAG Agent"}, {"id": "aihub-agent-gone-old"}],
+                return_value=[
+                    {"id": "aihub-agent-rag-default", "name": "RAG Agent", "meta": _PROVISIONED_META},
+                    {"id": "aihub-agent-gone-old"},
+                ],
             ),
             patch.object(provisioner._openwebui, "create_model") as mock_create,
             patch.object(provisioner._openwebui, "delete_model") as mock_delete,
@@ -147,7 +212,7 @@ class TestSyncWorkspaceModels:
             patch.object(
                 provisioner._openwebui,
                 "list_models",
-                return_value=[{"id": "aihub-agent-rag-default", "name": "Old Name"}],
+                return_value=[{"id": "aihub-agent-rag-default", "name": "Old Name", "meta": _PROVISIONED_META}],
             ),
             patch.object(provisioner._openwebui, "create_model") as mock_create,
             patch.object(provisioner._openwebui, "update_model") as mock_update,
@@ -163,7 +228,8 @@ class TestSyncWorkspaceModels:
             assert update_data["name"] == "RAG Agent"
 
     @pytest.mark.asyncio
-    async def test_sync_does_not_update_when_name_unchanged(self, provisioner: OpenWebuiProvisioner) -> None:
+    async def test_sync_backfills_capabilities_on_existing_model(self, provisioner: OpenWebuiProvisioner) -> None:
+        """The name is untouched, so only the capability drift can pull this model into the update pass."""
         mock_client = AsyncMock(spec=httpx.AsyncClient)
 
         with (
@@ -171,6 +237,23 @@ class TestSyncWorkspaceModels:
                 provisioner._openwebui,
                 "list_models",
                 return_value=[{"id": "aihub-agent-rag-default", "name": "RAG Agent"}],
+            ),
+            patch.object(provisioner._openwebui, "update_model") as mock_update,
+        ):
+            await provisioner._sync_workspace_models(mock_client, [_RAG_AGENT])
+
+            mock_update.assert_called_once()
+            assert mock_update.call_args[0][1]["meta"]["capabilities"] == {"web_search": False}
+
+    @pytest.mark.asyncio
+    async def test_sync_does_not_update_when_name_unchanged(self, provisioner: OpenWebuiProvisioner) -> None:
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        with (
+            patch.object(
+                provisioner._openwebui,
+                "list_models",
+                return_value=[{"id": "aihub-agent-rag-default", "name": "RAG Agent", "meta": _PROVISIONED_META}],
             ),
             patch.object(provisioner._openwebui, "create_model") as mock_create,
             patch.object(provisioner._openwebui, "update_model") as mock_update,


### PR DESCRIPTION
Fixes bbvch-ai/aihub-core-private#126

## Problem

With a RAG agent selected, the **Web Search** toggle is offered but does nothing useful: OpenWebUI runs the search, then the agent answers "not found in the documents" anyway.

Three things line up to produce that:

1. OpenWebUI's `chat_web_search_handler` gates only on `features["web_search"]` — it never consults the model's capabilities, so the search runs.
2. With `BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL=true` the hits arrive as a `files` entry carrying **no file id**. `FileProcessingService._process_single_file` looks the id up via `Files.get_file_by_id()`, gets `None`, and drops the entry — the agent never receives a single result.
3. The RAG agent's `context_sufficient_guard_step` judges only the nodes retrieved from Milvus, so an empty retrieval rejects the turn regardless of what the web returned.

## Change

`OpenWebuiProvisioner` now pushes `meta.capabilities.web_search = false` on **agent** workspace models. OpenWebUI v0.9.5 hides the toggle when the selected model lacks that capability (`MessageInput.svelte` -> `showWebSearchButton`), so the button no longer appears for agents.

Plain LLM workspace models are untouched — they bypass the pipe and reach LiteLLM directly, where OpenWebUI's own web search works.

`_compute_model_diff` also had to learn about capability drift. It previously reconciled the display name only, so models provisioned before this change would have kept their stale `meta` forever; it now pulls a model into the update pass when a capability we manage differs. Capabilities we do not manage (an admin toggling `vision`, say) are ignored, so there is no update loop.

## Notes / limitations

- This is a **UI-level** gate, the same one OpenWebUI uses for `vision` and `file_upload`. The backend does not enforce it, so a client that posts `features.web_search` directly still triggers a search whose results are still dropped.
- A real web-search fallback for the RAG agent (search step in `packages/agent`, SearXNG client, config surface, ADR) is deliberately **not** in scope here — the issue's stated expectation is to disable the option.
- No ADR: this stays within `docs/arc42/decisions/2026_03_05_aihub_manages_openwebui_model_visibility.md` ("AI-Hub pushes model state to OpenWebUI, no OpenWebUI modification").
- The docs page claimed web search was a per-agent capability; corrected to say it applies to plain model chats. `index.de.md` still needs `pnpm run docs:translate`.

## Test plan

- [x] `pytest -m unit` in `packages/core` — 1640 passed (2 pre-existing failures in `test_milvus_vector_store_factory.py` need a live Milvus)
- [ ] Manual: agent selected in OpenWebUI -> no Web Search button; plain LLM model selected -> button still present
- [ ] Manual: an agent model provisioned before this change gets its capability back-filled on the next sync

## Demo


https://github.com/user-attachments/assets/ce60ce89-7ba1-4ea4-b2fa-2321f470be1b

