### PR TITLE
fix(rag): Reject knowledge-database configuration keys the ingestor did not announce

### DIFF
--- a/docs/docs/3_sdk/3_building_pipelines/index.en.md
+++ b/docs/docs/3_sdk/3_building_pipelines/index.en.md
@@ -130,9 +130,13 @@ If your pipeline never appears in the dialog, check in order: the code location 
 running in the Dagster UI, the row exists in the platform database, and the API can reach that same database.
 
 To add a setting of your own, extend `DocumentIngestionConfig` with a field such as `crawl_depth: int | InputNumber`,
-pass its `as_form()` to the factory as `config=`, and read it back per run in your ops. The class works the same way an
-agent's config does, so a nested section or a repeated entry needs no extra work. Full details, including the exact
-call, are in the
+give that field an element in your `as_form()` override, pass the result to the factory as `config=`, and read it back
+per run in your ops. The class works the same way an agent's config does, so a nested section or a repeated entry needs
+no extra work.
+
+Setting the field in `as_form()` is what announces it. A field declared on the class but left at a plain default is not
+part of the form, is not part of the schema, and a configuration that carries it is rejected with a 400 naming it —
+rather than being stored and silently ignored at ingestion time. Full details, including the exact call, are in the
 [package README](https://github.com/bbvch-ai/aihub-core/tree/main/packages/pipeline#making-a-custom-pipeline-selectable-in-the-ui).
 
 ## Next Steps

--- a/packages/api/playground/testing/tests/agent/test_instance_config_helper.py
+++ b/packages/api/playground/testing/tests/agent/test_instance_config_helper.py
@@ -12,6 +12,8 @@ import pytest
 from fastapi import HTTPException
 from pydantic import BaseModel
 from swiss_ai_hub.core.agents.agent_config import AgentConfig
+from swiss_ai_hub.core.form import FormkitElement, Group, InputText, Repeater
+from swiss_ai_hub.core.form.base.html_element import HtmlElement
 from swiss_ai_hub.core.processes.process_config import ProcessConfig
 from swiss_ai_hub.jambo import SchemaConverter
 
@@ -120,3 +122,68 @@ def test_config_without_identity_fields_is_left_alone():
         some_setting: str
 
     InstanceConfigHelper.validate_identity_locale_fields(Unrelated(some_setting="x"))
+
+
+class TestUndeclaredFields:
+    """The walk that holds a submission to the elements its owner announced (#1850).
+
+    Exercised directly rather than through a service, because the shapes that matter are the ones a
+    well-behaved frontend never produces: a group that arrived as the wrong type, a repeater whose
+    entries are not objects, a decorative element carrying no name at all.
+    """
+
+    @staticmethod
+    def _elements() -> list[FormkitElement]:
+        return [
+            InputText(name="title", label="Title"),
+            HtmlElement(el="h2", children="Section"),
+            Group(name="enrichment", children=[InputText(name="model", label="Model")]),
+            Repeater(name="sources", children=[InputText(name="model", label="Model")]),
+        ]
+
+    @staticmethod
+    def _reject(config: dict) -> str:
+        with pytest.raises(HTTPException) as exc_info:
+            InstanceConfigHelper.reject_undeclared_fields(TestUndeclaredFields._elements(), config)
+        assert exc_info.value.status_code == 400
+        return exc_info.value.detail
+
+    def test_a_configuration_of_only_announced_fields_is_accepted(self):
+        InstanceConfigHelper.reject_undeclared_fields(
+            self._elements(),
+            {"title": "t", "enrichment": {"model": "m"}, "sources": [{"model": "m"}]},
+        )
+
+    def test_a_disabled_nullable_group_is_not_walked(self):
+        """A cleared sub-form submits `null`; there is nothing to hold to the announced children."""
+        InstanceConfigHelper.reject_undeclared_fields(self._elements(), {"enrichment": None, "sources": []})
+
+    def test_a_group_of_the_wrong_type_is_left_to_the_model_validator(self):
+        """`validate_config_for_create` already names it; reporting it twice would say two different things."""
+        InstanceConfigHelper.reject_undeclared_fields(self._elements(), {"enrichment": "not-an-object"})
+
+    def test_repeater_entries_that_are_not_objects_are_left_to_the_model_validator(self):
+        InstanceConfigHelper.reject_undeclared_fields(self._elements(), {"sources": ["not-an-object", 3]})
+
+    def test_an_element_without_a_name_declares_nothing_and_matches_nothing(self):
+        """A decorative element carries no name, so it must neither declare a key nor crash the walk."""
+        assert "bogus" in self._reject({"bogus": 1})
+
+    def test_a_formkit_bookkeeping_key_is_ignored_at_every_depth(self):
+        """`normalize_form_configuration` only strips these at the top level."""
+        InstanceConfigHelper.reject_undeclared_fields(
+            self._elements(),
+            {"_form_name": "X", "enrichment": {"model": "m", "__enabled": True}},
+        )
+
+    def test_every_offending_path_is_reported_in_one_exception(self):
+        detail = self._reject(
+            {
+                "bogus": 1,
+                "enrichment": {"model": "m", "deep": 2},
+                "sources": [{"model": "m"}, {"model": "m", "deeper": 3}],
+            }
+        )
+        assert "bogus" in detail
+        assert "enrichment.deep" in detail
+        assert "sources.1.deeper" in detail

--- a/packages/api/playground/testing/tests/knowledge/test_knowledge_create_database_service_unit_tests.py
+++ b/packages/api/playground/testing/tests/knowledge/test_knowledge_create_database_service_unit_tests.py
@@ -5,7 +5,7 @@ import pytest
 from fastapi import HTTPException
 from mongoengine import DoesNotExist, NotUniqueError
 from pydantic import Field
-from swiss_ai_hub.core.form import Checkbox, Form, ModelSelect
+from swiss_ai_hub.core.form import Checkbox, Form, InputNumber, ModelSelect
 from swiss_ai_hub.core.i18n import LocaleString
 from swiss_ai_hub.core.ingestors import IngestorConfig
 from swiss_ai_hub.core.persistence import ConfigSpecsEntity
@@ -43,7 +43,7 @@ class _RagConfig(IngestorConfig):
 class _CrawlConfig(IngestorConfig):
     """A second, differently shaped ingestor."""
 
-    crawl_depth: Annotated[int, Field(description="Depth")] = 2
+    crawl_depth: Annotated[int | InputNumber, Field(description="Depth")] = 2
     llm_model: Annotated[str | ModelSelect, Field(description="Text model")]
 
     @classmethod
@@ -52,6 +52,7 @@ class _CrawlConfig(IngestorConfig):
         return cls(
             name=base.name,
             description=base.description,
+            crawl_depth=InputNumber(label=LocaleString(en="Depth"), value=2),
             llm_model=ModelSelect(label=LocaleString(en="Text"), mode="chat"),
         )
 
@@ -350,6 +351,142 @@ class TestAnnouncedConfiguration:
         assert bucket_cls.create_bucket.call_args.kwargs["configuration"]["crawl_depth"] == 5
         assert exc_info.value.status_code == 400
         assert "embedding_model" in exc_info.value.detail
+
+
+class TestUndeclaredConfiguration:
+    """A submission is held to the fields the ingestor announced, not merely to the ones it declared types for.
+
+    #1822 promised a configuration that does not match its ingestor's form is refused by name. Mismatching a
+    *declared* field was already caught; a field the form never announced was accepted, stored and then ignored
+    at ingestion time (#1850).
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_typo_on_an_optional_knob_is_rejected_naming_it(self, locale_handler, s3_service):
+        """The reproduction from #1850: the misspelling is silent, so nothing else would ever surface it."""
+        with patch(f"{_SERVICE_MODULE}.BucketEntity") as bucket_cls:
+            bucket_cls.get_bucket_by_bucket_name.side_effect = DoesNotExist
+
+            with pytest.raises(HTTPException) as exc_info:
+                await KnowledgeService.create_database(
+                    DATABASE, _rag_request(with_summarys=True), locale_handler, s3_service, _user()
+                )
+
+        assert exc_info.value.status_code == 400
+        assert "with_summarys" in exc_info.value.detail
+        bucket_cls.create_bucket.assert_not_called()
+        s3_service.ensure_bucket_with_cors.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_knob_another_ingestor_announces_is_undeclared_here(self, locale_handler, s3_service):
+        """Otherwise complete, so the rejection can only come from the foreign key itself."""
+        with patch(f"{_SERVICE_MODULE}.BucketEntity") as bucket_cls:
+            bucket_cls.get_bucket_by_bucket_name.side_effect = DoesNotExist
+
+            with pytest.raises(HTTPException) as exc_info:
+                await KnowledgeService.create_database(
+                    DATABASE, _rag_request(crawl_depth=5), locale_handler, s3_service, _user()
+                )
+
+        assert exc_info.value.status_code == 400
+        assert "crawl_depth" in exc_info.value.detail
+        bucket_cls.create_bucket.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_an_omitted_optional_knob_is_still_accepted_and_stays_out_of_the_row(
+        self, locale_handler, s3_service
+    ):
+        """The database must fall back to the deployment default, which it can only do if nothing is stored."""
+        with patch(f"{_SERVICE_MODULE}.BucketEntity") as bucket_cls:
+            bucket_cls.get_bucket_by_bucket_name.side_effect = DoesNotExist
+            bucket_cls.create_bucket.return_value = _created_bucket()
+
+            await KnowledgeService.create_database(DATABASE, _rag_request(), locale_handler, s3_service, _user())
+
+        assert bucket_cls.create_bucket.call_args.kwargs["configuration"] == {"embedding_model": "embedding/default"}
+
+    @pytest.mark.asyncio
+    async def test_an_undeclared_key_inside_a_group_or_a_repeater_is_named_by_its_path(
+        self, locale_handler, s3_service
+    ):
+        """A typo one level down is exactly as silent as one at the top, so the walk must reach it."""
+        identity = {"name": {"en": "Nested"}, "description": {"en": "x"}}
+        in_group = {**identity, "enrichment": {"model": "text-generation/pick", "bogus": 1}, "sources": []}
+        in_repeater = {
+            **identity,
+            "enrichment": {"model": "text-generation/pick"},
+            "sources": [{"model": "embedding/pick", "bogus": 1}],
+        }
+        with patch(f"{_SERVICE_MODULE}.BucketEntity") as bucket_cls:
+            bucket_cls.get_bucket_by_bucket_name.side_effect = DoesNotExist
+
+            with pytest.raises(HTTPException) as group_error:
+                await KnowledgeService.create_database(
+                    "nested",
+                    CreateDatabaseRequest(ingestor="nested", configuration=in_group),
+                    locale_handler,
+                    s3_service,
+                    _user(),
+                )
+            with pytest.raises(HTTPException) as repeater_error:
+                await KnowledgeService.create_database(
+                    "nested",
+                    CreateDatabaseRequest(ingestor="nested", configuration=in_repeater),
+                    locale_handler,
+                    s3_service,
+                    _user(),
+                )
+
+        assert "enrichment.bogus" in group_error.value.detail
+        assert "sources.0.bogus" in repeater_error.value.detail
+        bucket_cls.create_bucket.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_every_offending_field_is_named_in_one_rejection(self, locale_handler, s3_service):
+        """Naming one at a time would cost the admin a round trip per typo."""
+        with patch(f"{_SERVICE_MODULE}.BucketEntity") as bucket_cls:
+            bucket_cls.get_bucket_by_bucket_name.side_effect = DoesNotExist
+
+            with pytest.raises(HTTPException) as exc_info:
+                await KnowledgeService.create_database(
+                    DATABASE,
+                    _rag_request(with_summarys=True, embeding_model="embedding/default"),
+                    locale_handler,
+                    s3_service,
+                    _user(),
+                )
+
+        assert "with_summarys" in exc_info.value.detail
+        assert "embeding_model" in exc_info.value.detail
+
+
+class TestStoredConfigurationIsCanonical:
+    """What is stored is the validated configuration, not the submission that produced it."""
+
+    @pytest.mark.asyncio
+    async def test_a_knob_is_stored_in_the_type_its_pipeline_declared(self, locale_handler, s3_service):
+        """A row that says `"5"` where the pipeline declared an int reads as deliberate and is not."""
+        with patch(f"{_SERVICE_MODULE}.BucketEntity") as bucket_cls:
+            bucket_cls.get_bucket_by_bucket_name.side_effect = DoesNotExist
+            bucket_cls.create_bucket.return_value = _created_bucket(ingestor="crawler")
+
+            await KnowledgeService.create_database(
+                "sites",
+                CreateDatabaseRequest(
+                    ingestor="crawler",
+                    configuration={
+                        "name": {"en": "Sites"},
+                        "description": {"en": "Crawled"},
+                        "crawl_depth": "5",
+                        "llm_model": "text-generation/pick",
+                    },
+                ),
+                locale_handler,
+                s3_service,
+                _user(),
+            )
+
+        assert bucket_cls.create_bucket.call_args.kwargs["configuration"]["crawl_depth"] == 5
 
 
 class TestModelSelection:

--- a/packages/api/playground/testing/tests/knowledge/test_knowledge_create_database_service_unit_tests.py
+++ b/packages/api/playground/testing/tests/knowledge/test_knowledge_create_database_service_unit_tests.py
@@ -5,7 +5,7 @@ import pytest
 from fastapi import HTTPException
 from mongoengine import DoesNotExist, NotUniqueError
 from pydantic import Field
-from swiss_ai_hub.core.form import Checkbox, Form, InputNumber, ModelSelect
+from swiss_ai_hub.core.form import Checkbox, ConfigSpecs, Form, InputNumber, ModelSelect
 from swiss_ai_hub.core.i18n import LocaleString
 from swiss_ai_hub.core.ingestors import IngestorConfig
 from swiss_ai_hub.core.persistence import ConfigSpecsEntity
@@ -105,11 +105,15 @@ NESTED = _ingestor("nested", _NestedConfig.as_form())
 def registered_ingestors():
     """The entity is Mongo-backed; stub it with two differently shaped ingestors so these tests need no database."""
     labels_only = MagicMock(form=[], config_specs=None)
+    # A row whose schema is present but empty: a pipeline that built its `Ingestor` by hand rather than
+    # through `from_config`, so `config_specs` defaults to a schema jambo cannot build a model from.
+    schema_without_form = MagicMock(form=[], config_specs=ConfigSpecsEntity.from_specs(ConfigSpecs()))
     rows = {
         RAG.id: _registered(RAG),
         CRAWLER.id: _registered(CRAWLER),
         NESTED.id: _registered(NESTED),
         "stale": labels_only,
+        "formless": schema_without_form,
     }
     with patch(f"{_SERVICE_MODULE}.IngestorEntity") as ingestor_entity:
         ingestor_entity.find.side_effect = lambda ingestor_id: rows.get(ingestor_id)
@@ -597,6 +601,27 @@ class TestAnnouncedFormIsRequired:
             accessible_tenant_ids=set(),
             t=MagicMock(),
         )
