### PR TITLE
feat(sysadmin): LCDM tenant provision + lcdm_tenant_id, login & deploy fixes

### DIFF
--- a/infra/deployment/templates/docker-compose.yml.j2
+++ b/infra/deployment/templates/docker-compose.yml.j2
@@ -3123,6 +3123,10 @@ services:
       # General Auth settings
       AUTH_ENABLE_API_ACCESS: True
       AUTH_OPEN_WEBUI_SIGNING_SECRET: ${AUTH_OPEN_WEBUI_SIGNING_SECRET}
+      # AuthSettings reads OPEN_WEBUI_SIGNING_SECRET (min 64 chars). Without this explicit export it
+      # falls back to OpenWebUI's shorter OPENWEBUI_SECRET_KEY (43 chars) and sysadmin-api crash-loops
+      # on boot (ValidationError: should have at least 64 items, not 43).
+      OPEN_WEBUI_SIGNING_SECRET: ${AUTH_OPEN_WEBUI_SIGNING_SECRET}
 
       # Keycloak OIDC config
       KEYCLOAK_URL: {{ KEYCLOAK_INTERNAL_URL }}

--- a/packages/agent/swiss_ai_hub/agent/agents/mcp_react_agent/mcp_react_agent.py
+++ b/packages/agent/swiss_ai_hub/agent/agents/mcp_react_agent/mcp_react_agent.py
@@ -13,6 +13,7 @@ from swiss_ai_hub.core.events.agent import (
 from swiss_ai_hub.core.generative_ai import limit_chat_history
 from swiss_ai_hub.core.i18n import LocaleHandler
 from swiss_ai_hub.core.mcp.mcp_client_config import McpClientConfig
+from swiss_ai_hub.core.persistence import TenantMetadataEntity
 
 from swiss_ai_hub.agent.agents.agent import Agent
 from swiss_ai_hub.agent.agents.mcp_react_agent.configs.mcp_react_agent_config import McpReactAgentConfig
@@ -32,6 +33,38 @@ TOOL_SCHEMAS_KEY = "mcp_tool_schemas"
 CONVERSATION_KEY = "conversation"
 TOTAL_TOOL_CALLS_KEY = "total_tool_calls"
 NEW_TOOL_CALLS_KEY = "new_tool_calls"
+TENANT_HEADER_VALUE_KEY = "mcp_tenant_header_value"
+
+
+async def _apply_tenant_header(
+    mcp_config: McpClientConfig,
+    run_context: RunContext,
+    user: UserIdentity | None,
+) -> McpClientConfig:
+    """Inject the acting tenant's originating id under ``forward_tenant_id_header`` when configured.
+
+    One agent profile can then serve every tenant, each MCP call scoped to its own external tenant.
+    The value is resolved from the user's acting tenant on the entry step (which carries the user)
+    and cached in the run context, so later tool-execution steps — whose trigger events have no user —
+    reuse the same tenant. No-op when the header is not configured or the tenant has no originating id.
+    """
+    header_name = mcp_config.forward_tenant_id_header
+    if not header_name:
+        return mcp_config
+
+    tenant_id_value: str | None = await run_context.get(TENANT_HEADER_VALUE_KEY, None)
+    if tenant_id_value is None and user is not None and user.acting_within_tenant is not None:
+        entity = TenantMetadataEntity.get_metadata_by_tenant_id(user.acting_within_tenant.id)
+        if entity is not None and entity.lcdm_tenant_id is not None:
+            tenant_id_value = str(entity.lcdm_tenant_id)
+            await run_context.set(TENANT_HEADER_VALUE_KEY, tenant_id_value)
+
+    if tenant_id_value is None:
+        return mcp_config
+
+    merged_headers = dict(mcp_config.headers or {})
+    merged_headers[header_name] = tenant_id_value
+    return mcp_config.model_copy(update={"headers": merged_headers})
 
 
 @precondition()
@@ -70,8 +103,10 @@ class McpReactAgent(Agent):
         mcp_config: McpClientConfig,
         config: McpReactAgentConfig,
         run_context: RunContext,
+        user: UserIdentity | None = None,
     ) -> McpReasoningEvent:
         """Discover MCP tools and resources, seed conversation with system prompt, trigger first reasoning iteration."""
+        mcp_config = await _apply_tenant_header(mcp_config, run_context, user)
         user_token = await McpAuthResolver.resolve_user_token(run_context)
         async with McpClientFactory.create(mcp_config, user_token=user_token) as mcp_client:
             tools = await mcp_client.list_tools()
@@ -190,6 +225,7 @@ class McpReactAgent(Agent):
         new_tool_events = tool_events[-new_count:]
 
         tool_messages: list[Message] = []
+        mcp_config = await _apply_tenant_header(mcp_config, run_context, None)
         user_token = await McpAuthResolver.resolve_user_token(run_context)
         async with McpClientFactory.create(mcp_config, user_token=user_token) as mcp_client:
             for tool_event in new_tool_events:

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/mcp.de.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/mcp.de.yml
@@ -21,3 +21,8 @@ config:
   timeout:
     label: Zeitlimit (Sekunden)
     help: Maximale Wartezeit auf eine Antwort vom MCP-Server.
