### PR TITLE
fix(deploy): Match the Playwright server image to the client OpenWebUI 0.11.3 ships

### DIFF
--- a/infra/deployment/Makefile
+++ b/infra/deployment/Makefile
@@ -47,14 +47,14 @@ build-and-push-open-terminal-image:
 # changes. After running, non-build stages pick up the new image automatically
 # via `docker compose pull`.
 build-and-push-playwright-image:
-	@echo "Building ghcr.io/bbvch-ai/aihub-core/playwright:v1.58.0-jammy..."
+	@echo "Building ghcr.io/bbvch-ai/aihub-core/playwright:v1.60.0-jammy..."
 	@docker login ghcr.io
 	@docker build \
-		-t ghcr.io/bbvch-ai/aihub-core/playwright:v1.58.0-jammy \
+		-t ghcr.io/bbvch-ai/aihub-core/playwright:v1.60.0-jammy \
 		-f docker/playwright/Dockerfile \
 		docker/playwright
-	@docker push ghcr.io/bbvch-ai/aihub-core/playwright:v1.58.0-jammy
-	@echo "Successfully published playwright:v1.58.0-jammy"
+	@docker push ghcr.io/bbvch-ai/aihub-core/playwright:v1.60.0-jammy
+	@echo "Successfully published playwright:v1.60.0-jammy"
 
 # Mirror an image from source to target
 # Usage: make mirror-image SOURCE=source/image:tag TARGET=target/image:tag

--- a/infra/deployment/compose-config.yml
+++ b/infra/deployment/compose-config.yml
@@ -47,7 +47,7 @@ image_tags:
   oauth2proxy: ghcr.io/bbvch-ai/bbvch-ai/oauth2-proxy:latest
   open_webui: open-webui:v0.11.3
   open_webui_init: postgres:17
-  playwright: playwright:v1.58.0-jammy
+  playwright: playwright:v1.60.0-jammy
   vllm: vllm-openai:v0.15.1
   speaches: speaches-ai/speaches:latest-cuda-12.6.3
   pgbouncer: pgbouncer:v1.24.1-p1

--- a/infra/docker-compose.build.gpu.yml
+++ b/infra/docker-compose.build.gpu.yml
@@ -1739,7 +1739,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   playwright:
     container_name: playwright-server
-    image: ghcr.io/bbvch-ai/aihub-core/playwright:v1.58.0-jammy
+    image: ghcr.io/bbvch-ai/aihub-core/playwright:v1.60.0-jammy
     restart: always
     ports: [3036:3000]
     environment:

--- a/infra/docker-compose.build.yml
+++ b/infra/docker-compose.build.yml
@@ -1556,7 +1556,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   playwright:
     container_name: playwright-server
-    image: ghcr.io/bbvch-ai/aihub-core/playwright:v1.58.0-jammy
+    image: ghcr.io/bbvch-ai/aihub-core/playwright:v1.60.0-jammy
     restart: always
     ports: [3036:3000]
     environment:

--- a/infra/docker-compose.dev.gpu.yml
+++ b/infra/docker-compose.dev.gpu.yml
@@ -1427,7 +1427,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   playwright:
     container_name: playwright-server
-    image: ghcr.io/bbvch-ai/aihub-core/playwright:v1.58.0-jammy
+    image: ghcr.io/bbvch-ai/aihub-core/playwright:v1.60.0-jammy
     restart: always
     ports: [3036:3000]
     environment:

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -1244,7 +1244,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   playwright:
     container_name: playwright-server
-    image: ghcr.io/bbvch-ai/aihub-core/playwright:v1.58.0-jammy
+    image: ghcr.io/bbvch-ai/aihub-core/playwright:v1.60.0-jammy
     restart: always
     ports: [3036:3000]
     environment:

--- a/infra/docker-compose.latest.gpu.yml
+++ b/infra/docker-compose.latest.gpu.yml
@@ -1701,7 +1701,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   playwright:
     container_name: playwright-server
