### PR TITLE
fix(ci-cd): Skip the CLA check on Dependabot pull requests

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,11 +18,17 @@ jobs:
   cla:
     name: CLA Signature Check
     runs-on: ubuntu-24.04-arm
+    # Dependabot-triggered runs get no access to secrets.CLA_ASSISTANT_PAT, and the
+    # action reads the remote signature repository with that token even when the
+    # allowlist has already filtered every committer out.
     if: >-
-      contains(github.event.comment.body, 'I have read the CONTRIBUTOR_AGREEMENT and
+      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.issue.user.login != 'dependabot[bot]' &&
+      (contains(github.event.comment.body, 'I have read the CONTRIBUTOR_AGREEMENT and
       I hereby sign the CLA') ||
       contains(github.event.comment.body, 'recheck') ||
-      github.event_name == 'pull_request'
+      github.event_name == 'pull_request')
     timeout-minutes: 5
     steps:
       - name: CLA Assistant


### PR DESCRIPTION
## Summary

The CLA check fails on every Dependabot PR. The `dependabot[bot]` entry in `allowlist`
does its job — it filters Dependabot out of the committer list — but the action then
reads the remote signature repository unconditionally, and that read needs a token
Dependabot runs cannot see.

Dependabot-triggered runs read secrets from the Dependabot secret store, not the Actions
store, so `secrets.CLA_ASSISTANT_PAT` resolves to an empty string:

```
Secret source: Dependabot
PERSONAL_ACCESS_TOKEN:
##[error]Please add a personal access token as an environment variable for writing
signatures in a remote repository/organization as mentioned in the README.md file
##[error]Could not retrieve repository contents. Status: unknown
```

In [`setupClaCheck.ts`](https://github.com/contributor-assistant/github-action/blob/ca4a40a7d1004f18d9960b404b97e5f30a505a08/src/setupClaCheck.ts#L22-L27),
`checkAllowList()` runs first, then `getCLAFileContentandSHA()` runs regardless of
whether any committer is left. Because `remote-repository-name` is configured,
[`getFileContent()`](https://github.com/contributor-assistant/github-action/blob/ca4a40a7d1004f18d9960b404b97e5f30a505a08/src/persistence/persistence.ts#L9-L20)
takes the PAT client for the *read* as well as the write — so an empty PAT fails the job
even when there is nothing left to check.

Fix: skip the job entirely when the pull request belongs to Dependabot.

## Changes

- `.github/workflows/cla.yml`: guard the `cla` job with three actor checks —
  `github.actor` covers the `pull_request` event, and
  `github.event.pull_request.user.login` / `github.event.issue.user.login` cover a
  maintainer posting `recheck` on a Dependabot PR (there the actor is a human, but the
  run fails identically).
- Kept `dependabot[bot]` in `allowlist`: still needed when a Dependabot-authored commit
  rides along in someone else's PR.

## Alternative considered

Adding the same PAT to the repository's **Dependabot** secret store would also make the
job pass, since the allowlist already handles the committer. Rejected: it hands a
write-capable PAT for `bbvch-ai/cla-signatures` to Dependabot-triggered runs for no
benefit — a bot cannot sign a CLA, so the job has nothing to verify on these PRs.

Adding `dependabot[bot]` to `signatures/v1/cla.json` does not work at all: the job fails
while *reading* that file, before any signature comparison happens.

## Test plan

- [x] Reproduced on [PR #1848](https://github.com/bbvch-ai/aihub-core/pull/1848)
  ([failing run](https://github.com/bbvch-ai/aihub-core/actions/runs/34193581219)) and
  [PR #1815](https://github.com/bbvch-ai/aihub-core/pull/1815) — both fail on the missing
  PAT.
- [x] YAML validated with `yaml-lint`.
- [x] `CLA Signature Check` passes on this PR, so the new condition does not break the
  human-contributor path.
- [x] Verified `CLA Signature Check` is not in the required status checks of the `main`
  ruleset, so skipping the job does not block merges. Dependabot PRs will report
  `skipped` instead of a red X.
- [ ] Confirm on the next Dependabot PR after merge.

## Checklist

- [x] PR title follows `<type>(<scope>): <Subject starting with uppercase>`
- [x] Exactly one of `major` / `minor` / `patch` label applied
- [x] CLA signed
- [x] Tests added or updated where relevant — n/a, workflow-only change