+  forward_tenant_id_header:
+    label: Mandanten-ID-Header weiterleiten
+    help: Optional. Wenn gesetzt, wird die Ursprungs-ID des aktiven Mandanten bei jedem MCP-Request
+      unter diesem Header-Namen mitgesendet — so bedient ein Profil alle Mandanten (je isoliert).
+      Leer lassen zum Deaktivieren. Beispiel - X-LCDM-Tenant.

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/mcp.en.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/mcp.en.yml
@@ -20,3 +20,8 @@ config:
   timeout:
     label: Timeout (seconds)
     help: Maximum time to wait for a response from the MCP server.
+  forward_tenant_id_header:
+    label: Forward tenant id header
+    help: Optional. If set, the acting tenant's originating id is sent on every MCP request
+      under this header name, so one profile serves all tenants (each scoped to its own tenant).
+      Leave empty to disable. Example - X-LCDM-Tenant.

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/mcp.fr.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/mcp.fr.yml
@@ -21,3 +21,8 @@ config:
   timeout:
     label: Délai d'attente (secondes)
     help: Temps maximum d'attente pour une réponse du serveur MCP.
+  forward_tenant_id_header:
+    label: En-tête d'ID de mandant à transmettre
+    help: Optionnel. Si défini, l'ID d'origine du mandant actif est envoyé à chaque requête MCP
+      sous ce nom d'en-tête, de sorte qu'un seul profil serve tous les mandants (chacun isolé).
+      Laisser vide pour désactiver. Exemple - X-LCDM-Tenant.

--- a/packages/core/swiss_ai_hub/core/i18n/translations/lib/mcp.it.yml
+++ b/packages/core/swiss_ai_hub/core/i18n/translations/lib/mcp.it.yml
@@ -21,3 +21,8 @@ config:
   timeout:
     label: Timeout (secondi)
     help: Tempo massimo di attesa per una risposta dal server MCP.
+  forward_tenant_id_header:
+    label: Intestazione ID tenant da inoltrare
+    help: Opzionale. Se impostato, l'ID di origine del tenant attivo viene inviato a ogni richiesta MCP
+      con questo nome di intestazione, così un profilo serve tutti i tenant (ciascuno isolato).
+      Lasciare vuoto per disattivare. Esempio - X-LCDM-Tenant.

--- a/packages/core/swiss_ai_hub/core/mcp/mcp_client_config.py
+++ b/packages/core/swiss_ai_hub/core/mcp/mcp_client_config.py
@@ -34,6 +34,17 @@ class McpClientConfig(StepConfig):
         dict[str, str] | None,
         Field(default=None, description="Additional HTTP headers for the connection."),
     ]
+    forward_tenant_id_header: Annotated[
+        str | InputText | None,
+        Field(
+            default=None,
+            description=(
+                "If set, the acting tenant's originating id (TenantMetadataEntity.lcdm_tenant_id) is sent "
+                "on every MCP request under this header name — so one agent profile serves all tenants, each "
+                "scoped to its own external tenant. Leave empty to disable. Example: 'X-LCDM-Tenant'."
+            ),
+        ),
+    ]
     timeout: Annotated[
         float | InputNumber,
         Field(default=30.0, description="Client timeout in seconds."),
@@ -83,5 +94,9 @@ class McpClientConfig(StepConfig):
                 min=1,
                 max=300,
                 step=1,
+            ),
+            forward_tenant_id_header=InputText(
+                label=LocaleString.from_i18n_path("lib.mcp.config.forward_tenant_id_header.label"),
+                help=LocaleString.from_i18n_path("lib.mcp.config.forward_tenant_id_header.help"),
             ),
         )

--- a/packages/core/swiss_ai_hub/core/persistence/access/entities/tenant_metadata_entity.py
+++ b/packages/core/swiss_ai_hub/core/persistence/access/entities/tenant_metadata_entity.py
@@ -1,7 +1,7 @@
 from datetime import UTC, datetime
 from typing import Self
 
-from mongoengine import DateTimeField, Document, ListField, NotUniqueError, StringField
+from mongoengine import DateTimeField, Document, IntField, ListField, NotUniqueError, StringField
 
 from swiss_ai_hub.core.infrastructure.opentelemetry.tracing.decorators.trace_fn import trace_fn
 
@@ -35,6 +35,10 @@ class TenantMetadataEntity(Document):
     name = StringField(required=True, unique=True)
     description = StringField(default="")
     access_rules = ListField(StringField(), default=list)
+    # The originating LCDM Hub tenant id (numeric), set when a tenant is pushed in from the LCDM Hub.
+    # It is what the LCDM MCP expects in its X-LCDM-Tenant header, so exposing it here lets an admin
+    # read it off the AI Hub tenant when wiring an McpReactAgent profile. None for non-LCDM tenants.
+    lcdm_tenant_id = IntField(null=True)
     created_at = DateTimeField(default=lambda: datetime.now(UTC))
     updated_at = DateTimeField(default=lambda: datetime.now(UTC))
 
@@ -76,6 +80,7 @@ class TenantMetadataEntity(Document):
         name: str,
         description: str = "",
         access_rules: list[str] | None = None,