+
+
+class TestFormlessIngestorIsRejected:
+    """An empty announced form is no more usable than a missing one, and must not reach the model builder."""
+
+    @pytest.mark.asyncio
+    async def test_an_ingestor_whose_form_is_empty_is_rejected_not_served_a_500(self, locale_handler, s3_service):
+        """jambo raises on the title-less schema such a row carries, and every key would be undeclared anyway."""
+        with patch(f"{_SERVICE_MODULE}.BucketEntity") as bucket_cls:
+            with pytest.raises(HTTPException) as exc_info:
+                await KnowledgeService.create_database(
+                    DATABASE,
+                    CreateDatabaseRequest(ingestor="formless", configuration={"name": {"en": "X"}}),
+                    locale_handler,
+                    s3_service,
+                    _user(),
+                )
+
+        assert exc_info.value.status_code == 400
+        assert "no running pipeline has announced it" in exc_info.value.detail
+        bucket_cls.create_bucket.assert_not_called()
 
 
 class TestCreateDatabaseNameValidation:

--- a/packages/api/playground/testing/tests/knowledge/test_knowledge_create_database_service_unit_tests.py
+++ b/packages/api/playground/testing/tests/knowledge/test_knowledge_create_database_service_unit_tests.py
@@ -354,7 +354,7 @@ class TestAnnouncedConfiguration:
 
         assert bucket_cls.create_bucket.call_args.kwargs["configuration"]["crawl_depth"] == 5
         assert exc_info.value.status_code == 400