-    image: ghcr.io/bbvch-ai/aihub-core/playwright:v1.58.0-jammy
+    image: ghcr.io/bbvch-ai/aihub-core/playwright:v1.60.0-jammy
     restart: always
     environment:
       NODE_ENV: production

--- a/infra/docker-compose.latest.yml
+++ b/infra/docker-compose.latest.yml
@@ -1522,7 +1522,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   playwright:
     container_name: playwright-server
-    image: ghcr.io/bbvch-ai/aihub-core/playwright:v1.58.0-jammy
+    image: ghcr.io/bbvch-ai/aihub-core/playwright:v1.60.0-jammy
     restart: always
     environment:
       NODE_ENV: production

--- a/infra/docker-compose.local.gpu.yml
+++ b/infra/docker-compose.local.gpu.yml
@@ -1732,7 +1732,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   playwright:
     container_name: playwright-server
-    image: ghcr.io/bbvch-ai/aihub-core/playwright:v1.58.0-jammy
+    image: ghcr.io/bbvch-ai/aihub-core/playwright:v1.60.0-jammy
     restart: always
     ports: [3036:3000]
     environment:

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -1549,7 +1549,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   playwright:
     container_name: playwright-server
-    image: ghcr.io/bbvch-ai/aihub-core/playwright:v1.58.0-jammy
+    image: ghcr.io/bbvch-ai/aihub-core/playwright:v1.60.0-jammy
     restart: always
     ports: [3036:3000]
     environment:

--- a/infra/docker-compose.nightly.gpu.yml
+++ b/infra/docker-compose.nightly.gpu.yml
@@ -1701,7 +1701,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   playwright:
     container_name: playwright-server
-    image: ghcr.io/bbvch-ai/aihub-core/playwright:v1.58.0-jammy
+    image: ghcr.io/bbvch-ai/aihub-core/playwright:v1.60.0-jammy
     restart: always
     environment:
       NODE_ENV: production

--- a/infra/docker-compose.nightly.yml
+++ b/infra/docker-compose.nightly.yml
@@ -1522,7 +1522,7 @@ services:
   # License: Apache-2.0 — third-party (see LICENSE_REPORT.md)
   playwright:
     container_name: playwright-server
-    image: ghcr.io/bbvch-ai/aihub-core/playwright:v1.58.0-jammy
+    image: ghcr.io/bbvch-ai/aihub-core/playwright:v1.60.0-jammy
     restart: always
     environment:
       NODE_ENV: production


### PR DESCRIPTION
closes https://github.com/bbvch-ai/aihub-core-private/issues/242
## Summary

OpenWebUI 0.11.3 bundles a Playwright client requiring server v1.60.0, but compose still pinned
the Playwright browser server at v1.58.0-jammy. Playwright enforces exact client/server version
matching, so every remote browser connection was refused at the WebSocket handshake — breaking
web page attachment and web search for every URL.

## Changes

- Bump `playwright` image tag in `compose-config.yml` from `v1.58.0-jammy` to `v1.60.0-jammy`,
  matching what OpenWebUI 0.11.3's `requirements.txt` pins (`playwright==1.60.0`) and what
  `docker/playwright/Dockerfile` already builds (bumped separately, previously unreferenced by
  any tag).
- Update the `build-and-push-playwright-image` Make target to build/tag/push `v1.60.0-jammy`
  instead of `v1.58.0-jammy`, so a future rebuild doesn't republish under the stale tag name.
- Regenerate all 10 stage compose variants via `make generate-compose`.

## Root cause

Reproduced locally by pointing an `open-webui:v0.11.3` container's Playwright client at a
`playwright:v1.58.0-jammy` server: the connection fails in ~60ms with an explicit version-mismatch
error before any page is requested, which is why the failure is identical and immediate for every
URL rather than site-specific:

