### PR TITLE
fix(deploy): Raise the SeaweedFS volume cap from 100 to 500

### DIFF
--- a/infra/deployment/templates/docker-compose.yml.j2
+++ b/infra/deployment/templates/docker-compose.yml.j2
@@ -207,12 +207,15 @@ services:
       - "8080"
       - "18080"
     {%- endif %}
+    {#- -max caps volume slots, not disk: the master runs without preallocation, so an empty volume
+        costs nothing. Each collection (one per knowledge database, plus one per infrastructure
+        service) claims a batch of 7 slots on its first write, so 100 ran out at ~8 databases. #}
     command: >
       volume
       -mserver="{{ SEAWEEDFS_MASTER_ENDPOINT }}"
       -ip.bind=0.0.0.0
       -port=8080
-      -max=100
+      -max=500
       -dataCenter=dc1
     environment:
       WEED_JWT_SIGNING_KEY: ${SEAWEEDFS_TOKEN}

--- a/infra/docker-compose.build.gpu.yml
+++ b/infra/docker-compose.build.gpu.yml
@@ -131,7 +131,7 @@ services:
       -mserver="seaweedfs-master:9333"
       -ip.bind=0.0.0.0
       -port=8080
-      -max=100
+      -max=500
       -dataCenter=dc1
     environment:
       WEED_JWT_SIGNING_KEY: ${SEAWEEDFS_TOKEN}

--- a/infra/docker-compose.build.yml
+++ b/infra/docker-compose.build.yml
@@ -131,7 +131,7 @@ services:
       -mserver="seaweedfs-master:9333"
       -ip.bind=0.0.0.0
       -port=8080
-      -max=100
+      -max=500
       -dataCenter=dc1
     environment:
       WEED_JWT_SIGNING_KEY: ${SEAWEEDFS_TOKEN}

--- a/infra/docker-compose.dev.gpu.yml
+++ b/infra/docker-compose.dev.gpu.yml
@@ -77,7 +77,7 @@ services:
       -mserver="seaweedfs-master:9333"
       -ip.bind=0.0.0.0
       -port=8080
-      -max=100
+      -max=500
       -dataCenter=dc1
     environment:
       WEED_JWT_SIGNING_KEY: ${SEAWEEDFS_TOKEN}

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -77,7 +77,7 @@ services:
       -mserver="seaweedfs-master:9333"
       -ip.bind=0.0.0.0
       -port=8080
-      -max=100
+      -max=500
       -dataCenter=dc1
     environment:
       WEED_JWT_SIGNING_KEY: ${SEAWEEDFS_TOKEN}

--- a/infra/docker-compose.latest.gpu.yml
+++ b/infra/docker-compose.latest.gpu.yml
@@ -127,7 +127,7 @@ services:
       -mserver="seaweedfs-master:9333"
       -ip.bind=0.0.0.0
       -port=8080
-      -max=100
+      -max=500
       -dataCenter=dc1
     environment:
       WEED_JWT_SIGNING_KEY: ${SEAWEEDFS_TOKEN}

--- a/infra/docker-compose.latest.yml
+++ b/infra/docker-compose.latest.yml
@@ -127,7 +127,7 @@ services:
       -mserver="seaweedfs-master:9333"
       -ip.bind=0.0.0.0
       -port=8080
-      -max=100
+      -max=500
       -dataCenter=dc1
     environment:
       WEED_JWT_SIGNING_KEY: ${SEAWEEDFS_TOKEN}

--- a/infra/docker-compose.local.gpu.yml
+++ b/infra/docker-compose.local.gpu.yml
@@ -131,7 +131,7 @@ services:
       -mserver="seaweedfs-master:9333"
       -ip.bind=0.0.0.0
       -port=8080
-      -max=100
+      -max=500
       -dataCenter=dc1
     environment:
       WEED_JWT_SIGNING_KEY: ${SEAWEEDFS_TOKEN}

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -131,7 +131,7 @@ services:
       -mserver="seaweedfs-master:9333"
       -ip.bind=0.0.0.0
       -port=8080
-      -max=100
+      -max=500
       -dataCenter=dc1
     environment:
       WEED_JWT_SIGNING_KEY: ${SEAWEEDFS_TOKEN}

--- a/infra/docker-compose.nightly.gpu.yml
+++ b/infra/docker-compose.nightly.gpu.yml
@@ -127,7 +127,7 @@ services:
       -mserver="seaweedfs-master:9333"
       -ip.bind=0.0.0.0
       -port=8080
-      -max=100
+      -max=500
       -dataCenter=dc1
     environment:
       WEED_JWT_SIGNING_KEY: ${SEAWEEDFS_TOKEN}

--- a/infra/docker-compose.nightly.yml
+++ b/infra/docker-compose.nightly.yml
@@ -127,7 +127,7 @@ services:
       -mserver="seaweedfs-master:9333"
       -ip.bind=0.0.0.0
       -port=8080
-      -max=100
+      -max=500
       -dataCenter=dc1
     environment:
       WEED_JWT_SIGNING_KEY: ${SEAWEEDFS_TOKEN}


### PR DESCRIPTION
Closes #1858

## What

`-max=100` on the SeaweedFS volume server, raised to `500` in the compose template and regenerated into the ten compose files.

## Why

The cap governs **allocation slots, not disk**. Each collection claims a batch of 7 slots on its first write, and infrastructure collections (langfuse, open-webui, milvus, dagster, backups, …) hold 42 of them — so a stack ran out at roughly 8 knowledge databases. Past that point creating a database still succeeded and it appeared in the UI, but every upload to it failed with a bare `500 InternalError` while the S3 gateway logged `No writable volumes and no free volumes left`.

Nothing is preallocated (`-volumePreallocate=false` on the master), so the dev stack sat at 9% disk while completely out of slots. Empty volumes cost nothing.

## Scope

Configuration only — no code, no new dependency, no contract change. Surfacing storage exhaustion as its own error on the upload path is [out of scope per the issue](https://github.com/bbvch-ai/aihub-core/issues/1858) and remains worth doing separately.

## Verification

Against the dev stack, which was at 100/100 slots before the change:

| Check | Result |
| --- | --- |
| Cap applied | `/dir/status` reports `Max: 500`, `Free: 400` |
| Pre-existing volumes survive the cap raise | all 100 volumes remount with identical ids (`1-49 57-63 127-140 148-177`), 15 collections intact |
| A new collection allocates | new bucket + 2 MB object → upload and read-back succeed, collection takes 7 slots (`Free` 400 → 393) |
| Deletion frees slots | bucket deleted → collection gone, `Free` back to 400 within seconds |
| Generated compose parses | `docker compose config` valid for `dev` and `latest` |
| Env consistency | `make check-env` clean on latest CPU and GPU |

The `expose:` blocks stay untouched: the rationale for the number lives in the template as a Jinja comment, so each generated file is a one-line diff.

## Headroom

~65 lightly-loaded knowledge databases after the 42 infrastructure slots. That is a bigger ceiling, not the removal of one — a database whose volumes fill to `volumeSizeLimitMB` (1 GB dev / 29 GB prod) keeps allocating beyond its initial 7.

## Test plan

- [x] `make check-env`
- [ ] `make test`
- [x] Existing knowledge database still lists and serves its documents
- [x] New knowledge database ingests a document on a stack that was previously full