-        assert "embedding_model" in exc_info.value.detail
+        assert "crawl_depth" in exc_info.value.detail
 
 
 class TestUndeclaredConfiguration:
@@ -380,6 +380,35 @@ class TestUndeclaredConfiguration:
         assert "with_summarys" in exc_info.value.detail
         bucket_cls.create_bucket.assert_not_called()
         s3_service.ensure_bucket_with_cors.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_misspelled_required_knob_is_named_as_the_typo_not_as_a_missing_field(
+        self, locale_handler, s3_service
+    ):
+        """The model drops the typo and reports the correct name as missing, which hides what the user typed.
+
+        Naming `embedding_model: Field required` describes the consequence; the mistake is `embeding_model`,
+        and only that message tells the user their value went nowhere.
+        """
+        configuration = {
+            "name": {"en": "Research Docs"},
+            "description": {"en": "Papers"},
+            "embeding_model": "embedding/default",
+        }
+        with patch(f"{_SERVICE_MODULE}.BucketEntity") as bucket_cls:
+            bucket_cls.get_bucket_by_bucket_name.side_effect = DoesNotExist
+
+            with pytest.raises(HTTPException) as exc_info:
+                await KnowledgeService.create_database(
+                    DATABASE,
+                    CreateDatabaseRequest(ingestor=RAG.id, configuration=configuration),
+                    locale_handler,
+                    s3_service,
+                    _user(),
+                )
+
+        assert "embeding_model" in exc_info.value.detail
+        bucket_cls.create_bucket.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_a_knob_another_ingestor_announces_is_undeclared_here(self, locale_handler, s3_service):

