### PR TITLE
fix(ui): Take the displayed version from the deployment, not the build

### DIFF
--- a/packages/sysadmin-web/config.template.js
+++ b/packages/sysadmin-web/config.template.js
@@ -6,6 +6,7 @@
 // API_BASE_URL is set authoritatively in app.vue to '/api/v1' (same-origin
 // against sysadmin-api on sysadmin.${DOMAIN}); no need to inject it here.
 window.__AIHUB_CONFIG__ = {
+  APP_VERSION: '${APP_VERSION}',
   OAUTH_CLIENT_ID: '${OAUTH_CLIENT_ID}',
   OAUTH_AUTHORITY_URL: '${OAUTH_AUTHORITY_URL}',
   MAIN_APP_URL: '${MAIN_APP_URL}',

--- a/packages/web/composables/app/useAppVersion.ts
+++ b/packages/web/composables/app/useAppVersion.ts
@@ -1,34 +1,32 @@
 import { getHealth } from '@core/sdk/client'
 import { minutesToMilliseconds } from 'date-fns'
 
-// Surfaces the running version of both services. The UI service version is baked
-// into the static bundle at build time (runtimeConfig.public.appVersion); the API
-// version is read from the health endpoint. When both agree a single number is
-// shown, otherwise both are shown as `UI / API`.
+// Surfaces the running version of both services. When both name the same release
+// a single version is shown, otherwise both are shown as `UI / API` so a genuine
+// skew — one service rolled, the other not — stays visible.
 //
-// A release is promoted by retagging the exact `-rc.N` build that was tested, so
-// the baked UI version keeps its release-candidate suffix (e.g. `v0.317.0-rc.3`)
-// even though the artifact IS the final release. A container cannot read its own
-// image tag, so the release has to be inferred from what the API reports, and the
-// two deployment flavours report it differently: docker-compose pins the channel
-// tag (`latest`), while Helm pins an exact `vX.Y.Z` per instance and leaves the
-// API on its package metadata (`0.319.0`). Both are release signals; on either
-// one the suffix is dropped so a promoted build shows its release version.
+// Neither container can know its own version at build time: a release is promoted
+// by retagging the exact `-rc.N` build that was tested, so anything baked into an
+// image keeps the candidate's name even though the artifact IS the final release.
+// The deployment is the only party that knows the tag it pulled, so both sides
+// take their version from it — the UI through APP_VERSION in /config.js (see
+// plugins/0.runtime-config.client.ts), the API through its AIHUB_VERSION env var.
+// Each falls back to its build-time value when the deployment injects nothing,
+// which is why a promoted build can still report `-rc.N` on one side only.
+//
+// docker-compose is the one flavour that pins a rolling channel tag instead of an
+// exact version, so it reports the channel name (`latest`) rather than a number.
 //
 // Versions are compared with the leading `v` normalised away, because one side is
-// a git tag (`v0.319.0`) and the other Python package metadata (`0.319.0`) — the
-// same version, and rendering it as `UI / API` would read as skew.
-//
-// Every other case is genuinely a candidate or a rolling build (another channel
-// such as `staging`, an API pinned to an explicit `-rc.N`, a nightly), so the
-// suffix stays to keep the build identifiable.
+// a git tag (`v0.319.0`) and the other can be Python package metadata (`0.319.0`)
+// — the same version, and rendering it as `UI / API` would read as skew.
 const RELEASE_CHANNEL = 'latest'
 const RC_SUFFIX = /-rc\.\d+$/
 const toReleaseVersion = (version: string): string => version.replace(RC_SUFFIX, '')
-const toComparable = (version: string): string => version.replace(/^v/, '')
+const toComparable = (version: string): string => toReleaseVersion(version.replace(/^v/, ''))
 
 export const useAppVersion = defineQuery(() => {
-  const bakedUiVersion = useRuntimeConfig().public.appVersion as string
+  const declaredUiVersion = useRuntimeConfig().public.appVersion as string
 
   const { data: apiVersion } = useQuery<string>({
     key: () => ['app-version', 'api'],
@@ -39,23 +37,23 @@ export const useAppVersion = defineQuery(() => {
     },
   })
 
-  // An API version that still carries `-rc.N` can never equal the stripped UI
-  // version, so a candidate deployment fails this check without a separate guard.
-  const isReleaseDeployment = computed(() => {
+  // The one version both services agree on, or null when they genuinely differ.
+  const agreedVersion = computed(() => {
     const api = apiVersion.value
-    if (!api) return false
-    return api === RELEASE_CHANNEL || toComparable(api) === toComparable(toReleaseVersion(bakedUiVersion))
+    if (!api) return declaredUiVersion
+    if (api === RELEASE_CHANNEL) return toReleaseVersion(declaredUiVersion)
+    if (toComparable(api) !== toComparable(declaredUiVersion)) return null
+    // Same release. If either side reports the promoted, suffix-free name then
+    // that is what this deployment is; if both still carry `-rc.N` it really is a
+    // candidate build and the suffix stays to keep it identifiable.
+    return RC_SUFFIX.test(declaredUiVersion) ? api : declaredUiVersion
   })
 
-  const uiVersion = computed(() =>
-    isReleaseDeployment.value ? toReleaseVersion(bakedUiVersion) : bakedUiVersion,
+  const uiVersion = computed(() => agreedVersion.value ?? declaredUiVersion)
+
+  const versionDisplay = computed(
+    () => agreedVersion.value ?? `${declaredUiVersion} / ${apiVersion.value}`,
   )
-
-  const versionDisplay = computed(() => {
-    const api = apiVersion.value
-    if (!api || toComparable(api) === toComparable(uiVersion.value)) return uiVersion.value
-    return `${uiVersion.value} / ${api}`
-  })
 
   return { uiVersion, apiVersion, versionDisplay }
 })

--- a/packages/web/config.template.js
+++ b/packages/web/config.template.js
@@ -5,6 +5,7 @@
 // 0.runtime-config.client.ts reads globalThis.__AIHUB_CONFIG__ with no fetch,
 // no async, no plugin-ordering concerns. One image, many environments.
 globalThis.__AIHUB_CONFIG__ = {
+  APP_VERSION: '${APP_VERSION}',
   OAUTH_CLIENT_ID: '${OAUTH_CLIENT_ID}',
   OAUTH_AUTHORITY_URL: '${OAUTH_AUTHORITY_URL}',
   WEBUI_URL: '${WEBUI_URL}',

--- a/packages/web/plugins/0.runtime-config.client.ts
+++ b/packages/web/plugins/0.runtime-config.client.ts
@@ -50,6 +50,11 @@ export default defineNuxtPlugin(() => {
   assign(group('sysadmin'), 'url', injected.SYSADMIN_URL)
   assign(group('mainApp'), 'url', injected.MAIN_APP_URL)
   if (injected.API_BASE_URL) publicConfig.apiBaseUrl = injected.API_BASE_URL
+  // The version actually deployed. A release is promoted by retagging the exact
+  // `-rc.N` build that was tested, so whatever was baked into the bundle at build
+  // time keeps the candidate's name — the deployment is the only party that knows
+  // the tag it pulled. Falls back to the baked value when nothing is injected.
+  if (injected.APP_VERSION) publicConfig.appVersion = injected.APP_VERSION
 
   isConfigLoaded.value = true
 })


### PR DESCRIPTION
## Problem

On Kubernetes the UI shows `v0.320.0-rc.9` after `v0.320.0` is deployed, even though #1788 was supposed to fix exactly that.

```
$ curl -s https://test.k8s.ai-agents.ch/api/v1/health/
{"status":"ok","code":200,"version":"v0.320.0-rc.9","checks":null}
```

The value is baked into the served HTML at build time:

```
$ curl -s https://test.k8s.ai-agents.ch/ | grep -o 'appVersion:"[^"]*"'
appVersion:"v0.320.0-rc.9"
```

## Root cause

A release is promoted by **retagging the tested rc build without rebuilding** (`retag-clean-docker` in `promote.yml`), so anything captured at build time keeps the candidate's name. Both services capture it at build time:

- `packages/web/Dockerfile` passes `VERSION` into `APP_VERSION` before `pnpm run build`, so Nuxt writes the string straight into `index.html`.
- `packages/api/Dockerfile` bakes `ENV AIHUB_VERSION=${VERSION}`.

docker-compose overrides the API's value (`AIHUB_VERSION: ${AIHUB_VERSION}`, `latest` on prod), which is what the `RELEASE_CHANNEL` branch in `useAppVersion` keys off — so compose displays correctly. Helm sets that variable on `sysadmin-api` only, so on Kubernetes the API echoes the same baked rc string. #1788 assumed the opposite ("Helm … leaves the API on its package metadata"), but the image `ENV` wins over the `version("swiss-ai-hub-core")` default, so the inference never fires.

Because both sides then report the *identical* string, the UI renders one value instead of `UI / API` — which is why it looks like nothing is wrong.

## Change

Version becomes a deploy-time fact for the UI, through the runtime-config channel the app already has for every other environment-dependent value (`config.template.js` → nginx `envsubst` → `window.__AIHUB_CONFIG__` → `runtimeConfig.public`, see `plugins/0.runtime-config.client.ts`). Version was the only such value still bypassing it.

- `packages/web/config.template.js`, `packages/sysadmin-web/config.template.js`: expose `APP_VERSION`.
- `plugins/0.runtime-config.client.ts`: map it onto `publicConfig.appVersion`, using the same defensive `if (injected.X)` shape as `API_BASE_URL` — nothing injected means the baked value still applies, so no deployment changes behaviour until it opts in.
- `composables/app/useAppVersion.ts`: replace the release *inference* with agreement between two now-authoritative sources. When both name the same release, the promoted (suffix-free) name wins; when both still carry `-rc.N` it really is a candidate and the suffix stays; when they name different releases the `UI / API` skew display is unchanged.

Nothing is required of a deployment for this to be safe, and either side can start injecting first.

## Behaviour matrix

Verified against the resolution logic (`ui` = value the UI has, `api` = `/health/`):

| Scenario | ui | api | displayed |
|---|---|---|---|
| compose prod (unchanged today) | `v0.320.0-rc.9` | `latest` | `v0.320.0` |
| Helm, only the API injecting | `v0.320.0-rc.9` | `v0.320.0` | `v0.320.0` |
| Helm, only the UI injecting | `v0.320.0` | `v0.320.0-rc.9` | `v0.320.0` |
| Helm, both injecting | `v0.320.0` | `v0.320.0` | `v0.320.0` |
| Helm, neither (today) | `v0.320.0-rc.9` | `v0.320.0-rc.9` | `v0.320.0-rc.9` |
| genuine rc deployment | `v0.321.0-rc.3` | `v0.321.0-rc.3` | `v0.321.0-rc.3` |
| dev | `0.321.0` | `0.321.0` | `0.321.0` |
| git tag vs python metadata | `v0.319.0` | `0.319.0` | `v0.319.0` |
| genuine skew | `v0.321.0` | `v0.320.0` | `v0.321.0 / v0.320.0` |
| `/health/` unreachable | `v0.320.0` | — | `v0.320.0` |

Note rows 1 and 5: **compose is untouched** and a not-yet-migrated Helm instance keeps exactly today's behaviour. Rows 2 and 3 mean the two repos can roll out in either order without a transient false `UI / API` skew.

## Deliberately not changed

`docker-compose.yml.j2` does **not** get `APP_VERSION`. It would resolve to `${AIHUB_VERSION}` = `latest` on prod, and the UI would then display the channel name instead of `v0.320.0` — technically honest, but a visible regression for compose users. Compose keeps taking the `RELEASE_CHANNEL` path. Happy to revisit if you'd rather compose pinned a real version in `.env.prod`.

## Relationship to bbvch-ai/aihub-k8s#30

Neither PR blocks the other and there is no broken state in between.

aihub-k8s#30 sets `AIHUB_VERSION` on the API (plus `APP_VERSION` on the two SPA ConfigMaps, inert until this ships) and **on its own already makes Kubernetes instances display the right version**, because the release inference in the currently deployed image starts working the moment the API confirms the release. So the user-visible bug is fixed there, not here.

This PR is the cleanup: the SPA stops needing that inference at all, because it is told its version directly. It changes nothing until a deployment injects `APP_VERSION` — aihub-k8s#30 already provides it, and compose keeps taking the `RELEASE_CHANNEL` path.

## Validation

- `eslint` clean on all changed web files. (`packages/sysadmin-web` lint needs `nuxi prepare` first, which was not run here; its change is a one-line addition mirroring `packages/web`'s.)
- The resolution logic was exercised against all ten rows above.
- Not run: a full `pnpm build` / browser check.