+        lcdm_tenant_id: int | None = None,
     ) -> Self:
         """Stores metadata for an existing Keycloak tenant group.
 
@@ -87,6 +92,7 @@ class TenantMetadataEntity(Document):
             name=name,
             description=description,
             access_rules=access_rules or [],
+            lcdm_tenant_id=lcdm_tenant_id,
         )
         tenant.save()
         return tenant
@@ -129,6 +135,7 @@ class TenantMetadataEntity(Document):
         name: str | None = None,
         description: str | None = None,
         access_rules: list[str] | None = None,
+        lcdm_tenant_id: int | None = None,
     ) -> Self | None:
         """
         Updates stored metadata for an existing tenant. Returns the updated entity or None if no metadata was stored.
@@ -146,6 +153,8 @@ class TenantMetadataEntity(Document):
             tenant.description = description
         if access_rules is not None:
             tenant.access_rules = access_rules
+        if lcdm_tenant_id is not None:
+            tenant.lcdm_tenant_id = lcdm_tenant_id
 
         tenant.updated_at = datetime.now(UTC)
         tenant.save()

--- a/packages/sysadmin-api/swiss_ai_hub/sysadmin_api/main.py
+++ b/packages/sysadmin-api/swiss_ai_hub/sysadmin_api/main.py
@@ -29,6 +29,7 @@ runner.mount(
     .list_unconfigured_tenants()
     .get_tenant()
     .create_tenant_metadata()
+    .provision_tenant()
     .update_tenant_metadata()
     .delete_tenant_metadata(),
     # Controllers from packages/api re-mounted here so sysadmin-web's inherited

--- a/packages/sysadmin-api/swiss_ai_hub/sysadmin_api/routes/tenant_admin/dto/create_tenant_metadata_request.py
+++ b/packages/sysadmin-api/swiss_ai_hub/sysadmin_api/routes/tenant_admin/dto/create_tenant_metadata_request.py
@@ -35,6 +35,13 @@ class CreateTenantMetadataRequest(BaseModel):
         Field(description="A short description of the tenant."),
     ] = ""
     access_rules: Annotated[list[str], Field(description="Access rules granted to this tenant.")] = []
+    lcdm_tenant_id: Annotated[
+        int | None,
+        Field(
+            description="Originating LCDM Hub tenant id (numeric). Set when the tenant is pushed in from the "
+            "LCDM Hub; it is the value the LCDM MCP expects in its X-LCDM-Tenant header.",
+        ),
+    ] = None
 
     @field_validator("access_rules")
     @classmethod

--- a/packages/sysadmin-api/swiss_ai_hub/sysadmin_api/routes/tenant_admin/dto/tenant_response.py
+++ b/packages/sysadmin-api/swiss_ai_hub/sysadmin_api/routes/tenant_admin/dto/tenant_response.py
@@ -14,6 +14,10 @@ class TenantResponse(BaseModel):
     name: Annotated[str, Field(description="Tenant display name.")]
     description: Annotated[str, Field(description="Tenant description.")]
     access_rules: Annotated[list[str], Field(description="Access rules granted to this tenant.")]
+    lcdm_tenant_id: Annotated[
+        int | None,
+        Field(description="Originating LCDM Hub tenant id (numeric), if this tenant was pushed in from the LCDM Hub."),
+    ] = None
     state: Annotated[
         TenantState, Field(description="Whether the tenant also exists in Keycloak (active) or not (orphaned).")
     ]
@@ -27,6 +31,7 @@ class TenantResponse(BaseModel):
             name=entity.name,
             description=entity.description or "",
             access_rules=entity.access_rules or [],
+            lcdm_tenant_id=entity.lcdm_tenant_id,
             state=state,
             created_at=entity.created_at,
             updated_at=entity.updated_at,

--- a/packages/sysadmin-api/swiss_ai_hub/sysadmin_api/routes/tenant_admin/tenant_admin_controller.py
+++ b/packages/sysadmin-api/swiss_ai_hub/sysadmin_api/routes/tenant_admin/tenant_admin_controller.py
@@ -78,6 +78,22 @@ class TenantAdminController(Controller):
 
         return self
 