--- a/packages/api/playground/testing/tests/services/test_model_creation.py
+++ b/packages/api/playground/testing/tests/services/test_model_creation.py
@@ -1,12 +1,24 @@
+from datetime import datetime
+from enum import Enum
 from types import UnionType
-from typing import Union, get_args, get_origin
+from typing import Annotated, Union, get_args, get_origin
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from swiss_ai_hub.core.agents import AgentConfig, WorkflowGraph
 from swiss_ai_hub.core.events import BaseEvent, EventSpecs
 from swiss_ai_hub.core.events.agent import AgentClassDiscoveryResponseEvent
-from swiss_ai_hub.core.form import ConfigSpecs
+from swiss_ai_hub.core.form import (
+    ChipsInput,
+    ConfigSpecs,
+    DatePicker,
+    Form,
+    InputNumber,
+    ModelSelect,
+    Select,
+    Slider,
+    Textarea,
+)
 from swiss_ai_hub.core.i18n import LocaleString
 
 from playground.testing.tests.services.TestEvent import Level2Model, Level3Model, NestedTestModel, TestEvent
@@ -750,3 +762,99 @@ class TestSchemaValidation:
         reserialized_data = final_event.model_dump()
         final_deserialized = BaseEvent.deserialize_event(reserialized_data)
         assert final_deserialized._parent_event_names == ["TestEvent"]
+
+
+class TestConfigRoundTrip:
+    """A validated configuration must dump back to what was submitted, for every announceable shape.
+
+    `KnowledgeService.create_database` stores the dump rather than the submission, so that a knob is
+    persisted in the type its pipeline declared. That is only safe while jambo reproduces each shape
+    faithfully — a gap here would silently rewrite an admin's choice, which is the very defect (#1850)
+    the storing-the-dump change was part of fixing. Pinned per element type so a jambo upgrade that
+    loses one says which.
+    """
+
+    class _Mode(str, Enum):
+        FAST = "fast"
+        DEEP = "deep"
+
+    class _Section(Form):
+        model: Annotated[str | ModelSelect, Field(description="Nested picker")]
+        depth: Annotated[int | InputNumber | None, Field(description="Nested number")] = None
+
+    class _Source(Form):
+        model: Annotated[str | ModelSelect, Field(description="Repeated picker")]
+
+    class _EveryShapeConfig(AgentConfig):
+        tags: Annotated[list[str] | ChipsInput, Field(description="Chips")] = []
+        since: Annotated[datetime | DatePicker | None, Field(description="Date")] = None
+        mode: Annotated["TestConfigRoundTrip._Mode | Select | None", Field(description="Enum")] = None
+        ratio: Annotated[float | Slider | None, Field(description="Slider")] = None
+        prompt: Annotated[LocaleString | Textarea | None, Field(description="Locale text")] = None
+        llm_model: Annotated[str | ModelSelect, Field(description="Picker")] = ""
+        section: Annotated["TestConfigRoundTrip._Section | None", Field(description="Group")] = None
+        sources: Annotated[list["TestConfigRoundTrip._Source"], Field(description="Repeater")] = []
+
+        @classmethod
+        def as_form(cls) -> "TestConfigRoundTrip._EveryShapeConfig":
+            base = AgentConfig.as_form()
+            label = LocaleString(en="x")
+            return cls(
+                **dict(base),
+                tags=ChipsInput(label=label),
+                since=DatePicker(label=label),
+                mode=Select(label=label, options=[]),
+                ratio=Slider(label=label),
+                prompt=Textarea(label=label),
+                llm_model=ModelSelect(label=label, mode="chat"),
+                section=TestConfigRoundTrip._Section(
+                    model=ModelSelect(label=label, mode="chat"), depth=InputNumber(label=label)
+                ),
+                sources=[TestConfigRoundTrip._Source(model=ModelSelect(label=label, mode="embedding"))],
+            )
+
+    SUBMISSION = {
+        "tags": ["a", "b"],
+        "since": "2026-01-15T00:00:00",
+        "mode": "deep",
+        "ratio": 0.75,
+        "prompt": {"en": "hi", "de": "hallo"},
+        "llm_model": "text-generation/pick",
+        "section": {"model": "text-generation/pick", "depth": 3},
+        "sources": [{"model": "embedding/pick"}, {"model": "embedding/other"}],
+    }
+
+    @pytest.fixture
+    def dumped(self) -> dict:
+        specs = ConfigSpecs.from_form(self._EveryShapeConfig.as_form(), "EveryShapeConfig")
+        model = ModelCreationService.create_config_model(specs)
+        submitted = {"agent_id": "a", "name": {"en": "n"}, "description": {"en": "d"}, **self.SUBMISSION}
+        return model.model_validate(submitted).model_dump(mode="json", exclude_unset=True)
+
+    @pytest.mark.parametrize("field", sorted(SUBMISSION))
+    def test_an_announced_value_survives_the_round_trip_unchanged(self, field, dumped):
+        assert dumped[field] == self.SUBMISSION[field]
+
+    def test_an_omitted_optional_stays_absent_so_it_cannot_shadow_a_default(self, dumped):
+        """Dumping it as `null` would store a choice the user never made, over the deployment's own default."""
+        specs = ConfigSpecs.from_form(self._EveryShapeConfig.as_form(), "EveryShapeConfig")
+        model = ModelCreationService.create_config_model(specs)
+        minimal = {"agent_id": "a", "name": {"en": "n"}, "description": {"en": "d"}}
+
+        dump = model.model_validate(minimal).model_dump(mode="json", exclude_unset=True)
+
+        assert set(dump) == set(minimal)
+
+    def test_an_omitted_optional_inside_a_group_stays_absent_too(self):
+        specs = ConfigSpecs.from_form(self._EveryShapeConfig.as_form(), "EveryShapeConfig")
+        model = ModelCreationService.create_config_model(specs)
+        submitted = {
+            "agent_id": "a",
+            "name": {"en": "n"},
+            "description": {"en": "d"},
+            "section": {"model": "text-generation/pick"},
+        }
+
+        dump = model.model_validate(submitted).model_dump(mode="json", exclude_unset=True)
+
+        assert dump["section"] == {"model": "text-generation/pick"}

