### PR TITLE
chore(deploy): Remove the retained Jupyter container

### DIFF
--- a/.claude/agents/connectivity-researcher.md
+++ b/.claude/agents/connectivity-researcher.md
@@ -44,8 +44,8 @@ Use these exact L2 container labels in your output. They match the LikeC4 model 
 > `packages/core` is a shared library with no container of its own.
 
 **Infrastructure**: `LiteLLM Gateway`, `NATS`, `PostgreSQL`, `FerretDB`, `Valkey`, `Neo4j`, `Milvus`, `ClickHouse`,
-`etcd`, `SeaweedFS Cluster`, `Keycloak`, `Presidio`, `MinerU`, `vLLM`, `Speaches`, `SearXNG`, `Jupyter`, `Playwright`,
-`Attu`, `Traefik`, `OIDC Middleware`, `pgbouncer`, `Docker Socket Proxy`, `OTEL Collector`, `Langfuse`
+`etcd`, `SeaweedFS Cluster`, `Keycloak`, `Presidio`, `MinerU`, `vLLM`, `Speaches`, `SearXNG`, `Open Terminal`,
+`Playwright`, `Attu`, `Traefik`, `OIDC Middleware`, `pgbouncer`, `Docker Socket Proxy`, `OTEL Collector`, `Langfuse`
 
 **L1 externals**: `Identity Provider`, `LLM Provider`, `Document Source`, `Collaboration Platform`,
 `Observability Sink`, `Notification Target`, `External MCP Tools`