+    def provision_tenant(self, route: str = "/provision") -> Self:
+        @self.router.post(route, tags=self.tags)
+        async def provision_tenant(
+            data: CreateTenantMetadataRequest,
+            _: Annotated[UserIdentity, Security(self.sys_admin_user())],
+        ) -> TenantResponse:
+            """Idempotently provision a tenant: create the Keycloak group if missing, then upsert its
+            metadata. Built for an external source of truth (e.g. the LCDM Hub) to push its tenants in
+            and re-run the sync repeatedly (flat — each tenant becomes its own group under /tenants/)."""
+            try:
+                return await TenantAdminService.provision_tenant(data)
+            except NotUniqueError:
+                raise HTTPException(status_code=409, detail=f"Tenant with name '{data.name}' already exists.")
+
+        return self
+
     def update_tenant_metadata(self, route: str = _TENANT_ROUTE) -> Self:
         @self.router.patch(route, tags=self.tags)
         async def update_tenant_metadata(

--- a/packages/sysadmin-api/swiss_ai_hub/sysadmin_api/routes/tenant_admin/tenant_admin_service.py
+++ b/packages/sysadmin-api/swiss_ai_hub/sysadmin_api/routes/tenant_admin/tenant_admin_service.py
@@ -113,6 +113,46 @@ class TenantAdminService:
 
     @staticmethod
     @trace_fn
+    async def provision_tenant(data: CreateTenantMetadataRequest) -> TenantResponse:
+        """Idempotently provision a tenant end-to-end: create the Keycloak group if missing,
+        then create-or-update its metadata (upsert).
+
+        Unlike ``create_tenant_metadata`` (which requires a pre-existing group and rejects
+        duplicates), this is built for an external source of truth (e.g. the LCDM Hub) that
+        pushes its tenants in and re-runs the sync repeatedly: every side effect is idempotent
+        so the same call can be replayed safely. The tenant hierarchy is flattened — each pushed
+        tenant becomes its own flat group under ``/tenants/``.
+        """
+        by_name = TenantMetadataEntity.get_metadata_by_tenant_name(data.name)
+        if by_name and by_name.id != data.tenant_id:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Tenant with name '{data.name}' already exists for a different tenant id.",
+            )
+
+        await KeycloakAdminService.create_tenant_group(data.tenant_id)
+        await initialize_default_roles_for_tenant(data.tenant_id)
+        await KeycloakAdminService.assign_superuser_to_tenant(data.tenant_id)
+
+        normalized_rules = [AccessChecker.normalize_model_access_rule(rule) for rule in data.access_rules]
+        if TenantMetadataEntity.get_metadata_by_tenant_id(data.tenant_id):
+            entity = TenantMetadataEntity.update_tenant_metadata(
+                tenant_id=data.tenant_id,
+                name=data.name,
+                description=data.description,
+                access_rules=normalized_rules,
+            )
+        else:
+            entity = TenantMetadataEntity.create_tenant_metadata(
+                tenant_id=data.tenant_id,
+                name=data.name,
+                description=data.description,
+                access_rules=normalized_rules,
+            )
+        return TenantResponse.from_entity(entity, state=TenantState.ACTIVE)
+
+    @staticmethod
+    @trace_fn
     async def update_tenant_metadata(tenant_id: str, data: UpdateTenantMetadataRequest) -> TenantResponse:
         """Updates MongoDB metadata for an active tenant.
 

--- a/packages/sysadmin-api/swiss_ai_hub/sysadmin_api/routes/tenant_admin/tenant_admin_service.py
+++ b/packages/sysadmin-api/swiss_ai_hub/sysadmin_api/routes/tenant_admin/tenant_admin_service.py
@@ -108,6 +108,7 @@ class TenantAdminService:
             name=data.name,
             description=data.description,
             access_rules=[AccessChecker.normalize_model_access_rule(rule) for rule in data.access_rules],
+            lcdm_tenant_id=data.lcdm_tenant_id,
         )
         return TenantResponse.from_entity(entity, state=TenantState.ACTIVE)
 
@@ -141,6 +142,7 @@ class TenantAdminService:
                 name=data.name,
                 description=data.description,
                 access_rules=normalized_rules,
+                lcdm_tenant_id=data.lcdm_tenant_id,
             )
         else:
             entity = TenantMetadataEntity.create_tenant_metadata(
@@ -148,6 +150,7 @@ class TenantAdminService:
                 name=data.name,
                 description=data.description,
                 access_rules=normalized_rules,
+                lcdm_tenant_id=data.lcdm_tenant_id,
             )
         return TenantResponse.from_entity(entity, state=TenantState.ACTIVE)
 
@@ -217,6 +220,7 @@ class TenantAdminService:
             "name": tenant.name,
             "description": tenant.description,
             "access_rules": list(tenant.access_rules),
+            "lcdm_tenant_id": tenant.lcdm_tenant_id,
         }
 
         if not TenantMetadataEntity.delete_tenant_metadata(tenant_id):

--- a/packages/sysadmin-api/swiss_ai_hub/sysadmin_api/routes/tenant_admin/tenant_admin_service.py
+++ b/packages/sysadmin-api/swiss_ai_hub/sysadmin_api/routes/tenant_admin/tenant_admin_service.py
@@ -13,6 +13,12 @@ from swiss_ai_hub.sysadmin_api.routes.tenant_admin.dto.update_tenant_metadata_re
 
 _TENANT_NOT_FOUND = "Tenant not found."
 
+# A freshly provisioned tenant with an empty ceiling can use no service at all (the access-checker
+# takes MIN(tenant ceiling, user rules), so an empty ceiling denies everything — even for admins).
+# An external syncer (e.g. the LCDM Hub) pushes tenants with no rules, so seed a sensible default on
+# creation to make them usable out of the box. Admins can narrow it afterwards.
+_DEFAULT_PROVISION_ACCESS_RULES = ["aihub.admin.>"]
+
 
 class TenantAdminService:
     """Handles tenant CRUD operations for system administrators.
@@ -137,19 +143,23 @@ class TenantAdminService:
 
         normalized_rules = [AccessChecker.normalize_model_access_rule(rule) for rule in data.access_rules]
         if TenantMetadataEntity.get_metadata_by_tenant_id(data.tenant_id):
+            # Update: an empty rule set means "unchanged" (None) so a re-sync from an external source
+            # that always sends [] never wipes a ceiling an admin has since customized.
             entity = TenantMetadataEntity.update_tenant_metadata(
                 tenant_id=data.tenant_id,
                 name=data.name,
                 description=data.description,
-                access_rules=normalized_rules,
+                access_rules=normalized_rules or None,
                 lcdm_tenant_id=data.lcdm_tenant_id,
             )
         else:
+            # Create: seed a usable default ceiling when the caller sends none, so an externally
+            # synced tenant is not born locked out of every service.
             entity = TenantMetadataEntity.create_tenant_metadata(
                 tenant_id=data.tenant_id,
                 name=data.name,
                 description=data.description,
-                access_rules=normalized_rules,
+                access_rules=normalized_rules or _DEFAULT_PROVISION_ACCESS_RULES,
                 lcdm_tenant_id=data.lcdm_tenant_id,
             )
         return TenantResponse.from_entity(entity, state=TenantState.ACTIVE)

--- a/packages/sysadmin-api/tests/tenant_admin/test_provision_tenant.py
+++ b/packages/sysadmin-api/tests/tenant_admin/test_provision_tenant.py
@@ -1,0 +1,98 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+from swiss_ai_hub.core.auth.keycloak.keycloak_admin_service import KeycloakAdminService
+from swiss_ai_hub.core.persistence.access.entities.tenant_metadata_entity import TenantMetadataEntity
+
+from swiss_ai_hub.sysadmin_api.routes.tenant_admin.dto.create_tenant_metadata_request import CreateTenantMetadataRequest
+from swiss_ai_hub.sysadmin_api.routes.tenant_admin.tenant_admin_service import TenantAdminService
+
+INIT_ROLES_PATH = (
+    "swiss_ai_hub.sysadmin_api.routes.tenant_admin.tenant_admin_service.initialize_default_roles_for_tenant"
+)
+
+
+def _stub_metadata_lookups(monkeypatch: pytest.MonkeyPatch, by_id=None, by_name=None) -> None:
+    monkeypatch.setattr(TenantMetadataEntity, "get_metadata_by_tenant_id", lambda tenant_id: by_id)
+    monkeypatch.setattr(TenantMetadataEntity, "get_metadata_by_tenant_name", lambda name: by_name)
+
+
+def _fake_entity() -> MagicMock:
+    entity = MagicMock()
+    entity.id = "my-tenant"
+    entity.name = "My Tenant"
+    entity.description = "desc"
+    entity.access_rules = []
+    entity.created_at = datetime.now(UTC)
+    entity.updated_at = datetime.now(UTC)
+    return entity
+
+
+def _make_request() -> CreateTenantMetadataRequest:
+    return CreateTenantMetadataRequest(tenant_id="my-tenant", name="My Tenant", description="desc", access_rules=[])
+
+
+@pytest.mark.asyncio
+async def test_provision_new_tenant_creates_group_then_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A brand-new tenant: the Keycloak group is created (idempotent) and metadata is created."""
+    _stub_metadata_lookups(monkeypatch)  # neither id nor name exists
+    create_group = AsyncMock(return_value="kc-group-id")
+    monkeypatch.setattr(KeycloakAdminService, "create_tenant_group", create_group)
+    monkeypatch.setattr(INIT_ROLES_PATH, AsyncMock(return_value=None))
+    monkeypatch.setattr(KeycloakAdminService, "assign_superuser_to_tenant", AsyncMock(return_value=None))
+
+    create_mock = MagicMock(return_value=_fake_entity())
+    update_mock = MagicMock()
+    monkeypatch.setattr(TenantMetadataEntity, "create_tenant_metadata", create_mock)
+    monkeypatch.setattr(TenantMetadataEntity, "update_tenant_metadata", update_mock)
+
+    result = await TenantAdminService.provision_tenant(_make_request())
+
+    create_group.assert_awaited_once_with("my-tenant")
+    create_mock.assert_called_once()
+    update_mock.assert_not_called()
+    assert result.id == "my-tenant"
+
+
+@pytest.mark.asyncio
+async def test_provision_existing_tenant_updates_metadata_idempotently(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Re-running the sync for an already-configured tenant updates metadata instead of failing (upsert)."""
+    _stub_metadata_lookups(monkeypatch, by_id=MagicMock(id="my-tenant"), by_name=MagicMock(id="my-tenant"))
+    monkeypatch.setattr(KeycloakAdminService, "create_tenant_group", AsyncMock(return_value=None))
+    monkeypatch.setattr(INIT_ROLES_PATH, AsyncMock(return_value=None))
+    monkeypatch.setattr(KeycloakAdminService, "assign_superuser_to_tenant", AsyncMock(return_value=None))
+
+    create_mock = MagicMock()
+    update_mock = MagicMock(return_value=_fake_entity())
+    monkeypatch.setattr(TenantMetadataEntity, "create_tenant_metadata", create_mock)
+    monkeypatch.setattr(TenantMetadataEntity, "update_tenant_metadata", update_mock)
+
+    result = await TenantAdminService.provision_tenant(_make_request())
+
+    update_mock.assert_called_once()
+    create_mock.assert_not_called()
+    assert result.id == "my-tenant"
+
+
+@pytest.mark.asyncio
+async def test_provision_rejects_name_taken_by_other_tenant_before_side_effects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The name belongs to a different tenant id → 409, and no group/side effects run."""
+    _stub_metadata_lookups(monkeypatch, by_name=MagicMock(id="other-tenant", name="My Tenant"))
+    create_group = AsyncMock()
+    roles_mock = AsyncMock()
+    superuser_mock = AsyncMock()
+    monkeypatch.setattr(KeycloakAdminService, "create_tenant_group", create_group)
+    monkeypatch.setattr(INIT_ROLES_PATH, roles_mock)
+    monkeypatch.setattr(KeycloakAdminService, "assign_superuser_to_tenant", superuser_mock)
+
+    with pytest.raises(HTTPException) as exc:
+        await TenantAdminService.provision_tenant(_make_request())
+
+    assert exc.value.status_code == 409
+    create_group.assert_not_awaited()
+    roles_mock.assert_not_awaited()
+    superuser_mock.assert_not_awaited()

--- a/packages/sysadmin-api/tests/tenant_admin/test_provision_tenant.py
+++ b/packages/sysadmin-api/tests/tenant_admin/test_provision_tenant.py
@@ -119,6 +119,40 @@ async def test_provision_passes_lcdm_tenant_id_through_on_update(monkeypatch: py
 
 
 @pytest.mark.asyncio
+async def test_provision_new_tenant_seeds_default_ceiling_when_none_given(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A brand-new tenant with no access rules gets a usable default ceiling (not an empty, locked one)."""
+    _stub_metadata_lookups(monkeypatch)  # not existing
+    monkeypatch.setattr(KeycloakAdminService, "create_tenant_group", AsyncMock(return_value=None))
+    monkeypatch.setattr(INIT_ROLES_PATH, AsyncMock(return_value=None))
+    monkeypatch.setattr(KeycloakAdminService, "assign_superuser_to_tenant", AsyncMock(return_value=None))
+
+    create_mock = MagicMock(return_value=_fake_entity())
+    monkeypatch.setattr(TenantMetadataEntity, "create_tenant_metadata", create_mock)
+    monkeypatch.setattr(TenantMetadataEntity, "update_tenant_metadata", MagicMock())
+
+    await TenantAdminService.provision_tenant(_make_request())  # access_rules=[]
+
+    assert create_mock.call_args.kwargs["access_rules"] == ["aihub.admin.>"]
+
+
+@pytest.mark.asyncio
+async def test_provision_existing_tenant_empty_rules_preserves_ceiling(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Re-syncing with no rules must NOT wipe a ceiling an admin customized — pass None (unchanged)."""
+    _stub_metadata_lookups(monkeypatch, by_id=MagicMock(id="my-tenant"), by_name=MagicMock(id="my-tenant"))
+    monkeypatch.setattr(KeycloakAdminService, "create_tenant_group", AsyncMock(return_value=None))
+    monkeypatch.setattr(INIT_ROLES_PATH, AsyncMock(return_value=None))
+    monkeypatch.setattr(KeycloakAdminService, "assign_superuser_to_tenant", AsyncMock(return_value=None))
+
+    update_mock = MagicMock(return_value=_fake_entity())
+    monkeypatch.setattr(TenantMetadataEntity, "create_tenant_metadata", MagicMock())
+    monkeypatch.setattr(TenantMetadataEntity, "update_tenant_metadata", update_mock)
+
+    await TenantAdminService.provision_tenant(_make_request())  # access_rules=[]
+
+    assert update_mock.call_args.kwargs["access_rules"] is None
+
+
+@pytest.mark.asyncio
 async def test_provision_rejects_name_taken_by_other_tenant_before_side_effects(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/sysadmin-api/tests/tenant_admin/test_provision_tenant.py
+++ b/packages/sysadmin-api/tests/tenant_admin/test_provision_tenant.py
@@ -25,13 +25,20 @@ def _fake_entity() -> MagicMock:
     entity.name = "My Tenant"
     entity.description = "desc"
     entity.access_rules = []
+    entity.lcdm_tenant_id = 5
     entity.created_at = datetime.now(UTC)
     entity.updated_at = datetime.now(UTC)
     return entity
 
 
-def _make_request() -> CreateTenantMetadataRequest:
-    return CreateTenantMetadataRequest(tenant_id="my-tenant", name="My Tenant", description="desc", access_rules=[])
+def _make_request(lcdm_tenant_id: int | None = None) -> CreateTenantMetadataRequest:
+    return CreateTenantMetadataRequest(
+        tenant_id="my-tenant",
+        name="My Tenant",
+        description="desc",
+        access_rules=[],
+        lcdm_tenant_id=lcdm_tenant_id,
+    )
 
 
 @pytest.mark.asyncio
@@ -74,6 +81,41 @@ async def test_provision_existing_tenant_updates_metadata_idempotently(monkeypat
     update_mock.assert_called_once()
     create_mock.assert_not_called()
     assert result.id == "my-tenant"
+
+
+@pytest.mark.asyncio
+async def test_provision_passes_lcdm_tenant_id_through_on_create(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The LCDM tenant id from the request is stored on create so it can be read off the AI Hub tenant."""
+    _stub_metadata_lookups(monkeypatch)
+    monkeypatch.setattr(KeycloakAdminService, "create_tenant_group", AsyncMock(return_value=None))
+    monkeypatch.setattr(INIT_ROLES_PATH, AsyncMock(return_value=None))
+    monkeypatch.setattr(KeycloakAdminService, "assign_superuser_to_tenant", AsyncMock(return_value=None))
+
+    create_mock = MagicMock(return_value=_fake_entity())
+    monkeypatch.setattr(TenantMetadataEntity, "create_tenant_metadata", create_mock)
+    monkeypatch.setattr(TenantMetadataEntity, "update_tenant_metadata", MagicMock())
+
+    result = await TenantAdminService.provision_tenant(_make_request(lcdm_tenant_id=5))
+
+    assert create_mock.call_args.kwargs["lcdm_tenant_id"] == 5
+    assert result.lcdm_tenant_id == 5
+
+
+@pytest.mark.asyncio
+async def test_provision_passes_lcdm_tenant_id_through_on_update(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Re-syncing an existing tenant transfers the LCDM id via update, not just on first insert."""
+    _stub_metadata_lookups(monkeypatch, by_id=MagicMock(id="my-tenant"), by_name=MagicMock(id="my-tenant"))
+    monkeypatch.setattr(KeycloakAdminService, "create_tenant_group", AsyncMock(return_value=None))
+    monkeypatch.setattr(INIT_ROLES_PATH, AsyncMock(return_value=None))
+    monkeypatch.setattr(KeycloakAdminService, "assign_superuser_to_tenant", AsyncMock(return_value=None))
+
+    update_mock = MagicMock(return_value=_fake_entity())
+    monkeypatch.setattr(TenantMetadataEntity, "create_tenant_metadata", MagicMock())
+    monkeypatch.setattr(TenantMetadataEntity, "update_tenant_metadata", update_mock)
+
+    await TenantAdminService.provision_tenant(_make_request(lcdm_tenant_id=5))
+
+    assert update_mock.call_args.kwargs["lcdm_tenant_id"] == 5
 
 
 @pytest.mark.asyncio

--- a/packages/sysadmin-web/nginx.conf
+++ b/packages/sysadmin-web/nginx.conf
@@ -19,8 +19,14 @@ server {
         try_files $uri =404;
     }
 
-    # SPA routing: every non-file path returns index.html
+    # SPA routing: every non-file path returns index.html.
+    # index.html must NOT be cached: after a redeploy the shell references new hashed
+    # /_nuxt chunks, and a browser that cached the old shell requests dead chunk hashes
+    # (404) so the app half-loads (e.g. login provider buttons never render). This bites
+    # every browser after every deploy — it only looked "Edge-specific" because a fresh
+    # profile had no stale shell cached. Hashed assets under /_nuxt stay immutable-cached.
     location / {
+        add_header Cache-Control "no-store" always;
         try_files $uri /index.html;
     }
 

--- a/packages/web/composables/auth/useAuth.ts
+++ b/packages/web/composables/auth/useAuth.ts
@@ -1,8 +1,13 @@
 export const useAuth = () => {
-  const login = (idpHint?: string) => {
+  const login = async (idpHint?: string) => {
     const { $auth } = useNuxtApp()
     const extraQueryParams = idpHint ? { kc_idp_hint: idpHint } : {}
-    $auth.signinRedirect({ prompt: 'login', extraQueryParams })
+    // Drop orphaned signin-state left in web storage by abandoned or superseded login attempts
+    // (e.g. from an earlier deployment that used a different OAUTH client id). A stale entry is a
+    // common cause of "mismatching_state" on the callback in a long-lived browser profile, where it
+    // works only in a fresh incognito window. Clearing before starting a new flow keeps the store clean.
+    await $auth.clearStaleState()
+    await $auth.signinRedirect({ prompt: 'login', extraQueryParams })
   }
 
   const logout = async () => {

--- a/packages/web/nginx.conf
+++ b/packages/web/nginx.conf
@@ -31,8 +31,13 @@ server {
         try_files $uri =404;
     }
 
-    # Handle the aihub application routes (SPA: all non-file routes serve index.html)
+    # Handle the aihub application routes (SPA: all non-file routes serve index.html).
+    # index.html must NOT be cached: after a redeploy the shell references new hashed
+    # /_nuxt chunks, and a browser that cached the old shell requests dead chunk hashes
+    # (404) so the app half-loads (e.g. login provider buttons never render). This bites
+    # every browser after every deploy. Hashed assets under /_nuxt stay immutable-cached.
     location / {
+        add_header Cache-Control "no-store" always;
         try_files $uri /index.html;
     }
 

--- a/packages/web/pages/auth/callback.vue
+++ b/packages/web/pages/auth/callback.vue
@@ -42,6 +42,9 @@ try {
 }
 catch (err) {
   error.value = err.message || t('auth.callback.genericError')
+  // A failed exchange (e.g. mismatching_state) leaves the consumed/orphaned state behind; clear it
+  // so the retry starts from a clean store instead of tripping over the same stale entry.
+  await $auth.clearStaleState()
   setTimeout(() => {
     navigateTo(`/${locale.value}/auth/login`)
   }, 3000)

--- a/packages/web/plugins/oidc-client.ts
+++ b/packages/web/plugins/oidc-client.ts
@@ -20,6 +20,10 @@ export default defineNuxtPlugin(async ({ $i18n, $router }) => {
     silentRequestTimeoutInSeconds: 30,
     accessTokenExpiringNotificationTimeInSeconds: 120,
     userStore: new WebStorageStateStore({ store: globalThis?.localStorage }),
+    // Purge orphaned signin-state sooner (default 900s) so an abandoned attempt cannot linger and
+    // cause a later "mismatching_state" on the callback. The in-flight state of an active login is
+    // age 0 and never at risk from clearStaleState().
+    staleStateAgeInSeconds: 300,
     // Keycloak supports PKCE
     disablePKCE: false,
     // Disabled: OpenWebUI logout destroys the Keycloak SSO session, but we


### PR DESCRIPTION
## Context

Integration of the **Swiss LCDM Hub** with the **Swiss AI Hub**. The LCDM Hub (source of truth for tenants) pushes its tenants flat into the AI Hub, and a multi-tenant MCP serves per-tenant GTO data through a single agent profile. Validated end-to-end against the dev VM (tenant sync 19/19, `lcdm_tenant_id` transferred across all tenants, MCP multi-tenant header live, per-tenant data isolation proven across bbv/HSLU/Palme/FHNW).

> ⚠️ **Before merge:** run `make generate-compose` once — commit 4 changes a compose *template* (`OPEN_WEBUI_SIGNING_SECRET`); the regenerated `infra/docker-compose.*.yml` are intentionally not in this branch (authored without a local `uv`).

## Commits

**1. `feat(sysadmin): Add idempotent tenant provision endpoint for external sync`**
`POST /admin/tenants/provision` (sysadmin, `sys_admin_user()` gate). Idempotent: creates the Keycloak group if missing, seeds roles + superuser, then upserts metadata. Built for an external source of truth (LCDM Hub) that re-runs the sync repeatedly.

**2. `feat(sysadmin): Store originating LCDM tenant id (lcdm_tenant_id)`**
New nullable `lcdm_tenant_id: IntField` on `TenantMetadataEntity`, threaded through create/update (+ delete-restore snapshot), exposed on `CreateTenantMetadataRequest`/`TenantResponse`, passed through in `provision_tenant` on insert and update. It's the value the LCDM MCP expects in its `X-LCDM-Tenant` header.

**3. `fix(web): Clear stale OIDC state before login (mismatching_state)`**
A long-lived browser profile accumulates orphaned `oidc-client-ts` signin-state, tripping `mismatching_state` on the callback (tenant admin only worked in incognito). `login()` clears stale state before `signinRedirect`, the callback clears it on a failed exchange, and `staleStateAgeInSeconds` is lowered.

**4. `fix(deploy): Export OPEN_WEBUI_SIGNING_SECRET for sysadmin-api (crash-loop fix)`**
`sysadmin-api` reads `OPEN_WEBUI_SIGNING_SECRET` (min 64 chars) but the template only set `AUTH_OPEN_WEBUI_SIGNING_SECRET`, so it fell back to OpenWebUI's 43-char key and crash-looped. Adds the explicit export. **Template-only — run `make generate-compose`.**

**5. `fix(web): Never cache the SPA shell (index.html)`**
`web`/`sysadmin-web` nginx served `index.html` without `Cache-Control`; after a redeploy a cached old shell references dead hashed `/_nuxt` chunks (404) and the app half-loads — the login buttons never render. Adds `Cache-Control: no-store` to the index.html fallback; hashed assets stay immutable. Real production bug, hits any browser after any web deploy (looked "Edge-specific" only because fresh Chrome had no stale shell).

**6. `feat(swiss-ai-hub): Auto-forward acting tenant id as an MCP header`**
New optional `McpClientConfig.forward_tenant_id_header`: when set (e.g. `X-LCDM-Tenant`), McpReactAgent sends the acting tenant's `lcdm_tenant_id` on every MCP request, resolved from the user's acting tenant on the entry step and cached in the run context for tool-execution steps. One agent profile serves all tenants, each call scoped to its own external tenant. No-op when unset. Form field + i18n (de/en/fr/it).

**7. `feat(sysadmin): Seed a default access ceiling for provisioned tenants`**
An externally-synced tenant with `access_rules: []` gets an empty ceiling, which MIN(ceiling, user-rules) turns into "deny every service" (agent-service 403 for everyone). Provision now seeds `['aihub.admin.>']` on CREATE when none is given; on UPDATE an empty rule set means "unchanged" so a re-sync never wipes an admin-customized ceiling.

## Tests
- `sysadmin-api`: `test_provision_tenant.py` — create / idempotent re-run / name conflict / `lcdm_tenant_id` on create+update / default-ceiling seeding.
- Validated live on the dev VM: authenticated provision returned 200 + stored `lcdm_tenant_id`; tenant sync from LCDM populated `lcdm_tenant_id` on all synced `lcdm-<id>` tenants (19/19).

## Follow-ups (not in this PR)
- **Traefik cold-boot race:** `depends_on: docker-socket-proxy` doesn't apply to the Docker daemon auto-restarting `restart: always` containers after a VM reboot, so Traefik can come up with 0 routers; its healthcheck is `NONE` so it never self-heals. Workaround today: `docker restart traefik`.
- `mcp_react_agent` into `compose-config.yml` (local/nightly/latest) + Dockerfile `COPY packages/agent/README.md`.