--- a/packages/api/playground/testing/tests/services/test_model_creation.py
+++ b/packages/api/playground/testing/tests/services/test_model_creation.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from types import UnionType
 from typing import Annotated, Union, get_args, get_origin
 
@@ -774,7 +774,7 @@ class TestConfigRoundTrip:
     loses one says which.
     """
 
-    class _Mode(str, Enum):
+    class _Mode(StrEnum):
         FAST = "fast"
         DEEP = "deep"
 

--- a/packages/api/swiss_ai_hub/api/routes/knowledge/knowledge_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/knowledge/knowledge_service.py
@@ -471,8 +471,11 @@ class KnowledgeService:
         form_elements = ingestor.form_elements
         config = InstanceConfigHelper.normalize_form_configuration(request.configuration)
         config_model = ModelCreationService.create_config_model(ingestor.config_specs.to_specs())
-        config_instance = InstanceConfigHelper.validate_config_for_create(config, config_model)
+        # Before the model validation, so a misspelled key is named as itself. The generated model drops an
+        # unrecognised key and then reports the correctly-spelled one as missing, which names the consequence
+        # rather than the mistake and says nothing about the value the user actually typed.
         InstanceConfigHelper.reject_undeclared_fields(form_elements, config)
+        config_instance = InstanceConfigHelper.validate_config_for_create(config, config_model)
         await ConfigAuthorizationService.validate_for_user_or_raise(
             form_elements=ingestor.form, config=config, user=user, t=t
         )

--- a/packages/api/swiss_ai_hub/api/routes/knowledge/knowledge_service.py
+++ b/packages/api/swiss_ai_hub/api/routes/knowledge/knowledge_service.py
@@ -444,7 +444,7 @@ class KnowledgeService:
             raise HTTPException(status_code=400, detail=str(invalid_name)) from None
 
         ingestor = IngestorEntity.find(request.ingestor)
-        if ingestor is None or ingestor.config_specs is None:
+        if ingestor is None or ingestor.config_specs is None or not ingestor.form:
             raise HTTPException(
                 status_code=400,
                 detail=(
@@ -468,18 +468,25 @@ class KnowledgeService:
                 ),
             )
 
+        form_elements = ingestor.form_elements
         config = InstanceConfigHelper.normalize_form_configuration(request.configuration)
         config_model = ModelCreationService.create_config_model(ingestor.config_specs.to_specs())
         config_instance = InstanceConfigHelper.validate_config_for_create(config, config_model)
+        InstanceConfigHelper.reject_undeclared_fields(form_elements, config)
         await ConfigAuthorizationService.validate_for_user_or_raise(
             form_elements=ingestor.form, config=config, user=user, t=t
         )
-        await KnowledgeService._validate_model_selections(ingestor.form_elements, config, user)
+        await KnowledgeService._validate_model_selections(form_elements, config, user)
 
         metadata = InstanceConfigHelper.extract_config_metadata(config_instance, fallback_icon="")
         locale = InstanceConfigHelper.build_locale_entities(metadata.name, metadata.description, database, "")
+        # Dumped from the validated instance rather than copied from the submission, so a knob is stored in the
+        # type its pipeline declared. `exclude_unset` keeps that to the keys the user actually sent: an omitted
+        # optional must stay absent, or it would override the deployment default the pipeline falls back to.
         configuration = {
-            key: value for key, value in config.items() if key not in InstanceConfigHelper.IDENTITY_LOCALE_FIELDS
+            key: value
+            for key, value in config_instance.model_dump(mode="json", exclude_unset=True).items()
+            if key not in InstanceConfigHelper.IDENTITY_LOCALE_FIELDS
         }
 
         # Persist the entity before provisioning storage: the unique bucket_name index serialises

--- a/packages/api/swiss_ai_hub/api/util/instance_config_helper.py
+++ b/packages/api/swiss_ai_hub/api/util/instance_config_helper.py
@@ -3,7 +3,13 @@ from typing import Any, NamedTuple, TypeVar
 from fastapi import HTTPException
 from pydantic import BaseModel, ValidationError
 from swiss_ai_hub.core.agents import CRON_CONFIG_KEY
-from swiss_ai_hub.core.form import normalize_empty_locale_strings, normalize_empty_objects_to_none
+from swiss_ai_hub.core.form import (
+    FormkitElement,
+    Group,
+    Repeater,
+    normalize_empty_locale_strings,
+    normalize_empty_objects_to_none,
+)
 from swiss_ai_hub.core.i18n import LOCALES, LocaleString
 from swiss_ai_hub.core.persistence import AgentInstanceRef
 from swiss_ai_hub.core.persistence.i18n.locale_string_entity import LocaleStringEntity
@@ -77,6 +83,55 @@ class InstanceConfigHelper:
         InstanceConfigHelper.validate_identity_locale_fields(instance)
         InstanceConfigHelper.validate_cron_field(config, agent)
         return instance
+
+    @staticmethod
+    def reject_undeclared_fields(elements: list[FormkitElement], config: dict[str, Any]) -> None:
+        """Reject a submission carrying a field the announced form never declared.
+
+        The generated model cannot do this: jambo builds it with Pydantic's default `extra="ignore"`, so an
+        unrecognised key validates and is dropped rather than refused — and the caller stores what was
+        submitted, so a mistyped knob is persisted and then silently ignored by whoever reads it back.
+
+        Checked against the announced elements rather than the announced schema, because the two disagree on
+        exactly the shapes that matter. `name` and `description` are `$ref` objects in the schema but leaf
+        elements on the form, so a schema walk would descend into a `LocaleString` and reject its locale keys;
+        and only the schema needs `$ref`/`anyOf`/`items` resolution to reach a nested section at all.
+        """
+        undeclared = InstanceConfigHelper._undeclared_fields(elements, config, prefix="")
+        if not undeclared:
+            return
+
+        raise HTTPException(status_code=400, detail=f"Configuration validation failed: {'; '.join(undeclared)}")
+
+    @staticmethod
+    def _undeclared_fields(elements: list[FormkitElement], config: dict[str, Any], prefix: str) -> list[str]:
+        """Every config path with no element of that name, deepest-last, as `field`, `group.field`,
+        `repeater.0.field`."""
+        declared = {name for element in elements if (name := getattr(element, "name", None))}
+        # `normalize_form_configuration` strips FormKit's own keys only at the top level, and making it
+        # recursive would change what the agent and process paths persist — `Form.deserialize_form` dispatches
+        # on a nested `_form_name`. So the same convention is applied locally, at every depth.
+        undeclared = [
+            f"{prefix}{key}: not a configurable field of the announced form"
+            for key in config
+            if key not in declared and not key.startswith("_")
+        ]
+
+        for element in elements:
+            name = getattr(element, "name", None)
+            if not name:
+                continue
+            value = config.get(name)
+            if isinstance(element, Group) and isinstance(value, dict):
+                undeclared.extend(InstanceConfigHelper._undeclared_fields(element.children, value, f"{prefix}{name}."))
+            elif isinstance(element, Repeater) and isinstance(value, list):
+                for index, entry in enumerate(value):
+                    if isinstance(entry, dict):
+                        undeclared.extend(
+                            InstanceConfigHelper._undeclared_fields(element.children, entry, f"{prefix}{name}.{index}.")
+                        )
+
+        return undeclared
 
     @staticmethod
     def validate_cron_field(config: dict[str, Any], agent: AgentInstanceRef | None = None) -> None:

--- a/packages/api/swiss_ai_hub/api/util/instance_config_helper.py
+++ b/packages/api/swiss_ai_hub/api/util/instance_config_helper.py
@@ -92,10 +92,14 @@ class InstanceConfigHelper:
         unrecognised key validates and is dropped rather than refused — and the caller stores what was
         submitted, so a mistyped knob is persisted and then silently ignored by whoever reads it back.
 
-        Checked against the announced elements rather than the announced schema, because the two disagree on
-        exactly the shapes that matter. `name` and `description` are `$ref` objects in the schema but leaf
-        elements on the form, so a schema walk would descend into a `LocaleString` and reject its locale keys;
-        and only the schema needs `$ref`/`anyOf`/`items` resolution to reach a nested section at all.
+        Checked against the announced elements rather than by forbidding extras on the generated model, which
+        does work: jambo ignores `additionalProperties`, so the submission schema cannot carry the rule, but
+        mutating each built model's `extra` and rebuilding does reject the same keys with better error
+        locations. It is declined on scope and coupling. `create_config_model` is shared with the agent and
+        process paths, where an unannounced key is legitimate — `AgentConfig.cron` is deliberately absent from
+        the form and injected only for schedulable classes — so forbidding extras would change those surfaces
+        blind. And the rebuild is only correct while jambo's ref cache happens to hold children before parents,
+        which it does not promise.
         """
         undeclared = InstanceConfigHelper._undeclared_fields(elements, config, prefix="")
         if not undeclared:

--- a/packages/api/swiss_ai_hub/api/util/instance_config_helper.py
+++ b/packages/api/swiss_ai_hub/api/util/instance_config_helper.py
@@ -119,18 +119,33 @@ class InstanceConfigHelper:
 
         for element in elements:
             name = getattr(element, "name", None)
-            if not name:
-                continue
-            value = config.get(name)
-            if isinstance(element, Group) and isinstance(value, dict):
-                undeclared.extend(InstanceConfigHelper._undeclared_fields(element.children, value, f"{prefix}{name}."))
-            elif isinstance(element, Repeater) and isinstance(value, list):
-                for index, entry in enumerate(value):
-                    if isinstance(entry, dict):
-                        undeclared.extend(
-                            InstanceConfigHelper._undeclared_fields(element.children, entry, f"{prefix}{name}.{index}.")
-                        )
+            if name:
+                undeclared.extend(
+                    InstanceConfigHelper._undeclared_in_element(element, config.get(name), f"{prefix}{name}")
+                )
 
+        return undeclared
+
+    @staticmethod
+    def _undeclared_in_element(element: FormkitElement, value: Any, field_path: str) -> list[str]:
+        """One element of an announced form: a container to walk into, or a leaf whose value is opaque.
+
+        Only a group and a repeater put a caller-supplied key space underneath them; anything a leaf holds is
+        that element's own value, and descending into it would start rejecting the keys of a `LocaleString`.
+        """
+        if isinstance(element, Group) and isinstance(value, dict):
+            return InstanceConfigHelper._undeclared_fields(element.children, value, f"{field_path}.")
+        if isinstance(element, Repeater) and isinstance(value, list):
+            return InstanceConfigHelper._undeclared_in_entries(element.children, value, field_path)
+        return []
+
+    @staticmethod
+    def _undeclared_in_entries(children: list[FormkitElement], entries: list[Any], field_path: str) -> list[str]:
+        """Each repeated entry against the same announced children, indexed so a rejection names the row."""
+        undeclared: list[str] = []
+        for index, entry in enumerate(entries):
+            if isinstance(entry, dict):
+                undeclared.extend(InstanceConfigHelper._undeclared_fields(children, entry, f"{field_path}.{index}."))
         return undeclared
 
     @staticmethod