--- a/.claude/agents/deployment-reviewer.md
+++ b/.claude/agents/deployment-reviewer.md
@@ -46,7 +46,7 @@ infra/configs/{service}/*.{stage}{.gpu}.*    → ~80 generated config files
 | Network   | Purpose                 | ICC    | What goes here                                              |
 | --------- | ----------------------- | ------ | ----------------------------------------------------------- |
 | `proxy`   | External ingress        | Yes    | traefik, api, web, open-webui, langfuse-web                 |
-| `backend` | Application services    | Yes    | litellm, langfuse-\*, mineru-api, vLLM (GPU), jupyter, otel |
+| `backend` | Application services    | Yes    | litellm, langfuse-\*, mineru-api, vLLM (GPU), otel          |
 | `data`    | Databases and messaging | Yes    | postgres, ferretdb, milvus, neo4j, valkey, nats, clickhouse |
 | `storage` | SeaweedFS cluster       | Yes    | seaweedfs-\*, etcd                                          |
 | `egress`  | Outbound internet only  | **No** | playwright (containers can't reach each other)              |

--- a/.claude/skills/docker-dev/SKILL.md
+++ b/.claude/skills/docker-dev/SKILL.md
@@ -71,29 +71,28 @@ docker stats --no-stream --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}"
 
 ### `ports` — Show all exposed service URLs
 
-| Service        | Port   | Purpose                                 |
-| -------------- | ------ | --------------------------------------- |
-| API            | :8000  | REST API + WebSocket (local)            |
-| OpenWebUI      | :8080  | Chat interface                          |
-| Admin UI       | :3333  | Nuxt management UI (local)              |
-| Dagster        | :3000  | Pipeline orchestrator (local)           |
-| LiteLLM        | :4000  | LLM proxy                               |
-| Langfuse       | :6006  | LLM observability                       |
-| MinerU         | :5001  | Document parsing                        |
-| PostgreSQL     | :5432  | Relational DB (4 databases)             |
-| FerretDB       | :27017 | MongoDB-compatible                      |
-| Milvus         | :19530 | Vector DB                               |
-| Neo4j          | :7474  | Graph DB (web), :7687 (bolt)            |
-| Valkey         | :6379  | Redis-compatible cache                  |
-| NATS           | :4222  | Message broker, :8222 (monitor)         |
-| SeaweedFS      | :8889  | Filer UI, :9000 (S3 gateway)            |
-| Rclone         | :5572  | Cloud sync RC API                       |
-| Speaches       | :8185  | STT/TTS                                 |
-| Open Terminal  | :8200  | Code execution sandbox (OpenWebUI)      |
-| Jupyter        | :8888  | Retained; no longer OpenWebUI code path |
-| Playwright     | :3036  | Browser automation                      |
-| Attu           | :3003  | Milvus admin UI                         |
-| OTEL Collector | :4317  | gRPC receiver, :4318 (HTTP)             |
+| Service        | Port   | Purpose                            |
+| -------------- | ------ | ---------------------------------- |
+| API            | :8000  | REST API + WebSocket (local)       |
+| OpenWebUI      | :8080  | Chat interface                     |
+| Admin UI       | :3333  | Nuxt management UI (local)         |
+| Dagster        | :3000  | Pipeline orchestrator (local)      |
+| LiteLLM        | :4000  | LLM proxy                          |
+| Langfuse       | :6006  | LLM observability                  |
+| MinerU         | :5001  | Document parsing                   |
+| PostgreSQL     | :5432  | Relational DB (4 databases)        |
+| FerretDB       | :27017 | MongoDB-compatible                 |
+| Milvus         | :19530 | Vector DB                          |
+| Neo4j          | :7474  | Graph DB (web), :7687 (bolt)       |
+| Valkey         | :6379  | Redis-compatible cache             |
+| NATS           | :4222  | Message broker, :8222 (monitor)    |
+| SeaweedFS      | :8889  | Filer UI, :9000 (S3 gateway)       |
+| Rclone         | :5572  | Cloud sync RC API                  |
+| Speaches       | :8185  | STT/TTS                            |
+| Open Terminal  | :8200  | Code execution sandbox (OpenWebUI) |
+| Playwright     | :3036  | Browser automation                 |
+| Attu           | :3003  | Milvus admin UI                    |
+| OTEL Collector | :4317  | gRPC receiver, :4318 (HTTP)        |
 
 Note: API (:8000), Admin UI (:3333), and Dagster (:3000) run **locally outside Docker** in dev — they're not in
 `infra/docker-compose.dev.yml`.

--- a/.env.dev
+++ b/.env.dev
@@ -188,8 +188,6 @@ LOCAL_LLM_TOKEN='d8f9a2c1e7b5d3f1a9c7e5b3d1f9a7c5e3b1d9f7a5c3e1b7d5f3a1c9e7b5d3f
 # -----------------------------------------------------------------------------
 # Service Configuration
 # -----------------------------------------------------------------------------
-# Jupyter Token
-JUPYTER_TOKEN='be5b01e5910bf6cedb58b3640211900d0d7315605d9a555f9ec31578f0671b97'
 # -----------------------------------------------------------------------------
 # Open Terminal API Key (OpenWebUI code-execution sandbox).
 # Alphanumeric/hex only — interpolated into the JSON TERMINAL_SERVER_CONNECTIONS string.
@@ -461,9 +459,6 @@ NATS_ENDPOINT='nats://localhost:4222'
 
 # Redis / Valkey (host-side reach)
 REDIS_URL='redis://localhost:6379'
-
-# Jupyter (host-side reach)
-JUPYTER_URL='http://localhost:8888'
 
 # Rclone (host-side reach)
 RCLONE_URL='http://localhost:5572'

--- a/.env.prod
+++ b/.env.prod
@@ -168,7 +168,6 @@ LOCAL_LLM_TOKEN='REPLACE_WITH_RANDOM_STRING'
 # -----------------------------------------------------------------------------
 # Service Configuration
 # -----------------------------------------------------------------------------
-JUPYTER_TOKEN='REPLACE_WITH_RANDOM_STRING'
 # Use an ALPHANUMERIC / HEX value only: this key is interpolated into the JSON
 # TERMINAL_SERVER_CONNECTIONS connection string, so a " or \ would corrupt it.
 OPEN_TERMINAL_API_KEY='REPLACE_WITH_RANDOM_STRING'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,9 +90,8 @@ backup/restore
 
 **Observability**: Langfuse web (:6006) + worker, OTEL Collector (:4317/:4318)
 
-**Utility**: Open Terminal (:8200 in dev, code execution sandbox for OpenWebUI — plain LLM models only), Jupyter Lab
-(:8888, retained in stack but no longer the OpenWebUI code path), Playwright (:3036, browser automation), Attu (:3003,
-Milvus admin UI)
+**Utility**: Open Terminal (:8200 in dev, code execution sandbox for OpenWebUI — plain LLM models only), Playwright
+(:3036, browser automation), Attu (:3003, Milvus admin UI)
 
 ## Package Architecture
 

--- a/README.md
+++ b/README.md
@@ -178,13 +178,12 @@ wired together.
 <details>
 <summary><strong>Integrations & utilities</strong></summary>
 
-| Component               | Powered by                                                             | Role                                                                                                                   |
-| ----------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| MS Teams & Slack bots   | [Microsoft Agents SDK](https://github.com/microsoft/Agents-for-python) | Connects agents to Teams, Slack, and web chat channels                                                                 |
-| Code execution sandbox  | [Open Terminal](https://github.com/open-webui/open-terminal)           | Sandboxed Python runtime for OpenWebUI code execution (plain LLM models); per-user isolation, downloadable file output |
-| Code execution (legacy) | [Jupyter](https://jupyter.org/)                                        | Retained in the stack but no longer used by OpenWebUI for code execution                                               |
-| Browser automation      | [Playwright](https://playwright.dev/)                                  | Headless browser for agent web search and page parsing                                                                 |
-| Docker socket proxy     | [Tecnativa](https://github.com/Tecnativa/docker-socket-proxy)          | Read-only Docker API access for Traefik, preventing container escape                                                   |
+| Component              | Powered by                                                             | Role                                                                                                                   |
+| ---------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| MS Teams & Slack bots  | [Microsoft Agents SDK](https://github.com/microsoft/Agents-for-python) | Connects agents to Teams, Slack, and web chat channels                                                                 |
+| Code execution sandbox | [Open Terminal](https://github.com/open-webui/open-terminal)           | Sandboxed Python runtime for OpenWebUI code execution (plain LLM models); per-user isolation, downloadable file output |
+| Browser automation     | [Playwright](https://playwright.dev/)                                  | Headless browser for agent web search and page parsing                                                                 |
+| Docker socket proxy    | [Tecnativa](https://github.com/Tecnativa/docker-socket-proxy)          | Read-only Docker API access for Traefik, preventing container escape                                                   |
 
 </details>
 

--- a/docs/arc42/chapters/07_deployment_view.md
+++ b/docs/arc42/chapters/07_deployment_view.md
@@ -36,7 +36,6 @@ graph TB
             MinerU2["MinerU :8002 (GPU only)"]
             Pres["Presidio :3001"]
             OTELc["OTEL Collector"]
-            Jupy["Jupyter :8888 (retained)"]
             AgentC["Agent containers"]
             PipeC["Pipeline workers"]
         end
@@ -123,9 +122,8 @@ routes requests to backend services. Services that need to be directly reachable
 web UI, SeaweedFS S3 gateway) attach to this network.
 
 The **backend** network connects application services that process requests but should not be directly reachable from
-outside. LiteLLM, the vLLM inference servers (GPU only), Speaches, Presidio, MinerU, OTEL Collector, Jupyter (retained;
-no longer the OpenWebUI code path), and all agents and pipeline workers communicate over this network. Traefik also
-attaches to backend so it can forward proxied requests.
+outside. LiteLLM, the vLLM inference servers (GPU only), Speaches, Presidio, MinerU, OTEL Collector, and all agents and
+pipeline workers communicate over this network. Traefik also attaches to backend so it can forward proxied requests.
 
 The **data** network connects databases, caches, and the message broker: PostgreSQL (both instances), FerretDB, Milvus,
 Neo4j, ClickHouse, NATS, Valkey, and etcd. Services that need database access (API, Langfuse, Dagster, LiteLLM) attach

--- a/docs/arc42/decisions/2026_06_22_openwebui_code_execution_open_terminal.md
+++ b/docs/arc42/decisions/2026_06_22_openwebui_code_execution_open_terminal.md
@@ -99,3 +99,7 @@ Route OpenWebUI's code-execution path to a new **`open-terminal`** service:
 - **Licensing** — Open Terminal is **MIT** (standard, OSI-approved; no branding clause and no end-user threshold). This
   is distinct from `open-webui`, whose modified-BSD "Open WebUI License" carries the branding/≤50-user clause — that
   obligation comes from open-webui, not from adding this sandbox.
+
+> **Amendment 2026-09-10 — Jupyter has been removed.** The follow-up cleanup anticipated above is done: the `jupyter`
+> service, its `JUPYTER_TOKEN`/`JUPYTER_URL` variables, the `minimal-notebook` image pin, and its license entry are gone
+> from the compose template and all generated stages. Open Terminal is now the only code-execution runtime in the stack.

--- a/docs/docs/1_vision_and_positioning/4_infrastructure_layers/index.de.md
+++ b/docs/docs/1_vision_and_positioning/4_infrastructure_layers/index.de.md
@@ -62,15 +62,16 @@ die Rolle AIHubDeveloper). MongoDB speichert Gesprächsverläufe, Benutzerpräfe
 Ereignisverläufe dauerhaft. Diese Auswahl bietet Cloud-native Speicherstrategien, die On-Premise oder in
 Cloud-Umgebungen identisch funktionieren.
 
-Die Plattform umfasst integrierte KI-Tools, die das Chat-Erlebnis verbessern. **Jupyter Lab** ermöglicht die
-Code-Interpretation und -Ausführung, wenn Benutzer den LLM bitten, Daten zu analysieren oder Berechnungen durchzuführen.
-Der LLM kann Python-Code schreiben, der sicher in einer isolierten Jupyter-Umgebung ausgeführt wird und die Ergebnisse
-direkt in der Konversation zurückgibt. **SearXNG** bietet Web-Suchfunktionen, wenn Benutzer aktuelle Informationen
-benötigen, indem es Ergebnisse von mehreren Suchmaschinen aggregiert und gleichzeitig die Privatsphäre wahrt.
-**Playwright** extrahiert Inhalte von Websites, die über die Suche entdeckt wurden, und extrahiert den vollständigen
-Text, wenn Such-Snippets nicht ausreichen. **MinerU** parst Dokumente, die Benutzer in den Chat hochladen, und
-extrahiert Text und Struktur aus PDFs, Word-Dokumenten und Präsentationen, wobei Tabellen und Formatierungen erhalten
-bleiben, die für eine präzise Beantwortung von Fragen erforderlich sind.
+Die Plattform umfasst integrierte KI-Tools, die das Chat-Erlebnis verbessern. **Open Terminal** ermöglicht die
+Code-Ausführung, wenn Benutzer ein reines LLM-Modell bitten, Daten zu analysieren oder Berechnungen durchzuführen. Das
+Modell schreibt Python-Code, der in einer isolierten Sandbox pro Benutzer mit vorinstallierten gängigen
+Dokumentbibliotheken ausgeführt wird; erzeugte Dateien (Berichte, Tabellen, Diagramme) erscheinen zum Download im Chat.
+**SearXNG** bietet Web-Suchfunktionen, wenn Benutzer aktuelle Informationen benötigen, indem es Ergebnisse von mehreren
+Suchmaschinen aggregiert und gleichzeitig die Privatsphäre wahrt. **Playwright** extrahiert Inhalte von Websites, die
+über die Suche entdeckt wurden, und extrahiert den vollständigen Text, wenn Such-Snippets nicht ausreichen. **MinerU**
+parst Dokumente, die Benutzer in den Chat hochladen, und extrahiert Text und Struktur aus PDFs, Word-Dokumenten und
+Präsentationen, wobei Tabellen und Formatierungen erhalten bleiben, die für eine präzise Beantwortung von Fragen
+erforderlich sind.
 
 Die Observability beginnt vom ersten Tag an, wobei **OpenTelemetry** Metriken, Traces und Logs von jeder Komponente
 sammelt. Die Daten fliessen an entsprechende Backends: Metriken an Prometheus, Traces an Jaeger, Logs an Loki. Dieser

--- a/docs/docs/2_platform/2_architecture/2_containers/index.de.md
+++ b/docs/docs/2_platform/2_architecture/2_containers/index.de.md
@@ -100,9 +100,10 @@ eigene Datenabhängigkeiten (ClickHouse, Postgres, Valkey, SeaweedFS) gehören z
 
 ## Hilfsschicht
 
-Hilfsservices, die die Anwendungsschicht unterstützen, ohne zu ihrem Kern zu gehören: SearXNG für die Websuche, Jupyter
-als Code-Ausführungs-Sandbox, Playwright für die Browser-Automatisierung und Attu als Milvus-Admin-Konsole für
-Operatoren. Diese werden hauptsächlich von OpenWebUI (als Agenten-Tools) und von Operatoren genutzt.
+Hilfsservices, die die Anwendungsschicht unterstützen, ohne zu ihrem Kern zu gehören: SearXNG für die Websuche, Open
+Terminal als Code-Ausführungs-Sandbox für OpenWebUI (reine LLM-Modelle; Isolation pro Benutzer, herunterladbare
+Dateiausgabe), Playwright für die Browser-Automatisierung und Attu als Milvus-Admin-Konsole für Operatoren. Diese werden
+hauptsächlich von OpenWebUI (als Agenten-Tools) und von Operatoren genutzt.
 
 <likec4-view view-id="tier_utility" style="display:block;height:420px"></likec4-view>
 

--- a/docs/docs/2_platform/2_architecture/2_containers/index.en.md
+++ b/docs/docs/2_platform/2_architecture/2_containers/index.en.md
@@ -92,9 +92,9 @@ Valkey, SeaweedFS) belong to the Data tier.
 ## Utility tier
 
 Auxiliary services that support the application tier without being core to it: SearXNG for web search, Open Terminal as
-the code-execution sandbox for OpenWebUI (plain LLM models; per-user isolation, downloadable file output), Jupyter
-(retained in the stack but no longer the OpenWebUI code path), Playwright for browser automation, and Attu as a Milvus
-admin console for operators. These are consumed mostly by OpenWebUI (as agent tools) and by operators.
+the code-execution sandbox for OpenWebUI (plain LLM models; per-user isolation, downloadable file output), Playwright
+for browser automation, and Attu as a Milvus admin console for operators. These are consumed mostly by OpenWebUI (as
+agent tools) and by operators.
 
 <likec4-view view-id="tier_utility" style="display:block;height:420px"></likec4-view>
 

--- a/docs/docs/2_platform/2_architecture/4_network_isolation/index.de.md
+++ b/docs/docs/2_platform/2_architecture/4_network_isolation/index.de.md
@@ -51,7 +51,6 @@ Interne Anwendungs- und Verarbeitungs-Services:
 - **presidio-analyzer/anonymizer**: PII-Erkennung und -Anonymisierung
 - **vLLM**: Lokale LLM-Inferenz (Chat, Embedding, Reranking) – nur GPU Deployments
 - **speaches**: Spracherkennung und Text-zu-Sprache
-- **jupyter**: Code-Ausführungsumgebung
 - **playwright**: Web-Scraping und Automatisierung (auch im `egress` für Internetzugriff)
 - **agents**: Alle Agent Workers (RAG, Expert, Wrapping)
 - **pipelines**: Datenverarbeitungs-Pipelines
@@ -117,7 +116,6 @@ flowchart TB
         presidio[presidio]
         vllm[vLLM]
         agents[agents]
-        jupyter[jupyter]
         playwright[playwright]
         dagster[dagster-*]
         pipelines[pipelines]

--- a/docs/docs/2_platform/2_architecture/4_network_isolation/index.en.md
+++ b/docs/docs/2_platform/2_architecture/4_network_isolation/index.en.md
@@ -57,7 +57,6 @@ Internal application and processing services:
 - **presidio-analyzer/anonymizer**: PII detection and anonymization
 - **vLLM**: Local LLM inference (chat, embedding, reranking) — GPU deployments only
 - **speaches**: Speech-to-text and text-to-speech
-- **jupyter**: Code execution environment (retained; no longer used by OpenWebUI)
 - **playwright**: Web scraping and automation (also on `egress` for internet access)
 - **agents**: All agent workers (rag, expert, wrapping)
 - **pipelines**: Data processing pipelines
@@ -136,7 +135,6 @@ flowchart TB
         presidio[presidio]
         vllm[vLLM]
         agents[agents]
-        jupyter[jupyter]
         playwright[playwright]
         dagster[dagster-*]
         pipelines[pipelines]

--- a/docs/docs/2_platform/3_deployment_guide/9_environment_variables/index.de.md
+++ b/docs/docs/2_platform/3_deployment_guide/9_environment_variables/index.de.md
@@ -66,7 +66,6 @@ Diese Variablen werden als `${VAR}` (ohne einen `${VAR:-default}` Fallback) irge
 | `EXPERT_ASKING_CHANNEL_TYPE` | | `expert_asking_agent` | |
 | `GEMINI_API_KEY` | | `litellm` | |
 | `HUGGINGFACE_API_KEY` | | `litellm`, `vllm`, `vllm-bge-m3`, `vllm-bge-reranker` | |
-| `JUPYTER_TOKEN` | | `api`, `jupyter` | |
 | `KEYCLOAK_ADMIN_PASSWORD` | | `keycloak`, `keycloak-config` | |
 | `KEYCLOAK_ADMIN_USER` | | `keycloak`, `keycloak-config` | |
 | `KEYCLOAK_API_SERVICE_CLIENT_SECRET` | `KeycloakSettings.API_SERVICE_CLIENT_SECRET` | `api`, `bot`, `keycloak`, `keycloak-config`, `sysadmin-api` | Client Secret für das API-Service-Konto |

--- a/docs/docs/2_platform/3_deployment_guide/9_environment_variables/index.en.md
+++ b/docs/docs/2_platform/3_deployment_guide/9_environment_variables/index.en.md
@@ -68,7 +68,6 @@ These variables are referenced as `${VAR}` (without a `${VAR:-default}` fallback
 | `EXPERT_ASKING_CHANNEL_TYPE` |  | `expert_asking_agent` |  |
 | `GEMINI_API_KEY` |  | `litellm` |  |
 | `HUGGINGFACE_API_KEY` |  | `litellm`, `vllm`, `vllm-bge-m3`, `vllm-bge-reranker` |  |
-| `JUPYTER_TOKEN` |  | `api`, `jupyter` |  |
 | `KEYCLOAK_ADMIN_PASSWORD` |  | `keycloak`, `keycloak-config` |  |
 | `KEYCLOAK_ADMIN_USER` |  | `keycloak`, `keycloak-config` |  |
 | `KEYCLOAK_API_SERVICE_CLIENT_SECRET` | `KeycloakSettings.API_SERVICE_CLIENT_SECRET` | `api`, `bot`, `keycloak`, `keycloak-config`, `sysadmin-api` | Client secret for the API service account |

--- a/docs/likec4/model/2_containers.c4
+++ b/docs/likec4/model/2_containers.c4
@@ -281,14 +281,6 @@ model {
       description "Code execution sandbox for OpenWebUI (plain LLM models). Per-user isolation; generated files surfaced to users via OpenWebUI's Files panel. Lives alone in the dedicated code-sandbox network (callers only) — no path to backend/data/NATS."
     }
 
-    jupyter = container "Jupyter" {
-      #tier-utility
-      technology "Jupyter Lab"
-      icon tech:jupyter
-      style { color gray }
-      description "Code execution sandbox — retained in the stack but no longer used by OpenWebUI for code execution."
-    }
-
     playwright = container "Playwright" {
       #tier-utility
       technology "Playwright (Chromium)"

--- a/docs/likec4/views/2_containers.c4
+++ b/docs/likec4/views/2_containers.c4
@@ -89,10 +89,10 @@ views {
 
   view tier_utility of hub {
     title       "Utility / Tools Tier"
-    description "Auxiliary services consumed mostly by OpenWebUI and operators. Open Terminal is the active code-execution sandbox (plain LLM models); Jupyter is retained but no longer the OpenWebUI code path. Attu provides a Milvus admin surface."
+    description "Auxiliary services consumed mostly by OpenWebUI and operators. Open Terminal is the code-execution sandbox (plain LLM models). Attu provides a Milvus admin surface."
 
     include
-      hub.searxng, hub.open_terminal, hub.jupyter, hub.playwright, hub.attu,
+      hub.searxng, hub.open_terminal, hub.playwright, hub.attu,
       hub.openwebui, hub.milvus, hub.oidc_middleware
   }
 }

--- a/infra/deployment/CLAUDE.md
+++ b/infra/deployment/CLAUDE.md
@@ -191,7 +191,7 @@ routes through Traefik.
 | Network        | Purpose                           | Internal | ICC | Key Services                                                  |
 | -------------- | --------------------------------- | -------- | --- | ------------------------------------------------------------- |
 | `proxy`        | External ingress via Traefik      | No       | Yes | traefik, api, web, open-webui, langfuse-web                   |
-| `backend`      | Application/processing services   | Yes\*    | Yes | litellm, langfuse-\*, mineru-api, vLLM (GPU), jupyter, otel   |
+| `backend`      | Application/processing services   | Yes\*    | Yes | litellm, langfuse-\*, mineru-api, vLLM (GPU), otel            |
 | `data`         | Databases, caches, message broker | Yes\*    | Yes | postgres, ferretdb, milvus, neo4j, valkey, nats, click        |
 | `storage`      | SeaweedFS cluster                 | Yes\*    | Yes | seaweedfs-\*, etcd                                            |
 | `egress`       | Outbound internet only            | No       | No  | playwright (ICC disabled — containers can't reach each other) |

--- a/infra/deployment/compose-config.yml
+++ b/infra/deployment/compose-config.yml
@@ -36,7 +36,6 @@ image_tags:
   litellm: litellm:v1.83.10-stable
   mineru_api: mineru-api:v2.7.5
   mineru_vlm: mineru-vlm:v2.7.5
-  jupyter: minimal-notebook:notebook-7.0.6
   open_terminal: open-terminal-office:0.11.34
   otel_collector: otel/opentelemetry-collector-contrib:0.154.0
   traefik: traefik:v3.6.2

--- a/infra/deployment/templates/docker-compose.yml.j2
+++ b/infra/deployment/templates/docker-compose.yml.j2
@@ -60,7 +60,6 @@
 {%- set NATS_ENDPOINT = "nats://nats:4222" %}
 {%- set REDIS_ENDPOINT = "redis://valkey:6379" %}
 {%- set LITE_LLM_PROXY_BASE_URL = "http://litellm:4000" %}
-{%- set JUPYTER_URL = "http://jupyter:8888" %}
 {%- set MINERU_API_BASE_URL = "http://mineru-api:8000" %}
 {%- set PRESIDIO_ANALYZER_API_BASE = "http://presidio-analyzer:3000" %}
 {%- set PRESIDIO_ANONYMIZER_API_BASE = "http://presidio-anonymizer:3000" %}
@@ -1887,37 +1886,9 @@ services:
   # ===================================================================
   # Utility & Code Execution Services
   # ===================================================================
-  # These services provide code execution runtimes (Jupyter) and
+  # These services provide code execution runtimes (Open Terminal) and
   # browser automation (Playwright) for various platform features.
   # ===================================================================
-
-  {{ service_license('jupyter') }}
-  jupyter:
-    container_name: jupyter-lab
-    image: {{ global.registry_prefix }}{{ image_tags.jupyter }}
-    restart: always
-    {%- if stage in ['dev', 'local', 'build'] %}
-    ports:
-      - "8888:8888"
-    {%- endif %}
-    volumes:
-      - {{ global.volume_root }}/jupyter-data:/home/jovyan/work
-    environment:
-      JUPYTER_ENABLE_LAB: true
-      JUPYTER_TOKEN: ${JUPYTER_TOKEN}
-    healthcheck:
-      test: ["CMD", "/etc/jupyter/docker_healthcheck.py"]
-      interval: 15s
-      timeout: 3s
-      start_period: 10s
-      retries: 3
-    logging:
-      driver: json-file
-      options:
-        max-size: 10m
-        max-file: 2
-    networks:
-      - backend
 
   {{ service_license('open-terminal') }}
   open-terminal:
@@ -2971,10 +2942,6 @@ services:
       MEM0_EMBEDDING_MODEL_NAME: ${MEM0_EMBEDDING_MODEL_NAME}
       MEM0_RERANKING_MODEL_NAME: ${MEM0_RERANKING_MODEL_NAME}
       MEM0_TELEMETRY: ${MEM0_TELEMETRY}
-
-      # Jupyter (for open-webui code interpreter)
-      JUPYTER_URL: {{ JUPYTER_URL }}
-      JUPYTER_TOKEN: ${JUPYTER_TOKEN}
 
       # MinerU (document parsing)
       MINERU_API_BASE_URL: {{ MINERU_API_BASE_URL }}

--- a/infra/docker-compose.build.gpu.yml
+++ b/infra/docker-compose.build.gpu.yml
@@ -1671,34 +1671,9 @@ services:
   # ===================================================================
   # Utility & Code Execution Services
   # ===================================================================
-  # These services provide code execution runtimes (Jupyter) and
+  # These services provide code execution runtimes (Open Terminal) and
   # browser automation (Playwright) for various platform features.
   # ===================================================================
-
-  # License: BSD-3-Clause — third-party (see LICENSE_REPORT.md)
-  jupyter:
-    container_name: jupyter-lab
-    image: ghcr.io/bbvch-ai/aihub-core/minimal-notebook:notebook-7.0.6
-    restart: always
-    ports: [8888:8888]
-    volumes:
-      - ${VOLUME_ROOT:-./.docker-volumes}/jupyter-data:/home/jovyan/work
-    environment:
-      JUPYTER_ENABLE_LAB: true
-      JUPYTER_TOKEN: ${JUPYTER_TOKEN}
-    healthcheck:
-      test: [CMD, /etc/jupyter/docker_healthcheck.py]
-      interval: 15s
-      timeout: 3s
-      start_period: 10s
-      retries: 3
-    logging:
-      driver: json-file
-      options:
-        max-size: 10m
-        max-file: 2
-    networks:
-      - backend
 
   # License: MIT — third-party (see LICENSE_REPORT.md)
   open-terminal:
@@ -2640,10 +2615,6 @@ services:
       MEM0_EMBEDDING_MODEL_NAME: ${MEM0_EMBEDDING_MODEL_NAME}
       MEM0_RERANKING_MODEL_NAME: ${MEM0_RERANKING_MODEL_NAME}
       MEM0_TELEMETRY: ${MEM0_TELEMETRY}
-
-      # Jupyter (for open-webui code interpreter)
-      JUPYTER_URL: http://jupyter:8888
-      JUPYTER_TOKEN: ${JUPYTER_TOKEN}
 
       # MinerU (document parsing)
       MINERU_API_BASE_URL: http://mineru-api:8000

--- a/infra/docker-compose.build.yml
+++ b/infra/docker-compose.build.yml
@@ -1488,34 +1488,9 @@ services:
   # ===================================================================
   # Utility & Code Execution Services
   # ===================================================================
-  # These services provide code execution runtimes (Jupyter) and
+  # These services provide code execution runtimes (Open Terminal) and
   # browser automation (Playwright) for various platform features.
   # ===================================================================
-
-  # License: BSD-3-Clause — third-party (see LICENSE_REPORT.md)
-  jupyter:
-    container_name: jupyter-lab
-    image: ghcr.io/bbvch-ai/aihub-core/minimal-notebook:notebook-7.0.6
-    restart: always
-    ports: [8888:8888]
-    volumes:
-      - ${VOLUME_ROOT:-./.docker-volumes}/jupyter-data:/home/jovyan/work
-    environment:
-      JUPYTER_ENABLE_LAB: true
-      JUPYTER_TOKEN: ${JUPYTER_TOKEN}
-    healthcheck:
-      test: [CMD, /etc/jupyter/docker_healthcheck.py]
-      interval: 15s
-      timeout: 3s
-      start_period: 10s
-      retries: 3
-    logging:
-      driver: json-file
-      options:
-        max-size: 10m
-        max-file: 2
-    networks:
-      - backend
 
   # License: MIT — third-party (see LICENSE_REPORT.md)
   open-terminal:
@@ -2428,10 +2403,6 @@ services:
       MEM0_EMBEDDING_MODEL_NAME: ${MEM0_EMBEDDING_MODEL_NAME}
       MEM0_RERANKING_MODEL_NAME: ${MEM0_RERANKING_MODEL_NAME}
       MEM0_TELEMETRY: ${MEM0_TELEMETRY}
-
-      # Jupyter (for open-webui code interpreter)
-      JUPYTER_URL: http://jupyter:8888
-      JUPYTER_TOKEN: ${JUPYTER_TOKEN}
 
       # MinerU (document parsing)
       MINERU_API_BASE_URL: http://mineru-api:8000

--- a/infra/docker-compose.dev.gpu.yml
+++ b/infra/docker-compose.dev.gpu.yml
@@ -1359,34 +1359,9 @@ services:
   # ===================================================================
   # Utility & Code Execution Services
   # ===================================================================
-  # These services provide code execution runtimes (Jupyter) and
+  # These services provide code execution runtimes (Open Terminal) and
   # browser automation (Playwright) for various platform features.
   # ===================================================================
-
-  # License: BSD-3-Clause — third-party (see LICENSE_REPORT.md)
-  jupyter:
-    container_name: jupyter-lab
-    image: ghcr.io/bbvch-ai/aihub-core/minimal-notebook:notebook-7.0.6
-    restart: always
-    ports: [8888:8888]
-    volumes:
-      - ${VOLUME_ROOT:-./.docker-volumes}/jupyter-data:/home/jovyan/work
-    environment:
-      JUPYTER_ENABLE_LAB: true
-      JUPYTER_TOKEN: ${JUPYTER_TOKEN}
-    healthcheck:
-      test: [CMD, /etc/jupyter/docker_healthcheck.py]
-      interval: 15s
-      timeout: 3s
-      start_period: 10s
-      retries: 3
-    logging:
-      driver: json-file
-      options:
-        max-size: 10m
-        max-file: 2
-    networks:
-      - backend
 
   # License: MIT — third-party (see LICENSE_REPORT.md)
   open-terminal:

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -1176,34 +1176,9 @@ services:
   # ===================================================================
   # Utility & Code Execution Services
   # ===================================================================
-  # These services provide code execution runtimes (Jupyter) and
+  # These services provide code execution runtimes (Open Terminal) and
   # browser automation (Playwright) for various platform features.
   # ===================================================================
-
-  # License: BSD-3-Clause — third-party (see LICENSE_REPORT.md)
-  jupyter:
-    container_name: jupyter-lab
-    image: ghcr.io/bbvch-ai/aihub-core/minimal-notebook:notebook-7.0.6
-    restart: always
-    ports: [8888:8888]
-    volumes:
-      - ${VOLUME_ROOT:-./.docker-volumes}/jupyter-data:/home/jovyan/work
-    environment:
-      JUPYTER_ENABLE_LAB: true
-      JUPYTER_TOKEN: ${JUPYTER_TOKEN}
-    healthcheck:
-      test: [CMD, /etc/jupyter/docker_healthcheck.py]
-      interval: 15s
-      timeout: 3s
-      start_period: 10s
-      retries: 3
-    logging:
-      driver: json-file
-      options:
-        max-size: 10m
-        max-file: 2
-    networks:
-      - backend
 
   # License: MIT — third-party (see LICENSE_REPORT.md)
   open-terminal:

--- a/infra/docker-compose.latest.gpu.yml
+++ b/infra/docker-compose.latest.gpu.yml
@@ -1635,33 +1635,9 @@ services:
   # ===================================================================
   # Utility & Code Execution Services
   # ===================================================================
-  # These services provide code execution runtimes (Jupyter) and
+  # These services provide code execution runtimes (Open Terminal) and
   # browser automation (Playwright) for various platform features.
   # ===================================================================
-
-  # License: BSD-3-Clause — third-party (see LICENSE_REPORT.md)
-  jupyter:
-    container_name: jupyter-lab
-    image: ghcr.io/bbvch-ai/aihub-core/minimal-notebook:notebook-7.0.6
-    restart: always
-    volumes:
-      - ${VOLUME_ROOT:-./.docker-volumes}/jupyter-data:/home/jovyan/work
-    environment:
-      JUPYTER_ENABLE_LAB: true
-      JUPYTER_TOKEN: ${JUPYTER_TOKEN}
-    healthcheck:
-      test: [CMD, /etc/jupyter/docker_healthcheck.py]
-      interval: 15s
-      timeout: 3s
-      start_period: 10s
-      retries: 3
-    logging:
-      driver: json-file
-      options:
-        max-size: 10m
-        max-file: 2
-    networks:
-      - backend
 
   # License: MIT — third-party (see LICENSE_REPORT.md)
   open-terminal:
@@ -2588,10 +2564,6 @@ services:
       MEM0_EMBEDDING_MODEL_NAME: ${MEM0_EMBEDDING_MODEL_NAME}
       MEM0_RERANKING_MODEL_NAME: ${MEM0_RERANKING_MODEL_NAME}
       MEM0_TELEMETRY: ${MEM0_TELEMETRY}
-
-      # Jupyter (for open-webui code interpreter)
-      JUPYTER_URL: http://jupyter:8888
-      JUPYTER_TOKEN: ${JUPYTER_TOKEN}
 
       # MinerU (document parsing)
       MINERU_API_BASE_URL: http://mineru-api:8000

--- a/infra/docker-compose.latest.yml
+++ b/infra/docker-compose.latest.yml
@@ -1456,33 +1456,9 @@ services:
   # ===================================================================
   # Utility & Code Execution Services
   # ===================================================================
-  # These services provide code execution runtimes (Jupyter) and
+  # These services provide code execution runtimes (Open Terminal) and
   # browser automation (Playwright) for various platform features.
   # ===================================================================
-
-  # License: BSD-3-Clause — third-party (see LICENSE_REPORT.md)
-  jupyter:
-    container_name: jupyter-lab
-    image: ghcr.io/bbvch-ai/aihub-core/minimal-notebook:notebook-7.0.6
-    restart: always
-    volumes:
-      - ${VOLUME_ROOT:-./.docker-volumes}/jupyter-data:/home/jovyan/work
-    environment:
-      JUPYTER_ENABLE_LAB: true
-      JUPYTER_TOKEN: ${JUPYTER_TOKEN}
-    healthcheck:
-      test: [CMD, /etc/jupyter/docker_healthcheck.py]
-      interval: 15s
-      timeout: 3s
-      start_period: 10s
-      retries: 3
-    logging:
-      driver: json-file
-      options:
-        max-size: 10m
-        max-file: 2
-    networks:
-      - backend
 
   # License: MIT — third-party (see LICENSE_REPORT.md)
   open-terminal:
@@ -2382,10 +2358,6 @@ services:
       MEM0_EMBEDDING_MODEL_NAME: ${MEM0_EMBEDDING_MODEL_NAME}
       MEM0_RERANKING_MODEL_NAME: ${MEM0_RERANKING_MODEL_NAME}
       MEM0_TELEMETRY: ${MEM0_TELEMETRY}
-
-      # Jupyter (for open-webui code interpreter)
-      JUPYTER_URL: http://jupyter:8888
-      JUPYTER_TOKEN: ${JUPYTER_TOKEN}
 
       # MinerU (document parsing)
       MINERU_API_BASE_URL: http://mineru-api:8000

--- a/infra/docker-compose.local.gpu.yml
+++ b/infra/docker-compose.local.gpu.yml
@@ -1664,34 +1664,9 @@ services:
   # ===================================================================
   # Utility & Code Execution Services
   # ===================================================================
-  # These services provide code execution runtimes (Jupyter) and
+  # These services provide code execution runtimes (Open Terminal) and
   # browser automation (Playwright) for various platform features.
   # ===================================================================
-
-  # License: BSD-3-Clause — third-party (see LICENSE_REPORT.md)
-  jupyter:
-    container_name: jupyter-lab
-    image: ghcr.io/bbvch-ai/aihub-core/minimal-notebook:notebook-7.0.6
-    restart: always
-    ports: [8888:8888]
-    volumes:
-      - ${VOLUME_ROOT:-./.docker-volumes}/jupyter-data:/home/jovyan/work
-    environment:
-      JUPYTER_ENABLE_LAB: true
-      JUPYTER_TOKEN: ${JUPYTER_TOKEN}
-    healthcheck:
-      test: [CMD, /etc/jupyter/docker_healthcheck.py]
-      interval: 15s
-      timeout: 3s
-      start_period: 10s
-      retries: 3
-    logging:
-      driver: json-file
-      options:
-        max-size: 10m
-        max-file: 2
-    networks:
-      - backend
 
   # License: MIT — third-party (see LICENSE_REPORT.md)
   open-terminal:
@@ -2627,10 +2602,6 @@ services:
       MEM0_EMBEDDING_MODEL_NAME: ${MEM0_EMBEDDING_MODEL_NAME}
       MEM0_RERANKING_MODEL_NAME: ${MEM0_RERANKING_MODEL_NAME}
       MEM0_TELEMETRY: ${MEM0_TELEMETRY}
-
-      # Jupyter (for open-webui code interpreter)
-      JUPYTER_URL: http://jupyter:8888
-      JUPYTER_TOKEN: ${JUPYTER_TOKEN}
 
       # MinerU (document parsing)
       MINERU_API_BASE_URL: http://mineru-api:8000

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -1481,34 +1481,9 @@ services:
   # ===================================================================
   # Utility & Code Execution Services
   # ===================================================================
-  # These services provide code execution runtimes (Jupyter) and
+  # These services provide code execution runtimes (Open Terminal) and
   # browser automation (Playwright) for various platform features.
   # ===================================================================
-
-  # License: BSD-3-Clause — third-party (see LICENSE_REPORT.md)
-  jupyter:
-    container_name: jupyter-lab
-    image: ghcr.io/bbvch-ai/aihub-core/minimal-notebook:notebook-7.0.6
-    restart: always
-    ports: [8888:8888]
-    volumes:
-      - ${VOLUME_ROOT:-./.docker-volumes}/jupyter-data:/home/jovyan/work
-    environment:
-      JUPYTER_ENABLE_LAB: true
-      JUPYTER_TOKEN: ${JUPYTER_TOKEN}
-    healthcheck:
-      test: [CMD, /etc/jupyter/docker_healthcheck.py]
-      interval: 15s
-      timeout: 3s
-      start_period: 10s
-      retries: 3
-    logging:
-      driver: json-file
-      options:
-        max-size: 10m
-        max-file: 2
-    networks:
-      - backend
 
   # License: MIT — third-party (see LICENSE_REPORT.md)
   open-terminal:
@@ -2415,10 +2390,6 @@ services:
       MEM0_EMBEDDING_MODEL_NAME: ${MEM0_EMBEDDING_MODEL_NAME}
       MEM0_RERANKING_MODEL_NAME: ${MEM0_RERANKING_MODEL_NAME}
       MEM0_TELEMETRY: ${MEM0_TELEMETRY}
-
-      # Jupyter (for open-webui code interpreter)
-      JUPYTER_URL: http://jupyter:8888
-      JUPYTER_TOKEN: ${JUPYTER_TOKEN}
 
       # MinerU (document parsing)
       MINERU_API_BASE_URL: http://mineru-api:8000

--- a/infra/docker-compose.nightly.gpu.yml
+++ b/infra/docker-compose.nightly.gpu.yml
@@ -1635,33 +1635,9 @@ services:
   # ===================================================================
   # Utility & Code Execution Services
   # ===================================================================
-  # These services provide code execution runtimes (Jupyter) and
+  # These services provide code execution runtimes (Open Terminal) and
   # browser automation (Playwright) for various platform features.
   # ===================================================================
-
-  # License: BSD-3-Clause — third-party (see LICENSE_REPORT.md)
-  jupyter:
-    container_name: jupyter-lab
-    image: ghcr.io/bbvch-ai/aihub-core/minimal-notebook:notebook-7.0.6
-    restart: always
-    volumes:
-      - ${VOLUME_ROOT:-./.docker-volumes}/jupyter-data:/home/jovyan/work
-    environment:
-      JUPYTER_ENABLE_LAB: true
-      JUPYTER_TOKEN: ${JUPYTER_TOKEN}
-    healthcheck:
-      test: [CMD, /etc/jupyter/docker_healthcheck.py]
-      interval: 15s
-      timeout: 3s
-      start_period: 10s
-      retries: 3
-    logging:
-      driver: json-file
-      options:
-        max-size: 10m
-        max-file: 2
-    networks:
-      - backend
 
   # License: MIT — third-party (see LICENSE_REPORT.md)
   open-terminal:
@@ -2588,10 +2564,6 @@ services:
       MEM0_EMBEDDING_MODEL_NAME: ${MEM0_EMBEDDING_MODEL_NAME}
       MEM0_RERANKING_MODEL_NAME: ${MEM0_RERANKING_MODEL_NAME}
       MEM0_TELEMETRY: ${MEM0_TELEMETRY}
-
-      # Jupyter (for open-webui code interpreter)
-      JUPYTER_URL: http://jupyter:8888
-      JUPYTER_TOKEN: ${JUPYTER_TOKEN}
 
       # MinerU (document parsing)
       MINERU_API_BASE_URL: http://mineru-api:8000

--- a/infra/docker-compose.nightly.yml
+++ b/infra/docker-compose.nightly.yml
@@ -1456,33 +1456,9 @@ services:
   # ===================================================================
   # Utility & Code Execution Services
   # ===================================================================
-  # These services provide code execution runtimes (Jupyter) and
+  # These services provide code execution runtimes (Open Terminal) and
   # browser automation (Playwright) for various platform features.
   # ===================================================================
-
-  # License: BSD-3-Clause — third-party (see LICENSE_REPORT.md)
-  jupyter:
-    container_name: jupyter-lab
-    image: ghcr.io/bbvch-ai/aihub-core/minimal-notebook:notebook-7.0.6
-    restart: always
-    volumes:
-      - ${VOLUME_ROOT:-./.docker-volumes}/jupyter-data:/home/jovyan/work
-    environment:
-      JUPYTER_ENABLE_LAB: true
-      JUPYTER_TOKEN: ${JUPYTER_TOKEN}
-    healthcheck:
-      test: [CMD, /etc/jupyter/docker_healthcheck.py]
-      interval: 15s
-      timeout: 3s
-      start_period: 10s
-      retries: 3
-    logging:
-      driver: json-file
-      options:
-        max-size: 10m
-        max-file: 2
-    networks:
-      - backend
 
   # License: MIT — third-party (see LICENSE_REPORT.md)
   open-terminal:
@@ -2382,10 +2358,6 @@ services:
       MEM0_EMBEDDING_MODEL_NAME: ${MEM0_EMBEDDING_MODEL_NAME}
       MEM0_RERANKING_MODEL_NAME: ${MEM0_RERANKING_MODEL_NAME}
       MEM0_TELEMETRY: ${MEM0_TELEMETRY}
-
-      # Jupyter (for open-webui code interpreter)
-      JUPYTER_URL: http://jupyter:8888
-      JUPYTER_TOKEN: ${JUPYTER_TOKEN}
 
       # MinerU (document parsing)
       MINERU_API_BASE_URL: http://mineru-api:8000

--- a/licenses.config.json
+++ b/licenses.config.json
@@ -245,12 +245,6 @@
       "notes": "Permissive license, used by Langfuse for analytics"
     },
     {
-      "service": "jupyter",
-      "license": "BSD-3-Clause",
-      "status": "✅",
-      "notes": "Permissive license"
-    },
-    {
       "service": "litellm",
       "license": "MIT",
       "status": "✅",
@@ -309,12 +303,6 @@
       "license": "Apache-2.0",
       "status": "✅",
       "notes": "Permissive license"
-    },
-    {
-      "service": "minimal-notebook",
-      "license": "BSD-3-Clause",
-      "status": "✅",
-      "notes": "Jupyter base image"
     },
     {
       "service": "opentelemetry-collector-contrib",


### PR DESCRIPTION
Follow-up cleanup to #1524, which switched OpenWebUI's code execution to **Open Terminal** but deliberately kept the
`jupyter` service running as a fallback "in case open-terminal does not work as intended". That fallback has not been
needed, so this removes it. There was no tracking issue — the follow-up existed only as prose in #1524 and in the ADR's
consequences.

## What changed

- **`jupyter` service removed** from `infra/deployment/templates/docker-compose.yml.j2`, together with the `JUPYTER_URL`
  Jinja variable and the `JUPYTER_URL` / `JUPYTER_TOKEN` pair that was still being passed to the `api` container. Those
  two were dead: nothing under `packages/**` ever read them.
- **`minimal-notebook:notebook-7.0.6` pin dropped** from `compose-config.yml`, and both the `jupyter` and
  `minimal-notebook` entries removed from `licenses.config.json`.
- **`JUPYTER_TOKEN` / `JUPYTER_URL` removed** from `.env.dev` and `.env.prod`.
- **Regenerated** all 10 compose stages (`make generate-compose`) and the env-var reference page
  (`make generate-env-docs`).

## Docs

README, root and `infra/deployment` CLAUDE.md, arc42 ch. 07 (deployment view), the LikeC4 model + views, and the
containers / network-isolation / infrastructure-layers pages in **both EN and DE**, plus the `docker-dev`,
`deployment-reviewer` and `connectivity-researcher` references under `.claude/`.

The German containers and infrastructure-layers pages were still describing Jupyter as the *active* code sandbox — they
now match the English text. The Open Terminal ADR gets a dated amendment recording that the follow-up is done, rather
than a rewrite of its history.

## Known gap

`docs/media/architecture/**` (the drawio source and the four exported `tier_*.svg` files rendered in the vision docs)
still shows a "Jupyter Lab" box. The label ships with a base64-embedded Jupyter logo and the drawio source is
compressed, so hand-editing the SVGs would leave a wrong icon or a layout hole. This needs a re-export from draw.io and
is left out of scope here.

## Testing

No `packages/**` file changed, so no pytest scope is affected. Validated what actually changed instead:

- `make pr-ready` — passes.
- `npx likec4 validate` — ✓ Valid (6 files).
- `docker compose config` — parses cleanly for dev, local, build, latest and nightly.
- Grepped the tree: no `jupyter` references remain outside the CHANGELOG, the ADR's historical narrative, the
  `black[jupyter]` dev dependency, and the LikeC4 icon-pack name list.