--- a/packages/pipeline/CLAUDE.md
+++ b/packages/pipeline/CLAUDE.md
@@ -160,9 +160,9 @@ to the instance. That is what lets a second pipeline *type* be deployed alongsid
 `settings` is a `DocumentIngestionPipelineSettings` (`DOCUMENT_INGESTION_*`, read from the environment when omitted)
 carrying the text, embedding and vision models, the three enrichment flags and the observation schedule. The models and
 enrichment flags are **deployment defaults**, not the graph's shape: they pre-fill the form the pipeline announces, and
-are what a database that stores no value of its own falls back to at run time. The asset graph is
-identical for every database (`summary_nodes` always exists, and table refinement and figure descriptions are always in
-the `documents` graph), and each enrichment op decides per run from the bucket's configuration whether it has work.
+are what a database that stores no value of its own falls back to at run time. The asset graph is identical for every
+database (`summary_nodes` always exists, and table refinement and figure descriptions are always in the `documents`
+graph), and each enrichment op decides per run from the bucket's configuration whether it has work.
 
 Every pipeline built here registers itself: a sensor upserts an `IngestorEntity` carrying labels, form and schema, so
 the API's `GET /knowledge/ingestors` can offer it in the create-database dialog and validate what users submit. See
@@ -223,9 +223,11 @@ the whole code location down at load; this way it re-registers on the next tick 
 **What the API does with it.** `GET /knowledge/ingestors` returns every announced row with labels and form localized.
 `create_database` looks the ingestor up, builds a validator from its announced schema, rejects a mismatch with a 400
 naming the offending field, walks the announced elements for authorization, and checks every announced model picker
-against LiteLLM (mode, tenant access, and a declared `output_vector_size` for embedding pickers). The identity fields
-land on the bucket row and everything else in `BucketEntity.configuration`. The `ingestor` field is a plain `str` across
-the API boundary, not the `IngestorType` enum, so a deployment-defined value is representable on the wire.
+against LiteLLM (mode, tenant access, and a declared `output_vector_size` for embedding pickers). A field the form never
+announced is refused the same way, so a mistyped knob cannot be stored and then silently ignored per run. The identity
+fields land on the bucket row and everything the form announced in `BucketEntity.configuration`, dumped from the
+validated configuration so each knob is stored in the type its pipeline declared. The `ingestor` field is a plain `str`
+across the API boundary, not the `IngestorType` enum, so a deployment-defined value is representable on the wire.
 
 **The shipped pipeline is not special.** `document_ingestion` registers through the same sensor, with labels from
 `lib.ingestors.document_ingestion.*`. The API has no built-in ingestor and offers nothing until a pipeline is running. A

--- a/packages/pipeline/README.md
+++ b/packages/pipeline/README.md
@@ -114,9 +114,9 @@ markdown but is not yet retrievable, so it stays pending until then.
 
 Materialization is driven by eager automation, daily schedules, and a NATS sensor that fires when documents are uploaded
 through the API — so ingestion keeps up with changes without manual runs. Key
-`document_ingestion_pipeline_definitions()` settings: the per-database defaults `settings` carries (the text,
-embedding and vision models, the three enrichment switches and the observation schedule), plus
-`document_parser_loader_type` (MinerU or Document Intelligence) and `max_partitions`.
+`document_ingestion_pipeline_definitions()` settings: the per-database defaults `settings` carries (the text, embedding
+and vision models, the three enrichment switches and the observation schedule), plus `document_parser_loader_type`
+(MinerU or Document Intelligence) and `max_partitions`.
 
 ______________________________________________________________________
 
@@ -287,6 +287,11 @@ defs = document_ingestion_pipeline_definitions(
 `crawl_depth` now appears in the create dialog, is validated by the API and is stored on the database. Your ops read it
 per run with `ingestor_config_for_bucket(bucket, AcmeConfig).crawl_depth`, the same call that resolves the models and
 enrichment switches, so there is one place to look for every per-database setting.
+
+The `as_form()` line is what announces the knob, not the field declaration. A field left at a plain default is absent
+from both the form and the schema, and a configuration carrying it is refused with a 400 naming it. For key/value
+settings, declare a `Repeater` over a two-field `Form` rather than a raw `dict` field — a `dict` has no form element, so
+it can never be announced.
 
 The ingestor id must not collide with an inert or frozen platform routing token (`unassigned`, `default_rag`,
 `shared_rag`) or with the `datalake` subject token. The factory rejects those when the definitions are built.

--- a/packages/pipeline/swiss_ai_hub/pipeline/util/tests/test_model_builders.py
+++ b/packages/pipeline/swiss_ai_hub/pipeline/util/tests/test_model_builders.py
@@ -68,6 +68,18 @@ class TestIngestorConfigForBucket:
         assert config.embedding_model == "embedding/default"
         assert config.name.en == "orphan"
 
+    def test_a_row_carrying_a_key_the_class_never_declared_still_resolves(self, deployment_defaults):
+        """Rows written before the API rejected undeclared keys (#1850) must keep ingesting untouched.
+
+        This is what `IngestorConfig`'s `extra="allow"` buys, and the only place that says so: tightening it
+        to `extra="forbid"` looks like finishing that fix and would instead break every such database.
+        """
+        with patch(f"{_MODULE}._bucket_entity", return_value=_bucket({"with_table_refinemnt": False})):
+            config = model_builders.ingestor_config_for_bucket("contracts")
+
+        assert config.model_extra["with_table_refinemnt"] is False
+        assert config.with_table_refinement is True
+
     def test_a_custom_pipeline_reads_its_own_knobs_typed(self, deployment_defaults):
         class CrawlConfig(DocumentIngestionConfig):
             crawl_depth: Annotated[int | None, Field(description="How deep to crawl")] = None


### PR DESCRIPTION
## Summary

A knowledge database's `configuration` was only held to the fields its ingestor's form *declared*, not to the
fields it *announced*. A key no form element declares passed with HTTP 200, was stored verbatim, and was then
ignored at ingestion time — so a mistyped optional knob silently resolved to the deployment default while the
stored row looked deliberate. This completes an acceptance criterion of #1822 that #1841 delivered only half of.

closes #1850

## Changes

**The reported cause was wrong, and the correction shapes the fix.** #1850 blames `IngestorConfig`'s
`extra="allow"`. That setting never reaches the validator: `ConfigSpecs.from_form` builds the announced schema
from `to_configurable_submission_model()`, a bare `create_model` whose schema carries no `additionalProperties`,
and jambo's `ObjectTypeParser` hardcodes `ConfigDict(validate_assignment=True)` — so the generated model is
Pydantic-default `extra="ignore"` and *drops* unknown keys rather than refusing them. That is why
`ingestor_config.py:28` is untouched here.

**The keys reached Mongo through a second door.** `create_database` persisted the raw submission rather than the
validated instance. Both doors are now closed.

**Undeclared keys are refused, by path.** `InstanceConfigHelper.reject_undeclared_fields` walks the announced
form elements and reports every offending path in one 400 — `with_summarys`, `enrichment.bogus`,
`sources.1.deeper`. It walks the elements rather than the JSON schema deliberately: `name`/`description` are
`$ref` objects in the schema but leaf `LocaleInput` elements on the form, so a schema walk would descend into a
`LocaleString` and start policing its locale keys. It is a third instance of the recursive walk
`_validate_model_selections` and `ConfigAuthorizationService._validate_elements` already use.

**The stored configuration is now canonical.** Dumped from the validated instance with `exclude_unset`, so a knob
is persisted in the type its pipeline declared (`crawl_depth: "5"` → `5`) while an omitted optional stays absent
and keeps falling back to the deployment default.

**`IngestorConfig` keeps `extra="allow"`.** `ingestor_config_for_bucket` revalidates every stored row per run, so
rows carrying legacy undeclared keys must keep resolving. A pipeline test pins that, so nobody "finishes the job"
by tightening it.

**Also fixes a latent 500.** An ingestor registered with an empty form passed the gate and made jambo raise on a
title-less schema. `Ingestor.config_specs` defaults to `ConfigSpecs()` — non-`None` — so a pipeline building
`Ingestor(...)` by hand instead of through `from_config` produces exactly that row.

**Scope.** Agent and process configs are deliberately untouched: `AgentConfig.cron` is *not* announced (
`AgentRunner` injects `cron_form_field()` for schedulable classes only) while `validate_cron_field` reads
`config.get("cron")` unconditionally, so that path legitimately expects an unannounced key. Applying this check
there blind would break scheduling.

## Test plan

- [x] `make test` in `packages/api` (758 passed) and `packages/pipeline` (182 passed), re-run after merging main.
- [x] New tests cover: a mistyped optional knob; a knob belonging to another ingestor on an otherwise complete
      payload; an omitted optional still accepted and left out of the row; undeclared keys inside a group and
      inside a repeater entry, named by path; all offenders in one rejection; the empty-announced-form gate.
- [x] Helper-level negative space (`test_instance_config_helper.py`): a group valued `null` or a wrong type, a
      repeater with non-dict entries, an element with no name, a nested `_`-prefixed key.
- [x] **Round-trip fidelity guard** (`test_model_creation.py`): one config announcing `ChipsInput`, `DatePicker`,
      `Select` (enum), `Slider`, `Textarea` (LocaleString), `CronInput`, a `Group` and a `Repeater`, asserting
      every submitted value survives the dump unchanged. This is what makes storing the dump safe — a jambo
      upgrade that loses a shape will say which one.
- [x] AC-4 regression: a stored row carrying a key the class never declared still resolves via
      `ingestor_config_for_bucket`.
- [x] Each new rejection test verified to fail with the check removed.
- [ ] QC: create a database through the admin UI and confirm a valid configuration is still accepted.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>`
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [x] CLA signed
- [x] Tests added or updated where relevant
